### PR TITLE
Use WebMvcTest for SystemParameterControllerTest

### DIFF
--- a/lms-setup/src/test/java/com/lms/setup/controller/SystemParameterControllerTest.java
+++ b/lms-setup/src/test/java/com/lms/setup/controller/SystemParameterControllerTest.java
@@ -6,7 +6,7 @@ import com.lms.setup.service.SystemParameterService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
+@WebMvcTest(controllers = SystemParameterController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 class SystemParameterControllerTest {


### PR DESCRIPTION
## Summary
- run SystemParameterController tests using WebMvcTest to avoid full application context and DB startup

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.lms:lms-setup:1.0.0 due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5591f0620832fa1be6f83f3b2f405