### PR TITLE
refactor: standardize tenant header constant

### DIFF
--- a/lms-setup/src/main/resources/application-dev.yaml
+++ b/lms-setup/src/main/resources/application-dev.yaml
@@ -84,7 +84,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: true
-      header-name: X-Tenant-Id
+      header-name: x_tenant_id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -104,7 +104,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: X-Tenant-Id
+      header: x_tenant_id
       auto-generate: false
       mandatory: false
     user:
@@ -128,7 +128,7 @@ shared:
       include:
         - X-Correlation-ID
         - X-Request-ID
-        - X-Tenant-Id
+        - x_tenant_id
         - X-User-Id
   audit:
     enabled: true

--- a/lms-setup/src/main/resources/application-qa.yaml
+++ b/lms-setup/src/main/resources/application-qa.yaml
@@ -82,7 +82,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: true
-      header-name: X-Tenant-Id
+      header-name: x_tenant_id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -103,7 +103,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: X-Tenant-Id
+      header: x_tenant_id
       auto-generate: false
       mandatory: false
     user:
@@ -127,7 +127,7 @@ shared:
       include:
         - X-Correlation-ID
         - X-Request-ID
-        - X-Tenant-Id
+        - x_tenant_id
         - X-User-Id
   audit:
     enabled: true

--- a/shared-lib/shared-common/src/main/java/com/common/constants/HeaderNames.java
+++ b/shared-lib/shared-common/src/main/java/com/common/constants/HeaderNames.java
@@ -16,7 +16,11 @@ public final class HeaderNames {
     public static final String REFRESH_TOKEN = "X-Refresh-Token";
 
     // 🏢 Multi-tenancy
-    public static final String TENANT_ID = "X-Tenant-Id";
+    /**
+     * Canonical tenant identifier header. All services should read/write this
+     * header only and avoid using any legacy variants.
+     */
+    public static final String X_TENANT_ID = "x_tenant_id";
     public static final String TENANT_KEY = "X-Tenant-Key";
     public static final String MESSAGE_ID = "x-msg-id";
 

--- a/shared-lib/shared-common/src/main/java/com/common/context/CorrelationContextUtil.java
+++ b/shared-lib/shared-common/src/main/java/com/common/context/CorrelationContextUtil.java
@@ -33,7 +33,7 @@ public final class CorrelationContextUtil {
         }
         MDC.put(CORRELATION_ID, correlationId);
         if (tenantId != null && !tenantId.isBlank()) {
-            MDC.put(HeaderNames.TENANT_ID, tenantId);
+            MDC.put(HeaderNames.X_TENANT_ID, tenantId);
         }
     }
 
@@ -58,7 +58,7 @@ public final class CorrelationContextUtil {
      * @return the current tenant identifier from MDC or {@code null}
      */
     public static String getTenantId() {
-        return MDC.get(HeaderNames.TENANT_ID);
+        return MDC.get(HeaderNames.X_TENANT_ID);
     }
 
     /**
@@ -66,7 +66,7 @@ public final class CorrelationContextUtil {
      */
     public static void clear() {
         MDC.remove(CORRELATION_ID);
-        MDC.remove(HeaderNames.TENANT_ID);
+        MDC.remove(HeaderNames.X_TENANT_ID);
     }
 
     /**

--- a/shared-lib/shared-common/src/main/java/com/common/logging/LogMarkers.java
+++ b/shared-lib/shared-common/src/main/java/com/common/logging/LogMarkers.java
@@ -20,7 +20,7 @@ public final class LogMarkers {
     public static LogstashMarker correlation(String correlationId, String tenantId) {
         LogstashMarker marker = Markers.append("correlationId", correlationId);
         if (tenantId != null && !tenantId.isBlank()) {
-            marker = marker.and(Markers.append(HeaderNames.TENANT_ID, tenantId));
+            marker = marker.and(Markers.append(HeaderNames.X_TENANT_ID, tenantId));
         }
         return marker;
     }

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/config/AuditProperties.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/config/AuditProperties.java
@@ -154,7 +154,7 @@ public class AuditProperties {
   }
 
   public static class Tenant {
-    private String header = HeaderNames.TENANT_ID;
+    private String header = HeaderNames.X_TENANT_ID;
     private boolean required = true;
     public String getHeader() { return header; }
     public void setHeader(String header) { this.header = header; }

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/core/dispatch/sinks/DatabaseSink.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/core/dispatch/sinks/DatabaseSink.java
@@ -1,6 +1,7 @@
 // NEW VERSION – uses TransactionTemplate (REQUIRES_NEW)
 package com.shared.audit.starter.core.dispatch.sinks;
 
+import com.common.constants.HeaderNames;
 import com.shared.audit.starter.api.AuditEvent;
 import com.shared.audit.starter.util.JsonUtils;
 import com.common.exception.JsonSerializationException;
@@ -23,7 +24,7 @@ public class DatabaseSink implements Sink {
     this.table = (schema == null || schema.isBlank() ? "public" : schema) + "." + table;
     this.insertSql =
         "INSERT INTO " + this.table + " (" +
-        " id, ts_utc, tenant_id, actor_id, actor_username, action, entity_type, entity_id, outcome," +
+        " id, ts_utc, " + HeaderNames.X_TENANT_ID + ", actor_id, actor_username, action, entity_type, entity_id, outcome," +
         " data_class, sensitivity, resource_path, resource_method, correlation_id, span_id, message, payload) " +
         "VALUES (? , ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, cast(? as jsonb))";
   }

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/persistence/entity/AuditEventEntity.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/persistence/entity/AuditEventEntity.java
@@ -1,5 +1,6 @@
 package com.shared.audit.starter.persistence.entity;
 
+import com.common.constants.HeaderNames;
 import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.UUID;
@@ -10,7 +11,7 @@ public class AuditEventEntity {
   @Id
   private UUID id;
   @Column(name="ts_utc") private Instant tsUtc;
-  @Column(name="tenant_id") private String tenantId;
+  @Column(name = HeaderNames.X_TENANT_ID) private String xTenantId;
   @Column(name="actor_id") private String actorId;
   @Column(name="actor_username") private String actorUsername;
   @Column(name="action") private String action;

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/persistence/mapper/AuditEventMapper.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/shared/audit/starter/persistence/mapper/AuditEventMapper.java
@@ -12,7 +12,7 @@ public final class AuditEventMapper {
     try {
       var idF = AuditEventEntity.class.getDeclaredField("id"); idF.setAccessible(true); idF.set(en, e.getEventId());
       var tsF = AuditEventEntity.class.getDeclaredField("tsUtc"); tsF.setAccessible(true); tsF.set(en, e.getTimestamp());
-      var tF  = AuditEventEntity.class.getDeclaredField("tenantId"); tF.setAccessible(true); tF.set(en, e.getTenantId());
+      var tF  = AuditEventEntity.class.getDeclaredField("xTenantId"); tF.setAccessible(true); tF.set(en, e.getTenantId());
       var aF  = AuditEventEntity.class.getDeclaredField("actorId"); aF.setAccessible(true); aF.set(en, e.getActor()==null?null:e.getActor().id());
       var auF = AuditEventEntity.class.getDeclaredField("actorUsername"); auF.setAccessible(true); auF.set(en, e.getActor()==null?null:e.getActor().username());
       var acF = AuditEventEntity.class.getDeclaredField("action"); acF.setAccessible(true); acF.set(en, e.getAction().name());

--- a/shared-lib/shared-starters/starter-audit/src/main/resources/db/migration/V1__create_audit_tables.sql
+++ b/shared-lib/shared-starters/starter-audit/src/main/resources/db/migration/V1__create_audit_tables.sql
@@ -2,7 +2,7 @@
 CREATE TABLE IF NOT EXISTS setup.audit_logs (
   id               text PRIMARY KEY,
   ts_utc           timestamptz NOT NULL,
-  tenant_id        text,
+  x_tenant_id      text,
   actor_id         text,
   actor_username   text,
   action           text NOT NULL,
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS setup.audit_logs (
 
 -- helpful indexes
 CREATE INDEX IF NOT EXISTS idx_audit_logs_ts    ON setup.audit_logs (ts_utc);
-CREATE INDEX IF NOT EXISTS idx_audit_logs_tenant ON setup.audit_logs (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_x_tenant ON setup.audit_logs (x_tenant_id);
 CREATE INDEX IF NOT EXISTS idx_audit_logs_entity ON setup.audit_logs (entity_type, entity_id);
 
 CREATE TABLE  IF NOT EXISTS setup.audit_outbox (

--- a/shared-lib/shared-starters/starter-audit/src/main/resources/db/migration/V2__rename_tenant_id_to_x_tenant_id.sql
+++ b/shared-lib/shared-starters/starter-audit/src/main/resources/db/migration/V2__rename_tenant_id_to_x_tenant_id.sql
@@ -1,0 +1,9 @@
+-- Flyway: V2__rename_tenant_id_to_x_tenant_id.sql
+ALTER TABLE IF EXISTS setup.audit_logs
+  ADD COLUMN IF NOT EXISTS x_tenant_id text;
+
+UPDATE setup.audit_logs SET x_tenant_id = tenant_id WHERE x_tenant_id IS NULL;
+
+DROP INDEX IF EXISTS idx_audit_logs_tenant;
+ALTER TABLE IF EXISTS setup.audit_logs DROP COLUMN IF EXISTS tenant_id;
+CREATE INDEX IF NOT EXISTS idx_audit_logs_x_tenant ON setup.audit_logs (x_tenant_id);

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/config/CoreAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/config/CoreAutoConfiguration.java
@@ -215,11 +215,11 @@ public class CoreAutoConfiguration {
       private boolean enabled = true;
 
       /** Header and query parameter names */
-      private String headerName = HeaderNames.TENANT_ID;   // "X-Tenant-Id"
+      private String headerName = HeaderNames.X_TENANT_ID;   // "x_tenant_id"
       private String queryParam = "tenantId";
 
       /** MDC key for logs */
-      private String mdcKey = HeaderNames.TENANT_ID;
+      private String mdcKey = HeaderNames.X_TENANT_ID;
 
       /** Echo back the tenant in response header */
       private boolean echoResponseHeader = true;
@@ -276,7 +276,7 @@ public class CoreAutoConfiguration {
       private String[] allowedOrigins = new String[]{"*"};
       private String[] allowedMethods = new String[]{"GET","POST","PUT","PATCH","DELETE","OPTIONS"};
       private String[] allowedHeaders = new String[]{"*"};
-      private String[] exposedHeaders = new String[]{HeaderNames.CORRELATION_ID, HeaderNames.TENANT_ID};
+      private String[] exposedHeaders = new String[]{HeaderNames.CORRELATION_ID, HeaderNames.X_TENANT_ID};
       private boolean allowCredentials = false;
       private long maxAgeSeconds = 3600;
 

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/context/ContextFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/context/ContextFilter.java
@@ -46,11 +46,11 @@ public class ContextFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
 
         String tenantId      = trimToNull(firstNonNull(
-                request.getHeader(HeaderNames.TENANT_ID),
-                request.getParameter(HeaderNames.TENANT_ID)           // optional fallback
+                request.getHeader(HeaderNames.X_TENANT_ID),
+                request.getParameter(HeaderNames.X_TENANT_ID)           // optional fallback
         ));
         if (tenantId != null && !TENANT_PATTERN.matcher(tenantId).matches()) {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid " + HeaderNames.TENANT_ID);
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid " + HeaderNames.X_TENANT_ID);
             return;
         }
         String incomingCorrelation = trimToNull(
@@ -77,7 +77,7 @@ public class ContextFilter extends OncePerRequestFilter {
                 ContextManager.Tenant.set(tenantId);
             }
             // ---- Enrich logging context (appears on every log line)
-            putMdc(HeaderNames.TENANT_ID, tenantId);
+            putMdc(HeaderNames.X_TENANT_ID, tenantId);
             putMdc(HeaderNames.USER_ID, userId);
             putMdc(HeaderNames.CORRELATION_ID, correlationId);
 
@@ -89,7 +89,7 @@ public class ContextFilter extends OncePerRequestFilter {
             // ---- Always cleanup
             ContextManager.Tenant.clear();
             CorrelationContextUtil.clear();
-            MDC.remove(HeaderNames.TENANT_ID);
+            MDC.remove(HeaderNames.X_TENANT_ID);
             MDC.remove(HeaderNames.USER_ID);
             MDC.remove(HeaderNames.CORRELATION_ID);
         }

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/props/CoreProps.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/props/CoreProps.java
@@ -49,11 +49,11 @@ public class CoreProps implements BaseStarterProperties {
         private boolean enabled = true;
 
         /** Header and query parameter names */
-        private String headerName = HeaderNames.TENANT_ID;   // "X-Tenant-Id"
+        private String headerName = HeaderNames.X_TENANT_ID;   // "x_tenant_id"
         private String queryParam = "tenantId";
 
         /** MDC key for logs */
-        private String mdcKey = "tenantId";
+        private String mdcKey = HeaderNames.X_TENANT_ID;
 
         /** Echo back the tenant in response header */
         private boolean echoResponseHeader = true;

--- a/shared-lib/shared-starters/starter-crypto/src/main/java/com/shared/crypto/starter/audit/CryptoMdcFilter.java
+++ b/shared-lib/shared-starters/starter-crypto/src/main/java/com/shared/crypto/starter/audit/CryptoMdcFilter.java
@@ -24,7 +24,7 @@ import java.io.IOException;
  *
  * Default header names (override in your gateway if needed):
  *  - X-Correlation-Id
- *  - HeaderNames.TENANT_ID
+ *  - HeaderNames.X_TENANT_ID
  *  - X-User-Id
  */
 public class CryptoMdcFilter extends OncePerRequestFilter {
@@ -38,7 +38,7 @@ public class CryptoMdcFilter extends OncePerRequestFilter {
 
         // Read incoming headers
         String incomingCorrelation = headerOrNull(request, HeaderNames.CORRELATION_ID);
-        String incomingTenant = headerOrNull(request, HeaderNames.TENANT_ID);
+        String incomingTenant = headerOrNull(request, HeaderNames.X_TENANT_ID);
         String incomingUser = headerOrNull(request, HeaderNames.USER_ID);
  // Initialize correlation and tenant context (generates new id if missing)
         CorrelationContextUtil.init(incomingCorrelation, incomingTenant);

--- a/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/client/FeignHeaderInterceptor.java
+++ b/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/client/FeignHeaderInterceptor.java
@@ -16,7 +16,7 @@ public class FeignHeaderInterceptor implements RequestInterceptor {
       String value = switch (name) {
       case HeaderNames.CORRELATION_ID -> ContextManager.getCorrelationId();
       case HeaderNames.REQUEST_ID -> ContextManager.getRequestId();
-      case HeaderNames.TENANT_ID -> ContextManager.Tenant.get();
+      case HeaderNames.X_TENANT_ID -> ContextManager.Tenant.get();
       case HeaderNames.USER_ID -> ContextManager.getUserId();
         default -> null;
       };

--- a/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/client/PropagateHeadersInterceptor.java
+++ b/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/client/PropagateHeadersInterceptor.java
@@ -39,7 +39,7 @@ public class PropagateHeadersInterceptor implements ClientHttpRequestInterceptor
         String value = switch (name) {
         case HeaderNames.CORRELATION_ID -> ContextManager.getCorrelationId();
         case HeaderNames.REQUEST_ID -> ContextManager.getRequestId();
-        case HeaderNames.TENANT_ID -> ContextManager.Tenant.get();
+        case HeaderNames.X_TENANT_ID -> ContextManager.Tenant.get();
         case HeaderNames.USER_ID -> ContextManager.getUserId();
           default                 -> null;
         };

--- a/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/client/WebClientHeaderCustomizer.java
+++ b/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/client/WebClientHeaderCustomizer.java
@@ -31,7 +31,7 @@ public class WebClientHeaderCustomizer implements WebClientCustomizer {
         String value = switch (name) {
         case HeaderNames.CORRELATION_ID -> ContextManager.getCorrelationId();
         case HeaderNames.REQUEST_ID -> ContextManager.getRequestId();
-        case HeaderNames.TENANT_ID -> ContextManager.Tenant.get();
+        case HeaderNames.X_TENANT_ID -> ContextManager.Tenant.get();
         case HeaderNames.USER_ID -> ContextManager.getUserId();
           default                 -> null;
         };

--- a/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/config/SharedHeadersProperties.java
+++ b/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/config/SharedHeadersProperties.java
@@ -14,7 +14,7 @@ public class SharedHeadersProperties {
 
   private final Names correlation = new Names(HeaderNames.CORRELATION_ID, true, true);
   private final Names request = new Names(HeaderNames.REQUEST_ID, true, true);
-  private final Names tenant = new Names(HeaderNames.TENANT_ID, false, false);
+  private final Names tenant = new Names(HeaderNames.X_TENANT_ID, false, false);
   private final Names user = new Names(HeaderNames.USER_ID, false, false);
 
   private final Mdc mdc = new Mdc();
@@ -128,7 +128,7 @@ public class SharedHeadersProperties {
 
   public static class Propagation {
     private boolean enabled = true;
-    private List<String> include = List.of(HeaderNames.CORRELATION_ID,HeaderNames.REQUEST_ID,HeaderNames.TENANT_ID,HeaderNames.USER_ID);
+    private List<String> include = List.of(HeaderNames.CORRELATION_ID,HeaderNames.REQUEST_ID,HeaderNames.X_TENANT_ID,HeaderNames.USER_ID);
     public boolean isEnabled() { return enabled; }
     public void setEnabled(boolean enabled) { this.enabled = enabled; }
     public List<String> getInclude() { return include; }

--- a/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/http/CorrelationHeaderFilter.java
+++ b/shared-lib/shared-starters/starter-headers/src/main/java/com/shared/headers/starter/http/CorrelationHeaderFilter.java
@@ -76,7 +76,7 @@ public class CorrelationHeaderFilter implements Filter {
       var kv = new HashMap<String,String>();
       kv.put(HeaderNames.CORRELATION_ID, correlationId);
       kv.put(HeaderNames.REQUEST_ID, requestId);
-      if (tenantId != null) kv.put(HeaderNames.TENANT_ID, tenantId);
+      if (tenantId != null) kv.put(HeaderNames.X_TENANT_ID, tenantId);
       if (userId != null) kv.put(HeaderNames.USER_ID, userId);
       HeaderUtils.putMdc(kv);
     }
@@ -101,7 +101,7 @@ public class CorrelationHeaderFilter implements Filter {
       ContextManager.Tenant.clear();
       ContextManager.clearUserId();
       if (props.getMdc().isEnabled()) {
-        HeaderUtils.clearMdc(HeaderNames.REQUEST_ID, HeaderNames.TENANT_ID, HeaderNames.USER_ID);
+        HeaderUtils.clearMdc(HeaderNames.REQUEST_ID, HeaderNames.X_TENANT_ID, HeaderNames.USER_ID);
       }
     }
   }

--- a/shared-lib/shared-starters/starter-headers/src/main/resources/com/shared/headers/starter/headers-defaults.properties
+++ b/shared-lib/shared-starters/starter-headers/src/main/resources/com/shared/headers/starter/headers-defaults.properties
@@ -2,7 +2,7 @@
 shared.headers.enabled=true
 shared.headers.correlation.header=X-Correlation-Id
 shared.headers.request.header=X-Request-Id
-shared.headers.tenant.header=X-Tenant-Id
+shared.headers.tenant.header=x_tenant_id
 shared.headers.user.header=X-User-Id
 shared.headers.correlation.auto-generate=true
 shared.headers.request.auto-generate=true
@@ -38,4 +38,4 @@ shared.headers.forwarded.enabled=true
 
 # Outbound propagation
 shared.headers.propagation.enabled=true
-shared.headers.propagation.include=X-Correlation-Id,X-Request-Id,X-Tenant-Id,X-User-Id
+shared.headers.propagation.include=X-Correlation-Id,X-Request-Id,x_tenant_id,X-User-Id

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/JwtTenantFilter.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/JwtTenantFilter.java
@@ -33,7 +33,7 @@ class JwtTenantFilter extends HttpFilter {
                 if (tid != null) {
                         String tenant = String.valueOf(tid);
                         ContextManager.Tenant.set(tenant);
-                        response.setHeader(HeaderNames.TENANT_ID, tenant);
+                        response.setHeader(HeaderNames.X_TENANT_ID, tenant);
                 }
             }
             chain.doFilter(request, response);

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/shared/starter_security/SecurityAutoConfiguration.java
@@ -235,8 +235,8 @@ public class SecurityAutoConfiguration {
         HeaderNames.CONTENT_TYPE,
         "X-Requested-With",
         HeaderNames.CORRELATION_ID,
-        HeaderNames.TENANT_ID));
-    configuration.setExposedHeaders(Arrays.asList(HeaderNames.CORRELATION_ID, HeaderNames.TENANT_ID));
+        HeaderNames.X_TENANT_ID));
+    configuration.setExposedHeaders(Arrays.asList(HeaderNames.CORRELATION_ID, HeaderNames.X_TENANT_ID));
     configuration.setAllowCredentials(false);
     configuration.setMaxAge(3600L);
 

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/JwtTenantFilterTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/shared/starter_security/JwtTenantFilterTest.java
@@ -39,7 +39,7 @@ class JwtTenantFilterTest {
 
         filter.doFilter(req, res, chain);
 
-        assertEquals("acme", res.getHeader(HeaderNames.TENANT_ID));
+        assertEquals("acme", res.getHeader(HeaderNames.X_TENANT_ID));
         assertNull(ContextManager.Tenant.get());
     }
 }


### PR DESCRIPTION
## Summary
- introduce canonical `HeaderNames.X_TENANT_ID` constant
- propagate new header key across core filters, header utilities, security, audit, and config
- migrate audit persistence to `x_tenant_id`

## Testing
- `mvn -q -f shared-lib/pom.xml -pl shared-starters/starter-audit -am test` *(failed: Non-resolvable import POM: Network is unreachable)*

## Migration Checklist
- [ ] Clients send only `x_tenant_id` header
- [ ] Remove tenant identifiers from request/response bodies
- [ ] Audit pipelines capture `x_tenant_id`

## PR Checklist
- [ ] Removed tenant id from all response DTOs
- [ ] Added global response header injector
- [ ] Normalization filter + tests
- [ ] Feign/WebClient interceptors + tests
- [ ] Kafka header propagation + tests
- [ ] Audit DB migrations + repository/tests
- [ ] MDC/tracing attributes
- [ ] OpenAPI updated
- [ ] Feature flag wired + tests
- [ ] Legacy header readers covered (on/off)


------
https://chatgpt.com/codex/tasks/task_e_68b5829b37a4832f8fa1aabd3011376a