### PR TITLE
feat: add unpaged flag for listing endpoints

### DIFF
--- a/lms-setup/src/main/java/com/lms/setup/controller/CityController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/CityController.java
@@ -90,9 +90,10 @@ public class CityController {
             @PageableDefault(size = 20) Pageable pageable,
             @Parameter(description = "Search query for city names")
             @RequestParam(required = false) String q,
-            @Parameter(description = "Whether to return all cities (ignores pagination)")
-            @RequestParam(required = false) boolean all) {
-        return ResponseEntity.ok(cityService.list(pageable, q, all));
+            @Parameter(description = "Whether to retrieve all cities (ignores pagination)")
+            @RequestParam(name = "unpaged", defaultValue = "false") boolean unpaged) {
+        Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
+        return ResponseEntity.ok(cityService.list(effectivePageable, q, unpaged));
     }
 
     @GetMapping("/active")

--- a/lms-setup/src/main/java/com/lms/setup/controller/CountryController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/CountryController.java
@@ -93,9 +93,10 @@ public class CountryController {
             @PageableDefault(size = 20) Pageable pageable,
             @Parameter(description = "Search query for country names")
             @RequestParam(required = false) String q,
-            @Parameter(description = "Whether to return all countries (ignores pagination)")
-            @RequestParam(required = false) boolean all) {
-        return ResponseEntity.ok(countryService.list(pageable, q, all));
+            @Parameter(description = "Whether to retrieve all countries (ignores pagination)")
+            @RequestParam(name = "unpaged", defaultValue = "false") boolean unpaged) {
+        Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
+        return ResponseEntity.ok(countryService.list(effectivePageable, q, unpaged));
     }
 
     @GetMapping("/active")

--- a/lms-setup/src/main/java/com/lms/setup/controller/ResourceController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/ResourceController.java
@@ -91,9 +91,10 @@ public class ResourceController {
             @PageableDefault(size = 20) Pageable pageable,
             @Parameter(description = "Search query for resource names")
             @RequestParam(required = false) String q,
-            @Parameter(description = "Whether to return all resources (ignores pagination)")
-            @RequestParam(required = false) boolean all) {
-        return ResponseEntity.ok(resourceService.list(pageable, q, all));
+            @Parameter(description = "Whether to retrieve all resources (ignores pagination)")
+            @RequestParam(name = "unpaged", defaultValue = "false") boolean unpaged) {
+        Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
+        return ResponseEntity.ok(resourceService.list(effectivePageable, q, unpaged));
     }
 
     @GetMapping("/active")

--- a/lms-setup/src/main/java/com/lms/setup/controller/SystemParameterController.java
+++ b/lms-setup/src/main/java/com/lms/setup/controller/SystemParameterController.java
@@ -93,8 +93,11 @@ public class SystemParameterController {
             @Parameter(description = "Group filter for parameters")
             @RequestParam(required = false) String group,
             @Parameter(description = "Whether to return only active parameters")
-            @RequestParam(required = false) Boolean onlyActive) {
-        return ResponseEntity.ok(systemParameterService.list(pageable, group, onlyActive));
+            @RequestParam(required = false) Boolean onlyActive,
+            @Parameter(description = "Whether to retrieve all parameters (ignores pagination)")
+            @RequestParam(name = "unpaged", defaultValue = "false") boolean unpaged) {
+        Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
+        return ResponseEntity.ok(systemParameterService.list(effectivePageable, group, onlyActive));
     }
 
     @GetMapping("/by-key/{paramKey}")

--- a/lms-setup/src/main/java/com/lms/setup/service/CityService.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/CityService.java
@@ -12,6 +12,6 @@ public interface CityService {
   BaseResponse<CityDto> update(Integer id, CityDto request);
   BaseResponse<Void>    delete(Integer id);
   BaseResponse<CityDto> get(Integer id);
-  BaseResponse<Page<CityDto>> list(Pageable pageable, String q, boolean all);
+  BaseResponse<Page<CityDto>> list(Pageable pageable, String q, boolean unpaged);
   BaseResponse<List<CityDto>> listActiveByCountry(Integer countryId);
 }

--- a/lms-setup/src/main/java/com/lms/setup/service/CountryService.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/CountryService.java
@@ -15,7 +15,7 @@ public interface CountryService {
 
     BaseResponse<Country> get(Integer countryId);
 
-    BaseResponse<?> list(Pageable pageable, String q, boolean all);
+    BaseResponse<?> list(Pageable pageable, String q, boolean unpaged);
 
     BaseResponse<List<Country>> listActive();
 }

--- a/lms-setup/src/main/java/com/lms/setup/service/ResourceService.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/ResourceService.java
@@ -15,7 +15,7 @@ public interface ResourceService {
 
     BaseResponse<ResourceDto> get(Integer resourceId);
 
-    BaseResponse<Page<ResourceDto>> list(Pageable pageable, String q, boolean all);
+    BaseResponse<Page<ResourceDto>> list(Pageable pageable, String q, boolean unpaged);
 
     BaseResponse<List<ResourceDto>> listActive();
 

--- a/lms-setup/src/main/java/com/lms/setup/service/impl/CityServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/CityServiceImpl.java
@@ -91,14 +91,14 @@ public class CityServiceImpl implements CityService {
 	@Override
         @Transactional(Transactional.TxType.SUPPORTS)
         @Audited(action = AuditAction.READ, entity = "City", dataClass = DataClass.HEALTH, message = "List cities")
-        public BaseResponse<Page<CityDto>> list(Pageable pageable, String q, boolean all) {
+        public BaseResponse<Page<CityDto>> list(Pageable pageable, String q, boolean unpaged) {
                 Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
                                 "cityEnNm", "cityEnNm", "cityArNm", "cityCd");
                 final Pageable pg = (pageable == null || !pageable.isPaged()
                                 ? Pageable.unpaged()
                                 : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort));
 
-                if (all) {
+                if (unpaged) {
                         var spec = CitySpecifications.nameContains(q); // null => no filter
                         var entities = cityRepo.findAll(spec, sort);
                         return BaseResponse.success("City list", new PageImpl<>(mapper.toDtoList(entities)));

--- a/lms-setup/src/main/java/com/lms/setup/service/impl/CountryServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/CountryServiceImpl.java
@@ -80,14 +80,14 @@ public class CountryServiceImpl implements CountryService {
     @Override
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "Country", dataClass = DataClass.HEALTH, message = "List countries")
-    public BaseResponse<?> list(Pageable pageable, String q, boolean all) {
+    public BaseResponse<?> list(Pageable pageable, String q, boolean unpaged) {
         Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
                 "countryEnNm", "countryEnNm", "countryArNm", "countryCd");
         Pageable pg = (pageable == null || !pageable.isPaged()
                 ? Pageable.unpaged()
                 : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort));
 
-        if (all) {
+        if (unpaged) {
             List<Country> list;
             if (q == null || q.isBlank()) {
                 list = countryRepository.findAll(sort);

--- a/lms-setup/src/main/java/com/lms/setup/service/impl/ResourceServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/ResourceServiceImpl.java
@@ -120,14 +120,14 @@ public class ResourceServiceImpl implements ResourceService {
     @Override
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "Resource", dataClass = DataClass.HEALTH, message = "List resources")
-    public BaseResponse<Page<ResourceDto>> list(Pageable pageable, String q, boolean all) {
+    public BaseResponse<Page<ResourceDto>> list(Pageable pageable, String q, boolean unpaged) {
         try {
             Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
                     "resourceEnNm", "resourceEnNm", "resourceArNm", "resourceCd");
             Pageable pg = (pageable == null || !pageable.isPaged()
                     ? Pageable.unpaged()
                     : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort));
-            if (all) {
+            if (unpaged) {
                 List<Resource> list;
                 if (q == null || q.isBlank()) {
                     list = resourceRepository.findAll(sort);


### PR DESCRIPTION
## Summary
- allow ?unpaged=true on Country, City, Resource and SystemParameter listing endpoints to bypass pagination
- propagate unpaged flag through service layer

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b460f66cb4832fbcb5eed60d51cd68