### PR TITLE
Include tenant ID in responses and audit logs

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
@@ -1,5 +1,7 @@
 package com.common.dto;
+
 import com.common.context.CorrelationContextUtil;
+import com.common.context.ContextManager;
 import com.common.enums.StatusEnums.ApiStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nullable;
@@ -37,11 +39,14 @@ public class BaseResponse<T> {
 
     /** Timestamp of response */
     @Builder.Default
-    private Instant timestamp = Instant.now(); 
+    private Instant timestamp = Instant.now();
   /** Correlation identifier for tracking across services */
 
     /** Correlation identifier for tracking across services */
     private String correlationId;
+
+    /** Tenant identifier for multi-tenancy */
+    private String tenantId;
 
     @JsonProperty("correlationId")
     public String getCorrelationId() {
@@ -50,6 +55,14 @@ public class BaseResponse<T> {
         }
 
         return correlationId;
+    }
+
+    @JsonProperty("tenantId")
+    public String getTenantId() {
+        if (tenantId == null || tenantId.isBlank()) {
+            tenantId = ContextManager.Tenant.get();
+        }
+        return tenantId;
     }
 
     // ===== Static builders (nice usability) =====

--- a/shared-lib/shared-common/src/test/java/com/common/dto/BaseResponseTest.java
+++ b/shared-lib/shared-common/src/test/java/com/common/dto/BaseResponseTest.java
@@ -1,5 +1,6 @@
 package com.common.dto;
 
+import com.common.context.ContextManager;
 import com.common.enums.StatusEnums.ApiStatus;
 import org.junit.jupiter.api.Test;
 
@@ -68,5 +69,13 @@ class BaseResponseTest {
 
         assertNull(mapped.getData());
         assertEquals(original.getCode(), mapped.getCode());
+    }
+
+    @Test
+    void tenantIdDefaultsFromContext() {
+        try (ContextManager.Tenant.Scope ignore = ContextManager.Tenant.openScope("tenantA")) {
+            BaseResponse<Void> r = new BaseResponse<>();
+            assertEquals("tenantA", r.getTenantId());
+        }
     }
 }

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/tenant/TenantFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/tenant/TenantFilter.java
@@ -35,18 +35,16 @@ public class TenantFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
             throws ServletException, IOException {
-
-        try {
-            String tenant = resolver.resolve(req);
-            if (tenant != null) {
-                ContextManager.Tenant.set(tenant);
-                if (cfg.isEchoResponseHeader()) {
-                    res.setHeader(cfg.getHeaderName(), tenant);
-                }
+        String tenant = resolver.resolve(req);
+        if (tenant != null) {
+            if (cfg.isEchoResponseHeader()) {
+                res.setHeader(cfg.getHeaderName(), tenant);
             }
+            try (ContextManager.Tenant.Scope ignored = ContextManager.Tenant.openScope(tenant)) {
+                chain.doFilter(req, res);
+            }
+        } else {
             chain.doFilter(req, res);
-        } finally {
-        	ContextManager.Tenant.clear();
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose tenantId in BaseResponse so API responses include current tenant
- preserve tenant context in TenantFilter using scoped approach to ensure audit events persist tenant data
- add unit test covering tenantId defaulting from context

## Testing
- `mvn -f shared-lib/pom.xml -q -pl shared-common,shared-starters/starter-core -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b548150bb0832fa17d6ae4d395be3d