### PR TITLE
Add tenant lifecycle domain and API

### DIFF
--- a/tenant-service/pom.xml
+++ b/tenant-service/pom.xml
@@ -79,6 +79,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-cache</artifactId>
     </dependency>
     <dependency>

--- a/tenant-service/src/main/java/com/lms/tenantservice/TenantServiceApplication.java
+++ b/tenant-service/src/main/java/com/lms/tenantservice/TenantServiceApplication.java
@@ -1,0 +1,11 @@
+package com.lms.tenantservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TenantServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TenantServiceApplication.class, args);
+    }
+}

--- a/tenant-service/src/main/java/com/lms/tenantservice/domain/Tenant.java
+++ b/tenant-service/src/main/java/com/lms/tenantservice/domain/Tenant.java
@@ -1,0 +1,38 @@
+package com.lms.tenantservice.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Table(name = "tenant")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Tenant {
+    @Id
+    private UUID id;
+
+    private String name;
+
+    @Column(unique = true)
+    private String slug;
+
+    @Enumerated(EnumType.STRING)
+    private TenantStatus status;
+
+    private String locale;
+
+    private String timezone;
+
+    @ElementCollection
+    @CollectionTable(name = "tenant_domain", joinColumns = @JoinColumn(name = "tenant_id"))
+    @Column(name = "domain")
+    @Builder.Default
+    private Set<String> domains = new HashSet<>();
+}

--- a/tenant-service/src/main/java/com/lms/tenantservice/domain/TenantStatus.java
+++ b/tenant-service/src/main/java/com/lms/tenantservice/domain/TenantStatus.java
@@ -1,0 +1,8 @@
+package com.lms.tenantservice.domain;
+
+public enum TenantStatus {
+    CREATED,
+    ACTIVE,
+    SUSPENDED,
+    ARCHIVED
+}

--- a/tenant-service/src/main/java/com/lms/tenantservice/repository/TenantRepository.java
+++ b/tenant-service/src/main/java/com/lms/tenantservice/repository/TenantRepository.java
@@ -1,0 +1,9 @@
+package com.lms.tenantservice.repository;
+
+import com.lms.tenantservice.domain.Tenant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface TenantRepository extends JpaRepository<Tenant, UUID> {
+}

--- a/tenant-service/src/main/java/com/lms/tenantservice/service/TenantLifecycleService.java
+++ b/tenant-service/src/main/java/com/lms/tenantservice/service/TenantLifecycleService.java
@@ -1,0 +1,39 @@
+package com.lms.tenantservice.service;
+
+import com.lms.tenantservice.domain.Tenant;
+import com.lms.tenantservice.domain.TenantStatus;
+import com.lms.tenantservice.repository.TenantRepository;
+import com.lms.tenantservice.web.dto.CreateTenantRequest;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TenantLifecycleService {
+
+    private final TenantRepository tenantRepository;
+
+    public Tenant createTenant(CreateTenantRequest request) {
+        Tenant tenant = Tenant.builder()
+                .id(UUID.randomUUID())
+                .name(request.name())
+                .slug(request.slug())
+                .status(TenantStatus.CREATED)
+                .locale(request.locale())
+                .timezone(request.timezone())
+                .domains(request.domains() != null ? new HashSet<>(request.domains()) : new HashSet<>())
+                .build();
+        return tenantRepository.save(tenant);
+    }
+
+    public Tenant updateStatus(UUID id, TenantStatus status) {
+        Tenant tenant = tenantRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Tenant not found"));
+        tenant.setStatus(status);
+        return tenantRepository.save(tenant);
+    }
+}

--- a/tenant-service/src/main/java/com/lms/tenantservice/web/TenantController.java
+++ b/tenant-service/src/main/java/com/lms/tenantservice/web/TenantController.java
@@ -1,0 +1,33 @@
+package com.lms.tenantservice.web;
+
+import com.lms.tenantservice.domain.Tenant;
+import com.lms.tenantservice.domain.TenantStatus;
+import com.lms.tenantservice.service.TenantLifecycleService;
+import com.lms.tenantservice.web.dto.CreateTenantRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/tenants")
+@RequiredArgsConstructor
+public class TenantController {
+
+    private final TenantLifecycleService tenantService;
+
+    @PostMapping
+    public ResponseEntity<Tenant> createTenant(@RequestBody @Valid CreateTenantRequest request) {
+        Tenant created = tenantService.createTenant(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}/status/{status}")
+    public ResponseEntity<Tenant> updateStatus(@PathVariable UUID id, @PathVariable TenantStatus status) {
+        Tenant updated = tenantService.updateStatus(id, status);
+        return ResponseEntity.ok(updated);
+    }
+}

--- a/tenant-service/src/main/java/com/lms/tenantservice/web/dto/CreateTenantRequest.java
+++ b/tenant-service/src/main/java/com/lms/tenantservice/web/dto/CreateTenantRequest.java
@@ -1,0 +1,13 @@
+package com.lms.tenantservice.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.Set;
+
+public record CreateTenantRequest(
+        @NotBlank String name,
+        @NotBlank String slug,
+        Set<@NotBlank String> domains,
+        String locale,
+        String timezone
+) {
+}

--- a/tenant-service/src/main/resources/db/migration/V7__tenant_lifecycle.sql
+++ b/tenant-service/src/main/resources/db/migration/V7__tenant_lifecycle.sql
@@ -1,0 +1,11 @@
+-- Tenant lifecycle fields and domain table
+ALTER TABLE tenant ADD COLUMN IF NOT EXISTS slug VARCHAR(100);
+ALTER TABLE tenant ADD COLUMN IF NOT EXISTS status VARCHAR(20);
+ALTER TABLE tenant ADD COLUMN IF NOT EXISTS locale VARCHAR(20);
+ALTER TABLE tenant ADD COLUMN IF NOT EXISTS timezone VARCHAR(40);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_tenant_slug ON tenant(slug);
+CREATE TABLE IF NOT EXISTS tenant_domain (
+    tenant_id UUID NOT NULL REFERENCES tenant(id) ON DELETE CASCADE,
+    domain VARCHAR(255) NOT NULL,
+    PRIMARY KEY (tenant_id, domain)
+);

--- a/tenant-service/src/test/java/com/lms/tenantservice/repository/TenantRepositoryTest.java
+++ b/tenant-service/src/test/java/com/lms/tenantservice/repository/TenantRepositoryTest.java
@@ -1,0 +1,41 @@
+package com.lms.tenantservice.repository;
+
+import com.lms.tenantservice.domain.Tenant;
+import com.lms.tenantservice.domain.TenantStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class TenantRepositoryTest {
+
+    @Autowired
+    private TenantRepository tenantRepository;
+
+    @Test
+    void saveAndRetrieveTenant() {
+        Tenant tenant = Tenant.builder()
+                .id(UUID.randomUUID())
+                .name("Acme")
+                .slug("acme")
+                .status(TenantStatus.ACTIVE)
+                .locale("en_US")
+                .timezone("UTC")
+                .domains(Set.of("acme.example.com"))
+                .build();
+
+        tenantRepository.save(tenant);
+
+        Optional<Tenant> found = tenantRepository.findById(tenant.getId());
+        assertTrue(found.isPresent());
+        assertEquals("acme", found.get().getSlug());
+        assertEquals(TenantStatus.ACTIVE, found.get().getStatus());
+        assertEquals(Set.of("acme.example.com"), found.get().getDomains());
+    }
+}

--- a/tenant-service/src/test/resources/application.yml
+++ b/tenant-service/src/test/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  flyway:
+    enabled: true


### PR DESCRIPTION
## Summary
- introduce Tenant entity with slug, lifecycle status, locale, timezone and domains
- add REST API to create tenants and update their status
- add Flyway migration and unit test for tenant persistence

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fb2d8f48832f82ae413bdc1cf1f8