### PR TITLE
Fix missing context dependency in Kafka starter

### DIFF
--- a/shared-lib/shared-starters/starter-kafka/pom.xml
+++ b/shared-lib/shared-starters/starter-kafka/pom.xml
@@ -28,6 +28,12 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Shared utilities -->
+    <dependency>
+      <groupId>com.lms</groupId>
+      <artifactId>shared-common</artifactId>
+    </dependency>
+
     <!-- Kafka -->
     <dependency>
       <groupId>org.springframework.kafka</groupId>


### PR DESCRIPTION
## Summary
- add shared-common dependency to Kafka starter for ContextManager access

## Testing
- `mvn -q -pl shared-starters/starter-kafka -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b42d42e4a0832f89e2589ade571900