### PR TITLE
Add validation dependency to security starter

### DIFF
--- a/shared-lib/shared-starters/starter-security/pom.xml
+++ b/shared-lib/shared-starters/starter-security/pom.xml
@@ -63,6 +63,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Validation API -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Observability (opt-in) -->
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/SharedSecurityPropsTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/SharedSecurityPropsTest.java
@@ -14,7 +14,7 @@ class SharedSecurityPropsTest {
   void bindsHs256Secret() {
     MapConfigurationPropertySource source = new MapConfigurationPropertySource(
         Map.of("shared.security.hs256.secret", "s3cr3t"));
-    SharedSecurityProps props = Binder.get(source)
+    SharedSecurityProps props = new Binder(source)
         .bind("shared.security", SharedSecurityProps.class).get();
     assertEquals("s3cr3t", props.getHs256().getSecret());
   }


### PR DESCRIPTION
## Summary
- include `spring-boot-starter-validation` in starter-security to provide Jakarta validation annotations
- fix `SharedSecurityPropsTest` binder setup to compile

## Testing
- `mvn -q -pl shared-starters/starter-security -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a44e9074832f947b75c5873eb977