### PR TITLE
chore: enable flyway baseline

### DIFF
--- a/lms-setup/src/main/resources/application-dev.yaml
+++ b/lms-setup/src/main/resources/application-dev.yaml
@@ -26,6 +26,7 @@ spring:
 
   flyway:
     enabled: false
+    baseline-on-migrate: true
 
   kafka:
     bootstrap-servers: localhost:9092


### PR DESCRIPTION
## Summary
- ensure Flyway baselines existing schema by default

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68b465e0ef88832fac77572ea0933635