### PR TITLE
Improve JWT decoder configuration handling

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/JwtDecoderAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/JwtDecoderAutoConfiguration.java
@@ -1,19 +1,31 @@
 package com.shared.starter_security;
+
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
-import javax.crypto.spec.SecretKeySpec; import javax.crypto.SecretKey;
+import org.springframework.util.Assert;
+
 @AutoConfiguration
 @EnableConfigurationProperties(SharedSecurityProps.class)
 public class JwtDecoderAutoConfiguration {
+
   @Bean
-  public JwtDecoder jwtDecoder(SharedSecurityProps props){
-    if ("jwks".equalsIgnoreCase(props.getMode()) && props.getJwks().getUri()!=null) {
-      return NimbusJwtDecoder.withJwkSetUri(props.getJwks().getUri()).build();
+  public JwtDecoder jwtDecoder(SharedSecurityProps props) {
+    if ("jwks".equalsIgnoreCase(props.getMode())) {
+      String uri = props.getJwks().getUri();
+      Assert.hasText(uri, "shared.security.jwks.uri must not be null or empty when mode=jwks");
+      return NimbusJwtDecoder.withJwkSetUri(uri).build();
     }
-    SecretKey key = new SecretKeySpec(props.getHs256().getSecret().getBytes(), "HmacSHA256");
+
+    String secret = props.getHs256().getSecret();
+    Assert.hasText(secret, "shared.security.hs256.secret must not be null or empty when mode=hs256");
+    SecretKey key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
     return NimbusJwtDecoder.withSecretKey(key).build();
   }
 }

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/JwtDecoderAutoConfigurationTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/JwtDecoderAutoConfigurationTest.java
@@ -1,0 +1,32 @@
+package com.shared.starter_security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtDecoderAutoConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+      .withConfiguration(AutoConfigurations.of(JwtDecoderAutoConfiguration.class));
+
+  @Test
+  void missingSecretThrowsMeaningfulException() {
+    contextRunner.run(context -> {
+      assertThat(context).hasFailed();
+      assertThat(context.getStartupFailure())
+          .hasCauseInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("shared.security.hs256.secret");
+    });
+  }
+
+  @Test
+  void missingJwksUriThrowsMeaningfulException() {
+    contextRunner.withPropertyValues("shared.security.mode=jwks").run(context -> {
+      assertThat(context).hasFailed();
+      assertThat(context.getStartupFailure())
+          .hasCauseInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("shared.security.jwks.uri");
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- validate JWT mode-specific properties in `JwtDecoderAutoConfiguration`
- add tests covering missing HS256 secret and JWKS URI

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: com.lms:shared-bom:pom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b55ba61c78832f824f226c9d61042e