### PR TITLE
Document shared libraries with READMEs

### DIFF
--- a/shared-lib/shared-bom/README.md
+++ b/shared-lib/shared-bom/README.md
@@ -1,0 +1,27 @@
+# shared-bom
+
+Bill of Materials (BOM) providing aligned dependency versions for LMS services.
+
+## Use cases
+- Keep dependency versions consistent across modules.
+- Simplify dependency upgrades by centralizing version numbers.
+- Provide a single source of approved library versions.
+
+## Usage
+Import the BOM in your project's `dependencyManagement` section:
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.lms</groupId>
+      <artifactId>shared-bom</artifactId>
+      <version>1.0.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+```
+
+After importing you can omit versions for dependencies managed by the BOM.

--- a/shared-lib/shared-common/README.md
+++ b/shared-lib/shared-common/README.md
@@ -1,0 +1,26 @@
+# shared-common
+
+Reusable utilities, DTOs, constants and exception types used across services.
+
+## Use cases
+- Standard API response wrappers (`BaseResponse`, `ErrorResponse`).
+- Context propagation helpers and request metadata.
+- Utility classes for JSON, dates, strings, sorting and masking.
+- Common exception hierarchy for consistent error handling.
+
+## Usage
+Add the dependency:
+
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>shared-common</artifactId>
+</dependency>
+```
+
+Example:
+
+```java
+BaseResponse<CustomerDto> resp = BaseResponse.success(dto);
+String json = JsonUtils.toJson(resp);
+```

--- a/shared-lib/shared-config/README.md
+++ b/shared-lib/shared-config/README.md
@@ -1,0 +1,26 @@
+# shared-config
+
+Auto-configuration that exposes environment and application properties.
+
+## Use cases
+- Bind environment details such as region and stage via `EnvironmentProperties`.
+- Provide `AppProperties` for application name and version.
+- Automatically log active profiles and environment at startup.
+
+## Usage
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>shared-config</artifactId>
+</dependency>
+```
+
+Example `application.yml`:
+
+```yaml
+shared:
+  env: dev
+  app:
+    name: orders-service
+    version: 1.0.0
+```

--- a/shared-lib/shared-lib-crypto/README.md
+++ b/shared-lib/shared-lib-crypto/README.md
@@ -1,0 +1,32 @@
+# shared-lib-crypto
+
+Cryptography utilities and JWT token support.
+
+## Use cases
+- AES-GCM encryption/decryption with `CryptoFacade`.
+- HMAC SHA-256 signing helpers.
+- JWT token generation and validation with Spring Boot auto-configuration.
+
+## Usage
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>shared-lib-crypto</artifactId>
+</dependency>
+```
+
+Example properties:
+
+```yaml
+shared:
+  crypto:
+    jwt:
+      secret: top-secret-key
+```
+
+Example usage:
+
+```java
+String token = jwtTokenService.generateToken(claims);
+byte[] cipher = cryptoService.encrypt("data");
+```

--- a/shared-lib/shared-quality/README.md
+++ b/shared-lib/shared-quality/README.md
@@ -1,0 +1,22 @@
+# shared-quality
+
+Centralized Checkstyle and quality configuration for LMS projects.
+
+## Use cases
+- Enforce consistent code style across repositories.
+- Share suppression rules and Checkstyle configuration.
+- Reference in build plugins to apply the same rules everywhere.
+
+## Usage
+Reference the configuration in your Maven build:
+
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-checkstyle-plugin</artifactId>
+  <configuration>
+    <configLocation>shared-quality/checkstyle.xml</configLocation>
+    <suppressionsLocation>shared-quality/suppressions.xml</suppressionsLocation>
+  </configuration>
+</plugin>
+```

--- a/shared-lib/shared-starters/README.md
+++ b/shared-lib/shared-starters/README.md
@@ -1,0 +1,32 @@
+# shared-starters
+
+Collection of Spring Boot starters that provide common infrastructure for LMS services.
+
+## Available starters
+- **starter-actuator** – opinionated actuator endpoints.
+- **starter-audit** – pluggable audit logging.
+- **starter-core** – core web and logging infrastructure.
+- **starter-crypto** – crypto service auto-configuration.
+- **starter-data** – JPA helpers and multi-tenant support.
+- **starter-headers** – standardize HTTP headers.
+- **starter-health** – generic health endpoints.
+- **starter-kafka** – Kafka producers/consumers with idempotency.
+- **starter-mapstruct** – shared MapStruct configuration and mappers.
+- **starter-money-time** – money and time helpers.
+- **starter-observability** – logging and metrics defaults.
+- **starter-openapi** – Springdoc OpenAPI wiring.
+- **starter-ratelimit** – bucket-based rate limiting filter.
+- **starter-redis** – Redis connection, cache and session support.
+- **starter-resilience** – Resilience4j defaults.
+- **starter-security** – JWT resource server defaults.
+- **starter-validation** – extra Bean Validation constraints.
+
+## Usage
+Add the desired starter as a dependency. For example:
+
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>starter-core</artifactId>
+</dependency>
+```

--- a/shared-lib/shared-starters/starter-actuator/README.md
+++ b/shared-lib/shared-starters/starter-actuator/README.md
@@ -7,3 +7,13 @@ Spring Boot Actuator starter with:
 - Http exchanges repository (optional)
 - Actuator-only security chain (optional)
 - Custom endpoint: /actuator/whoami
+
+## Usage
+Add the dependency:
+
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>starter-actuator</artifactId>
+</dependency>
+```

--- a/shared-lib/shared-starters/starter-core/README.md
+++ b/shared-lib/shared-starters/starter-core/README.md
@@ -1,0 +1,21 @@
+# starter-core
+
+Fundamental web infrastructure for LMS services.
+
+## Use cases
+- Global exception handling and standardized API responses.
+- JSON configuration and performance optimizations.
+- Correlation ID and tenant context filters.
+- Utility beans such as `SpringContextHolder` and `DefaultTenantResolver`.
+
+## Usage
+Add the dependency:
+
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>starter-core</artifactId>
+</dependency>
+```
+
+Example: annotate controllers with `@RequireTenant` to enforce tenant headers.

--- a/shared-lib/shared-starters/starter-crypto/README.md
+++ b/shared-lib/shared-starters/starter-crypto/README.md
@@ -1,0 +1,25 @@
+# starter-crypto
+
+Auto-configures crypto services and metrics.
+
+## Use cases
+- Provides `CryptoService` and `JwtTokenService` beans.
+- MDC filter to log encryption identifiers.
+- Optional in-memory key provider for development.
+
+## Usage
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>starter-crypto</artifactId>
+</dependency>
+```
+
+Example properties:
+
+```yaml
+shared:
+  crypto:
+    jwt:
+      secret: top-secret-key
+```

--- a/shared-lib/shared-starters/starter-data/README.md
+++ b/shared-lib/shared-starters/starter-data/README.md
@@ -1,0 +1,19 @@
+# starter-data
+
+JPA and data-layer helpers with multi-tenancy support.
+
+## Use cases
+- Base entity classes (`BaseEntity`, `SoftDeleteEntity`).
+- Tenant filtering via Hibernate and annotations.
+- Pagination helpers for API responses.
+- Auto configuration for clock and tenant properties.
+
+## Usage
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>starter-data</artifactId>
+</dependency>
+```
+
+Entities can extend `BaseEntity` and use `@TenantScoped` to apply tenant filters.

--- a/shared-lib/shared-starters/starter-headers/README.md
+++ b/shared-lib/shared-starters/starter-headers/README.md
@@ -9,3 +9,11 @@
 - Support Forwarded/Proxy headers when behind a reverse proxy.
 
 Add the dependency and you get consistent IDs and security headers across all services.
+
+## Usage
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>starter-headers</artifactId>
+</dependency>
+```

--- a/shared-lib/shared-starters/starter-health/README.md
+++ b/shared-lib/shared-starters/starter-health/README.md
@@ -1,3 +1,16 @@
 # Shared Starter - Health
 
 Provides generic health endpoints for LMS services.
+
+## Use cases
+- Standard `/health` checks for databases and dependencies.
+
+## Usage
+Add the dependency:
+
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>starter-health</artifactId>
+</dependency>
+```

--- a/shared-lib/shared-starters/starter-kafka/README.md
+++ b/shared-lib/shared-starters/starter-kafka/README.md
@@ -1,0 +1,25 @@
+# starter-kafka
+
+Convenience auto-configuration for Kafka producers and consumers.
+
+## Use cases
+- Opinionated producer/consumer configs with JSON serde.
+- Topic naming helpers and envelope wrapper.
+- Idempotent listener with pluggable store.
+- Observability integration.
+
+## Usage
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>starter-kafka</artifactId>
+</dependency>
+```
+
+Example properties:
+
+```yaml
+shared:
+  kafka:
+    bootstrap-servers: localhost:9092
+```

--- a/shared-lib/shared-starters/starter-observability/README.md
+++ b/shared-lib/shared-starters/starter-observability/README.md
@@ -1,0 +1,16 @@
+# starter-observability
+
+Sets up logging and metrics using Micrometer and OpenTelemetry.
+
+## Use cases
+- Preconfigured `logback-spring.xml` with trace/span IDs.
+- Auto-configures Micrometer exporters.
+- Enables default tracing for HTTP clients and servers.
+
+## Usage
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>starter-observability</artifactId>
+</dependency>
+```

--- a/shared-lib/shared-starters/starter-ratelimit/README.md
+++ b/shared-lib/shared-starters/starter-ratelimit/README.md
@@ -1,0 +1,25 @@
+# starter-ratelimit
+
+Bucket4j-based rate limiting filter.
+
+## Use cases
+- Apply IP or tenant based rate limits.
+- Configure limits and window durations via properties.
+
+## Usage
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>starter-ratelimit</artifactId>
+</dependency>
+```
+
+Example properties:
+
+```yaml
+shared:
+  ratelimit:
+    enabled: true
+    capacity: 100
+    refill-period: 1m
+```

--- a/shared-lib/shared-starters/starter-redis/README.md
+++ b/shared-lib/shared-starters/starter-redis/README.md
@@ -24,3 +24,11 @@ Beans:
 - `RedisTemplate<String,String>` (named: `stringRedisTemplate`)
 - `RedisCacheManager` (with TTL & prefix)
 - Optional Spring Session via `@EnableRedisHttpSession` when on classpath
+
+## Usage
+```xml
+<dependency>
+  <groupId>com.lms</groupId>
+  <artifactId>starter-redis</artifactId>
+</dependency>
+```


### PR DESCRIPTION
## Summary
- add README files for shared libraries (BOM, common utilities, config, crypto, quality, starters)
- document core starter modules with usage instructions
- enhance existing starter docs with dependency examples

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b55583c764832f86704ddcd283516a