### PR TITLE
Sanitize sorting across service list operations

### DIFF
--- a/lms-setup/src/main/java/com/lms/setup/service/impl/CityServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/CityServiceImpl.java
@@ -9,6 +9,7 @@ import com.lms.setup.model.Country;
 import com.lms.setup.repository.CityRepository;
 import com.lms.setup.repository.CountryRepository;
 import com.lms.setup.service.CityService;
+import com.common.sort.SortUtils;
 import com.shared.audit.starter.api.AuditAction;
 import com.shared.audit.starter.api.DataClass;
 import com.shared.audit.starter.api.annotations.Audited;
@@ -88,10 +89,12 @@ public class CityServiceImpl implements CityService {
 	@Transactional(Transactional.TxType.SUPPORTS)
 	@Audited(action = AuditAction.READ, entity = "City", dataClass = DataClass.HEALTH, message = "List cities")
         public BaseResponse<?> list(Pageable pageable, String q, boolean all) {
-                final Pageable pg = (pageable == null ? Pageable.unpaged() : pageable);
+                Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
+                                "cityEnNm", "cityEnNm", "cityArNm", "cityCd");
+                final Pageable pg = (pageable == null ? Pageable.unpaged()
+                                : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort));
 
                 if (all) {
-                        var sort = pg.getSort().isSorted() ? pg.getSort() : Sort.by("cityEnNm").ascending();
                         var spec = CitySpecifications.nameContains(q); // null => no filter
                         var entities = cityRepo.findAll(spec, sort);
                         return BaseResponse.success("City list", mapper.toDtoList(entities));

--- a/lms-setup/src/main/java/com/lms/setup/service/impl/CountryServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/CountryServiceImpl.java
@@ -4,6 +4,7 @@ import com.common.dto.BaseResponse;
 import com.lms.setup.model.Country;
 import com.lms.setup.repository.CountryRepository;
 import com.lms.setup.service.CountryService;
+import com.common.sort.SortUtils;
 import com.shared.audit.starter.api.AuditAction;
 import com.shared.audit.starter.api.DataClass;
 import com.shared.audit.starter.api.annotations.Audited;
@@ -12,6 +13,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.data.domain.Sort;
 
@@ -79,24 +81,28 @@ public class CountryServiceImpl implements CountryService {
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "Country", dataClass = DataClass.HEALTH, message = "List countries")
     public BaseResponse<?> list(Pageable pageable, String q, boolean all) {
+        Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
+                "countryEnNm", "countryEnNm", "countryArNm", "countryCd");
+        Pageable pg = (pageable == null ? Pageable.unpaged()
+                : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort));
+
         if (all) {
             List<Country> list;
             if (q == null || q.isBlank()) {
-                list = countryRepository.findAll(Sort.by("countryEnNm").ascending());
+                list = countryRepository.findAll(sort);
             } else {
                 list = countryRepository
-                        .findByCountryEnNmContainingIgnoreCaseOrCountryArNmContainingIgnoreCase(q, q,
-                                Sort.by("countryEnNm").ascending());
+                        .findByCountryEnNmContainingIgnoreCaseOrCountryArNmContainingIgnoreCase(q, q, sort);
             }
             return BaseResponse.success("Countries list", list);
         }
 
         Page<Country> page;
         if (q == null || q.isBlank()) {
-            page = countryRepository.findAll(pageable);
+            page = countryRepository.findAll(pg);
         } else {
             page = countryRepository
-                    .findByCountryEnNmContainingIgnoreCaseOrCountryArNmContainingIgnoreCase(q, q, pageable);
+                    .findByCountryEnNmContainingIgnoreCaseOrCountryArNmContainingIgnoreCase(q, q, pg);
         }
         return BaseResponse.success("Countries page", page);
     }

--- a/lms-setup/src/main/java/com/lms/setup/service/impl/ResourceServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/ResourceServiceImpl.java
@@ -4,6 +4,7 @@ import com.common.dto.BaseResponse;
 import com.lms.setup.model.Resource;
 import com.lms.setup.repository.ResourceRepository;
 import com.lms.setup.service.ResourceService;
+import com.common.sort.SortUtils;
 import com.shared.audit.starter.api.AuditAction;
 import com.shared.audit.starter.api.DataClass;
 import com.shared.audit.starter.api.annotations.Audited;
@@ -113,9 +114,11 @@ public class ResourceServiceImpl implements ResourceService {
     @Audited(action = AuditAction.READ, entity = "Resource", dataClass = DataClass.HEALTH, message = "List resources")
     public BaseResponse<?> list(Pageable pageable, String q, boolean all) {
         try {
-            Pageable pg = (pageable == null ? Pageable.unpaged() : pageable);
+            Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
+                    "resourceEnNm", "resourceEnNm", "resourceArNm", "resourceCd");
+            Pageable pg = (pageable == null ? Pageable.unpaged()
+                    : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort));
             if (all) {
-                Sort sort = pg.getSort().isSorted() ? pg.getSort() : Sort.by("resourceEnNm").ascending();
                 List<Resource> list;
                 if (q == null || q.isBlank()) {
                     list = resourceRepository.findAll(sort);

--- a/lms-setup/src/main/java/com/lms/setup/service/impl/SystemParameterServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/SystemParameterServiceImpl.java
@@ -14,6 +14,9 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import com.common.sort.SortUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -100,13 +103,18 @@ public class SystemParameterServiceImpl implements SystemParameterService {
     @Audited(action = AuditAction.READ, entity = "SystemParameter", dataClass = DataClass.HEALTH, message = "List system parameters")
     public BaseResponse<Page<SystemParameter>> list(Pageable pageable, String group, Boolean onlyActive) {
         try {
+            Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
+                    "paramKey", "paramKey", "paramGroup", "paramValue");
+            Pageable pg = (pageable == null ? Pageable.unpaged()
+                    : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort));
+
             Page<SystemParameter> page;
             if (Boolean.TRUE.equals(onlyActive)) {
-                page = systemParameterRepository.findByIsActiveTrue(pageable);
+                page = systemParameterRepository.findByIsActiveTrue(pg);
             } else if (group != null && !group.isBlank()) {
-                page = systemParameterRepository.findByParamGroupIgnoreCase(group, pageable);
+                page = systemParameterRepository.findByParamGroupIgnoreCase(group, pg);
             } else {
-                page = systemParameterRepository.findAll(pageable);
+                page = systemParameterRepository.findAll(pg);
             }
             return BaseResponse.success("System parameters page", page);
         } catch (Exception ex) {

--- a/shared-lib/shared-common/pom.xml
+++ b/shared-lib/shared-common/pom.xml
@@ -24,6 +24,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Spring Data utilities for Sort/Pageable support -->
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-commons</artifactId>
+      <optional>true</optional>
+    </dependency>
+
   
     <dependency>
     <groupId>net.logstash.logback</groupId>

--- a/shared-lib/shared-common/src/main/java/com/common/sort/SortUtils.java
+++ b/shared-lib/shared-common/src/main/java/com/common/sort/SortUtils.java
@@ -1,0 +1,64 @@
+package com.common.sort;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Utility methods for sanitising {@link Sort} and {@link Pageable} instances.
+ * Removes orders with unknown properties and applies a default when necessary
+ * to avoid {@code PropertyReferenceException} at repository level.
+ */
+public final class SortUtils {
+
+    private SortUtils() {
+    }
+
+    /**
+     * Returns a safe {@link Sort}. If the supplied sort is {@code null},
+     * unsorted or contains only unknown properties, a sort on
+     * {@code defaultProperty} is returned.
+     *
+     * @param sort            sort to sanitize
+     * @param defaultProperty property to use when sort is empty or invalid
+     * @param allowedProps    properties allowed for sorting
+     * @return sanitized Sort never {@code null}
+     */
+    public static Sort sanitize(Sort sort, String defaultProperty, String... allowedProps) {
+        Sort safeSort = sort == null ? Sort.unsorted() : sort;
+        List<String> allowed = Arrays.asList(allowedProps);
+        List<Sort.Order> orders = new ArrayList<>();
+        safeSort.stream()
+                .filter(order -> allowed.isEmpty() || allowed.contains(order.getProperty()))
+                .forEach(orders::add);
+        if (orders.isEmpty()) {
+            return Sort.by(defaultProperty).ascending();
+        }
+        return Sort.by(orders);
+    }
+
+    /**
+     * Creates a {@link Pageable} with sanitized sort. Page number and size are
+     * preserved from the given pageable.
+     *
+     * @param pageable        pageable to sanitize (can be {@code null})
+     * @param defaultProperty property to use when sort is empty or invalid
+     * @param allowedProps    properties allowed for sorting
+     * @return sanitized pageable
+     */
+    public static Pageable sanitize(Pageable pageable, String defaultProperty, String... allowedProps) {
+        if (pageable == null || pageable.isUnpaged()) {
+            Sort sort = sanitize(Sort.unsorted(), defaultProperty, allowedProps);
+            if (pageable == null) {
+                return PageRequest.of(0, Integer.MAX_VALUE, sort);
+            }
+            return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+        }
+        Sort sort = sanitize(pageable.getSort(), defaultProperty, allowedProps);
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+    }
+}

--- a/shared-lib/shared-common/src/test/java/com/common/sort/SortUtilsTest.java
+++ b/shared-lib/shared-common/src/test/java/com/common/sort/SortUtilsTest.java
@@ -1,0 +1,15 @@
+package com.common.sort;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SortUtilsTest {
+    @Test
+    void sanitize_invalidPropertyFallsBackToDefault() {
+        Sort invalid = Sort.by("unknown");
+        Sort sanitized = SortUtils.sanitize(invalid, "name", "name");
+        assertEquals("name", sanitized.stream().findFirst().orElseThrow().getProperty());
+    }
+}


### PR DESCRIPTION
## Summary
- move SortUtils to shared common library for reuse
- add Spring Data Commons dependency and unit test in shared-common
- update services to import shared SortUtils

## Testing
- `mvn -q -f shared-lib/shared-common/pom.xml test` *(fails: Non-resolvable import POM and missing dependency versions)*
- `mvn -q -f lms-setup/pom.xml test` *(fails: Non-resolvable parent POM for com.lms:lms-setup:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b295a6759c832fa4a132dfbcc22441