### PR TITLE
Fix SystemParameterControllerTest mapping

### DIFF
--- a/lms-setup/src/test/java/com/lms/setup/controller/SystemParameterControllerTest.java
+++ b/lms-setup/src/test/java/com/lms/setup/controller/SystemParameterControllerTest.java
@@ -6,7 +6,7 @@ import com.lms.setup.service.SystemParameterService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(controllers = SystemParameterController.class)
+@SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 class SystemParameterControllerTest {


### PR DESCRIPTION
## Summary
- load full Spring context in SystemParameterControllerTest so controller mappings are available

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5510d93b0832fb14fc2be20eb3ba5