### PR TITLE
Propagate tenant id from JWT token

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/JwtTenantFilter.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/JwtTenantFilter.java
@@ -1,6 +1,7 @@
 package com.shared.starter_security;
 
 import com.common.context.ContextManager;
+import com.common.constants.HeaderNames;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpFilter;
@@ -30,12 +31,14 @@ class JwtTenantFilter extends HttpFilter {
                 Jwt jwt = jwtAuth.getToken();
                 Object tid = jwt.getClaims().get(tenantClaim);
                 if (tid != null) {
-                	ContextManager.Tenant.set((String.valueOf(tid)));
+                        String tenant = String.valueOf(tid);
+                        ContextManager.Tenant.set(tenant);
+                        response.setHeader(HeaderNames.TENANT_ID, tenant);
                 }
             }
             chain.doFilter(request, response);
         } finally {
-        	ContextManager.Tenant.clear();
+                ContextManager.Tenant.clear();
         }
     }
 }

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/JwtTenantFilterTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/JwtTenantFilterTest.java
@@ -1,0 +1,45 @@
+package com.shared.starter_security;
+
+import com.common.constants.HeaderNames;
+import com.common.context.ContextManager;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtTenantFilterTest {
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+        ContextManager.Tenant.clear();
+    }
+
+    @Test
+    void setsTenantFromJwtAndEchoesHeader() throws ServletException, IOException {
+        Jwt jwt = new Jwt("token", Instant.now(), Instant.now().plusSeconds(60), Map.of("alg","none"), Map.of("tenant","acme"));
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
+
+        JwtTenantFilter filter = new JwtTenantFilter("tenant");
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        FilterChain chain = (request, response) -> assertEquals("acme", ContextManager.Tenant.get());
+
+        filter.doFilter(req, res, chain);
+
+        assertEquals("acme", res.getHeader(HeaderNames.TENANT_ID));
+        assertNull(ContextManager.Tenant.get());
+    }
+}


### PR DESCRIPTION
## Summary
- Echo tenant id from JWT into response headers via `JwtTenantFilter`
- Cover tenant propagation with new unit test

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b54e7e2cb4832f984fe86fecabe027