### PR TITLE
feat: expose trace identifiers in API responses

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
@@ -1,6 +1,8 @@
 package com.common.dto;
 
+import com.common.context.TraceContextUtil;
 import com.common.enums.StatusEnums.ApiStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nullable;
 import java.time.Instant;
 import java.util.function.Function;
@@ -37,6 +39,18 @@ public class BaseResponse<T> {
     /** Timestamp of response */
     @Builder.Default
     private Instant timestamp = Instant.now();
+
+    /** Trace identifier for correlation across services */
+    @Builder.Default
+    private String traceId = TraceContextUtil.getTraceId();
+
+    /**
+     * Alias for {@link #traceId} to support clients expecting a correlationId field.
+     */
+    @JsonProperty("correlationId")
+    public String getCorrelationId() {
+        return traceId;
+    }
 
     // ===== Static builders (nice usability) =====
     public static <T> BaseResponse<T> success(T data) {

--- a/shared-lib/shared-common/src/main/java/com/common/dto/ErrorResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/common/dto/ErrorResponse.java
@@ -1,7 +1,7 @@
 package com.common.dto;
 
+import com.common.context.TraceContextUtil;
 import com.common.enums.StatusEnums.ApiStatus;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,8 +34,8 @@ public class ErrorResponse {
     private List<String> details;
 
     /** Trace/Correlation ID (for logs/monitoring) */
-    @JsonIgnore
-    private String traceId;
+    @Builder.Default
+    private String traceId = TraceContextUtil.getTraceId();
 
     /** Tenant ID (multi-tenant awareness) */
     private String tenantId;


### PR DESCRIPTION
## Summary
- include trace and correlation IDs in standard BaseResponse
- add trace and correlation IDs to ErrorResponse for consistent diagnostics

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: com.lms:shared-bom:pom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b38d06754c832fa50d1aaf633c125e