### PR TITLE
Fix test DTO types and update Kafka producer client ID

### DIFF
--- a/lms-setup/src/test/java/com/lms/setup/TestBase.java
+++ b/lms-setup/src/test/java/com/lms/setup/TestBase.java
@@ -7,6 +7,7 @@ import com.lms.setup.model.City;
 import com.lms.setup.model.Lookup;
 import com.lms.setup.model.Resource;
 import com.lms.setup.model.SystemParameter;
+import com.lms.setup.dto.CountryDto;
 import com.lms.testsupport.IntegrationTestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,6 +60,20 @@ public abstract class TestBase extends IntegrationTestSupport {
         country.setEnDescription("United States of America");
         country.setArDescription("الولايات المتحدة الأمريكية");
         return country;
+    }
+
+    protected CountryDto createTestCountryDto() {
+        CountryDto dto = new CountryDto();
+        dto.setCountryCd("US");
+        dto.setCountryEnNm("United States");
+        dto.setCountryArNm("الولايات المتحدة");
+        dto.setDialingCode("+1");
+        dto.setNationalityEn("American");
+        dto.setNationalityAr("أمريكي");
+        dto.setIsActive(true);
+        dto.setEnDescription("United States of America");
+        dto.setArDescription("الولايات المتحدة الأمريكية");
+        return dto;
     }
 
     protected City createTestCity() {

--- a/lms-setup/src/test/java/com/lms/setup/controller/CountryControllerTest.java
+++ b/lms-setup/src/test/java/com/lms/setup/controller/CountryControllerTest.java
@@ -3,6 +3,7 @@ package com.lms.setup.controller;
 import com.common.dto.BaseResponse;
 import com.lms.setup.TestBase;
 import com.lms.setup.model.Country;
+import com.lms.setup.dto.CountryDto;
 import com.lms.setup.service.CountryService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -33,38 +34,40 @@ class CountryControllerTest extends TestBase {
     @WithMockUser(roles = "ADMIN")
     void add_shouldCreateCountry_whenValidRequest() throws Exception {
         // Given
+        CountryDto request = createTestCountryDto();
         Country country = createTestCountry();
         BaseResponse<Country> response = BaseResponse.success("Country created", country);
-        when(countryService.add(any(Country.class))).thenReturn(response);
+        when(countryService.add(any(CountryDto.class))).thenReturn(response);
 
         // When & Then
-        mockMvc.perform(postRequest("/countries", country))
+        mockMvc.perform(postRequest("/countries", request))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.message").value("Country created"))
                 .andExpect(jsonPath("$.data.countryCd").value("US"));
 
-        verify(countryService).add(any(Country.class));
+        verify(countryService).add(any(CountryDto.class));
     }
 
     @Test
     @WithMockUser(roles = "ADMIN")
     void update_shouldUpdateCountry_whenValidRequest() throws Exception {
         // Given
+        CountryDto request = createTestCountryDto();
         Country country = createTestCountry();
         country.setCountryId(1);
         BaseResponse<Country> response = BaseResponse.success("Country updated", country);
-        when(countryService.update(eq(1), any(Country.class))).thenReturn(response);
+        when(countryService.update(eq(1), any(CountryDto.class))).thenReturn(response);
 
         // When & Then
-        mockMvc.perform(putRequest("/countries/1", country))
+        mockMvc.perform(putRequest("/countries/1", request))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.message").value("Country updated"));
 
-        verify(countryService).update(eq(1), any(Country.class));
+        verify(countryService).update(eq(1), any(CountryDto.class));
     }
 
     @Test
@@ -145,7 +148,7 @@ class CountryControllerTest extends TestBase {
     @WithMockUser(roles = "USER")
     void add_shouldReturn403_whenUserNotAdmin() throws Exception {
         // When & Then
-        mockMvc.perform(postRequest("/countries", createTestCountry()))
+        mockMvc.perform(postRequest("/countries", createTestCountryDto()))
                 .andExpect(status().isForbidden());
     }
 
@@ -153,7 +156,7 @@ class CountryControllerTest extends TestBase {
     @WithMockUser(roles = "USER")
     void update_shouldReturn403_whenUserNotAdmin() throws Exception {
         // When & Then
-        mockMvc.perform(putRequest("/countries/1", createTestCountry()))
+        mockMvc.perform(putRequest("/countries/1", createTestCountryDto()))
                 .andExpect(status().isForbidden());
     }
 }

--- a/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/config/KafkaProducerConfig.java
+++ b/shared-lib/shared-starters/starter-kafka/src/main/java/com/shared/kafka_starter/config/KafkaProducerConfig.java
@@ -18,7 +18,7 @@ import java.util.concurrent.Future;
 
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.ClientInstanceId;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -89,7 +89,7 @@ public class KafkaProducerConfig {
       }
 
       @Override
-      public ClientInstanceId clientInstanceId(Duration timeout) {
+      public Uuid clientInstanceId(Duration timeout) {
         return producer.clientInstanceId(timeout);
       }
 


### PR DESCRIPTION
## Summary
- use CountryDto in CountryController tests and helpers
- correct KafkaProducerConfig to use Uuid for client instance ID

## Testing
- `mvn -q -pl shared-starters/starter-kafka -am test` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:pom:3.5.5)*
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68b595e1a3a0832f997869ec53303fc1