### PR TITLE
Fix JwtTokenAutoConfiguration test configuration

### DIFF
--- a/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenAutoConfigurationTest.java
+++ b/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenAutoConfigurationTest.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest
+@SpringBootTest(classes = JwtTokenAutoConfiguration.class)
 @TestPropertySource(properties = {
         "shared.security.jwt.secret=01234567890123456789012345678901",
         "shared.security.jwt.token-period=PT5M"


### PR DESCRIPTION
## Summary
- specify auto-configuration class for JwtTokenAutoConfigurationTest

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: com.lms:shared-bom:1.0.0 network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b559a0c9a0832fbae81dca282cad15