### PR TITLE
feat(jwt): add token period support

### DIFF
--- a/lms-setup/src/main/resources/application-dev.yaml
+++ b/lms-setup/src/main/resources/application-dev.yaml
@@ -176,15 +176,18 @@ shared:
       activeKid: ${CRYPTO_ACTIVE_KID:local-dev-key}
       keys:
         local-dev-key: ${CRYPTO_LOCAL_DEV_KEY:4J8bfqUaEqzJCQakoJPM3w==}
-  security:
-    mode: hs256
-    hs256:
-      secret: ${JWT_SECRET:dev-secret}
-    resource-server:
-      enabled: true
-      permit-all:
-        - "/**"
-      disable-csrf: true
+    security:
+      mode: hs256
+      jwt:
+        secret: ${JWT_SECRET:dev-secret}
+        token-period: 15m
+      hs256:
+        secret: ${JWT_SECRET:dev-secret}
+      resource-server:
+        enabled: true
+        permit-all:
+          - "/**"
+        disable-csrf: true
       stateless: true
     roles-claim: roles
     tenant-claim: tenant

--- a/lms-setup/src/main/resources/application.yaml
+++ b/lms-setup/src/main/resources/application.yaml
@@ -29,3 +29,5 @@ shared:
     application-name: lms-setup
   security:
     enable-role-check: true
+    jwt:
+      token-period: 15m

--- a/lms-setup/src/test/resources/application-test.yml
+++ b/lms-setup/src/test/resources/application-test.yml
@@ -51,3 +51,6 @@ logging:
 shared:
   security:
     enable-role-check: false
+    jwt:
+      secret: test-secret
+      token-period: 5m

--- a/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenAutoConfiguration.java
+++ b/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenAutoConfiguration.java
@@ -10,6 +10,6 @@ public class JwtTokenAutoConfiguration {
 
     @Bean
     public JwtTokenService jwtTokenService(JwtTokenProperties props) {
-        return JwtTokenService.withSecret(props.getSecret());
+        return JwtTokenService.withSecret(props.getSecret(), props.getTokenPeriod());
     }
 }

--- a/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenProperties.java
+++ b/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenProperties.java
@@ -1,8 +1,10 @@
 package com.shared.crypto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+import java.time.Duration;
 
 @Validated
 @ConfigurationProperties("shared.security.jwt")
@@ -11,11 +13,22 @@ public class JwtTokenProperties {
     @NotBlank
     private String secret;
 
+    @NotNull
+    private Duration tokenPeriod;
+
     public String getSecret() {
         return secret;
     }
 
     public void setSecret(String secret) {
         this.secret = secret;
+    }
+
+    public Duration getTokenPeriod() {
+        return tokenPeriod;
+    }
+
+    public void setTokenPeriod(Duration tokenPeriod) {
+        this.tokenPeriod = tokenPeriod;
     }
 }

--- a/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenAutoConfigurationTest.java
+++ b/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenAutoConfigurationTest.java
@@ -1,6 +1,7 @@
 package com.shared.crypto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -13,7 +14,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
-@TestPropertySource(properties = "shared.security.jwt.secret=01234567890123456789012345678901")
+@TestPropertySource(properties = {
+        "shared.security.jwt.secret=01234567890123456789012345678901",
+        "shared.security.jwt.token-period=PT5M"
+})
 class JwtTokenAutoConfigurationTest {
 
     @Autowired
@@ -25,5 +29,6 @@ class JwtTokenAutoConfigurationTest {
         SecretKey key = Keys.hmacShaKeyFor("01234567890123456789012345678901".getBytes(StandardCharsets.UTF_8));
         Claims claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
         assertEquals("alice", claims.getSubject());
+        assertNotNull(claims.getExpiration());
     }
 }

--- a/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenServiceTest.java
+++ b/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenServiceTest.java
@@ -18,7 +18,7 @@ class JwtTokenServiceTest {
     void createTokenIncludesTenantAndRoles() {
         String secret = "01234567890123456789012345678901";
         SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
-        JwtTokenService service = JwtTokenService.withSecret(secret);
+        JwtTokenService service = JwtTokenService.withSecret(secret, null);
         Map<String, Object> claims = Map.of("custom", "value");
         List<String> roles = List.of("admin", "user");
         String token = service.createToken("user", "tenant1", roles, claims, Duration.ofMinutes(5));


### PR DESCRIPTION
## Summary
- support configurable token-period for JWTs via new property
- apply default expiration when generating tokens

## Testing
- `cd shared-lib && mvn -q test` *(fails: Network is unreachable)*
- `cd lms-setup && mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b554c06e6c832fa58626329ad1bb58