### PR TITLE
Fix correlation ID getter in ErrorResponse

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/common/dto/ErrorResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/common/dto/ErrorResponse.java
@@ -1,5 +1,4 @@
 package com.common.dto;
-import com.common.context.CorrelationContextUtil;
 
 import com.common.context.CorrelationContextUtil;
 import com.common.enums.StatusEnums.ApiStatus;
@@ -34,8 +33,8 @@ public class ErrorResponse {
     /** Optional detailed errors (e.g., field-level validation issues) */
     private List<String> details;
 
-    /** Correlation ID (for logs/monitoring) */ 
-   private String correlationId;
+    /** Correlation ID (for logs/monitoring) */
+    private String correlationId;
 
 
     /** Tenant ID (multi-tenant awareness) */
@@ -47,9 +46,11 @@ public class ErrorResponse {
 
     @JsonProperty("correlationId")
     public String getCorrelationId() {
-      if (correlationId == null || correlationId.isBlank()) {
+        if (correlationId == null || correlationId.isBlank()) {
             correlationId = CorrelationContextUtil.getCorrelationId();
         }
+        return correlationId;
+    }
 
     // ===== Static builders =====
     public static ErrorResponse of(String code, String message) {


### PR DESCRIPTION
## Summary
- ensure correlation ID field is returned and populated from `CorrelationContextUtil`

## Testing
- `mvn -q -f shared-lib/pom.xml -pl shared-common -am test` *(fails: Network is unreachable while resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b45245ccf8832fbc5e88722b861cce