### PR TITLE
test: avoid JsonProcessingException in JacksonConfigTest

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/test/java/com/shared/starter_core/config/JacksonConfigTest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/com/shared/starter_core/config/JacksonConfigTest.java
@@ -18,7 +18,10 @@ class JacksonConfigTest {
         ObjectMapper mapper = new JacksonConfig().objectMapper();
         Page<String> emptyPage = Page.<String>empty();
         BaseResponse<Page<String>> resp = BaseResponse.success("ok", emptyPage);
-        assertThatNoException().isThrownBy(() -> mapper.writeValueAsString(resp));
-        assertThat(mapper.writeValueAsString(resp)).doesNotContain("pageable");
+
+        assertThatNoException().isThrownBy(() -> {
+            String json = mapper.writeValueAsString(resp);
+            assertThat(json).doesNotContain("pageable");
+        });
     }
 }


### PR DESCRIPTION
## Summary
- avoid JsonProcessingException in JacksonConfigTest by wrapping serialization inside `assertThatNoException`

## Testing
- `mvn -q -pl shared-starters/starter-core -am test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b45cebaf8c832f8028923c0460720c