### PR TITLE
Refactor LookupControllerTest to use MVC slice

### DIFF
--- a/lms-setup/src/test/java/com/lms/setup/controller/LookupControllerTest.java
+++ b/lms-setup/src/test/java/com/lms/setup/controller/LookupControllerTest.java
@@ -1,27 +1,41 @@
 package com.lms.setup.controller;
 
+import com.common.dto.BaseResponse;
+import com.lms.setup.model.Lookup;
+import com.lms.setup.service.LookupService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import java.util.List;
 
-@SpringBootTest
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = LookupController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 class LookupControllerTest {
 
   @Autowired MockMvc mockMvc;
+  @MockBean LookupService lookupService;
 
   @Test
   void getAllLookups_ok() throws Exception {
+    BaseResponse<List<Lookup>> resp = BaseResponse.success("ok", List.of());
+    when(lookupService.getAllLookups()).thenReturn(resp);
+
     mockMvc.perform(get("/setup/lookups").accept(MediaType.APPLICATION_JSON))
-           .andExpect(status().isOk())
-           .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.message").value("ok"));
   }
 }


### PR DESCRIPTION
## Summary
- isolate `LookupControllerTest` with `@WebMvcTest` and mocked service

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b259343cdc832f85b6da64585900d5