### PR TITLE
feat: populate audit tenant id

### DIFF
--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/api/DefaultTenantProvider.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/api/DefaultTenantProvider.java
@@ -1,8 +1,20 @@
 package com.shared.audit.starter.api;
 
+import com.common.context.ContextManager;
+
+/**
+ * Default {@link TenantProvider} implementation that resolves the tenant
+ * identifier from the shared {@link ContextManager}. The context is typically
+ * populated by HTTP filters or other infrastructure components when a request
+ * enters the application.
+ */
 public class DefaultTenantProvider implements TenantProvider {
-	@Override
-	public String getTenantId() {
-		return null;
-	}
+
+    /**
+     * Return the current tenant identifier or {@code null} if none is set.
+     */
+    @Override
+    public String getTenantId() {
+        return ContextManager.Tenant.get();
+    }
 }


### PR DESCRIPTION
## Summary
- resolve tenant ID from ContextManager so audit entries record the tenant

## Testing
- `mvn -q -pl shared-starters/starter-audit -am test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cb92e1e0832fa44fae90cbb6e557