### PR TITLE
feat: enhance JWT token service

### DIFF
--- a/shared-lib/shared-lib-crypto/pom.xml
+++ b/shared-lib/shared-lib-crypto/pom.xml
@@ -74,13 +74,18 @@
                         <scope>runtime</scope>
                 </dependency>
 
-		<!-- Testing: JUnit 5 -->
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <!-- Testing: JUnit 5 -->
+                <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenService.java
+++ b/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenService.java
@@ -3,7 +3,11 @@ package com.shared.crypto;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import javax.crypto.SecretKey;
 
 /**
@@ -41,5 +45,37 @@ public class JwtTokenService {
                 .signWith(key, Jwts.SIG.HS256)
                 .compact();
 
+    }
+
+    /**
+     * Create a JWT token with additional claims and metadata.
+     *
+     * @param subject the subject claim value
+     * @param tenant tenant identifier to include as a claim
+     * @param roles list of role names
+     * @param extraClaims additional arbitrary claims
+     * @param ttl token time-to-live
+     * @return signed JWT token
+     */
+    public String createToken(String subject, String tenant, List<String> roles,
+            Map<String, Object> extraClaims, Duration ttl) {
+        var builder = Jwts.builder()
+                .subject(subject)
+                .issuedAt(new Date())
+                .signWith(key, Jwts.SIG.HS256);
+
+        if (tenant != null) {
+            builder.claim("tenant", tenant);
+        }
+        if (roles != null && !roles.isEmpty()) {
+            builder.claim("roles", roles);
+        }
+        if (extraClaims != null && !extraClaims.isEmpty()) {
+            extraClaims.forEach(builder::claim);
+        }
+        if (ttl != null) {
+            builder.expiration(Date.from(Instant.now().plus(ttl)));
+        }
+        return builder.compact();
     }
 }

--- a/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenServiceTest.java
+++ b/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenServiceTest.java
@@ -16,8 +16,9 @@ class JwtTokenServiceTest {
 
     @Test
     void createTokenIncludesTenantAndRoles() {
-        SecretKey key = Keys.hmacShaKeyFor("01234567890123456789012345678901".getBytes(StandardCharsets.UTF_8));
-        JwtTokenService service = new JwtTokenService(key);
+        String secret = "01234567890123456789012345678901";
+        SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        JwtTokenService service = JwtTokenService.withSecret(secret);
         Map<String, Object> claims = Map.of("custom", "value");
         List<String> roles = List.of("admin", "user");
         String token = service.createToken("user", "tenant1", roles, claims, Duration.ofMinutes(5));


### PR DESCRIPTION
## Summary
- extend JwtTokenService with new createToken allowing custom claims, roles, tenant, and expiration
- cover advanced token creation with updated JwtTokenServiceTest
- add spring-boot-starter-test dependency for auto-configuration tests

## Testing
- `mvn -q -pl shared-lib-crypto -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b554057a28832fa0777b7a4bf65ff0