### PR TITLE
fix: explicitly parameterize BaseResponse.success in tests

### DIFF
--- a/shared-lib/shared-common/src/test/java/com/common/dto/BaseResponseTest.java
+++ b/shared-lib/shared-common/src/test/java/com/common/dto/BaseResponseTest.java
@@ -50,7 +50,7 @@ class BaseResponseTest {
 
     @Test
     void mapTransformsPayloadPreservingMetadata() {
-        BaseResponse<String> original = BaseResponse.success("hello");
+        BaseResponse<String> original = BaseResponse.<String>success("hello");
 
         BaseResponse<Integer> mapped = original.map(String::length);
 
@@ -62,7 +62,7 @@ class BaseResponseTest {
 
     @Test
     void mapHandlesNullPayloadGracefully() {
-        BaseResponse<String> original = BaseResponse.success(null);
+        BaseResponse<String> original = BaseResponse.<String>success(null);
 
         BaseResponse<Integer> mapped = original.map(String::length);
 


### PR DESCRIPTION
## Summary
- specify generic type when calling `BaseResponse.success(...)` in tests to avoid type inference issues

## Testing
- `mvn -q -pl shared-common -am test` *(fails: Non-resolvable import POM: Could not transfer artifact from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68b455b46fe8832f9dc4c1310cec4127