### PR TITLE
Add policy API and OpenAPI config for tenant service

### DIFF
--- a/tenant-platform/tenant-api/pom.xml
+++ b/tenant-platform/tenant-api/pom.xml
@@ -4,7 +4,29 @@
   <parent><groupId>com.acme.tenant</groupId><artifactId>tenant-platform</artifactId><version>1.0.0-SNAPSHOT</version></parent>
   <artifactId>tenant-api</artifactId>
   <dependencies>
-    <dependency><groupId>com.shared</groupId><artifactId>shared-starter-openapi</artifactId></dependency>
-    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
+    <dependency>
+      <groupId>com.acme.tenant</groupId>
+      <artifactId>tenant-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.acme.tenant</groupId>
+      <artifactId>tenant-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.shared</groupId>
+      <artifactId>shared-starter-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.shared</groupId>
+      <artifactId>shared-starter-openapi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/OpenApiConfig.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/OpenApiConfig.java
@@ -1,0 +1,17 @@
+package com.acme.tenant.api;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+        .components(new Components())
+        .info(new Info().title("Tenant API").version("1.0.0"));
+  }
+}

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/PolicyController.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/PolicyController.java
@@ -1,0 +1,48 @@
+package com.acme.tenant.api;
+
+import com.acme.tenant.core.PolicyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/tenants/{tenantId}")
+public class PolicyController {
+  private final PolicyService service;
+
+  public PolicyController(PolicyService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/entitlements")
+  public ResponseEntity<PolicyService.Entitlements> entitlements(@PathVariable UUID tenantId) {
+    return ResponseEntity.ok(service.effective(tenantId));
+  }
+
+  @PostMapping("/features/{featureKey}/consume")
+  public ResponseEntity<PolicyService.EnforcementResult> consume(
+      @PathVariable UUID tenantId,
+      @PathVariable String featureKey,
+      @Valid @RequestBody ConsumeRequest req) {
+    var result = service.consumeOrOverage(
+        tenantId,
+        featureKey,
+        req.delta(),
+        req.periodStart(),
+        req.periodEnd(),
+        () -> req.currentUsage(),
+        req.idempotencyKey());
+    return ResponseEntity.ok(result);
+  }
+
+  public record ConsumeRequest(
+      long delta,
+      long currentUsage,
+      @NotNull Instant periodStart,
+      @NotNull Instant periodEnd,
+      String idempotencyKey) {}
+}

--- a/tenant-platform/tenant-core/pom.xml
+++ b/tenant-platform/tenant-core/pom.xml
@@ -1,1 +1,21 @@
-<project><modelVersion>4.0.0</modelVersion><parent><groupId>com.acme.tenant</groupId><artifactId>tenant-platform</artifactId><version>1.0.0-SNAPSHOT</version></parent><artifactId>tenant-core</artifactId></project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.acme.tenant</groupId>
+    <artifactId>tenant-platform</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>tenant-core</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.acme.tenant</groupId>
+      <artifactId>tenant-persistence</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
## Summary
- expose policy endpoints for retrieving entitlements and consuming features
- wire tenant-core and config modules with shared starter dependencies
- configure basic OpenAPI metadata

## Testing
- `mvn -q -f tenant-platform/pom.xml test` *(fails: Non-resolvable import POM: spring-boot-dependencies & shared-bom)*

------
https://chatgpt.com/codex/tasks/task_e_68b6055d9d2c832f9becf4651c805920