### PR TITLE
Fix binder usage in resilience and rate limit props tests

### DIFF
--- a/shared-lib/shared-starters/starter-ratelimit/src/test/java/com/shared/shared_starter_ratelimit/RateLimitPropsTest.java
+++ b/shared-lib/shared-starters/starter-ratelimit/src/test/java/com/shared/shared_starter_ratelimit/RateLimitPropsTest.java
@@ -16,8 +16,9 @@ class RateLimitPropsTest {
         Map.of("shared.ratelimit.capacity", "10",
                "shared.ratelimit.refill-per-minute", "5",
                "shared.ratelimit.key-strategy", "ip"));
-    RateLimitProps props = Binder.get(source)
-        .bind("shared.ratelimit", RateLimitProps.class).get();
+    RateLimitProps props = new Binder(source)
+        .bind("shared.ratelimit", RateLimitProps.class)
+        .get();
     assertEquals(10, props.getCapacity());
     assertEquals(5, props.getRefillPerMinute());
     assertEquals("ip", props.getKeyStrategy());

--- a/shared-lib/shared-starters/starter-resilience/src/test/java/com/shared/shared_starter_resilience/SharedResiliencePropsTest.java
+++ b/shared-lib/shared-starters/starter-resilience/src/test/java/com/shared/shared_starter_resilience/SharedResiliencePropsTest.java
@@ -15,8 +15,9 @@ class SharedResiliencePropsTest {
     MapConfigurationPropertySource source = new MapConfigurationPropertySource(
         Map.of("shared.resilience.http-timeout-ms", "1000",
                "shared.resilience.connect-timeout-ms", "500"));
-    SharedResilienceProps props = Binder.get(source)
-        .bind("shared.resilience", SharedResilienceProps.class).get();
+    SharedResilienceProps props = new Binder(source)
+        .bind("shared.resilience", SharedResilienceProps.class)
+        .get();
     assertEquals(1000, props.getHttpTimeoutMs());
     assertEquals(500, props.getConnectTimeoutMs());
   }


### PR DESCRIPTION
## Summary
- correct binder initialization in SharedResiliencePropsTest
- correct binder initialization in RateLimitPropsTest

## Testing
- `mvn -q -pl shared-starters/starter-ratelimit -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a8078c90832faea4a50d1aebec2f