### PR TITLE
feat: add builder and status helpers to BaseResponse

### DIFF
--- a/shared-lib/shared-common/pom.xml
+++ b/shared-lib/shared-common/pom.xml
@@ -30,9 +30,15 @@
     <artifactId>logstash-logback-encoder</artifactId>
   </dependency>
   
- <dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
@@ -3,6 +3,7 @@ package com.common.dto;
 import com.common.enums.StatusEnums.ApiStatus;
 import jakarta.annotation.Nullable;
 import java.time.Instant;
+import java.util.Objects;
 
 /**
  * Standard response wrapper for all Shared APIs.
@@ -104,5 +105,114 @@ public class BaseResponse<T> {
 
     public void setTimestamp(Instant timestamp) {
         this.timestamp = timestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BaseResponse<?> that = (BaseResponse<?>) o;
+        return status == that.status &&
+                Objects.equals(code, that.code) &&
+                Objects.equals(message, that.message) &&
+                Objects.equals(data, that.data) &&
+                Objects.equals(timestamp, that.timestamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(status, code, message, data, timestamp);
+    }
+
+    @Override
+    public String toString() {
+        return "BaseResponse{" +
+                "status=" + status +
+                ", code='" + code + '\'' +
+                ", message='" + message + '\'' +
+                ", data=" + data +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+
+    /**
+     * Convenience check for SUCCESS responses.
+     *
+     * @return true if status is ApiStatus.SUCCESS
+     */
+    public boolean isSuccess() {
+        return status == ApiStatus.SUCCESS;
+    }
+
+    /**
+     * Convenience check for ERROR responses.
+     *
+     * @return true if status is ApiStatus.ERROR
+     */
+    public boolean isError() {
+        return status == ApiStatus.ERROR;
+    }
+
+    /**
+     * Convenience check for WARNING responses.
+     *
+     * @return true if status is ApiStatus.WARNING
+     */
+    public boolean isWarning() {
+        return status == ApiStatus.WARNING;
+    }
+
+    /**
+     * Create a builder for {@link BaseResponse}.
+     *
+     * @param <T> payload type
+     * @return new Builder instance
+     */
+    public static <T> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    /**
+     * Builder for {@link BaseResponse} allowing fine-grained construction.
+     */
+    public static final class Builder<T> {
+        private ApiStatus status;
+        private String code;
+        private String message;
+        private T data;
+        private Instant timestamp = Instant.now();
+
+        private Builder() {}
+
+        public Builder<T> status(ApiStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder<T> code(String code) {
+            this.code = code;
+            return this;
+        }
+
+        public Builder<T> message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder<T> data(T data) {
+            this.data = data;
+            return this;
+        }
+
+        public Builder<T> timestamp(Instant timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        public BaseResponse<T> build() {
+            BaseResponse<T> response = new BaseResponse<>(status, code, message, data);
+            response.setTimestamp(timestamp);
+            return response;
+        }
     }
 }

--- a/shared-lib/shared-common/src/test/java/com/common/dto/BaseResponseTest.java
+++ b/shared-lib/shared-common/src/test/java/com/common/dto/BaseResponseTest.java
@@ -1,0 +1,50 @@
+package com.common.dto;
+
+import com.common.enums.StatusEnums.ApiStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BaseResponseTest {
+
+    @Test
+    void builderCreatesExpectedResponse() {
+        Instant now = Instant.now();
+        BaseResponse<String> response = BaseResponse.<String>builder()
+                .status(ApiStatus.SUCCESS)
+                .code("SUCCESS-200")
+                .message("ok")
+                .data("payload")
+                .timestamp(now)
+                .build();
+
+        assertEquals(ApiStatus.SUCCESS, response.getStatus());
+        assertEquals("SUCCESS-200", response.getCode());
+        assertEquals("ok", response.getMessage());
+        assertEquals("payload", response.getData());
+        assertEquals(now, response.getTimestamp());
+        assertTrue(response.isSuccess());
+    }
+
+    @Test
+    void equalityBasedOnFields() {
+        Instant now = Instant.now();
+        BaseResponse<String> r1 = BaseResponse.<String>builder()
+                .status(ApiStatus.ERROR)
+                .code("ERR")
+                .message("bad")
+                .timestamp(now)
+                .build();
+        BaseResponse<String> r2 = BaseResponse.<String>builder()
+                .status(ApiStatus.ERROR)
+                .code("ERR")
+                .message("bad")
+                .timestamp(now)
+                .build();
+
+        assertEquals(r1, r2);
+        assertEquals(r1.hashCode(), r2.hashCode());
+    }
+}


### PR DESCRIPTION
## Summary
- add builder pattern and status helper methods to BaseResponse for flexible response construction
- add unit tests and JUnit dependency for shared-common

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afb0b4642c832facab053f3d066563