### PR TITLE
Use Lombok getter for SharedException

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/common/exception/SharedException.java
+++ b/shared-lib/shared-common/src/main/java/com/common/exception/SharedException.java
@@ -1,12 +1,13 @@
 package com.common.exception;
 
-import com.common.constants.ErrorCodes;
+import lombok.Getter;
 import com.common.enums.StatusEnums;
 
 /**
  * Base runtime exception for all Shared services.
  * Provides a unified way to carry error codes, messages, and status.
  */
+@Getter
 public class SharedException extends RuntimeException {
 
     /**
@@ -50,18 +51,5 @@ public class SharedException extends RuntimeException {
         this.errorCode = errorCode;
         this.status = StatusEnums.ApiStatus.ERROR;
         this.details = details;
-    }
-
-    // ===== Getters =====
-    public String getErrorCode() {
-        return errorCode;
-    }
-
-    public StatusEnums.ApiStatus getStatus() {
-        return status;
-    }
-
-    public String getDetails() {
-        return details;
     }
 }


### PR DESCRIPTION
## Summary
- Simplify `SharedException` by using Lombok `@Getter`
- Remove redundant manual getter methods

## Testing
- `mvn -q test` *(fails: Non-resolvable import POMs - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b030a88cd4832f8e6f9f346892ab1c