### PR TITLE
Add OpenTelemetry logback dependency and fix CityServiceImplTest

### DIFF
--- a/lms-setup/pom.xml
+++ b/lms-setup/pom.xml
@@ -175,6 +175,12 @@
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
     </dependency>
 
+    <!-- Logging -->
+    <dependency>
+      <groupId>io.opentelemetry.instrumentation</groupId>
+      <artifactId>opentelemetry-logback-mdc-1.0</artifactId>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/lms-setup/src/test/java/com/lms/setup/service/CityServiceImplTest.java
+++ b/lms-setup/src/test/java/com/lms/setup/service/CityServiceImplTest.java
@@ -1,8 +1,10 @@
 package com.lms.setup.service;
 
 import com.common.dto.BaseResponse;
+import com.lms.setup.mapper.CityMapper;
 import com.lms.setup.model.City;
 import com.lms.setup.repository.CityRepository;
+import com.lms.setup.repository.CountryRepository;
 import com.lms.setup.service.impl.CityServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,12 +15,14 @@ import org.mockito.MockitoAnnotations;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 class CityServiceImplTest {
 
-    @Mock
-    private CityRepository cityRepository;
+    @Mock private CityRepository cityRepository;
+    @Mock private CountryRepository countryRepository;
+    @Mock private CityMapper mapper;
 
     @InjectMocks
     private CityServiceImpl service;
@@ -30,7 +34,11 @@ class CityServiceImplTest {
 
     @Test
     void list_ok() {
-        when(cityRepository.findAll()).thenReturn(Collections.singletonList(new City()));
+        var cityPage = new org.springframework.data.domain.PageImpl<>(Collections.singletonList(new City()));
+        when(cityRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class), any(org.springframework.data.domain.Pageable.class)))
+                .thenReturn(cityPage);
+        when(mapper.toDtoPage(cityPage)).thenReturn(org.springframework.data.domain.Page.empty());
+
         BaseResponse<?> resp = service.list(org.springframework.data.domain.Pageable.unpaged(), null, false);
         assertNotNull(resp);
     }


### PR DESCRIPTION
## Summary
- add missing OpenTelemetry Logback MDC dependency so the logging appender is available
- mock mapper and country repository in CityServiceImplTest and stub repository calls to avoid NPE

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: could not transfer org.springframework.boot:spring-boot-starter-parent:3.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b54b9b44832f911dad88328e4d40