### PR TITLE
Fix DataSource configuration in DatabaseConfig

### DIFF
--- a/lms-setup/src/main/java/com/lms/setup/config/DatabaseConfig.java
+++ b/lms-setup/src/main/java/com/lms/setup/config/DatabaseConfig.java
@@ -65,9 +65,9 @@ public class DatabaseConfig {
     }
 
     @Bean
-    public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
         LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
-        em.setDataSource(dataSource());
+        em.setDataSource(dataSource);
         em.setPackagesToScan("com.lms.setup.model");
 
         HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
@@ -113,9 +113,9 @@ public class DatabaseConfig {
     }
 
     @Bean
-    public PlatformTransactionManager transactionManager() {
+    public PlatformTransactionManager transactionManager(LocalContainerEntityManagerFactoryBean entityManagerFactory) {
         JpaTransactionManager transactionManager = new JpaTransactionManager();
-        transactionManager.setEntityManagerFactory(entityManagerFactory().getObject());
+        transactionManager.setEntityManagerFactory(entityManagerFactory.getObject());
         transactionManager.setDefaultTimeout(30); // 30 seconds default timeout
         return transactionManager;
     }


### PR DESCRIPTION
## Summary
- accept a `DataSource` bean when creating the entity manager factory and remove direct bean call
- inject the entity manager factory into the transaction manager to avoid argument mismatch

## Testing
- ⚠️ `mvn -q -f shared-lib/pom.xml install -DskipTests` (failed: Non-resolvable import POM due to network is unreachable)
- ⚠️ `mvn -q -f lms-setup/pom.xml test` (failed: Non-resolvable parent POM due to network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68b25270c90c832f95671e3c498f5b07