### PR TITLE
Fix missing imports and handle JsonProcessingException

### DIFF
--- a/lms-setup/src/main/java/com/lms/setup/controller/CityController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/CityController.java
@@ -20,6 +20,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @RestController
 @RequestMapping("/setup/cities")

--- a/lms-setup/src/main/java/com/lms/setup/controller/LookupController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/LookupController.java
@@ -18,6 +18,7 @@ import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.util.List;
 

--- a/shared-lib/shared-starters/starter-core/src/test/java/com/shared/starter_core/config/JacksonConfigTest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/com/shared/starter_core/config/JacksonConfigTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import com.common.dto.BaseResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 
@@ -14,7 +15,7 @@ import org.springframework.data.domain.Page;
 class JacksonConfigTest {
 
     @Test
-    void serializingBaseResponseWithUnpagedPageDoesNotFail() {
+    void serializingBaseResponseWithUnpagedPageDoesNotFail() throws JsonProcessingException {
         ObjectMapper mapper = new JacksonConfig().objectMapper();
         Page<String> emptyPage = Page.<String>empty();
         BaseResponse<Page<String>> resp = BaseResponse.success("ok", emptyPage);


### PR DESCRIPTION
## Summary
- add missing java.util.List import for CityController
- bring in PreAuthorize import for LookupController
- handle JsonProcessingException in JacksonConfigTest

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b45d13ce48832fa2c14fdf1f7904b6