### PR TITLE
refactor: remove duplicate tenant header

### DIFF
--- a/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/core/Headers.java
+++ b/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/core/Headers.java
@@ -1,9 +1,0 @@
-package com.shared.kafka_starter.core;
-
-public final class Headers {
-  public static final String TENANT_ID = "x-tenant-id";
-  public static final String CORRELATION_ID = "x-corr-id";
-  public static final String MESSAGE_ID = "x-msg-id";
-  public static final String SCHEMA_VERSION = "x-schema-ver";
-  private Headers() {}
-}

--- a/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/core/IdempotentKafkaListener.java
+++ b/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/core/IdempotentKafkaListener.java
@@ -1,5 +1,6 @@
 package com.shared.kafka_starter.core;
 
+import com.common.constants.HeaderNames;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 
@@ -13,7 +14,7 @@ public abstract class IdempotentKafkaListener<T> {
   }
 
   public final void handle(ConsumerRecord<String, T> record) {
-	  String messageId = header(record, Headers.MESSAGE_ID);
+          String messageId = header(record, HeaderNames.MESSAGE_ID);
 	  if (messageId == null) {
 	    if (record.key() != null) {
 	      messageId = record.key();

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SecurityAutoConfiguration.java
@@ -1,9 +1,11 @@
 package com.shared.starter_security;
 
+import com.common.constants.HeaderNames;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shared.starter_security.Role;
 import com.shared.starter_security.web.JsonAccessDeniedHandler;
 import com.shared.starter_security.web.JsonAuthEntryPoint;
-import com.shared.starter_security.Role;
+import java.nio.charset.StandardCharsets;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -12,8 +14,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -36,9 +38,13 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -218,8 +224,13 @@ public class SecurityAutoConfiguration {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedOriginPatterns(List.of("https://*.lms.com", "http://localhost:3000"));
     configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-    configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "X-Correlation-ID", "X-Tenant-Id"));
-    configuration.setExposedHeaders(Arrays.asList("X-Correlation-ID", "X-Tenant-Id"));
+    configuration.setAllowedHeaders(Arrays.asList(
+        HeaderNames.AUTHORIZATION,
+        HeaderNames.CONTENT_TYPE,
+        "X-Requested-With",
+        HeaderNames.CORRELATION_ID,
+        HeaderNames.TENANT_ID));
+    configuration.setExposedHeaders(Arrays.asList(HeaderNames.CORRELATION_ID, HeaderNames.TENANT_ID));
     configuration.setAllowCredentials(true);
     configuration.setMaxAge(3600L);
 


### PR DESCRIPTION
## Summary
- remove duplicated Kafka header constants
- use shared HeaderNames for message identification
- reference shared tenant header constant in security CORS config

## Testing
- `mvn -q test -pl shared-lib/shared-starters/starter-security -am` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5766bf080832fa1d2e9a0455a776c