### PR TITLE
Add validation dependency to crypto module

### DIFF
--- a/shared-lib/shared-lib-crypto/pom.xml
+++ b/shared-lib/shared-lib-crypto/pom.xml
@@ -45,10 +45,17 @@
 			<optional>true</optional>
 		</dependency>
 
-		<!-- Depend on core shared utilities -->
+                <!-- Depend on core shared utilities -->
                 <dependency>
                         <groupId>com.lms</groupId>
                         <artifactId>shared-common</artifactId>
+                </dependency>
+
+                <!-- Jakarta Bean Validation annotations used by JwtTokenProperties -->
+                <dependency>
+                        <groupId>jakarta.validation</groupId>
+                        <artifactId>jakarta.validation-api</artifactId>
+                        <optional>true</optional>
                 </dependency>
 
                 <!-- JWT support -->


### PR DESCRIPTION
## Summary
- include jakarta validation API in crypto library so `JwtTokenProperties` compiles

## Testing
- `mvn -pl shared-lib-crypto test` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b552fe55f4832fbfe262ea49aaa106