### PR TITLE
Add reusable tenant-config module

### DIFF
--- a/tenant-config/README.md
+++ b/tenant-config/README.md
@@ -1,0 +1,41 @@
+# tenant-config (shared module)
+
+Reusable Spring Boot module providing multi-tenant plumbing:
+
+- `TenantContext` (ThreadLocal)
+- `TenantResolverService` (slug/domain → tenant UUID)
+- `TenantResolverFilter` (extracts tenant, sets MDC + Postgres `app.current_tenant`)
+- `TenantAwareDataSource` + BeanPostProcessor (ensures every borrowed connection runs `set_config`)
+- Auto-configuration via Spring Boot imports; configurable with properties
+
+## Install / Use
+Add dependency to your service `pom.xml`:
+```xml
+<dependency>
+  <groupId>com.lms.tenant</groupId>
+  <artifactId>tenant-config</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+</dependency>
+```
+
+Ensure your service has Postgres + Flyway with a `tenant` table (id, slug, domains\[], status enum).
+
+## Configuration (application.yaml)
+
+```yaml
+lms:
+  tenant:
+    resolution:
+      use-subdomain: true              # parse subdomain as tenant key
+      header-primary: X-Tenant-ID      # fallback header
+      header-secondary: X-Auth-Tenant  # secondary fallback
+      wrap-data-source: true           # wrap DataSource to set app.current_tenant per connection
+```
+
+## Notes
+
+* The filter sets `MDC[tenant_id]` for log correlation.
+* `TenantAwareDataSource` avoids leaks when multiple connections are used in a single request.
+* If your shared-library provides a resolver API, you can replace `TenantResolverService` via a bean override.
+
+```

--- a/tenant-config/pom.xml
+++ b/tenant-config/pom.xml
@@ -1,0 +1,70 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.lms.tenant</groupId>
+  <artifactId>tenant-config</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>tenant-config</name>
+  <description>Reusable multi-tenant config (ThreadLocal, filter, DataSource wrapper, autoconfig)</description>
+  <packaging>jar</packaging>
+
+  <properties>
+    <java.version>21</java.version>
+    <spring-boot.version>3.5.2</spring-boot.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- optional shared BOM; if present align versions -->
+      <dependency>
+        <groupId>com.shared</groupId>
+        <artifactId>shared-bom</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- shared starters (optional) -->
+    <dependency><groupId>com.shared</groupId><artifactId>shared-starter-core</artifactId></dependency>
+    <dependency><groupId>com.shared</groupId><artifactId>shared-starter-headers</artifactId></dependency>
+
+    <!-- Spring Web/JDBC/Cache/Redis -->
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-jdbc</artifactId></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-cache</artifactId></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-data-redis</artifactId></dependency>
+
+    <!-- Optional: Postgres driver for direct SQL in filter/service (pulled from app usually) -->
+    <dependency><groupId>org.postgresql</groupId><artifactId>postgresql</artifactId></dependency>
+
+    <!-- annotations -->
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-autoconfigure</artifactId></dependency>
+    <dependency><groupId>org.springframework</groupId><artifactId>spring-context</artifactId></dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <parameters>true</parameters>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tenant-config/src/main/java/com/lms/tenant/config/TenantAwareDataSource.java
+++ b/tenant-config/src/main/java/com/lms/tenant/config/TenantAwareDataSource.java
@@ -1,0 +1,26 @@
+package com.lms.tenant.config;
+
+import org.springframework.jdbc.datasource.DelegatingDataSource;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/** Wraps a DataSource so every borrowed Connection sets app.current_tenant from TenantContext. */
+public class TenantAwareDataSource extends DelegatingDataSource {
+  public TenantAwareDataSource(DataSource targetDataSource) { super(targetDataSource); }
+
+  @Override public Connection getConnection() throws SQLException { return init(super.getConnection()); }
+  @Override public Connection getConnection(String username, String password) throws SQLException { return init(super.getConnection(username, password)); }
+
+  private Connection init(Connection c) throws SQLException {
+    String tid = TenantContext.get();
+    if (tid != null) {
+      try (Statement st = c.createStatement()) {
+        st.execute("select set_config('app.current_tenant', '" + tid + "', true)");
+      }
+    }
+    return c;
+  }
+}

--- a/tenant-config/src/main/java/com/lms/tenant/config/TenantAwareDataSourcePostProcessor.java
+++ b/tenant-config/src/main/java/com/lms/tenant/config/TenantAwareDataSourcePostProcessor.java
@@ -1,0 +1,21 @@
+package com.lms.tenant.config;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+
+/** Wraps any primary DataSource with TenantAwareDataSource when enabled. */
+@Component
+@ConditionalOnProperty(prefix = "lms.tenant.resolution", name = "wrap-data-source", havingValue = "true", matchIfMissing = true)
+public class TenantAwareDataSourcePostProcessor implements BeanPostProcessor {
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+    if (bean instanceof DataSource ds && !(bean instanceof TenantAwareDataSource)) {
+      return new TenantAwareDataSource(ds);
+    }
+    return bean;
+  }
+}

--- a/tenant-config/src/main/java/com/lms/tenant/config/TenantConfigAutoConfiguration.java
+++ b/tenant-config/src/main/java/com/lms/tenant/config/TenantConfigAutoConfiguration.java
@@ -1,0 +1,23 @@
+package com.lms.tenant.config;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@AutoConfiguration
+@EnableConfigurationProperties(TenantResolutionProperties.class)
+@ConditionalOnClass({JdbcTemplate.class, TenantResolverFilter.class})
+public class TenantConfigAutoConfiguration {
+
+  @Bean
+  public TenantResolverService tenantResolverService(org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate jdbc) {
+    return new TenantResolverService(jdbc);
+  }
+
+  @Bean
+  public TenantResolverFilter tenantResolverFilter(JdbcTemplate jdbc, TenantResolverService resolver, TenantResolutionProperties props) {
+    return new TenantResolverFilter(jdbc, resolver, props);
+  }
+}

--- a/tenant-config/src/main/java/com/lms/tenant/config/TenantContext.java
+++ b/tenant-config/src/main/java/com/lms/tenant/config/TenantContext.java
@@ -1,0 +1,10 @@
+package com.lms.tenant.config;
+
+/** Holds the current tenant for the scope of a request/thread. */
+public final class TenantContext {
+  private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+  private TenantContext() {}
+  public static void set(String tenantId) { CURRENT.set(tenantId); }
+  public static String get() { return CURRENT.get(); }
+  public static void clear() { CURRENT.remove(); }
+}

--- a/tenant-config/src/main/java/com/lms/tenant/config/TenantResolutionProperties.java
+++ b/tenant-config/src/main/java/com/lms/tenant/config/TenantResolutionProperties.java
@@ -1,0 +1,23 @@
+package com.lms.tenant.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "lms.tenant.resolution")
+public class TenantResolutionProperties {
+  /** If true, try to parse subdomain as tenant key. */
+  private boolean useSubdomain = true;
+  /** Header names checked in order when subdomain not resolved. */
+  private String headerPrimary = "X-Tenant-ID";
+  private String headerSecondary = "X-Auth-Tenant";
+  /** Enable DataSource wrapping to set app.current_tenant on every borrowed connection. */
+  private boolean wrapDataSource = true;
+
+  public boolean isUseSubdomain() { return useSubdomain; }
+  public void setUseSubdomain(boolean useSubdomain) { this.useSubdomain = useSubdomain; }
+  public String getHeaderPrimary() { return headerPrimary; }
+  public void setHeaderPrimary(String headerPrimary) { this.headerPrimary = headerPrimary; }
+  public String getHeaderSecondary() { return headerSecondary; }
+  public void setHeaderSecondary(String headerSecondary) { this.headerSecondary = headerSecondary; }
+  public boolean isWrapDataSource() { return wrapDataSource; }
+  public void setWrapDataSource(boolean wrapDataSource) { this.wrapDataSource = wrapDataSource; }
+}

--- a/tenant-config/src/main/java/com/lms/tenant/config/TenantResolverFilter.java
+++ b/tenant-config/src/main/java/com/lms/tenant/config/TenantResolverFilter.java
@@ -1,0 +1,65 @@
+package com.lms.tenant.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Extract tenant key (subdomain or header), resolve to UUID, push to TenantContext + MDC,
+ * and set Postgres GUC `app.current_tenant` for the current connection.
+ */
+@Component
+public class TenantResolverFilter extends OncePerRequestFilter {
+  private static final Pattern SUBDOMAIN = Pattern.compile("^([a-z0-9-]+)\\.");
+  private final JdbcTemplate jdbc;
+  private final TenantResolverService resolver;
+  private final TenantResolutionProperties props;
+
+  public TenantResolverFilter(JdbcTemplate jdbc, TenantResolverService resolver, TenantResolutionProperties props) {
+    this.jdbc = jdbc; this.resolver = resolver; this.props = props;
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+      throws ServletException, IOException {
+    String tenantKey = extract(req);
+    var tenant = resolver.resolve(tenantKey);
+    if (tenant == null) { res.sendError(404, "Tenant not found or inactive"); return; }
+
+    String tid = tenant.id().toString();
+    TenantContext.set(tid);
+    MDC.put("tenant_id", tid);
+    try {
+      // Set once for the current connection if re-used by JdbcTemplate; wrapped DataSource will handle others
+      jdbc.execute("select set_config('app.current_tenant', '" + tid + "', true)");
+      chain.doFilter(req, res);
+    } finally {
+      TenantContext.clear();
+      MDC.remove("tenant_id");
+    }
+  }
+
+  private String extract(HttpServletRequest req) {
+    if (props.isUseSubdomain()) {
+      String host = req.getHeader("host");
+      if (host != null) {
+        Matcher m = SUBDOMAIN.matcher(host);
+        if (m.find()) return m.group(1);
+      }
+    }
+    String hdr = req.getHeader(props.getHeaderPrimary());
+    if (hdr != null && !hdr.isBlank()) return hdr;
+    String claim = req.getHeader(props.getHeaderSecondary());
+    if (claim != null && !claim.isBlank()) return claim;
+    throw new IllegalArgumentException("Tenant not resolved");
+  }
+}

--- a/tenant-config/src/main/java/com/lms/tenant/config/TenantResolverService.java
+++ b/tenant-config/src/main/java/com/lms/tenant/config/TenantResolverService.java
@@ -1,0 +1,30 @@
+package com.lms.tenant.config;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class TenantResolverService {
+  private final NamedParameterJdbcTemplate jdbc;
+  public record TenantRow(UUID id, String slug, String status) {}
+  public TenantResolverService(NamedParameterJdbcTemplate jdbc) { this.jdbc = jdbc; }
+
+  /**
+   * Resolve tenant by slug or domain; requires a `tenant` table with (tenant_id, tenant_slug, domains[], status).
+   */
+  @Cacheable(value = "tenant_slug_cache", key = "#key", unless = "#result == null")
+  public TenantRow resolve(String key) {
+    String sql = """
+      select tenant_id as id, tenant_slug as slug, status::text as status
+      from tenant where (tenant_slug = :k or :k = any(domains)) and status='ACTIVE'::tenant_status
+      limit 1
+    """;
+    return jdbc.query(sql, Map.of("k", key), rs -> rs.next()
+        ? new TenantRow((UUID) rs.getObject("id"), rs.getString("slug"), rs.getString("status"))
+        : null);
+  }
+}

--- a/tenant-config/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tenant-config/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.lms.tenant.config.TenantConfigAutoConfiguration


### PR DESCRIPTION
## Summary
- add reusable multi-tenant configuration module with context holder, resolver, filter, and datasource wrapper
- auto-configure tenant utilities with Spring Boot imports
- document module usage and properties in README

## Testing
- `mvn -q -f tenant-config/pom.xml test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6067a724c832fab86fb6279c7572d