### PR TITLE
Add configurable EJADA_OFFICER and tenant role enforcement

### DIFF
--- a/lms-setup/src/main/java/com/lms/setup/controller/CityController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/CityController.java
@@ -34,7 +34,7 @@ public class CityController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Create a new city", description = "Creates a new city with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "City created successfully",
@@ -48,7 +48,7 @@ public class CityController {
     }
 
     @PutMapping("/{cityId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Update an existing city", description = "Updates the city with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "City updated successfully"),
@@ -64,7 +64,7 @@ public class CityController {
     }
 
     @GetMapping("/{cityId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Get city by ID", description = "Retrieves a city by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "City found successfully"),
@@ -78,7 +78,7 @@ public class CityController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "List cities", description = "Retrieves a paginated list of cities with optional search")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Cities retrieved successfully"),
@@ -94,7 +94,7 @@ public class CityController {
     }
 
     @GetMapping("/active")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "List active cities by country", description = "Retrieves all active cities for the given country")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Active cities retrieved successfully"),

--- a/lms-setup/src/main/java/com/lms/setup/controller/CountryController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/CountryController.java
@@ -36,7 +36,7 @@ public class CountryController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Create a new country", description = "Creates a new country with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Country created successfully",
@@ -50,7 +50,7 @@ public class CountryController {
     }
 
     @PutMapping("/{countryId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Update an existing country", description = "Updates the country with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Country updated successfully"),
@@ -67,7 +67,7 @@ public class CountryController {
     }
 
     @GetMapping("/{countryId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Get country by ID", description = "Retrieves a country by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Country found successfully"),
@@ -81,7 +81,7 @@ public class CountryController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "List countries", description = "Retrieves a paginated list of countries with optional search")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Countries retrieved successfully"),
@@ -97,7 +97,7 @@ public class CountryController {
     }
 
     @GetMapping("/active")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "List active countries", description = "Retrieves all active countries")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Active countries retrieved successfully"),

--- a/lms-setup/src/main/java/com/lms/setup/controller/LookupController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/LookupController.java
@@ -35,7 +35,7 @@ public class LookupController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Create a new lookup", description = "Creates a new lookup value with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookup created successfully",
@@ -49,7 +49,7 @@ public class LookupController {
     }
 
     @PutMapping("/{lookupItemId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Update an existing lookup", description = "Updates the lookup with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookup updated successfully"),
@@ -65,7 +65,7 @@ public class LookupController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Get all lookups", description = "Retrieves all lookup values")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),
@@ -76,7 +76,7 @@ public class LookupController {
     }
 
     @GetMapping("/group/{groupCode}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Get lookups by group", description = "Retrieves all lookups of a specific group")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),
@@ -89,7 +89,7 @@ public class LookupController {
     }
 
     @GetMapping("/all")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Get all lookups (alternative endpoint)", description = "Retrieves all lookup values")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),

--- a/lms-setup/src/main/java/com/lms/setup/controller/ResourceController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/ResourceController.java
@@ -34,7 +34,7 @@ public class ResourceController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Create a new resource", description = "Creates a new resource with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resource created successfully",
@@ -48,7 +48,7 @@ public class ResourceController {
     }
 
     @PutMapping("/{resourceId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Update an existing resource", description = "Updates the resource with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resource updated successfully"),
@@ -64,7 +64,7 @@ public class ResourceController {
     }
 
     @GetMapping("/{resourceId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Get resource by ID", description = "Retrieves a resource by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resource found successfully"),
@@ -78,7 +78,7 @@ public class ResourceController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "List resources", description = "Retrieves a paginated list of resources with optional search")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resources retrieved successfully"),
@@ -94,7 +94,7 @@ public class ResourceController {
     }
 
     @GetMapping("/active")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "List active resources", description = "Retrieves all active resources")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Active resources retrieved successfully"),

--- a/lms-setup/src/main/java/com/lms/setup/controller/SystemParameterController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/SystemParameterController.java
@@ -37,7 +37,7 @@ public class SystemParameterController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Create a new system parameter", description = "Creates a new system parameter with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter created successfully",
@@ -51,7 +51,7 @@ public class SystemParameterController {
     }
 
     @PutMapping("/{paramId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Update an existing system parameter", description = "Updates the system parameter with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter updated successfully"),
@@ -67,7 +67,7 @@ public class SystemParameterController {
     }
 
     @GetMapping("/{paramId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Get system parameter by ID", description = "Retrieves a system parameter by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter found successfully"),
@@ -81,7 +81,7 @@ public class SystemParameterController {
     }
 
     @GetMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "List system parameters", description = "Retrieves a paginated list of system parameters with optional filtering")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameters retrieved successfully"),
@@ -97,7 +97,7 @@ public class SystemParameterController {
     }
 
     @GetMapping("/by-key/{paramKey}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Get system parameter by key", description = "Retrieves a system parameter by its key")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter found successfully"),
@@ -111,7 +111,7 @@ public class SystemParameterController {
     }
 
     @PostMapping("/by-keys")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Get system parameters by keys", description = "Retrieves multiple system parameters by their keys")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameters retrieved successfully"),

--- a/lms-setup/src/main/resources/application-dev.yaml
+++ b/lms-setup/src/main/resources/application-dev.yaml
@@ -184,6 +184,7 @@ shared:
       stateless: true
     roles-claim: roles
     tenant-claim: tenant
+    enable-role-check: false
 
 logging:
   level:
@@ -198,3 +199,4 @@ logging:
     org.springframework.cache: ERROR
     org.springframework.cache.interceptor.CacheAspectSupport: ERROR
 debug: false
+

--- a/lms-setup/src/main/resources/application.yaml
+++ b/lms-setup/src/main/resources/application.yaml
@@ -19,4 +19,5 @@ server:
 shared:
   observability:
     application-name: lms-setup
-
+  security:
+    enable-role-check: true

--- a/lms-setup/src/test/resources/application-test.yml
+++ b/lms-setup/src/test/resources/application-test.yml
@@ -47,3 +47,7 @@ logging:
     org.hibernate.orm.jdbc.bind: WARN
     com.zaxxer.hikari: WARN
     org.flywaydb: OFF
+
+shared:
+  security:
+    enable-role-check: false

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/Role.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/Role.java
@@ -1,0 +1,23 @@
+package com.shared.starter_security;
+
+/**
+ * Enumeration of application roles.
+ */
+public enum Role {
+    EJADA_OFFICER("ROLE_EJADA_OFFICER"),
+    TENANT_ADMIN("ROLE_TenantAdmin"),
+    TENANT_OFFICER("ROLE_TenantOfficer");
+
+    private final String authority;
+
+    Role(String authority) {
+        this.authority = authority;
+    }
+
+    /**
+     * @return full authority string including the ROLE_ prefix
+     */
+    public String getAuthority() {
+        return authority;
+    }
+}

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/RoleChecker.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/RoleChecker.java
@@ -1,0 +1,40 @@
+package com.shared.starter_security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+/**
+ * Evaluates whether the current user satisfies the required role.
+ */
+@Component("roleChecker")
+@RequiredArgsConstructor
+public class RoleChecker {
+
+    private final SharedSecurityProps securityProps;
+
+    /**
+     * Returns true when role checks are disabled or the authenticated user has at least one of the provided roles.
+     *
+     * @param authentication current authentication
+     * @param roles required roles
+     * @return whether access should be granted
+     */
+    public boolean hasRole(Authentication authentication, Role... roles) {
+        if (!securityProps.isEnableRoleCheck()) {
+            return true;
+        }
+        if (authentication == null) {
+            return false;
+        }
+        for (GrantedAuthority authority : authentication.getAuthorities()) {
+            for (Role role : roles) {
+                if (role.getAuthority().equals(authority.getAuthority())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SharedSecurityProps.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SharedSecurityProps.java
@@ -55,6 +55,9 @@ public class SharedSecurityProps implements BaseStarterProperties {
   /** Prefix for role authorities mapped from rolesClaim. */
   private String rolePrefix = "ROLE_";
 
+  /** Master switch to enable or disable role checks in services. */
+  private boolean enableRoleCheck = true;
+
   // --------- Resource Server defaults ---------
   private ResourceServer resourceServer = new ResourceServer();
 


### PR DESCRIPTION
## Summary
- centralize role checking in shared security starter with Role enum
- wire controllers to new shared RoleChecker implementation
- expose `shared.security.enable-role-check` flag across configs
- broaden role support with TenantAdmin and TenantOfficer constants and multi-role checker

## Testing
- `mvn -q -f shared-lib/shared-starters/starter-security/pom.xml test` *(fails: dependencies missing versions)*
- `mvn -q -f lms-setup/pom.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b38dee7038832fbf5a14fe5b7513f5