### PR TITLE
refactor: replace traceId with correlationId

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/common/constants/HeaderNames.java
+++ b/shared-lib/shared-common/src/main/java/com/common/constants/HeaderNames.java
@@ -23,7 +23,6 @@ public final class HeaderNames {
     // 📦 Request Context / Tracing
     public static final String REQUEST_ID = "X-Request-Id";
     public static final String CORRELATION_ID = "X-Correlation-Id";
-    public static final String TRACE_ID = "X-Trace-Id";
     public static final String SPAN_ID = "X-Span-Id";
 
     // 🌐 Client / Device Metadata

--- a/shared-lib/shared-common/src/main/java/com/common/context/CorrelationContextUtil.java
+++ b/shared-lib/shared-common/src/main/java/com/common/context/CorrelationContextUtil.java
@@ -1,0 +1,92 @@
+package com.common.context;
+
+import com.common.constants.HeaderNames;
+import org.slf4j.MDC;
+
+import java.util.UUID;
+
+/**
+ * Consolidated correlation context utility. This class lives in the {@code com.common.context}
+ * package and should be used for putting and getting values from the SLF4J MDC.
+ *
+ * <p>It replaces the duplicate implementations previously found in
+ * {@code com.common.logging.TraceContextUtil} and {@code com.common.util.TraceContextUtil}.
+ * The old classes delegate to this implementation and are marked as deprecated to
+ * preserve backward compatibility.</p>
+ */
+public final class CorrelationContextUtil {
+
+    /** MDC key for the correlation identifier. */
+    public static final String CORRELATION_ID = "correlationId";
+
+    private CorrelationContextUtil() {
+        // utility class
+    }
+
+    /**
+     * Initialize correlation context. Generates a UUID if no correlation id is provided.
+     *
+     * @param correlationId correlation identifier (optional)
+     * @param tenantId      tenant identifier (optional)
+     */
+    public static void init(String correlationId, String tenantId) {
+        if (correlationId == null || correlationId.isBlank()) {
+            correlationId = UUID.randomUUID().toString();
+        }
+        MDC.put(CORRELATION_ID, correlationId);
+        if (tenantId != null && !tenantId.isBlank()) {
+            MDC.put(HeaderNames.TENANT_ID, tenantId);
+        }
+    }
+
+    /**
+     * Retrieve the current correlation identifier. If none exists in the MDC a new
+     * identifier is generated, stored and returned. This guarantees that callers
+     * always receive a non-null correlation id even if no filter initialized it.
+     *
+     * @return the existing or newly generated correlation identifier
+     */
+    public static String getCorrelationId() {
+        String cid = MDC.get(CORRELATION_ID);
+        if (cid == null || cid.isBlank()) {
+            cid = UUID.randomUUID().toString();
+            MDC.put(CORRELATION_ID, cid);
+        }
+        return cid;
+    }
+
+    /**
+     * @return the current tenant identifier from MDC or {@code null}
+     */
+    public static String getTenantId() {
+        return MDC.get(HeaderNames.TENANT_ID);
+    }
+
+    /**
+     * Clear correlation and tenant identifiers from MDC.
+     */
+    public static void clear() {
+        MDC.remove(CORRELATION_ID);
+        MDC.remove(HeaderNames.TENANT_ID);
+    }
+
+    /**
+     * Put a custom key/value into MDC.
+     *
+     * @param key   MDC key
+     * @param value value to associate with the key
+     */
+    public static void put(String key, String value) {
+        MDC.put(key, value);
+    }
+
+    /**
+     * Get a custom value from MDC.
+     *
+     * @param key MDC key
+     * @return value associated with the key or {@code null}
+     */
+    public static String get(String key) {
+        return MDC.get(key);
+    }
+}

--- a/shared-lib/shared-common/src/main/java/com/common/context/TraceContextUtil.java
+++ b/shared-lib/shared-common/src/main/java/com/common/context/TraceContextUtil.java
@@ -1,83 +1,68 @@
 package com.common.context;
 
-import com.common.constants.HeaderNames;
-import org.slf4j.MDC;
-
-import java.util.UUID;
-
 /**
- * Consolidated trace context utility. This class lives in the {@code com.common.context}
- * package and should be used for putting and getting values from the SLF4J MDC.
- *
- * <p>It replaces the duplicate implementations previously found in
- * {@code com.common.logging.TraceContextUtil} and {@code com.common.util.TraceContextUtil}.
- * The old classes delegate to this implementation and are marked as deprecated to
- * preserve backward compatibility.</p>
+ * @deprecated Use {@link CorrelationContextUtil} instead. This class exists only
+ * for backwards compatibility and will be removed in a future release.
  */
+@Deprecated(forRemoval = true, since = "1.0.0")
 public final class TraceContextUtil {
 
-    /** MDC key for the trace identifier. */
-    public static final String TRACE_ID = "traceId";
-
     private TraceContextUtil() {
-        // utility class
     }
 
     /**
-     * Initialize trace context. Generates a UUID if no traceId is provided.
-     *
-     * @param traceId  trace identifier (optional)
-     * @param tenantId tenant identifier (optional)
+     * @deprecated Use {@link CorrelationContextUtil#init(String, String)} instead.
      */
-    public static void init(String traceId, String tenantId) {
-        if (traceId == null || traceId.isBlank()) {
-            traceId = UUID.randomUUID().toString();
-        }
-        MDC.put(TRACE_ID, traceId);
-        if (tenantId != null && !tenantId.isBlank()) {
-            MDC.put(HeaderNames.TENANT_ID, tenantId);
-        }
+    @Deprecated(forRemoval = true, since = "1.0.0")
+    public static void init(String correlationId, String tenantId) {
+        CorrelationContextUtil.init(correlationId, tenantId);
     }
 
     /**
-     * @return the current trace identifier from MDC or {@code null}
+     * @deprecated Use {@link CorrelationContextUtil#getCorrelationId()} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0")
+    public static String getCorrelationId() {
+        return CorrelationContextUtil.getCorrelationId();
+    }
+
+    /**
+     * @deprecated Legacy alias for {@link CorrelationContextUtil#getCorrelationId()}.
+     */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static String getTraceId() {
-        return MDC.get(TRACE_ID);
+        return CorrelationContextUtil.getCorrelationId();
     }
 
     /**
-     * @return the current tenant identifier from MDC or {@code null}
+     * @deprecated Use {@link CorrelationContextUtil#getTenantId()} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static String getTenantId() {
-        return MDC.get(HeaderNames.TENANT_ID);
+        return CorrelationContextUtil.getTenantId();
     }
 
     /**
-     * Clear trace and tenant identifiers from MDC.
+     * @deprecated Use {@link CorrelationContextUtil#clear()} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static void clear() {
-        MDC.remove(TRACE_ID);
-        MDC.remove(HeaderNames.TENANT_ID);
+        CorrelationContextUtil.clear();
     }
 
     /**
-     * Put a custom key/value into MDC.
-     *
-     * @param key   MDC key
-     * @param value value to associate with the key
+     * @deprecated Use {@link CorrelationContextUtil#put(String, String)} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static void put(String key, String value) {
-        MDC.put(key, value);
+        CorrelationContextUtil.put(key, value);
     }
 
     /**
-     * Get a custom value from MDC.
-     *
-     * @param key MDC key
-     * @return value associated with the key or {@code null}
+     * @deprecated Use {@link CorrelationContextUtil#get(String)} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0")
     public static String get(String key) {
-        return MDC.get(key);
+        return CorrelationContextUtil.get(key);
     }
 }

--- a/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
@@ -1,6 +1,6 @@
 package com.common.dto;
 
-import com.common.context.TraceContextUtil;
+import com.common.context.CorrelationContextUtil;
 import com.common.enums.StatusEnums.ApiStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nullable;
@@ -40,16 +40,13 @@ public class BaseResponse<T> {
     @Builder.Default
     private Instant timestamp = Instant.now();
 
-    /** Trace identifier for correlation across services */
+    /** Correlation identifier for tracking across services */
     @Builder.Default
-    private String traceId = TraceContextUtil.getTraceId();
+    private String correlationId = CorrelationContextUtil.getCorrelationId();
 
-    /**
-     * Alias for {@link #traceId} to support clients expecting a correlationId field.
-     */
     @JsonProperty("correlationId")
     public String getCorrelationId() {
-        return traceId;
+        return correlationId;
     }
 
     // ===== Static builders (nice usability) =====

--- a/shared-lib/shared-common/src/main/java/com/common/dto/ErrorResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/common/dto/ErrorResponse.java
@@ -1,6 +1,6 @@
 package com.common.dto;
 
-import com.common.context.TraceContextUtil;
+import com.common.context.CorrelationContextUtil;
 import com.common.enums.StatusEnums.ApiStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -33,9 +33,9 @@ public class ErrorResponse {
     /** Optional detailed errors (e.g., field-level validation issues) */
     private List<String> details;
 
-    /** Trace/Correlation ID (for logs/monitoring) */
+    /** Correlation ID (for logs/monitoring) */
     @Builder.Default
-    private String traceId = TraceContextUtil.getTraceId();
+    private String correlationId = CorrelationContextUtil.getCorrelationId();
 
     /** Tenant ID (multi-tenant awareness) */
     private String tenantId;
@@ -46,7 +46,7 @@ public class ErrorResponse {
 
     @JsonProperty("correlationId")
     public String getCorrelationId() {
-        return traceId;
+        return correlationId;
     }
 
     // ===== Static builders =====
@@ -58,22 +58,22 @@ public class ErrorResponse {
                 .build();
     }
 
-    public static ErrorResponse of(String code, String message, List<String> details, String traceId) {
+    public static ErrorResponse of(String code, String message, List<String> details, String correlationId) {
         return ErrorResponse.builder()
                 .code(code)
                 .message(message)
                 .details(details)
-                .traceId(traceId)
+                .correlationId(correlationId)
                 .timestamp(Instant.now())
                 .build();
     }
 
-    public static ErrorResponse of(String code, String message, List<String> details, String traceId, String tenantId) {
+    public static ErrorResponse of(String code, String message, List<String> details, String correlationId, String tenantId) {
         return ErrorResponse.builder()
                 .code(code)
                 .message(message)
                 .details(details)
-                .traceId(traceId)
+                .correlationId(correlationId)
                 .tenantId(tenantId)
                 .timestamp(Instant.now())
                 .build();

--- a/shared-lib/shared-common/src/main/java/com/common/dto/RequestMetadata.java
+++ b/shared-lib/shared-common/src/main/java/com/common/dto/RequestMetadata.java
@@ -16,8 +16,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RequestMetadata {
 
-    /** Unique request correlation ID (traceId) */
-    private String traceId;
+    /** Unique request correlation ID */
+    private String correlationId;
 
     /** Tenant identifier (for multi-tenancy) */
     private String tenantId;

--- a/shared-lib/shared-common/src/main/java/com/common/logging/LogMarkers.java
+++ b/shared-lib/shared-common/src/main/java/com/common/logging/LogMarkers.java
@@ -16,9 +16,9 @@ public final class LogMarkers {
         // utility class
     }
 
-    /** Trace markers (always attach traceId + tenantId) */
-    public static LogstashMarker trace(String traceId, String tenantId) {
-        LogstashMarker marker = Markers.append("traceId", traceId);
+    /** Correlation markers (always attach correlationId + tenantId) */
+    public static LogstashMarker correlation(String correlationId, String tenantId) {
+        LogstashMarker marker = Markers.append("correlationId", correlationId);
         if (tenantId != null && !tenantId.isBlank()) {
             marker = marker.and(Markers.append(HeaderNames.TENANT_ID, tenantId));
         }

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/config/AuditAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/config/AuditAutoConfiguration.java
@@ -13,7 +13,7 @@ import com.shared.audit.starter.core.dispatch.sinks.Sink;
 import com.shared.audit.starter.core.enrich.Enricher;
 import com.shared.audit.starter.core.enrich.HostEnricher;
 import com.shared.audit.starter.core.enrich.ContextHeaderEnricher;
-import com.shared.audit.starter.core.enrich.MdcTraceEnricher;
+import com.shared.audit.starter.core.enrich.MdcCorrelationEnricher;
 import com.shared.audit.starter.core.enrich.RequestEnricher;
 import com.shared.audit.starter.core.enrich.SecurityEnricher;
 import com.shared.audit.starter.core.enrich.TenantEnricher;
@@ -166,7 +166,7 @@ public class AuditAutoConfiguration {
 
   // ---------- Enrichers
 
-  @Bean @ConditionalOnMissingBean public MdcTraceEnricher mdcTraceEnricher() { return new MdcTraceEnricher(); }
+  @Bean @ConditionalOnMissingBean public MdcCorrelationEnricher mdcCorrelationEnricher() { return new MdcCorrelationEnricher(); }
   @Bean @ConditionalOnMissingBean public HostEnricher hostEnricher() { return new HostEnricher(); }
   @Bean @ConditionalOnMissingBean public ContextHeaderEnricher contextHeaderEnricher() { return new ContextHeaderEnricher(); }
 

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/core/dispatch/sinks/DatabaseSink.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/core/dispatch/sinks/DatabaseSink.java
@@ -24,7 +24,7 @@ public class DatabaseSink implements Sink {
     this.insertSql =
         "INSERT INTO " + this.table + " (" +
         " id, ts_utc, tenant_id, actor_id, actor_username, action, entity_type, entity_id, outcome," +
-        " data_class, sensitivity, resource_path, resource_method, trace_id, span_id, message, payload) " +
+        " data_class, sensitivity, resource_path, resource_method, correlation_id, span_id, message, payload) " +
         "VALUES (? , ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, cast(? as jsonb))";
   }
 
@@ -55,7 +55,7 @@ public class DatabaseSink implements Sink {
             e.getSensitivity() == null ? null : e.getSensitivity().name(),
             e.getResource().getOrDefault("path", null),
             e.getResource().getOrDefault("method", null),
-            e.getMetadata().getOrDefault("traceId", null),
+            e.getMetadata().getOrDefault("correlationId", null),
             e.getMetadata().getOrDefault("spanId", null),
             e.getMessage(),
             payload

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/core/enrich/MdcCorrelationEnricher.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/core/enrich/MdcCorrelationEnricher.java
@@ -3,11 +3,11 @@ package com.shared.audit.starter.core.enrich;
 import com.shared.audit.starter.api.AuditEvent;
 import org.slf4j.MDC;
 
-public class MdcTraceEnricher implements Enricher {
+public class MdcCorrelationEnricher implements Enricher {
   @Override public void enrich(AuditEvent.Builder b) {
-    String traceId = MDC.get("traceId");
+    String correlationId = MDC.get("correlationId");
     String spanId = MDC.get("spanId");
-    if (traceId != null) b.meta("traceId", traceId);
+    if (correlationId != null) b.meta("correlationId", correlationId);
     if (spanId != null) b.meta("spanId", spanId);
   }
 }

--- a/shared-lib/shared-starters/starter-audit/src/main/resources/db/migration/V1__create_audit_tables.sql
+++ b/shared-lib/shared-starters/starter-audit/src/main/resources/db/migration/V1__create_audit_tables.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS setup.audit_logs (
   sensitivity      text,
   resource_path    text,
   resource_method  text,
-  trace_id         text,
+  correlation_id   text,
   span_id          text,
   message          text,
   payload          jsonb NOT NULL

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/context/ContextFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/context/ContextFilter.java
@@ -9,7 +9,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.common.constants.HeaderNames;
 import com.common.context.ContextManager;
-import com.common.context.TraceContextUtil;
+import com.common.context.CorrelationContextUtil;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -49,11 +49,10 @@ public class ContextFilter extends OncePerRequestFilter {
                 request.getHeader(HeaderNames.TENANT_ID),
                 request.getParameter(HeaderNames.TENANT_ID)           // optional fallback
         ));
-        String incomingTrace = trimToNull(firstNonNull(
-                request.getHeader(HeaderNames.CORRELATION_ID),
-                request.getHeader(HeaderNames.TRACE_ID)
-        ));
-        String correlationId = incomingTrace != null ? incomingTrace : UUID.randomUUID().toString();
+        String incomingCorrelation = trimToNull(
+                request.getHeader(HeaderNames.CORRELATION_ID)
+        );
+        String correlationId = incomingCorrelation != null ? incomingCorrelation : UUID.randomUUID().toString();
         String userId        = trimToNull(firstNonNull(
                 request.getHeader(HeaderNames.USER_ID),
                 (String) request.getAttribute(HeaderNames.USER_ID)  // some stacks set it as an attribute
@@ -70,7 +69,7 @@ public class ContextFilter extends OncePerRequestFilter {
             if (tenantId != null) {
                 ContextManager.Tenant.set(tenantId);
             }
-            TraceContextUtil.put(TraceContextUtil.TRACE_ID, correlationId);
+            CorrelationContextUtil.put(CorrelationContextUtil.CORRELATION_ID, correlationId);
 
             // ---- Enrich logging context (appears on every log line)
             putMdc(HeaderNames.TENANT_ID, tenantId);
@@ -84,7 +83,7 @@ public class ContextFilter extends OncePerRequestFilter {
         } finally {
             // ---- Always cleanup
             ContextManager.Tenant.clear();
-            TraceContextUtil.clear();
+            CorrelationContextUtil.clear();
             MDC.remove(HeaderNames.TENANT_ID);
             MDC.remove(HeaderNames.USER_ID);
             MDC.remove(HeaderNames.CORRELATION_ID);

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/logging/CorrelationIdFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/logging/CorrelationIdFilter.java
@@ -1,7 +1,7 @@
 package com.shared.starter_core.logging;
 
 import com.common.constants.HeaderNames;
-import com.common.context.TraceContextUtil;
+import com.common.context.CorrelationContextUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -59,7 +59,7 @@ public class CorrelationIdFilter extends OncePerRequestFilter {
 
         if (!isBlank(correlationId)) {
             MDC.put(mdcKey, correlationId);
-            TraceContextUtil.put(TraceContextUtil.TRACE_ID, correlationId);
+            CorrelationContextUtil.put(CorrelationContextUtil.CORRELATION_ID, correlationId);
             // Set early to ensure response always has the header (even on exceptions)
             if (echoResponseHeader) {
                 res.setHeader(headerName, correlationId);
@@ -70,7 +70,7 @@ public class CorrelationIdFilter extends OncePerRequestFilter {
             chain.doFilter(req, res);
         } finally {
             MDC.remove(mdcKey);
-            TraceContextUtil.clear();
+            CorrelationContextUtil.clear();
         }
     }
 

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/logging/LoggingAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/logging/LoggingAutoConfiguration.java
@@ -15,7 +15,7 @@ import jakarta.annotation.PostConstruct;
 
 /**
  * Auto-configures logging for Shared services:
- *  - Adds MDC traceId/tenantId (from CoreAutoConfiguration filters).
+ *  - Adds MDC correlationId/tenantId (from CoreAutoConfiguration filters).
  *  - Optionally enables JSON/Logstash output.
  */
 @AutoConfiguration
@@ -29,7 +29,7 @@ public class LoggingAutoConfiguration {
             if (ctx.getLogger("ROOT").getAppender("CONSOLE") == null) {
                 PatternLayoutEncoder ple = new PatternLayoutEncoder();
                 ple.setContext(ctx);
-                ple.setPattern("%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger - %msg %X{traceId} %X{tenantId}%n");
+                ple.setPattern("%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger - %msg %X{correlationId} %X{tenantId}%n");
                 ple.start();
 
                 ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender<>();

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/ApiResponseEntityExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/ApiResponseEntityExceptionHandler.java
@@ -182,14 +182,13 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
         // tenant
         err.setTenantId(ContextManager.Tenant.get());
 
-        // correlation id (prefer MDC "correlationId", then "traceId", then headers)
+        // correlation id (prefer MDC "correlationId", then headers)
         String cid = firstNonBlank(
                 MDC.get(HeaderNames.CORRELATION_ID),
-                MDC.get(HeaderNames.TRACE_ID),
                 header(req, HeaderNames.CORRELATION_ID),
                 header(req, HeaderNames.REQUEST_ID)
         );
-        err.setTraceId(cid);
+        err.setCorrelationId(cid);
     }
 
     private String header(WebRequest req, String name) {

--- a/shared-lib/shared-starters/starter-crypto/src/main/java/com/shared/crypto/starter/audit/CryptoMdcFilter.java
+++ b/shared-lib/shared-starters/starter-crypto/src/main/java/com/shared/crypto/starter/audit/CryptoMdcFilter.java
@@ -14,11 +14,11 @@ import java.io.IOException;
 import java.util.UUID;
 
 /**
- * Ensures MDC has a correlation id (traceId) for all logs.
+ * Ensures MDC has a correlation id for all logs.
  * Also propagates optional tenantId/userId if provided via headers or upstream MDC.
  *
  * MDC keys used:
- *  - traceId
+ *  - correlationId
  *  - tenantId (optional)
  *  - userId   (optional)
  *
@@ -37,17 +37,17 @@ public class CryptoMdcFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         // Read incoming headers
-        String incomingTrace = headerOrNull(request, HeaderNames.CORRELATION_ID);
+        String incomingCorrelation = headerOrNull(request, HeaderNames.CORRELATION_ID);
         String incomingTenant = headerOrNull(request, HeaderNames.TENANT_ID);
         String incomingUser = headerOrNull(request, HeaderNames.USER_ID);
 
         // Prefer existing MDC (if upstream filter already set it)
-        boolean putTrace = false, putTenant = false, putUser = false;
+        boolean putCorrelation = false, putTenant = false, putUser = false;
 
-        if (!StringUtils.hasText(MDC.get(HeaderNames.TRACE_ID))) {
-            String traceId = StringUtils.hasText(incomingTrace) ? incomingTrace : genTraceId();
-            MDC.put(HeaderNames.TRACE_ID, traceId);
-            putTrace = true;
+        if (!StringUtils.hasText(MDC.get(HeaderNames.CORRELATION_ID))) {
+            String correlationId = StringUtils.hasText(incomingCorrelation) ? incomingCorrelation : genCorrelationId();
+            MDC.put(HeaderNames.CORRELATION_ID, correlationId);
+            putCorrelation = true;
         }
 
         if (!StringUtils.hasText(MDC.get(HeaderNames.TENANT_ID)) && StringUtils.hasText(incomingTenant)) {
@@ -55,18 +55,18 @@ public class CryptoMdcFilter extends OncePerRequestFilter {
             putTenant = true;
         }
 
-        if (!StringUtils.hasText(MDC.get(HeaderNames.TENANT_ID)) && StringUtils.hasText(incomingUser)) {
-            MDC.put(HeaderNames.TENANT_ID, incomingUser);
+        if (!StringUtils.hasText(MDC.get(HeaderNames.USER_ID)) && StringUtils.hasText(incomingUser)) {
+            MDC.put(HeaderNames.USER_ID, incomingUser);
             putUser = true;
         }
 
         try {
             // Echo correlation id in response for client-side tracing
-            response.setHeader(HeaderNames.CORRELATION_ID, MDC.get(HeaderNames.TENANT_ID));
+            response.setHeader(HeaderNames.CORRELATION_ID, MDC.get(HeaderNames.CORRELATION_ID));
             chain.doFilter(request, response);
         } finally {
             // Clean up only keys we added (don’t clobber upstream MDC)
-            if (putTrace)  MDC.remove(HeaderNames.TENANT_ID);
+            if (putCorrelation)  MDC.remove(HeaderNames.CORRELATION_ID);
             if (putTenant) MDC.remove(HeaderNames.TENANT_ID);
             if (putUser)   MDC.remove(HeaderNames.USER_ID);
         }
@@ -77,7 +77,7 @@ public class CryptoMdcFilter extends OncePerRequestFilter {
         return StringUtils.hasText(v) ? v.trim() : null;
     }
 
-    private static String genTraceId() {
+    private static String genCorrelationId() {
         // UUID v4 is fine for correlation; you can swap with ULID if preferred
         return UUID.randomUUID().toString();
     }

--- a/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/core/Headers.java
+++ b/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/core/Headers.java
@@ -3,7 +3,6 @@ package com.shared.kafka_starter.core;
 public final class Headers {
   public static final String TENANT_ID = "x-tenant-id";
   public static final String CORRELATION_ID = "x-corr-id";
-  public static final String TRACE_ID = "x-trace-id";
   public static final String MESSAGE_ID = "x-msg-id";
   public static final String SCHEMA_VERSION = "x-schema-ver";
   private Headers() {}

--- a/shared-lib/shared-starters/starter-observability/src/main/resources/logback-spring.xml
+++ b/shared-lib/shared-starters/starter-observability/src/main/resources/logback-spring.xml
@@ -7,7 +7,7 @@
         <loggerName/>
         <threadName/>
         <pattern>
-          <pattern>{"message":"%message","traceId":"%X{trace_id}","spanId":"%X{span_id}"}</pattern>
+          <pattern>{"message":"%message","correlationId":"%X{correlationId}","spanId":"%X{span_id}"}</pattern>
         </pattern>
         <mdc/>
       </providers>

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/web/JsonAccessDeniedHandler.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/web/JsonAccessDeniedHandler.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -36,9 +35,8 @@ public class JsonAccessDeniedHandler implements AccessDeniedHandler {
         request.getRequestURI()
     );
     body.setTenantId(ContextManager.Tenant.get());
-    body.setTraceId(firstNonBlank(
+    body.setCorrelationId(firstNonBlank(
         MDC.get(HeaderNames.CORRELATION_ID),
-        MDC.get(HeaderNames.TRACE_ID),
         request.getHeader(HeaderNames.CORRELATION_ID),
         request.getHeader(HeaderNames.REQUEST_ID)
     ));

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/web/JsonAuthEntryPoint.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/web/JsonAuthEntryPoint.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -37,9 +36,8 @@ public class JsonAuthEntryPoint implements AuthenticationEntryPoint {
     );
     // enrich
     body.setTenantId(ContextManager.Tenant.get());
-    body.setTraceId(firstNonBlank(
+    body.setCorrelationId(firstNonBlank(
         MDC.get(HeaderNames.CORRELATION_ID),
-        MDC.get(HeaderNames.TRACE_ID),
         request.getHeader(HeaderNames.CORRELATION_ID),
         request.getHeader(HeaderNames.REQUEST_ID)
     ));


### PR DESCRIPTION
## Summary
- remove `traceId` usage and standardize on `correlationId`
- update logging, filters, audit sinks, and response DTOs to use `correlationId`
- adjust headers, security handlers, and crypto filter accordingly
- ensure a correlation ID is always generated when missing
- provide deprecated `TraceContextUtil` wrapper for backward compatibility

## Testing
- `mvn -q -pl shared-common -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b430108134832fb0337d23d57a6e08