### PR TITLE
Use local Checkstyle DTD

### DIFF
--- a/shared-lib/shared-quality/checkstyle.xml
+++ b/shared-lib/shared-quality/checkstyle.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
-        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+        "configuration_1_3.dtd">
 <module name="Checker">
   <property name="charset" value="UTF-8"/>
   <property name="severity" value="warning"/>
@@ -19,7 +19,12 @@
   <module name="FileTabCharacter">
     <property name="eachLine" value="true"/>
   </module>
-  
+
+  <!-- Line length -->
+  <module name="LineLength">
+    <property name="max" value="120"/>
+  </module>
+
   <module name="TreeWalker">
     <!-- Naming conventions -->
     <module name="ConstantName"/>
@@ -44,9 +49,6 @@
     </module>
     <module name="ParameterNumber">
       <property name="max" value="7"/>
-    </module>
-    <module name="LineLength">
-      <property name="max" value="120"/>
     </module>
     
     <!-- Whitespace -->

--- a/shared-lib/shared-quality/configuration_1_3.dtd
+++ b/shared-lib/shared-quality/configuration_1_3.dtd
@@ -1,0 +1,54 @@
+<!-- Add the following to any file that is to be validated against this DTD:
+
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+-->
+
+<!ELEMENT module (module|property|metadata|message)*>
+<!ATTLIST module name NMTOKEN #REQUIRED>
+
+<!ELEMENT property EMPTY>
+<!ATTLIST property
+    name NMTOKEN #REQUIRED
+    value CDATA #REQUIRED
+    default CDATA #IMPLIED
+>
+
+<!--
+
+   Used to store metadata in the Checkstyle configuration file. This
+   information is ignored by Checkstyle. This may be useful if you want to
+   store plug-in specific information.
+
+   To avoid name clashes between different tools/plug-ins you are *strongly*
+   encouraged to prefix all names with your domain name. For example, use the
+   name "com.mycompany.parameter" instead of "parameter".
+
+   The prefix "com.puppycrawl." is reserved for Checkstyle.
+
+-->
+
+<!ELEMENT metadata EMPTY>
+<!ATTLIST metadata
+    name NMTOKEN #REQUIRED
+    value CDATA #REQUIRED
+>
+
+<!--
+   Can be used to replace some generic Checkstyle messages with a custom
+   messages.
+
+   The 'key' attribute specifies for which actual Checkstyle message the
+   replacing should occur, look into Checkstyle's message.properties for
+   the according message keys.
+
+   The 'value' attribute defines the custom message patterns including
+   message parameter placeholders as defined in the original Checkstyle
+   messages (again see message.properties for reference).
+-->
+<!ELEMENT message EMPTY>
+<!ATTLIST message
+    key NMTOKEN #REQUIRED
+    value CDATA #REQUIRED
+>


### PR DESCRIPTION
## Summary
- avoid external network access for Checkstyle by referencing a local `configuration_1_3.dtd`
- place the `LineLength` module at the root of the Checkstyle config so it is no longer under `TreeWalker`

## Testing
- `mvn -f shared-lib/pom.xml checkstyle:check -pl shared-quality -am` *(fails: Network is unreachable while resolving artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68b260906c24832f820683ce4dfe0505