### PR TITLE
Harden security contexts and configuration

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/common/context/ContextManager.java
+++ b/shared-lib/shared-common/src/main/java/com/common/context/ContextManager.java
@@ -15,7 +15,7 @@ public final class ContextManager {
     /**
      * The current context carrier.  Defaults to a thread‑local implementation.
      */
-    private static ContextCarrier CARRIER = new ThreadLocalContextCarrier();
+    private static volatile ContextCarrier CARRIER = new ThreadLocalContextCarrier();
 
     private ContextManager() {
         // utility class

--- a/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/common/dto/BaseResponse.java
@@ -68,13 +68,7 @@ public class BaseResponse<T> {
     // ===== Static builders (nice usability) =====
 
     public static <T> BaseResponse<T> success(T data) {
-        return BaseResponse.<T>builder()
-                .status(ApiStatus.SUCCESS)
-                .code("SUCCESS-200")
-                .message("Operation successful")
-                .data(data)
-                .timestamp(Instant.now())
-                .build();
+        return build(ApiStatus.SUCCESS, "SUCCESS-200", "Operation successful", data);
     }
 
     /**
@@ -85,27 +79,20 @@ public class BaseResponse<T> {
      * @return a new BaseResponse with status SUCCESS
      */
     public static <T> BaseResponse<T> success(String message, T data) {
-        return BaseResponse.<T>builder()
-                .status(ApiStatus.SUCCESS)
-                .code("SUCCESS-200")
-                .message(message)
-                .data(data)
-                .timestamp(Instant.now())
-                .build();
+        return build(ApiStatus.SUCCESS, "SUCCESS-200", message, data);
     }
 
     public static <T> BaseResponse<T> error(String code, String message) {
-        return BaseResponse.<T>builder()
-                .status(ApiStatus.ERROR)
-                .code(code)
-                .message(message)
-                .timestamp(Instant.now())
-                .build();
+        return build(ApiStatus.ERROR, code, message, null);
     }
 
     public static <T> BaseResponse<T> warning(String code, String message, T data) {
+        return build(ApiStatus.WARNING, code, message, data);
+    }
+
+    private static <T> BaseResponse<T> build(ApiStatus status, String code, String message, T data) {
         return BaseResponse.<T>builder()
-                .status(ApiStatus.WARNING)
+                .status(status)
                 .code(code)
                 .message(message)
                 .data(data)
@@ -158,6 +145,8 @@ public class BaseResponse<T> {
                 .message(message)
                 .data(newData)
                 .timestamp(timestamp)
+                .correlationId(getCorrelationId())
+                .tenantId(getTenantId())
                 .build();
     }
 

--- a/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenService.java
+++ b/shared-lib/shared-lib-crypto/src/main/java/com/shared/crypto/JwtTokenService.java
@@ -2,12 +2,12 @@ package com.shared.crypto;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Base64;
 import javax.crypto.SecretKey;
 
 /**
@@ -30,10 +30,14 @@ public class JwtTokenService {
      * @return configured service
      */
     public static JwtTokenService withSecret(String secret, Duration defaultTtl) {
-        if (secret == null || secret.length() < 32) {
-            throw new IllegalArgumentException("secret must be at least 32 characters");
+        if (secret == null) {
+            throw new IllegalArgumentException("secret must not be null");
         }
-        SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        byte[] keyBytes = Base64.getDecoder().decode(secret);
+        if (keyBytes.length < 32) {
+            throw new IllegalArgumentException("decoded secret must be at least 32 bytes");
+        }
+        SecretKey key = Keys.hmacShaKeyFor(keyBytes);
         return new JwtTokenService(key, defaultTtl);
     }
 

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/context/ContextFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/context/ContextFilter.java
@@ -17,6 +17,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -48,6 +49,10 @@ public class ContextFilter extends OncePerRequestFilter {
                 request.getHeader(HeaderNames.TENANT_ID),
                 request.getParameter(HeaderNames.TENANT_ID)           // optional fallback
         ));
+        if (tenantId != null && !TENANT_PATTERN.matcher(tenantId).matches()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid " + HeaderNames.TENANT_ID);
+            return;
+        }
         String incomingCorrelation = trimToNull(
                 request.getHeader(HeaderNames.CORRELATION_ID)
         );
@@ -105,4 +110,6 @@ public class ContextFilter extends OncePerRequestFilter {
     private static void putMdc(String key, String value) {
         if (value != null) MDC.put(key, value);
     }
+
+    private static final Pattern TENANT_PATTERN = Pattern.compile("[A-Za-z0-9_-]{1,36}");
 }

--- a/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/http/CorrelationHeaderFilter.java
+++ b/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/http/CorrelationHeaderFilter.java
@@ -101,9 +101,7 @@ public class CorrelationHeaderFilter implements Filter {
       ContextManager.Tenant.clear();
       ContextManager.clearUserId();
       if (props.getMdc().isEnabled()) {
-        MDC.remove("requestId");
-        MDC.remove("tenantId");
-        MDC.remove("userId");
+        HeaderUtils.clearMdc(HeaderNames.REQUEST_ID, HeaderNames.TENANT_ID, HeaderNames.USER_ID);
       }
     }
   }

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SecurityAutoConfiguration.java
@@ -223,9 +223,12 @@ public class SecurityAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public CorsConfigurationSource corsConfigurationSource() {
+  public CorsConfigurationSource corsConfigurationSource(SharedSecurityProps props) {
     CorsConfiguration configuration = new CorsConfiguration();
-    configuration.setAllowedOriginPatterns(List.of("https://*.lms.com", "http://localhost:3000"));
+    List<String> origins = props.getResourceServer().getAllowedOrigins();
+    if (origins != null && !origins.isEmpty()) {
+      configuration.setAllowedOrigins(origins);
+    }
     configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
     configuration.setAllowedHeaders(Arrays.asList(
         HeaderNames.AUTHORIZATION,
@@ -234,7 +237,7 @@ public class SecurityAutoConfiguration {
         HeaderNames.CORRELATION_ID,
         HeaderNames.TENANT_ID));
     configuration.setExposedHeaders(Arrays.asList(HeaderNames.CORRELATION_ID, HeaderNames.TENANT_ID));
-    configuration.setAllowCredentials(true);
+    configuration.setAllowCredentials(false);
     configuration.setMaxAge(3600L);
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SharedSecurityProps.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SharedSecurityProps.java
@@ -1,6 +1,7 @@
 package com.shared.starter_security;
 
 import com.shared.common.BaseStarterProperties;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -99,5 +100,8 @@ public class SharedSecurityProps implements BaseStarterProperties {
 
     /** Force stateless sessions for APIs. */
     private boolean stateless = true;
+
+    /** Allowed CORS origins. */
+    private List<String> allowedOrigins = List.of();
   }
 }

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/web/JsonAccessDeniedHandler.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/web/JsonAccessDeniedHandler.java
@@ -30,12 +30,12 @@ public class JsonAccessDeniedHandler implements AccessDeniedHandler {
 
     ErrorResponse body = ErrorResponse.of(
         ErrorCodes.AUTH_FORBIDDEN,                         // e.g., "ERR-403" or "ERR-FORBIDDEN"
-        safe(ex.getMessage(), "Forbidden"),
+        WebUtils.safe(ex.getMessage(), "Forbidden"),
         List.of(),
         request.getRequestURI()
     );
     body.setTenantId(ContextManager.Tenant.get());
-    body.setCorrelationId(firstNonBlank(
+    body.setCorrelationId(WebUtils.firstNonBlank(
         MDC.get(HeaderNames.CORRELATION_ID),
         request.getHeader(HeaderNames.CORRELATION_ID),
         request.getHeader(HeaderNames.REQUEST_ID)
@@ -47,12 +47,4 @@ public class JsonAccessDeniedHandler implements AccessDeniedHandler {
     mapper.writeValue(response.getWriter(), body);
   }
 
-  private static String safe(String s, String fallback) {
-    return (s == null || s.isBlank()) ? fallback : s;
-  }
-  private static String firstNonBlank(String... values) {
-    if (values == null) return null;
-    for (String v : values) if (v != null && !v.isBlank()) return v;
-    return null;
-  }
 }

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/web/JsonAuthEntryPoint.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/web/JsonAuthEntryPoint.java
@@ -30,13 +30,13 @@ public class JsonAuthEntryPoint implements AuthenticationEntryPoint {
 
     ErrorResponse body = ErrorResponse.of(
         ErrorCodes.AUTH_UNAUTHORIZED,                      // e.g., "ERR-401" or "ERR-UNAUTHORIZED"
-        safe(authException.getMessage(), "Unauthorized"),
+        WebUtils.safe(authException.getMessage(), "Unauthorized"),
         List.of(),
         request.getRequestURI()
     );
     // enrich
     body.setTenantId(ContextManager.Tenant.get());
-    body.setCorrelationId(firstNonBlank(
+    body.setCorrelationId(WebUtils.firstNonBlank(
         MDC.get(HeaderNames.CORRELATION_ID),
         request.getHeader(HeaderNames.CORRELATION_ID),
         request.getHeader(HeaderNames.REQUEST_ID)
@@ -48,12 +48,4 @@ public class JsonAuthEntryPoint implements AuthenticationEntryPoint {
     mapper.writeValue(response.getWriter(), body);
   }
 
-  private static String safe(String s, String fallback) {
-    return (s == null || s.isBlank()) ? fallback : s;
-  }
-  private static String firstNonBlank(String... values) {
-    if (values == null) return null;
-    for (String v : values) if (v != null && !v.isBlank()) return v;
-    return null;
-  }
 }

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/web/WebUtils.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/web/WebUtils.java
@@ -1,0 +1,19 @@
+package com.shared.starter_security.web;
+
+final class WebUtils {
+  private WebUtils() {}
+
+  static String safe(String s, String fallback) {
+    return (s == null || s.isBlank()) ? fallback : s;
+  }
+
+  static String firstNonBlank(String... values) {
+    if (values == null) return null;
+    for (String v : values) {
+      if (v != null && !v.isBlank()) {
+        return v;
+      }
+    }
+    return null;
+  }
+}

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/SharedSecurityPropsTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/SharedSecurityPropsTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -17,5 +18,14 @@ class SharedSecurityPropsTest {
     SharedSecurityProps props = new Binder(source)
         .bind("shared.security", SharedSecurityProps.class).get();
     assertEquals("s3cr3t", props.getHs256().getSecret());
+  }
+
+  @Test
+  void bindsAllowedOrigins() {
+    MapConfigurationPropertySource source = new MapConfigurationPropertySource(
+        Map.of("shared.security.resource-server.allowed-origins[0]", "https://app.example.com"));
+    SharedSecurityProps props = new Binder(source)
+        .bind("shared.security", SharedSecurityProps.class).get();
+    assertEquals(List.of("https://app.example.com"), props.getResourceServer().getAllowedOrigins());
   }
 }


### PR DESCRIPTION
## Summary
- use constants to clean up MDC in `CorrelationHeaderFilter`
- add thread-safety for context carrier and improve BaseResponse builder and mapping
- tighten tenant validation and CORS origins; extract shared web error helpers
- require Base64 encoded JWT secrets

## Testing
- `mvn -q -f shared-lib/pom.xml test` *(failed: Network is unreachable for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b57ebe982c832fb1e00913e7440cff