### PR TITLE
fix: update Kafka producer config

### DIFF
--- a/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/config/KafkaProducerConfig.java
+++ b/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/config/KafkaProducerConfig.java
@@ -11,7 +11,21 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.core.*;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
+
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
 
 public class KafkaProducerConfig {
 
@@ -28,12 +42,80 @@ public class KafkaProducerConfig {
         JsonSerializer.ADD_TYPE_INFO_HEADERS, false
     );
     DefaultKafkaProducerFactory<String,Object> pf = new DefaultKafkaProducerFactory<>(cfg);
-    pf.addRecordPostProcessor(rec -> {
-      String cid = ContextManager.getCorrelationId();
-      if (cid != null) {
-        rec.headers().add(HeaderNames.CORRELATION_ID, cid.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    pf.addPostProcessor(producer -> new Producer<>() {
+      private void addCorrelation(ProducerRecord<String, Object> rec) {
+        String cid = ContextManager.getCorrelationId();
+        if (cid != null) {
+          rec.headers().add(HeaderNames.CORRELATION_ID, cid.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        }
       }
-      return rec;
+
+      @Override
+      public Future<RecordMetadata> send(ProducerRecord<String, Object> rec) {
+        addCorrelation(rec);
+        return producer.send(rec);
+      }
+
+      @Override
+      public Future<RecordMetadata> send(ProducerRecord<String, Object> rec, Callback callback) {
+        addCorrelation(rec);
+        return producer.send(rec, callback);
+      }
+
+      @Override
+      public void flush() {
+        producer.flush();
+      }
+
+      @Override
+      public List<PartitionInfo> partitionsFor(String topic) {
+        return producer.partitionsFor(topic);
+      }
+
+      @Override
+      public Map<MetricName, ? extends Metric> metrics() {
+        return producer.metrics();
+      }
+
+      @Override
+      public void close() {
+        producer.close();
+      }
+
+      @Override
+      public void close(Duration timeout) {
+        producer.close(timeout);
+      }
+
+      @Override
+      public void initTransactions() {
+        producer.initTransactions();
+      }
+
+      @Override
+      public void beginTransaction() {
+        producer.beginTransaction();
+      }
+
+      @Override
+      public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, String groupId) {
+        producer.sendOffsetsToTransaction(offsets, groupId);
+      }
+
+      @Override
+      public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata groupMetadata) {
+        producer.sendOffsetsToTransaction(offsets, groupMetadata);
+      }
+
+      @Override
+      public void commitTransaction() {
+        producer.commitTransaction();
+      }
+
+      @Override
+      public void abortTransaction() {
+        producer.abortTransaction();
+      }
     });
     if (props.isExactlyOnce()) {
       pf.setTransactionIdPrefix(props.getTxIdPrefix());


### PR DESCRIPTION
## Summary
- adapt KafkaProducerConfig to new Spring Kafka API
- preserve correlation id header via producer post processor wrapper

## Testing
- `mvn -f shared-lib/pom.xml -pl shared-starters/starter-kafka -am test -DskipTests -Djava.net.preferIPv4Stack=true` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b58c76d64c832f988dbf68f2149358