### PR TITLE
Expose RoleChecker bean via auto-configuration

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/RoleChecker.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/RoleChecker.java
@@ -3,12 +3,10 @@ package com.shared.starter_security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.stereotype.Component;
 
 /**
  * Evaluates whether the current user satisfies the required role.
  */
-@Component("roleChecker")
 @RequiredArgsConstructor
 public class RoleChecker {
 

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SecurityAutoConfiguration.java
@@ -54,6 +54,15 @@ import java.util.stream.Collectors;
 public class SecurityAutoConfiguration {
 
   /* ---------------------------------------------------
+   * RoleChecker : exposes @roleChecker for SpEL usage
+   * --------------------------------------------------- */
+  @Bean
+  @ConditionalOnMissingBean(RoleChecker.class)
+  public RoleChecker roleChecker(SharedSecurityProps props) {
+    return new RoleChecker(props);
+  }
+
+  /* ---------------------------------------------------
    * JwtAuthenticationConverter : roles/scopes mapping
    * --------------------------------------------------- */
   @Bean

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/RoleCheckerAutoConfigurationTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/RoleCheckerAutoConfigurationTest.java
@@ -1,0 +1,25 @@
+package com.shared.starter_security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoleCheckerAutoConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+      .withConfiguration(AutoConfigurations.of(SecurityAutoConfiguration.class))
+      .withPropertyValues(
+          "shared.security.hs256.secret=secret",
+          "shared.security.resource-server.enabled=false");
+
+  @Test
+  void providesRoleCheckerBean() {
+    contextRunner.run(context -> {
+      assertTrue(context.containsBean("roleChecker"));
+      assertNotNull(context.getBean(RoleChecker.class));
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- provide RoleChecker bean through security auto-configuration
- remove component annotation from RoleChecker
- test that RoleChecker bean is auto-configured

## Testing
- `mvn -q -f shared-lib/shared-starters/starter-security/pom.xml test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b40f9735b4832f8a28afb34d1c217b