### PR TITLE
Add JWT token auto-configuration and properties

### DIFF
--- a/shared-lib/shared-lib-crypto/pom.xml
+++ b/shared-lib/shared-lib-crypto/pom.xml
@@ -46,10 +46,26 @@
 		</dependency>
 
 		<!-- Depend on core shared utilities -->
-		<dependency>
-			<groupId>com.lms</groupId>
-			<artifactId>shared-common</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>com.lms</groupId>
+                        <artifactId>shared-common</artifactId>
+                </dependency>
+
+                <!-- JWT support -->
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-api</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-impl</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-jackson</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
 
 		<!-- Testing: JUnit 5 -->
 		<dependency>

--- a/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenAutoConfiguration.java
+++ b/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenAutoConfiguration.java
@@ -1,0 +1,15 @@
+package com.shared.crypto;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@EnableConfigurationProperties(JwtTokenProperties.class)
+public class JwtTokenAutoConfiguration {
+
+    @Bean
+    public JwtTokenService jwtTokenService(JwtTokenProperties props) {
+        return JwtTokenService.withSecret(props.getSecret());
+    }
+}

--- a/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenProperties.java
+++ b/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenProperties.java
@@ -1,0 +1,21 @@
+package com.shared.crypto;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties("shared.security.jwt")
+public class JwtTokenProperties {
+
+    @NotBlank
+    private String secret;
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+}

--- a/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenService.java
+++ b/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenService.java
@@ -1,0 +1,44 @@
+package com.shared.crypto;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+
+/**
+ * Simple JWT token generator using an HMAC-SHA256 secret.
+ */
+public class JwtTokenService {
+
+    private final SecretKey key;
+
+    private JwtTokenService(SecretKey key) {
+        this.key = key;
+    }
+
+    /**
+     * Create a service instance using the provided shared secret.
+     *
+     * @param secret the HMAC secret
+     * @return configured service
+     */
+    public static JwtTokenService withSecret(String secret) {
+        SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        return new JwtTokenService(key);
+    }
+
+    /**
+     * Generate a JWT token with the given subject.
+     *
+     * @param subject the subject claim value
+     * @return signed JWT token
+     */
+    public String generateToken(String subject) {
+        return Jwts.builder()
+                .subject(subject)
+                .issuedAt(new Date())
+                .signWith(key, Jwts.SIG.HS256)
+                .compact();
+    }
+}

--- a/shared-lib/shared-lib-crypto/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/shared-lib/shared-lib-crypto/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.shared.crypto.JwtTokenAutoConfiguration

--- a/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenAutoConfigurationTest.java
+++ b/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenAutoConfigurationTest.java
@@ -1,0 +1,29 @@
+package com.shared.crypto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(properties = "shared.security.jwt.secret=01234567890123456789012345678901")
+class JwtTokenAutoConfigurationTest {
+
+    @Autowired
+    private JwtTokenService jwtTokenService;
+
+    @Test
+    void beanLoadsAndGeneratesToken() {
+        String token = jwtTokenService.generateToken("alice");
+        SecretKey key = Keys.hmacShaKeyFor("01234567890123456789012345678901".getBytes(StandardCharsets.UTF_8));
+        Claims claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+        assertEquals("alice", claims.getSubject());
+    }
+}


### PR DESCRIPTION
## Summary
- add `JwtTokenProperties` for configuring JWT secret
- auto-configure `JwtTokenService` bean via `JwtTokenAutoConfiguration`
- register auto-configuration and provide tests for token generation

## Testing
- `mvn -q -pl shared-lib-crypto -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5505bc5c8832f8869dcefa378f34d