### PR TITLE
Ignore pageable when serializing unpaged PageImpl

### DIFF
--- a/shared-lib/shared-starters/starter-core/pom.xml
+++ b/shared-lib/shared-starters/starter-core/pom.xml
@@ -68,6 +68,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-commons</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
       <optional>true</optional>

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/config/JacksonConfig.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/config/JacksonConfig.java
@@ -1,5 +1,6 @@
 package com.shared.starter_core.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -7,6 +8,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.PageImpl;
 
 @Configuration
 public class JacksonConfig {
@@ -31,6 +33,13 @@ public class JacksonConfig {
         // Exclude null fields from JSON output
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
+        // Avoid UnsupportedOperationException when serializing PageImpl#pageable
+        mapper.addMixIn(PageImpl.class, PageImplMixIn.class);
+
         return mapper;
     }
+
+    /** Mixin to ignore the "pageable" property of {@link PageImpl}. */
+    @JsonIgnoreProperties("pageable")
+    private interface PageImplMixIn {}
 }

--- a/shared-lib/shared-starters/starter-core/src/test/java/com/shared/starter_core/config/JacksonConfigTest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/com/shared/starter_core/config/JacksonConfigTest.java
@@ -1,0 +1,22 @@
+package com.shared.starter_core.config;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import com.common.dto.BaseResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+
+/**
+ * Tests for {@link JacksonConfig}.
+ */
+class JacksonConfigTest {
+
+    @Test
+    void serializingBaseResponseWithUnpagedPageDoesNotFail() {
+        ObjectMapper mapper = new JacksonConfig().objectMapper();
+        Page<String> emptyPage = Page.<String>empty();
+        BaseResponse<Page<String>> resp = BaseResponse.success("ok", emptyPage);
+        assertThatNoException().isThrownBy(() -> mapper.writeValueAsString(resp));
+    }
+}


### PR DESCRIPTION
## Summary
- prevent UnsupportedOperationException when serializing PageImpl with Pageable.unpaged by ignoring `pageable` field
- add optional spring-data-commons dependency and cover with unit test

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*
- `cd ../lms-setup && mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4303ab648832faffce178493ba68e