### PR TITLE
fix: add hikaricp provider

### DIFF
--- a/lms-setup/pom.xml
+++ b/lms-setup/pom.xml
@@ -72,6 +72,12 @@
       <artifactId>flyway-database-postgresql</artifactId>
     </dependency>
 
+    <!-- HikariCP support for Hibernate -->
+    <dependency>
+      <groupId>org.hibernate.orm</groupId>
+      <artifactId>hibernate-hikaricp</artifactId>
+    </dependency>
+
     <!-- MapStruct runtime (processor is wired via compiler plugin) -->
     <dependency>
       <groupId>org.mapstruct</groupId>

--- a/lms-setup/src/main/java/com/lms/setup/config/DatabaseConfig.java
+++ b/lms-setup/src/main/java/com/lms/setup/config/DatabaseConfig.java
@@ -96,7 +96,10 @@ public class DatabaseConfig {
         properties.setProperty("hibernate.connection.provider_disables_autocommit", "true");
         
         // Connection pooling
-        properties.setProperty("hibernate.connection.provider_class", "org.hibernate.hikari.internal.HikariConnectionProvider");
+        // Use the official Hibernate module for HikariCP
+        properties.setProperty(
+                "hibernate.connection.provider_class",
+                "org.hibernate.hikaricp.internal.HikariCPConnectionProvider");
         properties.setProperty("hibernate.hikari.connectionTimeout", "30000");
         properties.setProperty("hibernate.hikari.maximumPoolSize", "20");
         properties.setProperty("hibernate.hikari.minimumIdle", "5");


### PR DESCRIPTION
## Summary
- use official Hibernate HikariCP connection provider
- add hibernate-hikaricp dependency

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.lms:lms-setup:1.0.0: The following artifacts could not be resolved...)*

------
https://chatgpt.com/codex/tasks/task_e_68b25475a654832fadb6a8fb87e1eff8