### PR TITLE
Fix missing AssertJ import in JacksonConfigTest

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/test/java/com/shared/starter_core/config/JacksonConfigTest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/com/shared/starter_core/config/JacksonConfigTest.java
@@ -1,5 +1,6 @@
 package com.shared.starter_core.config;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 
 import com.common.dto.BaseResponse;


### PR DESCRIPTION
## Summary
- import `assertThatNoException` so JacksonConfigTest compiles

## Testing
- `mvn -q test -pl shared-starters/starter-core -am` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3 from/to central (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_68b45b2f12d8832fb40e4218f8a61ba6