### PR TITLE
Fix JWT auto-configuration test initialization

### DIFF
--- a/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenAutoConfigurationTest.java
+++ b/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenAutoConfigurationTest.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest
+@SpringBootTest(classes = JwtTokenAutoConfiguration.class)
 @TestPropertySource(properties = "shared.security.jwt.secret=01234567890123456789012345678901")
 class JwtTokenAutoConfigurationTest {
 


### PR DESCRIPTION
## Summary
- specify JwtTokenAutoConfiguration when bootstrapping JwtTokenAutoConfigurationTest

## Testing
- `mvn -q -pl shared-lib-crypto -am test` *(fails: Non-resolvable import POM: spring-boot-dependencies 3.3.3, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5553c09d8832fa162a08aff78b9e1