### PR TITLE
Fix Kafka starter interception API usage

### DIFF
--- a/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/config/KafkaConsumerConfig.java
+++ b/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/config/KafkaConsumerConfig.java
@@ -72,7 +72,7 @@ public class KafkaConsumerConfig {
         var errorHandler = new DefaultErrorHandler(recoverer, backoff);
         factory.setCommonErrorHandler(errorHandler);
 
-        factory.setRecordInterceptor(record -> {
+        factory.setRecordInterceptor((record, consumer) -> {
             Headers headers = record.headers();
             var header = headers.lastHeader(HeaderNames.CORRELATION_ID);
             if (header != null) {

--- a/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/config/KafkaProducerConfig.java
+++ b/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/config/KafkaProducerConfig.java
@@ -28,7 +28,7 @@ public class KafkaProducerConfig {
         JsonSerializer.ADD_TYPE_INFO_HEADERS, false
     );
     DefaultKafkaProducerFactory<String,Object> pf = new DefaultKafkaProducerFactory<>(cfg);
-    pf.addPostProcessor(rec -> {
+    pf.addRecordPostProcessor(rec -> {
       String cid = ContextManager.getCorrelationId();
       if (cid != null) {
         rec.headers().add(HeaderNames.CORRELATION_ID, cid.getBytes(java.nio.charset.StandardCharsets.UTF_8));


### PR DESCRIPTION
## Summary
- fix Kafka consumer RecordInterceptor lambda to include consumer parameter
- use record post processor to add correlation ID header to producer records

## Testing
- `mvn -q -pl shared-starters/starter-kafka -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b588e0007c832fa6ae91bb2fb07ea6