### PR TITLE
feat: filter unknown roles from JWT

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/JwtRoleFilterTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/JwtRoleFilterTest.java
@@ -1,0 +1,32 @@
+package com.shared.starter_security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+
+/**
+ * Verifies that only known roles are mapped to authorities.
+ */
+class JwtRoleFilterTest {
+
+  @Test
+  void ignoresUnknownRoles() {
+    SharedSecurityProps props = new SharedSecurityProps();
+    SecurityAutoConfiguration cfg = new SecurityAutoConfiguration();
+    JwtAuthenticationConverter conv = cfg.jwtAuthenticationConverter(props);
+
+    Jwt jwt = Jwt.withTokenValue("t").header("alg", "none")
+        .claim("roles", List.of("TENANT_ADMIN", "FAKE_ROLE"))
+        .build();
+
+    var auth = conv.convert(jwt);
+    assertNotNull(auth);
+    assertTrue(auth.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_TENANT_ADMIN")));
+    assertFalse(auth.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_FAKE_ROLE")));
+  }
+}
+


### PR DESCRIPTION
## Summary
- restrict JWT role mapping to values defined in Role enum
- test that tokens with unknown roles are ignored

## Testing
- `mvn -q -pl shared-starters/starter-security -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b568855ea4832f8a7eba1bf9be4a40