### PR TITLE
Fix JwtDecoderAutoConfiguration test to check root cause

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/JwtDecoderAutoConfigurationTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/JwtDecoderAutoConfigurationTest.java
@@ -15,7 +15,7 @@ class JwtDecoderAutoConfigurationTest {
     contextRunner.run(context -> {
       assertThat(context).hasFailed();
       assertThat(context.getStartupFailure())
-          .hasCauseInstanceOf(IllegalArgumentException.class)
+          .hasRootCauseInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("shared.security.hs256.secret");
     });
   }
@@ -25,7 +25,7 @@ class JwtDecoderAutoConfigurationTest {
     contextRunner.withPropertyValues("shared.security.mode=jwks").run(context -> {
       assertThat(context).hasFailed();
       assertThat(context.getStartupFailure())
-          .hasCauseInstanceOf(IllegalArgumentException.class)
+          .hasRootCauseInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("shared.security.jwks.uri");
     });
   }


### PR DESCRIPTION
## Summary
- adjust JwtDecoderAutoConfiguration tests to assert IllegalArgumentException as the root cause

## Testing
- `mvn -pl shared-starters/starter-security -am test` *(fails: Non-resolvable import POMs, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b55d01b400832fa7cc8bd395aa0b0b