### PR TITLE
chore: define checkstyle property path

### DIFF
--- a/lms-setup/pom.xml
+++ b/lms-setup/pom.xml
@@ -233,6 +233,7 @@
         <encoding>${project.build.sourceEncoding}</encoding>
         <consoleOutput>true</consoleOutput>
         <failOnViolation>false</failOnViolation>
+        <propertyExpansion>config_loc=${project.basedir}/../shared-lib/shared-quality</propertyExpansion>
       </configuration>
       <executions>
         <execution>


### PR DESCRIPTION
## Summary
- configure Maven Checkstyle plugin with config_loc property

## Testing
- `mvn -q verify` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.3; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b25a1dc4ac832fb0b6126ea322d1e5