### PR TITLE
Add configurable EJADA_Officer role enforcement

### DIFF
--- a/lms-setup/src/main/java/com/lms/setup/config/RoleChecker.java
+++ b/lms-setup/src/main/java/com/lms/setup/config/RoleChecker.java
@@ -1,0 +1,32 @@
+package com.lms.setup.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * Evaluates whether the current user satisfies the required role.
+ */
+@Component("roleChecker")
+@RequiredArgsConstructor
+public class RoleChecker {
+
+    private final SetupSecurityProperties securityProperties;
+
+    /**
+     * Returns true when role checks are disabled or the authenticated user has the EJADA_Officer role.
+     *
+     * @param authentication current authentication
+     * @return whether access should be granted
+     */
+    public boolean hasEjadaOfficerRole(Authentication authentication) {
+        if (!securityProperties.isEnableRoleCheck()) {
+            return true;
+        }
+        if (authentication == null) {
+            return false;
+        }
+        return authentication.getAuthorities().stream()
+                .anyMatch(a -> "ROLE_EJADA_Officer".equals(a.getAuthority()));
+    }
+}

--- a/lms-setup/src/main/java/com/lms/setup/config/SetupSecurityProperties.java
+++ b/lms-setup/src/main/java/com/lms/setup/config/SetupSecurityProperties.java
@@ -1,0 +1,21 @@
+package com.lms.setup.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration properties for security options specific to the setup service.
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "setup.security")
+public class SetupSecurityProperties {
+
+    /**
+     * Enables or disables role checks on API endpoints.
+     */
+    private boolean enableRoleCheck = true;
+}

--- a/lms-setup/src/main/java/com/lms/setup/controller/CityController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/CityController.java
@@ -34,7 +34,7 @@ public class CityController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Create a new city", description = "Creates a new city with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "City created successfully",
@@ -48,7 +48,7 @@ public class CityController {
     }
 
     @PutMapping("/{cityId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Update an existing city", description = "Updates the city with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "City updated successfully"),
@@ -64,7 +64,7 @@ public class CityController {
     }
 
     @GetMapping("/{cityId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Get city by ID", description = "Retrieves a city by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "City found successfully"),
@@ -78,7 +78,7 @@ public class CityController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "List cities", description = "Retrieves a paginated list of cities with optional search")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Cities retrieved successfully"),
@@ -94,7 +94,7 @@ public class CityController {
     }
 
     @GetMapping("/active")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "List active cities by country", description = "Retrieves all active cities for the given country")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Active cities retrieved successfully"),

--- a/lms-setup/src/main/java/com/lms/setup/controller/CountryController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/CountryController.java
@@ -36,7 +36,7 @@ public class CountryController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Create a new country", description = "Creates a new country with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Country created successfully",
@@ -50,7 +50,7 @@ public class CountryController {
     }
 
     @PutMapping("/{countryId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Update an existing country", description = "Updates the country with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Country updated successfully"),
@@ -67,7 +67,7 @@ public class CountryController {
     }
 
     @GetMapping("/{countryId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Get country by ID", description = "Retrieves a country by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Country found successfully"),
@@ -81,7 +81,7 @@ public class CountryController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "List countries", description = "Retrieves a paginated list of countries with optional search")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Countries retrieved successfully"),
@@ -97,7 +97,7 @@ public class CountryController {
     }
 
     @GetMapping("/active")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "List active countries", description = "Retrieves all active countries")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Active countries retrieved successfully"),

--- a/lms-setup/src/main/java/com/lms/setup/controller/LookupController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/LookupController.java
@@ -35,7 +35,7 @@ public class LookupController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Create a new lookup", description = "Creates a new lookup value with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookup created successfully",
@@ -49,7 +49,7 @@ public class LookupController {
     }
 
     @PutMapping("/{lookupItemId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Update an existing lookup", description = "Updates the lookup with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookup updated successfully"),
@@ -65,7 +65,7 @@ public class LookupController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Get all lookups", description = "Retrieves all lookup values")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),
@@ -76,7 +76,7 @@ public class LookupController {
     }
 
     @GetMapping("/group/{groupCode}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Get lookups by group", description = "Retrieves all lookups of a specific group")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),
@@ -89,7 +89,7 @@ public class LookupController {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Get all lookups (alternative endpoint)", description = "Retrieves all lookup values")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),

--- a/lms-setup/src/main/java/com/lms/setup/controller/ResourceController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/ResourceController.java
@@ -34,7 +34,7 @@ public class ResourceController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Create a new resource", description = "Creates a new resource with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resource created successfully",
@@ -48,7 +48,7 @@ public class ResourceController {
     }
 
     @PutMapping("/{resourceId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Update an existing resource", description = "Updates the resource with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resource updated successfully"),
@@ -64,7 +64,7 @@ public class ResourceController {
     }
 
     @GetMapping("/{resourceId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Get resource by ID", description = "Retrieves a resource by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resource found successfully"),
@@ -78,7 +78,7 @@ public class ResourceController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "List resources", description = "Retrieves a paginated list of resources with optional search")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resources retrieved successfully"),
@@ -94,7 +94,7 @@ public class ResourceController {
     }
 
     @GetMapping("/active")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "List active resources", description = "Retrieves all active resources")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Active resources retrieved successfully"),

--- a/lms-setup/src/main/java/com/lms/setup/controller/SystemParameterController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/SystemParameterController.java
@@ -37,7 +37,7 @@ public class SystemParameterController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Create a new system parameter", description = "Creates a new system parameter with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter created successfully",
@@ -51,7 +51,7 @@ public class SystemParameterController {
     }
 
     @PutMapping("/{paramId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Update an existing system parameter", description = "Updates the system parameter with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter updated successfully"),
@@ -67,7 +67,7 @@ public class SystemParameterController {
     }
 
     @GetMapping("/{paramId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Get system parameter by ID", description = "Retrieves a system parameter by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter found successfully"),
@@ -81,7 +81,7 @@ public class SystemParameterController {
     }
 
     @GetMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "List system parameters", description = "Retrieves a paginated list of system parameters with optional filtering")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameters retrieved successfully"),
@@ -97,7 +97,7 @@ public class SystemParameterController {
     }
 
     @GetMapping("/by-key/{paramKey}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Get system parameter by key", description = "Retrieves a system parameter by its key")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter found successfully"),
@@ -111,7 +111,7 @@ public class SystemParameterController {
     }
 
     @PostMapping("/by-keys")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasEjadaOfficerRole(authentication)")
     @Operation(summary = "Get system parameters by keys", description = "Retrieves multiple system parameters by their keys")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameters retrieved successfully"),

--- a/lms-setup/src/main/resources/application-dev.yaml
+++ b/lms-setup/src/main/resources/application-dev.yaml
@@ -198,3 +198,7 @@ logging:
     org.springframework.cache: ERROR
     org.springframework.cache.interceptor.CacheAspectSupport: ERROR
 debug: false
+
+setup:
+  security:
+    enable-role-check: false

--- a/lms-setup/src/main/resources/application.yaml
+++ b/lms-setup/src/main/resources/application.yaml
@@ -20,3 +20,7 @@ shared:
   observability:
     application-name: lms-setup
 
+
+setup:
+  security:
+    enable-role-check: true

--- a/lms-setup/src/test/resources/application-test.yml
+++ b/lms-setup/src/test/resources/application-test.yml
@@ -47,3 +47,7 @@ logging:
     org.hibernate.orm.jdbc.bind: WARN
     com.zaxxer.hikari: WARN
     org.flywaydb: OFF
+
+setup:
+  security:
+    enable-role-check: false


### PR DESCRIPTION
## Summary
- add SetupSecurityProperties to toggle role validation
- enforce EJADA_Officer role with new RoleChecker in all controllers
- expose enable-role-check flag across environment configs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b38dee7038832fbf5a14fe5b7513f5