### PR TITLE
feat: add tenant retrieval endpoints

### DIFF
--- a/tenant-service/src/main/java/com/lms/tenantservice/service/TenantLifecycleService.java
+++ b/tenant-service/src/main/java/com/lms/tenantservice/service/TenantLifecycleService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -35,5 +36,14 @@ public class TenantLifecycleService {
                 .orElseThrow(() -> new EntityNotFoundException("Tenant not found"));
         tenant.setStatus(status);
         return tenantRepository.save(tenant);
+    }
+
+    public Tenant getTenant(UUID id) {
+        return tenantRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Tenant not found"));
+    }
+
+    public List<Tenant> listTenants() {
+        return tenantRepository.findAll();
     }
 }

--- a/tenant-service/src/main/java/com/lms/tenantservice/web/TenantController.java
+++ b/tenant-service/src/main/java/com/lms/tenantservice/web/TenantController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -23,6 +24,16 @@ public class TenantController {
     public ResponseEntity<Tenant> createTenant(@RequestBody @Valid CreateTenantRequest request) {
         Tenant created = tenantService.createTenant(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Tenant>> listTenants() {
+        return ResponseEntity.ok(tenantService.listTenants());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Tenant> getTenant(@PathVariable UUID id) {
+        return ResponseEntity.ok(tenantService.getTenant(id));
     }
 
     @PutMapping("/{id}/status/{status}")

--- a/tenant-service/src/test/java/com/lms/tenantservice/service/TenantLifecycleServiceTest.java
+++ b/tenant-service/src/test/java/com/lms/tenantservice/service/TenantLifecycleServiceTest.java
@@ -1,0 +1,62 @@
+package com.lms.tenantservice.service;
+
+import com.lms.tenantservice.domain.Tenant;
+import com.lms.tenantservice.domain.TenantStatus;
+import com.lms.tenantservice.repository.TenantRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import(TenantLifecycleService.class)
+class TenantLifecycleServiceTest {
+
+    @Autowired
+    private TenantLifecycleService service;
+
+    @Autowired
+    private TenantRepository repository;
+
+    @Test
+    void getTenantReturnsPersistedTenant() {
+        Tenant tenant = Tenant.builder()
+                .id(UUID.randomUUID())
+                .name("Acme")
+                .slug("acme")
+                .status(TenantStatus.ACTIVE)
+                .domains(Set.of())
+                .build();
+        repository.save(tenant);
+
+        Tenant found = service.getTenant(tenant.getId());
+        assertEquals("acme", found.getSlug());
+    }
+
+    @Test
+    void listTenantsReturnsAllTenants() {
+        Tenant t1 = Tenant.builder()
+                .id(UUID.randomUUID())
+                .name("Tenant1")
+                .slug("tenant1")
+                .status(TenantStatus.CREATED)
+                .domains(Set.of())
+                .build();
+        Tenant t2 = Tenant.builder()
+                .id(UUID.randomUUID())
+                .name("Tenant2")
+                .slug("tenant2")
+                .status(TenantStatus.CREATED)
+                .domains(Set.of())
+                .build();
+        repository.save(t1);
+        repository.save(t2);
+
+        assertEquals(2, service.listTenants().size());
+    }
+}


### PR DESCRIPTION
## Summary
- expose endpoints to list tenants and fetch a tenant by ID
- add service methods for listing and retrieving tenants
- test tenant lifecycle service

## Testing
- `mvn -q -f shared-lib/pom.xml test` *(fails: Could not resolve dependencies, Network is unreachable)*
- `mvn -q -f lms-setup/pom.xml test` *(fails: Non-resolvable parent POM, Network is unreachable)*
- `mvn -q -f tenant-service/pom.xml test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fcd4afb4832fa60b2756f4317747