### PR TITLE
Add QA environment configuration with enforced security

### DIFF
--- a/lms-setup/src/main/resources/application-qa.yaml
+++ b/lms-setup/src/main/resources/application-qa.yaml
@@ -1,0 +1,208 @@
+spring:
+  datasource:
+    url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:lms}?currentSchema=setup}"
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      pool-name: HikariPool-LMS
+      maximum-pool-size: 10
+      minimum-idle: 2
+      idle-timeout: 30000        # 30s
+      connection-timeout: 300000 # 300s
+      max-lifetime: 1800000      # 30m
+
+  jpa:
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        default_schema: setup
+        hbm2ddl.create_namespaces: true
+        format_sql: true
+        jdbc.time_zone: UTC
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    client-id: lms-setup-qa
+    consumer:
+      group-id: lms-backend-qa
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      properties:
+        max.poll.interval.ms: 300000
+        max.poll.records: 500
+    producer:
+      acks: all
+      retries: 3
+      batch-size: 16384
+      compression-type: gzip
+      properties:
+        linger.ms: 5
+
+management:
+  endpoints:
+    web:
+      base-path: /actuator
+      exposure:
+        include: health,info,metrics,prometheus,beans,conditions,configprops,loggers,threaddump
+  endpoint:
+    health:
+      show-details: always
+  tracing:
+    sampling:
+      probability: 1.0
+
+springdoc:
+  api-docs:
+    enabled: true
+    path: /v3/api-docs
+  swagger-ui:
+    enabled: true
+    display-request-duration: true
+    filter: true
+    operationsSorter: method
+    tagsSorter: alpha
+
+shared:
+  core:
+    correlation:
+      header-name: X-Correlation-ID
+      generate-if-missing: true
+      echo-response-header: true
+    tenant:
+      enabled: true
+      header-name: X-Tenant-Id
+      query-param: tenantId
+      default-policy: OPTIONAL
+      echo-response-header: true
+    cors:
+      enabled: true
+      allowed-origins: http://localhost:3000
+      allowed-methods: GET,POST,PUT,DELETE,OPTIONS
+      allowed-headers: "*"
+  headers:
+    enabled: true
+    correlation:
+      header: X-Correlation-ID
+      auto-generate: true
+      mandatory: true
+    request:
+      header: X-Request-ID
+      auto-generate: true
+      mandatory: true
+    tenant:
+      header: X-Tenant-Id
+      auto-generate: false
+      mandatory: false
+    user:
+      header: X-User-Id
+      auto-generate: false
+      mandatory: false
+    mdc:
+      enabled: true
+    security:
+      enabled: true
+      hsts:
+        enabled: true
+        max-age: 31536000
+        include-subdomains: true
+      frame-options: SAMEORIGIN
+      content-type-options: nosniff
+      referrer-policy: no-referrer
+      xss-protection: "0"
+    propagation:
+      enabled: true
+      include:
+        - X-Correlation-ID
+        - X-Request-ID
+        - X-Tenant-Id
+        - X-User-Id
+  audit:
+    enabled: true
+    web:
+      enabled: true
+      include-headers: true
+      track-bodies: true
+    aop:
+      enabled: true
+    dispatcher:
+      async: true
+    retention:
+      enabled: true
+      days: 90
+    masking:
+      enabled: true
+      fields-by-key:
+        - password
+        - secret
+        - token
+        - ssn
+    sinks:
+      db:
+        enabled: true
+        schema: setup
+        table: audit_logs
+      kafka:
+        enabled: false
+      otlp:
+        enabled: false
+      outbox:
+        enabled: false
+  openapi:
+    enabled: true
+    title: "LMS - Setup Service API"
+    description: "Setup service endpoints for tenant/platform configuration."
+    version: "1.0.0"
+    servers:
+      - http://localhost:8080/core
+    group:
+      name: setup
+      packages-to-scan:
+        - com.lms.setup
+    jwt-security: true
+  redis:
+    host: localhost
+    port: 6379
+    timeout: 2s
+    key-prefix: lms
+    default-ttl: 600s
+    reactive: false
+  crypto:
+    algorithm: AES256_GCM
+    in-memory:
+      activeKid: ${CRYPTO_ACTIVE_KID:local-qa-key}
+      keys:
+        local-qa-key: ${CRYPTO_LOCAL_QA_KEY}
+    security:
+      mode: hs256
+      jwt:
+        secret: ${JWT_SECRET}
+        token-period: 15m
+      hs256:
+        secret: ${JWT_SECRET}
+      resource-server:
+        enabled: true
+        permit-all: []
+        disable-csrf: true
+      stateless: true
+    roles-claim: roles
+    tenant-claim: tenant
+    enable-role-check: false
+
+logging:
+  level:
+    root: ERROR
+    com.lms: ERROR
+    com.lms.audit.starter: ERROR
+    com.lms.audit.starter.core.dispatch: ERROR
+    com.lms.audit.starter.core.dispatch.sinks: ERROR
+    org.hibernate.tool.schema: ERROR
+    org.hibernate.SQL: ERROR
+    org.hibernate.orm.jdbc.bind: ERROR
+    org.springframework.cache: ERROR
+    org.springframework.cache.interceptor.CacheAspectSupport: ERROR
+debug: false
+


### PR DESCRIPTION
## Summary
- add `application-qa.yaml` for the setup service
- configure QA Kafka client and consumer groups
- enable JWT security and remove open `permit-all` paths

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b55b853bf8832fa08b005fc36d5899