### PR TITLE
feat: add JWT token service to shared library

### DIFF
--- a/shared-lib/shared-lib-crypto/pom.xml
+++ b/shared-lib/shared-lib-crypto/pom.xml
@@ -45,11 +45,27 @@
 			<optional>true</optional>
 		</dependency>
 
-		<!-- Depend on core shared utilities -->
-		<dependency>
-			<groupId>com.lms</groupId>
-			<artifactId>shared-common</artifactId>
-		</dependency>
+                <!-- Depend on core shared utilities -->
+                <dependency>
+                        <groupId>com.lms</groupId>
+                        <artifactId>shared-common</artifactId>
+                </dependency>
+
+                <!-- JJWT for JWT token creation -->
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-api</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-impl</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-jackson</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
 
 		<!-- Testing: JUnit 5 -->
 		<dependency>

--- a/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenService.java
+++ b/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenService.java
@@ -1,0 +1,64 @@
+package com.shared.crypto;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Simple service for creating HS256 signed JWT tokens.
+ */
+public class JwtTokenService {
+
+    private final SecretKey secretKey;
+
+    public JwtTokenService(SecretKey secretKey) {
+        this.secretKey = Objects.requireNonNull(secretKey, "secretKey");
+    }
+
+    /**
+     * Create a JWT with the given subject, tenant and roles.
+     *
+     * @param subject the subject (sub) claim
+     * @param tenant  tenant identifier
+     * @param roles   roles assigned to the subject
+     * @param claims  additional claims, may be null
+     * @param ttl     token time-to-live
+     * @return compact JWT string
+     */
+    public String createToken(String subject, String tenant, List<String> roles, Map<String, Object> claims, Duration ttl) {
+        Objects.requireNonNull(subject, "subject");
+        Objects.requireNonNull(tenant, "tenant");
+        Objects.requireNonNull(roles, "roles");
+        Objects.requireNonNull(ttl, "ttl");
+        Instant now = Instant.now();
+        JwtBuilder builder = Jwts.builder()
+                .subject(subject)
+                .claim("tenant", tenant)
+                .claim("roles", roles)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(ttl)));
+        if (claims != null && !claims.isEmpty()) {
+            claims.forEach(builder::claim);
+        }
+        return builder
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    /**
+     * Convenience factory creating service from a raw UTF-8 secret.
+     */
+    public static JwtTokenService withSecret(String secret) {
+        Objects.requireNonNull(secret, "secret");
+        SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        return new JwtTokenService(key);
+    }
+}

--- a/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenServiceTest.java
+++ b/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenServiceTest.java
@@ -1,0 +1,32 @@
+package com.shared.crypto;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtTokenServiceTest {
+
+    @Test
+    void createTokenIncludesTenantAndRoles() {
+        SecretKey key = Keys.hmacShaKeyFor("01234567890123456789012345678901".getBytes(StandardCharsets.UTF_8));
+        JwtTokenService service = new JwtTokenService(key);
+        Map<String, Object> claims = Map.of("custom", "value");
+        List<String> roles = List.of("admin", "user");
+        String token = service.createToken("user", "tenant1", roles, claims, Duration.ofMinutes(5));
+        assertNotNull(token);
+
+        var parsed = Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+        assertEquals("user", parsed.getPayload().getSubject());
+        assertEquals("tenant1", parsed.getPayload().get("tenant"));
+        assertEquals(roles, parsed.getPayload().get("roles", List.class));
+        assertEquals("value", parsed.getPayload().get("custom"));
+    }
+}


### PR DESCRIPTION
## Summary
- add dependencies for JJWT to shared crypto module
- implement JwtTokenService for generating HS256 JWTs
- cover token generation with unit tests
- extend token service to include tenant and roles claims

## Testing
- `mvn -f shared-lib/pom.xml -pl shared-lib-crypto test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b54992117c832f889cce37ae148b63