### PR TITLE
Enable Flyway baseline-on-migrate for setup service

### DIFF
--- a/lms-setup/src/main/resources/application-dev.yaml
+++ b/lms-setup/src/main/resources/application-dev.yaml
@@ -24,9 +24,6 @@ spring:
         format_sql: true
         jdbc.time_zone: UTC
 
-  flyway:
-    enabled: false
-
   kafka:
     bootstrap-servers: localhost:9092
     client-id: lms-setup-dev

--- a/lms-setup/src/main/resources/application.yaml
+++ b/lms-setup/src/main/resources/application.yaml
@@ -3,6 +3,9 @@ spring:
     name: lms-setup
   profiles:
     active: dev
+  flyway:
+    baseline-on-migrate: true
+    baseline-version: 0
 server:
   port: 8080
   shutdown: graceful


### PR DESCRIPTION
## Summary
- baseline Flyway on existing schemas to avoid startup errors
- remove explicit Flyway disablement from dev profile

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4678b8678832f918d80020ef044d0