### PR TITLE
Handle NoResourceFoundException globally

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/GlobalExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -105,6 +106,13 @@ public class GlobalExceptionHandler {
         log.error("Data integrity violation: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(BaseResponse.error("ERR_DATA_CONFLICT", "Data conflict occurred"));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<BaseResponse<?>> handleNoResourceFound(NoResourceFoundException ex, WebRequest request) {
+        log.warn("No resource found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(BaseResponse.error("ERR_RESOURCE_NOT_FOUND", ex.getMessage()));
     }
 
     @ExceptionHandler(AccessDeniedException.class)


### PR DESCRIPTION
## Summary
- handle missing static resources by adding a `NoResourceFoundException` handler in the global exception handler

## Testing
- `mvn -q -pl shared-starters/starter-core test` *(fails: Network is unreachable while resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b38b049e4c832f975fc4a2148aa44b