### PR TITLE
Add missing dependencies for starter-core

### DIFF
--- a/shared-lib/shared-starters/starter-core/pom.xml
+++ b/shared-lib/shared-starters/starter-core/pom.xml
@@ -42,6 +42,20 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Annotations used for FindBugs/SpotBugs -->
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Spring's data access exceptions -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Optional conveniences used by filters/handlers -->
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- include SpotBugs annotations and Spring data access dependency in starter-core pom

## Testing
- `mvn -q -pl shared-starters/starter-core -am test` *(fails: Network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68b385a5cf48832fbb27bf7039eb384e