### PR TITLE
Use Base64 encoded JWT secrets in tests

### DIFF
--- a/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenAutoConfigurationTest.java
+++ b/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenAutoConfigurationTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +15,7 @@ import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(classes = JwtTokenAutoConfiguration.class)
 @TestPropertySource(properties = {
-        "shared.security.jwt.secret=01234567890123456789012345678901",
+        "shared.security.jwt.secret=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=",
         "shared.security.jwt.token-period=PT5M"
 })
 class JwtTokenAutoConfigurationTest {
@@ -26,7 +26,8 @@ class JwtTokenAutoConfigurationTest {
     @Test
     void beanLoadsAndGeneratesToken() {
         String token = jwtTokenService.generateToken("alice");
-        SecretKey key = Keys.hmacShaKeyFor("01234567890123456789012345678901".getBytes(StandardCharsets.UTF_8));
+        byte[] keyBytes = Base64.getDecoder().decode("MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=");
+        SecretKey key = Keys.hmacShaKeyFor(keyBytes);
         Claims claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
         assertEquals("alice", claims.getSubject());
         assertNotNull(claims.getExpiration());

--- a/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenServiceTest.java
+++ b/shared-lib/shared-lib-crypto/src/test/java/com/shared/crypto/JwtTokenServiceTest.java
@@ -2,13 +2,12 @@ package com.shared.crypto;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import javax.crypto.SecretKey;
-import org.junit.jupiter.api.Test;
-
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -16,8 +15,9 @@ class JwtTokenServiceTest {
 
     @Test
     void createTokenIncludesTenantAndRoles() {
-        String secret = "01234567890123456789012345678901";
-        SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        String secret = "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=";
+        byte[] keyBytes = Base64.getDecoder().decode(secret);
+        SecretKey key = Keys.hmacShaKeyFor(keyBytes);
         JwtTokenService service = JwtTokenService.withSecret(secret, null);
         Map<String, Object> claims = Map.of("custom", "value");
         List<String> roles = List.of("admin", "user");


### PR DESCRIPTION
## Summary
- use Base64 encoded secrets to satisfy minimum key length requirement in JWT tests

## Testing
- `mvn -q -pl shared-lib-crypto -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b582b3fa70832fabdd482cec481ad4