### PR TITLE
Handle blank database URL

### DIFF
--- a/lms-setup/README.md
+++ b/lms-setup/README.md
@@ -1,2 +1,6 @@
 # lms-Setup
 Spring Boot microservice for reference lookups (multi-tenant). Uses Postgres + Redis, integrated with shared-lib starters.
+
+## Database configuration
+
+Provide connection details via `spring.datasource.url` in your `application-*.yaml` or through the `DB_URL`, `DB_USERNAME`, and `DB_PASSWORD` environment variables. If these values are absent or empty, the service now defaults to an in-memory H2 database, enabling the application to start without an external Postgres instance.

--- a/lms-setup/src/main/java/com/lms/setup/config/DatabaseConfig.java
+++ b/lms-setup/src/main/java/com/lms/setup/config/DatabaseConfig.java
@@ -46,9 +46,13 @@ public class DatabaseConfig {
         String jdbcUrl = properties.getUrl();
         if (jdbcUrl == null || jdbcUrl.isBlank()) {
             // Allow overriding via DB_URL env var as documented in README
-            jdbcUrl = env.getProperty(
-                    "DB_URL",
-                    "jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH");
+            String envJdbcUrl = env.getProperty("DB_URL");
+            if (envJdbcUrl == null || envJdbcUrl.isBlank()) {
+                jdbcUrl =
+                        "jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH";
+            } else {
+                jdbcUrl = envJdbcUrl;
+            }
             hikariConfig.setUsername(env.getProperty("DB_USERNAME", "sa"));
             hikariConfig.setPassword(env.getProperty("DB_PASSWORD", ""));
             String driver = jdbcUrl.startsWith("jdbc:h2")


### PR DESCRIPTION
## Summary
- ensure DataSource falls back to in-memory H2 when `DB_URL` is unset or blank
- document default database behavior in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b280029b5c832fad60ff54c03913ce