### PR TITLE
chore: update dependencies

### DIFF
--- a/lms-setup/pom.xml
+++ b/lms-setup/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.3</version>
+    <version>3.5.5</version>
     <relativePath/>
   </parent>
 

--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -43,7 +43,7 @@
     <plugin.clean.version>3.2.0</plugin.clean.version>     
     <plugin.site.version>3.12.1</plugin.site.version>      
 		<!-- if any module uses Boot plugin -->
-    <spring.boot.version>3.3.3</spring.boot.version>
+    <spring.boot.version>3.5.5</spring.boot.version>
   </properties>
 
   <!-- Centralize dependency versions -->

--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -12,11 +12,11 @@
 
   <properties>
     <!-- Platforms -->
-    <spring.boot.version>3.3.3</spring.boot.version>
+    <spring.boot.version>3.5.5</spring.boot.version>
     <spring.cloud.version>2024.0.2</spring.cloud.version> <!-- 2024.0.3 is not on Central -->
 
     <!-- Libraries not fully managed by Boot -->
-    <flyway.version>10.17.1</flyway.version>
+    <flyway.version>11.11.2</flyway.version>
 
     <!-- Observability / Testing -->
     <otel.version>1.45.0</otel.version>
@@ -29,7 +29,7 @@
     <!-- DB & misc -->
     <postgres.version>42.7.4</postgres.version>
     <hibernate.types.version>2.21.1</hibernate.types.version>
-    <jackson.version>2.17.2</jackson.version>
+    <jackson.version>2.19.2</jackson.version>
 
     <!-- Security / resilience -->
     <jjwt.version>0.13.0</jjwt.version> <!-- per jjwt install guide -->


### PR DESCRIPTION
## Summary
- use Spring Boot 3.5.5 across modules
- bump Flyway to 11.11.2 and Jackson to 2.19.2

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:pom:3.5.5, Network is unreachable)*
- `mvn -q -f lms-setup/pom.xml test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent:3.5.5, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b58304e6a0832fa13d9d918259fc96