### PR TITLE
Allow default property in SortUtils automatically

### DIFF
--- a/lms-setup/src/main/java/com/lms/setup/service/impl/CityServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/CityServiceImpl.java
@@ -93,7 +93,7 @@ public class CityServiceImpl implements CityService {
         @Audited(action = AuditAction.READ, entity = "City", dataClass = DataClass.HEALTH, message = "List cities")
         public BaseResponse<Page<CityDto>> list(Pageable pageable, String q, boolean unpaged) {
                 Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
-                                "cityEnNm", "cityEnNm", "cityArNm", "cityCd");
+                                "cityEnNm", "cityArNm", "cityCd");
                 final Pageable pg = (pageable == null || !pageable.isPaged()
                                 ? Pageable.unpaged()
                                 : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort));

--- a/lms-setup/src/main/java/com/lms/setup/service/impl/CountryServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/CountryServiceImpl.java
@@ -82,7 +82,7 @@ public class CountryServiceImpl implements CountryService {
     @Audited(action = AuditAction.READ, entity = "Country", dataClass = DataClass.HEALTH, message = "List countries")
     public BaseResponse<?> list(Pageable pageable, String q, boolean unpaged) {
         Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
-                "countryEnNm", "countryEnNm", "countryArNm", "countryCd");
+                "countryEnNm", "countryArNm", "countryCd");
         Pageable pg = (pageable == null || !pageable.isPaged()
                 ? Pageable.unpaged()
                 : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort));

--- a/lms-setup/src/main/java/com/lms/setup/service/impl/ResourceServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/ResourceServiceImpl.java
@@ -123,7 +123,7 @@ public class ResourceServiceImpl implements ResourceService {
     public BaseResponse<Page<ResourceDto>> list(Pageable pageable, String q, boolean unpaged) {
         try {
             Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
-                    "resourceEnNm", "resourceEnNm", "resourceArNm", "resourceCd");
+                    "resourceEnNm", "resourceArNm", "resourceCd");
             Pageable pg = (pageable == null || !pageable.isPaged()
                     ? Pageable.unpaged()
                     : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort));

--- a/lms-setup/src/main/java/com/lms/setup/service/impl/SystemParameterServiceImpl.java
+++ b/lms-setup/src/main/java/com/lms/setup/service/impl/SystemParameterServiceImpl.java
@@ -104,7 +104,7 @@ public class SystemParameterServiceImpl implements SystemParameterService {
     public BaseResponse<Page<SystemParameter>> list(Pageable pageable, String group, Boolean onlyActive) {
         try {
             Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
-                    "paramKey", "paramKey", "paramGroup", "paramValue");
+                    "paramKey", "paramGroup", "paramValue");
             Pageable pg = (pageable == null || !pageable.isPaged()
                     ? Pageable.unpaged()
                     : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort));

--- a/shared-lib/shared-common/src/main/java/com/common/sort/SortUtils.java
+++ b/shared-lib/shared-common/src/main/java/com/common/sort/SortUtils.java
@@ -6,7 +6,9 @@ import org.springframework.data.domain.Sort;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Utility methods for sanitising {@link Sort} and {@link Pageable} instances.
@@ -25,12 +27,14 @@ public final class SortUtils {
      *
      * @param sort            sort to sanitize
      * @param defaultProperty property to use when sort is empty or invalid
-     * @param allowedProps    properties allowed for sorting
+     * @param allowedProps    properties allowed for sorting; {@code defaultProperty}
+     *                        is always considered allowed
      * @return sanitized Sort never {@code null}
      */
     public static Sort sanitize(Sort sort, String defaultProperty, String... allowedProps) {
         Sort safeSort = sort == null ? Sort.unsorted() : sort;
-        List<String> allowed = Arrays.asList(allowedProps);
+        Set<String> allowed = new HashSet<>(Arrays.asList(allowedProps));
+        allowed.add(defaultProperty);
         List<Sort.Order> orders = new ArrayList<>();
         safeSort.stream()
                 .filter(order -> allowed.isEmpty() || allowed.contains(order.getProperty()))

--- a/shared-lib/shared-common/src/test/java/com/common/sort/SortUtilsTest.java
+++ b/shared-lib/shared-common/src/test/java/com/common/sort/SortUtilsTest.java
@@ -9,7 +9,7 @@ class SortUtilsTest {
     @Test
     void sanitize_invalidPropertyFallsBackToDefault() {
         Sort invalid = Sort.by("unknown");
-        Sort sanitized = SortUtils.sanitize(invalid, "name", "name");
+        Sort sanitized = SortUtils.sanitize(invalid, "name");
         assertEquals("name", sanitized.stream().findFirst().orElseThrow().getProperty());
     }
 }


### PR DESCRIPTION
## Summary
- ensure SortUtils always permits its default property to be sorted
- simplify service layer sort calls in city, country, resource and system parameter services
- update SortUtils test accordingly

## Testing
- `mvn -q -pl shared-common test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3 from/to central: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM for com.lms:lms-setup: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b3a762d4832f90b70e6fbf7a2fd8