### PR TITLE
Fix BindException handling after Spring update

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/ApiResponseEntityExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/ApiResponseEntityExceptionHandler.java
@@ -78,12 +78,8 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
 
     // ---- Validation: binding errors on query/path params, form params ------------
 
-    @Override
-    protected ResponseEntity<Object> handleBindException(
-            BindException ex,
-            HttpHeaders headers,
-            HttpStatusCode status,
-            WebRequest request) {
+    @org.springframework.web.bind.annotation.ExceptionHandler(BindException.class)
+    public ResponseEntity<Object> handleBindException(BindException ex, WebRequest request) {
 
         List<String> details = ex.getFieldErrors()
                 .stream()


### PR DESCRIPTION
## Summary
- replace removed handleBindException override with explicit `@ExceptionHandler`
- keep custom ErrorResponse mapping for validation failures

## Testing
- `mvn -pl shared-starters/starter-core -am test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68b586b7ffd0832f907cbc17f75252a7