### PR TITLE
refactor: improve setup services

### DIFF
--- a/lms-setup/src/main/java/com/lms/setup/constants/SetupServicesCatalog.java
+++ b/lms-setup/src/main/java/com/lms/setup/constants/SetupServicesCatalog.java
@@ -2,7 +2,7 @@ package com.lms.setup.constants;
 
 import java.io.Serializable;
 
-public class SetupServicesCatlog implements Serializable {
+public class SetupServicesCatalog implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -23,8 +23,9 @@ public class SetupServicesCatlog implements Serializable {
 	public static final String GET_LOOKUP_LIST_SERVICE = "/getLookupList";
 	public static final String GET_LOOKUP_LIST_BY_LOOKUP_GROUP_SERVICE = "/getLookupsByLookupGroupCode";
 
-	public static final String GET_APPLICATION_RESOURCES_LIST_SERVICE = "/AppResources";
-public static final String UPLOAD_DOCUMENT_SERVICE = "/uploadDocument";
+        public static final String GET_APPLICATION_RESOURCES_LIST_SERVICE = "/AppResources";
+
+        public static final String UPLOAD_DOCUMENT_SERVICE = "/uploadDocument";
 	
 	public static final String GET_DOCUMENT_DETAILS_SERVICE = "/getDocumentDetails";
 	public static final String ADD_DOCUMENT_SERVICE = "/addDocument";

--- a/lms-setup/src/main/java/com/lms/setup/controller/CityController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/CityController.java
@@ -2,6 +2,7 @@ package com.lms.setup.controller;
 
 import com.common.dto.BaseResponse;
 import com.lms.setup.dto.CityDto;
+import com.lms.setup.security.SetupAuthorized;
 import com.lms.setup.service.CityService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,10 +14,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,7 +35,7 @@ public class CityController {
     }
 
     @PostMapping
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Create a new city", description = "Creates a new city with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "City created successfully",
@@ -48,7 +49,7 @@ public class CityController {
     }
 
     @PutMapping("/{cityId}")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Update an existing city", description = "Updates the city with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "City updated successfully"),
@@ -64,7 +65,7 @@ public class CityController {
     }
 
     @GetMapping("/{cityId}")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Get city by ID", description = "Retrieves a city by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "City found successfully"),
@@ -78,13 +79,13 @@ public class CityController {
     }
 
     @GetMapping
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "List cities", description = "Retrieves a paginated list of cities with optional search")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Cities retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<?> list(
+    public ResponseEntity<BaseResponse<Page<CityDto>>> list(
             @PageableDefault(size = 20) Pageable pageable,
             @Parameter(description = "Search query for city names")
             @RequestParam(required = false) String q,
@@ -94,13 +95,13 @@ public class CityController {
     }
 
     @GetMapping("/active")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "List active cities by country", description = "Retrieves all active cities for the given country")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Active cities retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<?> listActive(
+    public ResponseEntity<BaseResponse<List<CityDto>>> listActive(
             @Parameter(description = "Country ID to filter cities", required = true)
             @RequestParam @Min(1) Integer countryId) {
         return ResponseEntity.ok(cityService.listActiveByCountry(countryId));

--- a/lms-setup/src/main/java/com/lms/setup/controller/CountryController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/CountryController.java
@@ -2,6 +2,7 @@ package com.lms.setup.controller;
 
 import com.common.dto.BaseResponse;
 import com.lms.setup.model.Country;
+import com.lms.setup.security.SetupAuthorized;
 import com.lms.setup.service.CountryService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,9 +19,10 @@ import jakarta.validation.constraints.Size;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/setup/countries")
@@ -36,7 +38,7 @@ public class CountryController {
     }
 
     @PostMapping
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Create a new country", description = "Creates a new country with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Country created successfully",
@@ -50,7 +52,7 @@ public class CountryController {
     }
 
     @PutMapping("/{countryId}")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Update an existing country", description = "Updates the country with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Country updated successfully"),
@@ -67,7 +69,7 @@ public class CountryController {
     }
 
     @GetMapping("/{countryId}")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Get country by ID", description = "Retrieves a country by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Country found successfully"),
@@ -81,7 +83,7 @@ public class CountryController {
     }
 
     @GetMapping
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "List countries", description = "Retrieves a paginated list of countries with optional search")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Countries retrieved successfully"),
@@ -90,20 +92,20 @@ public class CountryController {
     public ResponseEntity<?> list(
             @PageableDefault(size = 20) Pageable pageable,
             @Parameter(description = "Search query for country names")
-            @RequestParam(required = false) String q, 
+            @RequestParam(required = false) String q,
             @Parameter(description = "Whether to return all countries (ignores pagination)")
             @RequestParam(required = false) boolean all) {
         return ResponseEntity.ok(countryService.list(pageable, q, all));
     }
 
     @GetMapping("/active")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "List active countries", description = "Retrieves all active countries")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Active countries retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<?> listActive() {
+    public ResponseEntity<BaseResponse<List<Country>>> listActive() {
         return ResponseEntity.ok(countryService.listActive());
     }
 }

--- a/lms-setup/src/main/java/com/lms/setup/controller/LookupController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/LookupController.java
@@ -2,6 +2,7 @@ package com.lms.setup.controller;
 
 import com.common.dto.BaseResponse;
 import com.lms.setup.model.Lookup;
+import com.lms.setup.security.SetupAuthorized;
 import com.lms.setup.service.LookupService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,7 +16,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,7 +35,7 @@ public class LookupController {
     }
 
     @PostMapping
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Create a new lookup", description = "Creates a new lookup value with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookup created successfully",
@@ -49,7 +49,7 @@ public class LookupController {
     }
 
     @PutMapping("/{lookupItemId}")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Update an existing lookup", description = "Updates the lookup with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookup updated successfully"),
@@ -65,7 +65,7 @@ public class LookupController {
     }
 
     @GetMapping
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Get all lookups", description = "Retrieves all lookup values")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),
@@ -76,7 +76,7 @@ public class LookupController {
     }
 
     @GetMapping("/group/{groupCode}")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Get lookups by group", description = "Retrieves all lookups of a specific group")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),

--- a/lms-setup/src/main/java/com/lms/setup/controller/ResourceController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/ResourceController.java
@@ -1,7 +1,8 @@
 package com.lms.setup.controller;
 
 import com.common.dto.BaseResponse;
-import com.lms.setup.model.Resource;
+import com.lms.setup.dto.ResourceDto;
+import com.lms.setup.security.SetupAuthorized;
 import com.lms.setup.service.ResourceService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,12 +14,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/setup/resources")
@@ -34,7 +37,7 @@ public class ResourceController {
     }
 
     @PostMapping
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Create a new resource", description = "Creates a new resource with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resource created successfully",
@@ -43,12 +46,12 @@ public class ResourceController {
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "409", description = "Resource already exists")
     })
-    public ResponseEntity<BaseResponse<Resource>> add(@Valid @RequestBody Resource body) {
+    public ResponseEntity<BaseResponse<ResourceDto>> add(@Valid @RequestBody ResourceDto body) {
         return ResponseEntity.ok(resourceService.add(body));
     }
 
     @PutMapping("/{resourceId}")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Update an existing resource", description = "Updates the resource with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resource updated successfully"),
@@ -56,35 +59,35 @@ public class ResourceController {
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "404", description = "Resource not found")
     })
-    public ResponseEntity<BaseResponse<Resource>> update(
+    public ResponseEntity<BaseResponse<ResourceDto>> update(
             @Parameter(description = "ID of the resource to update", required = true)
             @PathVariable @Min(1) Integer resourceId,
-            @Valid @RequestBody Resource body) {
+            @Valid @RequestBody ResourceDto body) {
         return ResponseEntity.ok(resourceService.update(resourceId, body));
     }
 
     @GetMapping("/{resourceId}")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Get resource by ID", description = "Retrieves a resource by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resource found successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "404", description = "Resource not found")
     })
-    public ResponseEntity<BaseResponse<Resource>> get(
+    public ResponseEntity<BaseResponse<ResourceDto>> get(
             @Parameter(description = "ID of the resource to retrieve", required = true)
             @PathVariable @Min(1) Integer resourceId) {
         return ResponseEntity.ok(resourceService.get(resourceId));
     }
 
     @GetMapping
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "List resources", description = "Retrieves a paginated list of resources with optional search")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Resources retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<?> list(
+    public ResponseEntity<BaseResponse<Page<ResourceDto>>> list(
             @PageableDefault(size = 20) Pageable pageable,
             @Parameter(description = "Search query for resource names")
             @RequestParam(required = false) String q,
@@ -94,13 +97,13 @@ public class ResourceController {
     }
 
     @GetMapping("/active")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "List active resources", description = "Retrieves all active resources")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Active resources retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<?> listActive() {
+    public ResponseEntity<BaseResponse<List<ResourceDto>>> listActive() {
         return ResponseEntity.ok(resourceService.listActive());
     }
 }

--- a/lms-setup/src/main/java/com/lms/setup/controller/SystemParameterController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/SystemParameterController.java
@@ -2,6 +2,7 @@ package com.lms.setup.controller;
 
 import com.common.dto.BaseResponse;
 import com.lms.setup.model.SystemParameter;
+import com.lms.setup.security.SetupAuthorized;
 import com.lms.setup.service.SystemParameterService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,10 +15,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,7 +38,7 @@ public class SystemParameterController {
     }
 
     @PostMapping
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Create a new system parameter", description = "Creates a new system parameter with the provided details")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter created successfully",
@@ -51,7 +52,7 @@ public class SystemParameterController {
     }
 
     @PutMapping("/{paramId}")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Update an existing system parameter", description = "Updates the system parameter with the specified ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter updated successfully"),
@@ -67,7 +68,7 @@ public class SystemParameterController {
     }
 
     @GetMapping("/{paramId}")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Get system parameter by ID", description = "Retrieves a system parameter by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter found successfully"),
@@ -81,13 +82,13 @@ public class SystemParameterController {
     }
 
     @GetMapping
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "List system parameters", description = "Retrieves a paginated list of system parameters with optional filtering")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameters retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<?> list(
+    public ResponseEntity<BaseResponse<Page<SystemParameter>>> list(
             @PageableDefault(size = 20) Pageable pageable,
             @Parameter(description = "Group filter for parameters")
             @RequestParam(required = false) String group,
@@ -97,7 +98,7 @@ public class SystemParameterController {
     }
 
     @GetMapping("/by-key/{paramKey}")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Get system parameter by key", description = "Retrieves a system parameter by its key")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameter found successfully"),
@@ -111,7 +112,7 @@ public class SystemParameterController {
     }
 
     @PostMapping("/by-keys")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+    @SetupAuthorized
     @Operation(summary = "Get system parameters by keys", description = "Retrieves multiple system parameters by their keys")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "System parameters retrieved successfully"),

--- a/lms-setup/src/main/java/com/lms/setup/dto/ResourceDto.java
+++ b/lms-setup/src/main/java/com/lms/setup/dto/ResourceDto.java
@@ -1,0 +1,41 @@
+package com.lms.setup.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResourceDto {
+    @Null
+    private Integer id;
+
+    @NotBlank
+    @Size(max = 128)
+    private String resourceCd;
+
+    @NotBlank
+    @Size(max = 256)
+    private String resourceEnNm;
+
+    @NotBlank
+    @Size(max = 256)
+    private String resourceArNm;
+
+    @Size(max = 512)
+    private String path;
+
+    @Size(max = 16)
+    private String httpMethod;
+
+    private Integer parentResourceId;
+
+    @NotNull
+    private Boolean isActive;
+
+    @Size(max = 1000)
+    private String enDescription;
+
+    @Size(max = 1000)
+    private String arDescription;
+}

--- a/lms-setup/src/main/java/com/lms/setup/mapper/ResourceMapper.java
+++ b/lms-setup/src/main/java/com/lms/setup/mapper/ResourceMapper.java
@@ -1,0 +1,27 @@
+package com.lms.setup.mapper;
+
+import com.lms.setup.dto.ResourceDto;
+import com.lms.setup.model.Resource;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface ResourceMapper {
+    @Mapping(source = "resourceId", target = "id")
+    ResourceDto toDto(Resource entity);
+
+    @InheritInverseConfiguration(name = "toDto")
+    Resource toEntity(ResourceDto dto);
+
+    List<ResourceDto> toDtoList(List<Resource> entities);
+
+    default Page<ResourceDto> toDtoPage(Page<Resource> page) {
+        if (page == null) return Page.empty();
+        return new PageImpl<>(toDtoList(page.getContent()), page.getPageable(), page.getTotalElements());
+    }
+}

--- a/lms-setup/src/main/java/com/lms/setup/security/SetupAuthorized.java
+++ b/lms-setup/src/main/java/com/lms/setup/security/SetupAuthorized.java
@@ -1,0 +1,16 @@
+package com.lms.setup.security;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@PreAuthorize("@roleChecker.hasRole(authentication, T(com.shared.starter_security.Role).EJADA_OFFICER, T(com.shared.starter_security.Role).TENANT_ADMIN, T(com.shared.starter_security.Role).TENANT_OFFICER)")
+public @interface SetupAuthorized {
+}

--- a/lms-setup/src/main/java/com/lms/setup/service/CityService.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/CityService.java
@@ -2,8 +2,7 @@ package com.lms.setup.service;
 
 import com.common.dto.BaseResponse;
 import com.lms.setup.dto.CityDto;
-import com.lms.setup.model.City;
-
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -13,6 +12,6 @@ public interface CityService {
   BaseResponse<CityDto> update(Integer id, CityDto request);
   BaseResponse<Void>    delete(Integer id);
   BaseResponse<CityDto> get(Integer id);
-  public BaseResponse<?> list(Pageable pageable, String q, boolean all) ;
+  BaseResponse<Page<CityDto>> list(Pageable pageable, String q, boolean all);
   BaseResponse<List<CityDto>> listActiveByCountry(Integer countryId);
 }

--- a/lms-setup/src/main/java/com/lms/setup/service/ResourceService.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/ResourceService.java
@@ -1,22 +1,23 @@
 package com.lms.setup.service;
 
 import com.common.dto.BaseResponse;
-import com.lms.setup.model.Resource;
+import com.lms.setup.dto.ResourceDto;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface ResourceService {
 
-    BaseResponse<Resource> add(Resource request);
+    BaseResponse<ResourceDto> add(ResourceDto request);
 
-    BaseResponse<Resource> update(Integer resourceId, Resource request);
+    BaseResponse<ResourceDto> update(Integer resourceId, ResourceDto request);
 
-    BaseResponse<Resource> get(Integer resourceId);
+    BaseResponse<ResourceDto> get(Integer resourceId);
 
-    BaseResponse<?> list(Pageable pageable, String q, boolean all);
+    BaseResponse<Page<ResourceDto>> list(Pageable pageable, String q, boolean all);
 
-    BaseResponse<List<Resource>> listActive();
+    BaseResponse<List<ResourceDto>> listActive();
 
-    BaseResponse<List<Resource>> childrenOf(Integer parentResourceId);
+    BaseResponse<List<ResourceDto>> childrenOf(Integer parentResourceId);
 }

--- a/lms-setup/src/main/java/com/lms/setup/service/impl/CityServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/CityServiceImpl.java
@@ -13,6 +13,7 @@ import com.common.sort.SortUtils;
 import com.shared.audit.starter.api.AuditAction;
 import com.shared.audit.starter.api.DataClass;
 import com.shared.audit.starter.api.annotations.Audited;
+import com.common.exception.ResourceNotFoundException;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -35,8 +36,8 @@ public class CityServiceImpl implements CityService {
         @Transactional
         @CacheEvict(cacheNames = {"cities", "cities:byCountry"}, allEntries = true)
         public BaseResponse<CityDto> add(CityDto request) {
-		Country country = countryRepo.findById(request.getCountryId())
-				.orElseThrow(() -> new IllegalArgumentException("Country not found"));
+                Country country = countryRepo.findById(request.getCountryId())
+                                .orElseThrow(() -> new ResourceNotFoundException("Country", String.valueOf(request.getCountryId())));
 
 		City entity = mapper.toEntity(request);
 		entity.setCountry(country);
@@ -48,7 +49,8 @@ public class CityServiceImpl implements CityService {
         @Transactional
         @CacheEvict(cacheNames = {"cities", "cities:byCountry"}, allEntries = true)
         public BaseResponse<CityDto> update(Integer id, CityDto request) {
-		City city = cityRepo.findById(id).orElseThrow(() -> new IllegalArgumentException("City not found"));
+                City city = cityRepo.findById(id)
+                                .orElseThrow(() -> new ResourceNotFoundException("City", String.valueOf(id)));
 
 		// update mutable fields
 		city.setCityCd(request.getCityCd());
@@ -57,8 +59,8 @@ public class CityServiceImpl implements CityService {
 		city.setIsActive(request.getIsActive());
 
 		if (!city.getCountry().getCountryId().equals(request.getCountryId())) {
-			Country country = countryRepo.findById(request.getCountryId())
-					.orElseThrow(() -> new IllegalArgumentException("Country not found"));
+                        Country country = countryRepo.findById(request.getCountryId())
+                                        .orElseThrow(() -> new ResourceNotFoundException("Country", String.valueOf(request.getCountryId())));
 			city.setCountry(country);
 		}
 
@@ -78,17 +80,18 @@ public class CityServiceImpl implements CityService {
 	}
 
 	@Override
-        @Transactional
+        @Transactional(Transactional.TxType.SUPPORTS)
         @Cacheable(cacheNames = "cities", key = "#id")
         public BaseResponse<CityDto> get(Integer id) {
-                City city = cityRepo.findById(id).orElseThrow(() -> new IllegalArgumentException("City not found"));
+                City city = cityRepo.findById(id)
+                                .orElseThrow(() -> new ResourceNotFoundException("City", String.valueOf(id)));
                 return BaseResponse.success("OK", mapper.toDto(city));
         }
 
 	@Override
-	@Transactional(Transactional.TxType.SUPPORTS)
-	@Audited(action = AuditAction.READ, entity = "City", dataClass = DataClass.HEALTH, message = "List cities")
-        public BaseResponse<?> list(Pageable pageable, String q, boolean all) {
+        @Transactional(Transactional.TxType.SUPPORTS)
+        @Audited(action = AuditAction.READ, entity = "City", dataClass = DataClass.HEALTH, message = "List cities")
+        public BaseResponse<Page<CityDto>> list(Pageable pageable, String q, boolean all) {
                 Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
                                 "cityEnNm", "cityEnNm", "cityArNm", "cityCd");
                 final Pageable pg = (pageable == null || !pageable.isPaged()
@@ -98,7 +101,7 @@ public class CityServiceImpl implements CityService {
                 if (all) {
                         var spec = CitySpecifications.nameContains(q); // null => no filter
                         var entities = cityRepo.findAll(spec, sort);
-                        return BaseResponse.success("City list", mapper.toDtoList(entities));
+                        return BaseResponse.success("City list", new PageImpl<>(mapper.toDtoList(entities)));
                 }
 
                 var spec = Specification.where(CitySpecifications.isActive()).and(CitySpecifications.nameContains(q));

--- a/lms-setup/src/main/java/com/lms/setup/service/impl/ResourceServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/ResourceServiceImpl.java
@@ -1,6 +1,8 @@
 package com.lms.setup.service.impl;
 
 import com.common.dto.BaseResponse;
+import com.lms.setup.dto.ResourceDto;
+import com.lms.setup.mapper.ResourceMapper;
 import com.lms.setup.model.Resource;
 import com.lms.setup.repository.ResourceRepository;
 import com.lms.setup.service.ResourceService;
@@ -14,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -28,15 +31,17 @@ public class ResourceServiceImpl implements ResourceService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceServiceImpl.class);
 
     private final ResourceRepository resourceRepository;
+    private final ResourceMapper mapper;
 
-    public ResourceServiceImpl(ResourceRepository resourceRepository) {
+    public ResourceServiceImpl(ResourceRepository resourceRepository, ResourceMapper mapper) {
         this.resourceRepository = resourceRepository;
+        this.mapper = mapper;
     }
 
     @Override
     @Audited(action = AuditAction.CREATE, entity = "Resource", dataClass = DataClass.HEALTH, message = "Create resource")
     @CacheEvict(cacheNames = {"resources:children"}, allEntries = true)
-    public BaseResponse<Resource> add(Resource request) {
+    public BaseResponse<ResourceDto> add(ResourceDto request) {
         try {
             if (request.getResourceCd() == null || request.getResourceCd().isBlank()) {
                 return BaseResponse.error("ERR_RESOURCE_CD_REQUIRED", "Resource code is required");
@@ -48,8 +53,9 @@ public class ResourceServiceImpl implements ResourceService {
                 resourceRepository.findByPathIgnoreCaseAndHttpMethodIgnoreCase(request.getPath(), request.getHttpMethod()).isPresent()) {
                 return BaseResponse.error("ERR_RESOURCE_DUP_ENDPOINT", "A resource with same path+method exists");
             }
-            Resource saved = resourceRepository.save(request);
-            return BaseResponse.success("Resource created", saved);
+            Resource entity = mapper.toEntity(request);
+            Resource saved = resourceRepository.save(entity);
+            return BaseResponse.success("Resource created", mapper.toDto(saved));
         } catch (Exception ex) {
             LOGGER.error("Add resource failed", ex);
             return BaseResponse.error("ERR_RESOURCE_ADD", ex.getMessage());
@@ -59,7 +65,7 @@ public class ResourceServiceImpl implements ResourceService {
     @Override
     @Audited(action = AuditAction.UPDATE, entity = "Resource", dataClass = DataClass.HEALTH, message = "Update resource")
     @CacheEvict(cacheNames = {"resources:children"}, allEntries = true)
-    public BaseResponse<Resource> update(Integer resourceId, Resource request) {
+    public BaseResponse<ResourceDto> update(Integer resourceId, ResourceDto request) {
         try {
             Resource existing = resourceRepository.findById(resourceId).orElse(null);
             if (existing == null) {
@@ -84,9 +90,11 @@ public class ResourceServiceImpl implements ResourceService {
             if (request.getHttpMethod() != null)  existing.setHttpMethod(request.getHttpMethod());
             if (request.getParentResourceId() != null) existing.setParentResourceId(request.getParentResourceId());
             if (request.getIsActive() != null)    existing.setIsActive(request.getIsActive());
+            if (request.getEnDescription() != null) existing.setEnDescription(request.getEnDescription());
+            if (request.getArDescription() != null) existing.setArDescription(request.getArDescription());
 
             Resource saved = resourceRepository.save(existing);
-            return BaseResponse.success("Resource updated", saved);
+            return BaseResponse.success("Resource updated", mapper.toDto(saved));
         } catch (IllegalStateException ise) {
             return BaseResponse.error("ERR_RESOURCE_DUP_ENDPOINT", ise.getMessage());
         } catch (Exception ex) {
@@ -98,10 +106,10 @@ public class ResourceServiceImpl implements ResourceService {
     @Override
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "Resource", dataClass = DataClass.HEALTH, message = "Get resource")
-    public BaseResponse<Resource> get(Integer resourceId) {
+    public BaseResponse<ResourceDto> get(Integer resourceId) {
         try {
             return resourceRepository.findById(resourceId)
-                    .map(r -> BaseResponse.success("Resource", r))
+                    .map(r -> BaseResponse.success("Resource", mapper.toDto(r)))
                     .orElseGet(() -> BaseResponse.error("ERR_RESOURCE_NOT_FOUND", "Resource not found"));
         } catch (Exception ex) {
             LOGGER.error("Get resource failed", ex);
@@ -112,7 +120,7 @@ public class ResourceServiceImpl implements ResourceService {
     @Override
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "Resource", dataClass = DataClass.HEALTH, message = "List resources")
-    public BaseResponse<?> list(Pageable pageable, String q, boolean all) {
+    public BaseResponse<Page<ResourceDto>> list(Pageable pageable, String q, boolean all) {
         try {
             Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
                     "resourceEnNm", "resourceEnNm", "resourceArNm", "resourceCd");
@@ -128,7 +136,7 @@ public class ResourceServiceImpl implements ResourceService {
                             .findByResourceEnNmContainingIgnoreCaseOrResourceArNmContainingIgnoreCase(q, q, PageRequest.of(0, Integer.MAX_VALUE, sort))
                             .getContent();
                 }
-                return BaseResponse.success("Resources list", list);
+                return BaseResponse.success("Resources list", new PageImpl<>(mapper.toDtoList(list)));
             }
 
             Page<Resource> page;
@@ -137,7 +145,7 @@ public class ResourceServiceImpl implements ResourceService {
             } else {
                 page = resourceRepository.findByResourceEnNmContainingIgnoreCaseOrResourceArNmContainingIgnoreCase(q, q, pg);
             }
-            return BaseResponse.success("Resources page", page);
+            return BaseResponse.success("Resources page", mapper.toDtoPage(page));
         } catch (Exception ex) {
             LOGGER.error("List resources failed", ex);
             return BaseResponse.error("ERR_RESOURCE_LIST", ex.getMessage());
@@ -147,12 +155,12 @@ public class ResourceServiceImpl implements ResourceService {
     @Override
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "Resource", dataClass = DataClass.HEALTH, message = "List active resources")
-    public BaseResponse<List<Resource>> listActive() {
+    public BaseResponse<List<ResourceDto>> listActive() {
         try {
             List<Resource> list = resourceRepository
                     .findByIsActiveTrue(Pageable.unpaged())
                     .getContent();
-            return BaseResponse.success("Active resources", list);
+            return BaseResponse.success("Active resources", mapper.toDtoList(list));
         } catch (Exception ex) {
             LOGGER.error("List active resources failed", ex);
             return BaseResponse.error("ERR_RESOURCE_LIST_ACTIVE", ex.getMessage());
@@ -168,9 +176,9 @@ public class ResourceServiceImpl implements ResourceService {
     @Override
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "Resource", dataClass = DataClass.HEALTH, message = "Children of resource")
-    public BaseResponse<List<Resource>> childrenOf(Integer parentResourceId) {
+    public BaseResponse<List<ResourceDto>> childrenOf(Integer parentResourceId) {
         try {
-            return BaseResponse.success("Children", childrenRaw(parentResourceId));
+            return BaseResponse.success("Children", mapper.toDtoList(childrenRaw(parentResourceId)));
         } catch (Exception ex) {
             LOGGER.error("List children resources failed", ex);
             return BaseResponse.error("ERR_RESOURCE_CHILDREN", ex.getMessage());

--- a/lms-setup/src/test/java/com/lms/setup/controller/CityControllerTest.java
+++ b/lms-setup/src/test/java/com/lms/setup/controller/CityControllerTest.java
@@ -32,7 +32,7 @@ class CityControllerTest {
 
   @Test
   void list_ok() throws Exception {
-    BaseResponse<?> resp = BaseResponse.success("ok", Page.<CityDto>empty());
+    BaseResponse<Page<CityDto>> resp = BaseResponse.success("ok", Page.<CityDto>empty());
 
     doReturn(resp)
         .when(cityService)
@@ -46,7 +46,7 @@ class CityControllerTest {
 
   @Test
   void getCities_ok() throws Exception {
-    BaseResponse<?> resp = BaseResponse.success("ok", Page.<CityDto>empty());
+    BaseResponse<Page<CityDto>> resp = BaseResponse.success("ok", Page.<CityDto>empty());
 
     // Same broad stub covers q = null and any pageable/flag
     doReturn(resp)

--- a/lms-setup/src/test/java/com/lms/setup/controller/ResourceControllerTest.java
+++ b/lms-setup/src/test/java/com/lms/setup/controller/ResourceControllerTest.java
@@ -1,0 +1,45 @@
+package com.lms.setup.controller;
+
+import com.common.dto.BaseResponse;
+import com.lms.setup.dto.ResourceDto;
+import com.lms.setup.service.ResourceService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ResourceController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class ResourceControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean ResourceService resourceService;
+
+    @Test
+    void list_ok() throws Exception {
+        BaseResponse<Page<ResourceDto>> resp = BaseResponse.success("ok", Page.<ResourceDto>empty());
+
+        doReturn(resp)
+                .when(resourceService)
+                .list(any(Pageable.class), nullable(String.class), anyBoolean());
+
+        mockMvc.perform(get("/setup/resources").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("ok"));
+    }
+}

--- a/lms-setup/src/test/java/com/lms/setup/controller/SystemParameterControllerTest.java
+++ b/lms-setup/src/test/java/com/lms/setup/controller/SystemParameterControllerTest.java
@@ -1,0 +1,44 @@
+package com.lms.setup.controller;
+
+import com.common.dto.BaseResponse;
+import com.lms.setup.model.SystemParameter;
+import com.lms.setup.service.SystemParameterService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = SystemParameterController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class SystemParameterControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean SystemParameterService systemParameterService;
+
+    @Test
+    void list_ok() throws Exception {
+        BaseResponse<Page<SystemParameter>> resp = BaseResponse.success("ok", Page.<SystemParameter>empty());
+
+        doReturn(resp)
+                .when(systemParameterService)
+                .list(any(Pageable.class), nullable(String.class), nullable(Boolean.class));
+
+        mockMvc.perform(get("/setup/system-parameters").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("ok"));
+    }
+}

--- a/lms-setup/src/test/java/com/lms/setup/service/CityServiceImplTest.java
+++ b/lms-setup/src/test/java/com/lms/setup/service/CityServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.lms.setup.service;
 
 import com.common.dto.BaseResponse;
+import com.lms.setup.dto.CityDto;
 import com.lms.setup.mapper.CityMapper;
 import com.lms.setup.model.City;
 import com.lms.setup.repository.CityRepository;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
 
 import java.util.Collections;
 
@@ -37,9 +39,9 @@ class CityServiceImplTest {
         var cityPage = new org.springframework.data.domain.PageImpl<>(Collections.singletonList(new City()));
         when(cityRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class), any(org.springframework.data.domain.Pageable.class)))
                 .thenReturn(cityPage);
-        when(mapper.toDtoPage(cityPage)).thenReturn(org.springframework.data.domain.Page.empty());
+        when(mapper.toDtoPage(cityPage)).thenReturn(org.springframework.data.domain.Page.<CityDto>empty());
 
-        BaseResponse<?> resp = service.list(org.springframework.data.domain.Pageable.unpaged(), null, false);
+        BaseResponse<Page<CityDto>> resp = service.list(org.springframework.data.domain.Pageable.unpaged(), null, false);
         assertNotNull(resp);
     }
 }


### PR DESCRIPTION
## Summary
- replace generic IllegalArgumentException with ResourceNotFoundException in city service and add read-only list and get methods
- centralize controller access checks with @SetupAuthorized and use explicit generic response types
- introduce Resource DTO/mapper and rename SetupServicesCatalog constants

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM)*
- `cd shared-lib && mvn -q test` *(failed: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b423cdb35c832fb8f2137d8982e12c