### PR TITLE
Add H2 fallback datasource for local runs

### DIFF
--- a/lms-setup/pom.xml
+++ b/lms-setup/pom.xml
@@ -207,7 +207,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
## Summary
- default to an in-memory H2 datasource when no external DB properties are set
- auto-select Hibernate dialect based on chosen driver
- include H2 dependency at runtime

## Testing
- `mvn -q -f shared-lib/pom.xml install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2735c41d8832f9fa89be94dbb5b4d