### PR TITLE
Fix binder usage in resilience props test

### DIFF
--- a/shared-lib/shared-starters/starter-resilience/src/test/java/com/shared/shared_starter_resilience/SharedResiliencePropsTest.java
+++ b/shared-lib/shared-starters/starter-resilience/src/test/java/com/shared/shared_starter_resilience/SharedResiliencePropsTest.java
@@ -15,8 +15,9 @@ class SharedResiliencePropsTest {
     MapConfigurationPropertySource source = new MapConfigurationPropertySource(
         Map.of("shared.resilience.http-timeout-ms", "1000",
                "shared.resilience.connect-timeout-ms", "500"));
-    SharedResilienceProps props = Binder.get(source)
-        .bind("shared.resilience", SharedResilienceProps.class).get();
+    SharedResilienceProps props = new Binder(source)
+        .bind("shared.resilience", SharedResilienceProps.class)
+        .get();
     assertEquals(1000, props.getHttpTimeoutMs());
     assertEquals(500, props.getConnectTimeoutMs());
   }


### PR DESCRIPTION
## Summary
- correct binder initialization in SharedResiliencePropsTest

## Testing
- `mvn -q -pl shared-starters/starter-resilience -am test` *(fails: Non-resolvable import POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a8078c90832faea4a50d1aebec2f