### PR TITLE
Fix generics in CountryControllerTest

### DIFF
--- a/lms-setup/src/test/java/com/lms/setup/controller/CountryControllerTest.java
+++ b/lms-setup/src/test/java/com/lms/setup/controller/CountryControllerTest.java
@@ -92,8 +92,8 @@ class CountryControllerTest extends TestBase {
         // Given
         List<Country> countries = Arrays.asList(createTestCountry());
         Page<Country> page = new PageImpl<>(countries, PageRequest.of(0, 20), 1);
-        BaseResponse<Page<Country>> response = BaseResponse.success("Countries page", page);
-        when(countryService.list(any(Pageable.class), anyString(), anyBoolean())).thenReturn((BaseResponse<?>) response);
+        BaseResponse<?> response = BaseResponse.success("Countries page", page);
+        when(countryService.list(any(Pageable.class), anyString(), anyBoolean())).thenReturn(response);
 
         // When & Then
         mockMvc.perform(getRequest("/countries?page=0&size=20"))


### PR DESCRIPTION
## Summary
- Align CountryControllerTest with CountryService.list by using unbounded `BaseResponse<?>` when stubbing the list method to resolve generics mismatch.

## Testing
- `MAVEN_OPTS='-Djava.net.preferIPv4Stack=true' mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b229df30832f8d53c0823154893f