### PR TITLE
Fix shared common response and exception classes

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
@@ -8,7 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import java.util.Objects;
 
 /**
  * Standard response wrapper for all Shared APIs.
@@ -46,6 +45,7 @@ public class BaseResponse<T> {
                 .code("SUCCESS-200")
                 .message("Operation successful")
                 .data(data)
+                .timestamp(Instant.now())
                 .build();
     }
 
@@ -62,6 +62,7 @@ public class BaseResponse<T> {
                 .code("SUCCESS-200")
                 .message(message)
                 .data(data)
+                .timestamp(Instant.now())
                 .build();
     }
 
@@ -70,6 +71,7 @@ public class BaseResponse<T> {
                 .status(ApiStatus.ERROR)
                 .code(code)
                 .message(message)
+                .timestamp(Instant.now())
                 .build();
     }
 
@@ -79,6 +81,7 @@ public class BaseResponse<T> {
                 .code(code)
                 .message(message)
                 .data(data)
+                .timestamp(Instant.now())
                 .build();
     }
 
@@ -126,35 +129,8 @@ public class BaseResponse<T> {
                 .code(code)
                 .message(message)
                 .data(newData)
+                .timestamp(timestamp)
                 .build();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        BaseResponse<?> that = (BaseResponse<?>) o;
-        return status == that.status &&
-                Objects.equals(code, that.code) &&
-                Objects.equals(message, that.message) &&
-                Objects.equals(data, that.data) &&
-                Objects.equals(timestamp, that.timestamp);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(status, code, message, data, timestamp);
-    }
-
-    @Override
-    public String toString() {
-        return "BaseResponse{" +
-                "status=" + status +
-                ", code='" + code + '\'' +
-                ", message='" + message + '\'' +
-                ", data=" + data +
-                ", timestamp=" + timestamp +
-                '}';
     }
 
 }

--- a/shared-lib/shared-common/src/main/java/com/common/dto/ErrorResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/common/dto/ErrorResponse.java
@@ -51,14 +51,31 @@ public class ErrorResponse {
 
     // ===== Static builders =====
     public static ErrorResponse of(String code, String message) {
-        return ErrorResponse.builder().code(code).message(message).build();
+        return ErrorResponse.builder()
+                .code(code)
+                .message(message)
+                .timestamp(Instant.now())
+                .build();
     }
 
     public static ErrorResponse of(String code, String message, List<String> details, String traceId) {
-        return ErrorResponse.builder().code(code).message(message).details(details).traceId(traceId).build();
+        return ErrorResponse.builder()
+                .code(code)
+                .message(message)
+                .details(details)
+                .traceId(traceId)
+                .timestamp(Instant.now())
+                .build();
     }
 
     public static ErrorResponse of(String code, String message, List<String> details, String traceId, String tenantId) {
-        return ErrorResponse.builder().code(code).message(message).details(details).traceId(traceId).tenantId(tenantId).build();
+        return ErrorResponse.builder()
+                .code(code)
+                .message(message)
+                .details(details)
+                .traceId(traceId)
+                .tenantId(tenantId)
+                .timestamp(Instant.now())
+                .build();
     }
 }

--- a/shared-lib/shared-common/src/main/java/com/common/exception/ResourceNotFoundException.java
+++ b/shared-lib/shared-common/src/main/java/com/common/exception/ResourceNotFoundException.java
@@ -28,13 +28,4 @@ public class ResourceNotFoundException extends NotFoundException {
         super(message);
     }
 
-    /**
-     * Create a ResourceNotFoundException with a custom message and details.
-     *
-     * @param message custom not-found message
-     * @param details more specific explanation
-     */
-    public ResourceNotFoundException(String message, String details) {
-        super(message, details);
-    }
 }


### PR DESCRIPTION
## Summary
- construct BaseResponse and ErrorResponse via Lombok builders
- remove manual overrides in BaseResponse

## Testing
- `mvn -q -pl shared-common -am test` *(fails: Non-resolvable import POM: Could not transfer artifact ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a1d2d938832f94c7ce0be5752c42