### PR TITLE
feat: add tenant events outbox module

### DIFF
--- a/tenant-events/README.md
+++ b/tenant-events/README.md
@@ -1,0 +1,52 @@
+# tenant-events (com.lms.tenant.events)
+
+Transactional Outbox + Publisher for multi-tenant services.
+
+- **Outbox table** holds events until published
+- **Publisher** uses SKIP LOCKED to fetch batches safely across replicas
+- **KafkaPublisher** (preferred, via shared/spring Kafka)
+- **LogPublisher** fallback when Kafka not available
+- **Tenant headers** sourced from MDC or `TenantContext` if on classpath
+
+## Flyway migration (add to your service)
+```sql
+-- Vx__outbox.sql
+do $$ begin
+  if not exists (select 1 from information_schema.tables where table_name='outbox_event') then
+    create table outbox_event (
+      event_id uuid primary key,
+      event_type text not null,
+      aggregate_type text not null,
+      aggregate_id uuid not null,
+      occurred_at timestamptz not null default now(),
+      payload jsonb not null,
+      headers jsonb not null,
+      status text not null default 'NEW',
+      attempts int not null default 0,
+      published_at timestamptz
+    );
+    create index ix_outbox_status_occurred on outbox_event(status, occurred_at);
+  end if;
+end $$;
+```
+
+## Configuration
+
+```yaml
+lms:
+  events:
+    topicPrefix: lms.tenant
+    batchSize: 200
+    maxAttempts: 10
+    schedule: PT1S
+    cleanupAfterDays: 14
+```
+
+## Usage
+
+* Inject `OutboxService` and call `append(event, headers)` inside the same transaction as your domain change.
+* The scheduled `OutboxPublisher` publishes to Kafka (or logs) and marks events as `PUBLISHED`.
+
+**Note:** Replace topic naming / partitioning to your conventions. For dead-lettering, configure Kafka DLQ or extend the publisher.
+
+```

--- a/tenant-events/pom.xml
+++ b/tenant-events/pom.xml
@@ -1,0 +1,75 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.lms.tenant</groupId>
+  <artifactId>tenant-events</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>tenant-events</name>
+  <description>Transactional outbox + publisher with shared-library Kafka integration</description>
+
+  <properties>
+    <java.version>21</java.version>
+    <spring-boot.version>3.5.2</spring-boot.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.shared</groupId>
+        <artifactId>shared-bom</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Shared starters (preferred) -->
+    <dependency><groupId>com.shared</groupId><artifactId>shared-starter-core</artifactId></dependency>
+    <dependency><groupId>com.shared</groupId><artifactId>shared-starter-headers</artifactId></dependency>
+    <dependency><groupId>com.shared</groupId><artifactId>shared-starter-kafka</artifactId></dependency>
+
+    <!-- Spring infra -->
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter</artifactId></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-jdbc</artifactId></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-data-jpa</artifactId></dependency>
+    <dependency><groupId>org.springframework.kafka</groupId><artifactId>spring-kafka</artifactId></dependency>
+
+    <!-- Jackson -->
+    <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId></dependency>
+
+    <!-- Postgres driver for JSONB + SKIP LOCKED -->
+    <dependency><groupId>org.postgresql</groupId><artifactId>postgresql</artifactId></dependency>
+
+    <!-- Test -->
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <parameters>true</parameters>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tenant-events/src/main/java/com/lms/tenant/events/config/EventsAutoConfiguration.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/config/EventsAutoConfiguration.java
@@ -1,0 +1,44 @@
+package com.lms.tenant.events.config;
+
+import com.lms.tenant.events.publisher.*;
+import com.lms.tenant.events.support.TenantHeaderSupplier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@AutoConfiguration
+@EnableConfigurationProperties(EventsProperties.class)
+public class EventsAutoConfiguration {
+
+  @Bean
+  public OutboxService outboxService(JdbcTemplate jdbc) { return new OutboxService(jdbc); }
+
+  @Bean
+  @ConditionalOnClass(name = "org.springframework.kafka.core.KafkaTemplate")
+  public KafkaPublisher kafkaPublisher(org.springframework.kafka.core.KafkaTemplate<String, String> template,
+                                       EventsProperties props,
+                                       TenantHeaderSupplier tenantHeaderSupplier) {
+    return new KafkaPublisher(template, props, tenantHeaderSupplier);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(KafkaPublisher.class)
+  public LogPublisher logPublisher(EventsProperties props, TenantHeaderSupplier tenantHeaderSupplier) {
+    return new LogPublisher(props, tenantHeaderSupplier);
+  }
+
+  @Bean
+  public OutboxPublisher outboxPublisher(OutboxService outboxService,
+                                         EventsProperties props,
+                                         java.util.Optional<KafkaPublisher> kafka,
+                                         java.util.Optional<LogPublisher> log) {
+    return new OutboxPublisher(outboxService, props, kafka.orElse(null), log.orElse(null));
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(TenantHeaderSupplier.class)
+  public TenantHeaderSupplier defaultTenantHeaderSupplier() { return new TenantHeaderSupplier.Default(); }
+}

--- a/tenant-events/src/main/java/com/lms/tenant/events/config/EventsProperties.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/config/EventsProperties.java
@@ -1,0 +1,28 @@
+package com.lms.tenant.events.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "lms.events")
+public class EventsProperties {
+  /** base topic prefix (final topic: <topicPrefix>.<eventType>), e.g. lms.tenant */
+  private String topicPrefix = "lms.tenant";
+  /** batch size for outbox publisher */
+  private int batchSize = 200;
+  /** max attempts before marking DEAD */
+  private int maxAttempts = 10;
+  /** schedule delay (ISO-8601), default PT1S */
+  private String schedule = "PT1S";
+  /** cleanup after days */
+  private int cleanupAfterDays = 14;
+
+  public String getTopicPrefix() { return topicPrefix; }
+  public void setTopicPrefix(String topicPrefix) { this.topicPrefix = topicPrefix; }
+  public int getBatchSize() { return batchSize; }
+  public void setBatchSize(int batchSize) { this.batchSize = batchSize; }
+  public int getMaxAttempts() { return maxAttempts; }
+  public void setMaxAttempts(int maxAttempts) { this.maxAttempts = maxAttempts; }
+  public String getSchedule() { return schedule; }
+  public void setSchedule(String schedule) { this.schedule = schedule; }
+  public int getCleanupAfterDays() { return cleanupAfterDays; }
+  public void setCleanupAfterDays(int cleanupAfterDays) { this.cleanupAfterDays = cleanupAfterDays; }
+}

--- a/tenant-events/src/main/java/com/lms/tenant/events/core/DomainEvent.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/core/DomainEvent.java
@@ -1,0 +1,12 @@
+package com.lms.tenant.events.core;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** Marker for domain events. Keep flat, JSON-friendly fields in implementations. */
+public interface DomainEvent {
+  String eventType();            // e.g. TenantCreated
+  UUID aggregateId();            // e.g. tenantId
+  String aggregateType();        // e.g. tenant
+  Instant occurredAt();
+}

--- a/tenant-events/src/main/java/com/lms/tenant/events/core/EventEnvelope.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/core/EventEnvelope.java
@@ -1,0 +1,16 @@
+package com.lms.tenant.events.core;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/** Persisted envelope for publishing; includes headers (e.g., tenant_id, trace_id). */
+public record EventEnvelope(
+    UUID eventId,
+    String eventType,
+    String aggregateType,
+    UUID aggregateId,
+    Instant occurredAt,
+    Map<String, Object> payload,
+    Map<String, Object> headers
+) {}

--- a/tenant-events/src/main/java/com/lms/tenant/events/core/OutboxEvent.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/core/OutboxEvent.java
@@ -1,0 +1,34 @@
+package com.lms.tenant.events.core;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "outbox_event")
+public class OutboxEvent {
+  @Id @Column(name = "event_id", nullable = false) private UUID eventId;
+  @Column(name = "event_type", nullable = false) private String eventType;
+  @Column(name = "aggregate_type", nullable = false) private String aggregateType;
+  @Column(name = "aggregate_id", nullable = false) private UUID aggregateId;
+  @Column(name = "occurred_at", nullable = false) private Instant occurredAt;
+  @Column(name = "payload", columnDefinition = "jsonb", nullable = false) private String payloadJson;
+  @Column(name = "headers", columnDefinition = "jsonb", nullable = false) private String headersJson;
+  @Enumerated(EnumType.STRING) @Column(name = "status", nullable = false) private OutboxStatus status = OutboxStatus.NEW;
+  @Column(name = "attempts", nullable = false) private int attempts = 0;
+  @Column(name = "published_at") private Instant publishedAt;
+
+  @PrePersist public void prePersist(){ if(eventId==null) eventId=UUID.randomUUID(); if(occurredAt==null) occurredAt=Instant.now(); }
+
+  // getters/setters
+  public UUID getEventId(){return eventId;} public void setEventId(UUID v){eventId=v;}
+  public String getEventType(){return eventType;} public void setEventType(String v){eventType=v;}
+  public String getAggregateType(){return aggregateType;} public void setAggregateType(String v){aggregateType=v;}
+  public UUID getAggregateId(){return aggregateId;} public void setAggregateId(UUID v){aggregateId=v;}
+  public Instant getOccurredAt(){return occurredAt;} public void setOccurredAt(Instant v){occurredAt=v;}
+  public String getPayloadJson(){return payloadJson;} public void setPayloadJson(String v){payloadJson=v;}
+  public String getHeadersJson(){return headersJson;} public void setHeadersJson(String v){headersJson=v;}
+  public OutboxStatus getStatus(){return status;} public void setStatus(OutboxStatus v){status=v;}
+  public int getAttempts(){return attempts;} public void setAttempts(int v){attempts=v;}
+  public Instant getPublishedAt(){return publishedAt;} public void setPublishedAt(Instant v){publishedAt=v;}
+}

--- a/tenant-events/src/main/java/com/lms/tenant/events/core/OutboxRepository.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/core/OutboxRepository.java
@@ -1,0 +1,20 @@
+package com.lms.tenant.events.core;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface OutboxRepository extends JpaRepository<OutboxEvent, UUID> {
+
+  @Query(value = """
+    select * from outbox_event
+     where status in ('NEW','FAILED')
+     order by occurred_at
+     for update skip locked
+     limit :n
+  """ , nativeQuery = true)
+  List<OutboxEvent> lockNextBatch(@Param("n") int n);
+}

--- a/tenant-events/src/main/java/com/lms/tenant/events/core/OutboxStatus.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/core/OutboxStatus.java
@@ -1,0 +1,2 @@
+package com.lms.tenant.events.core;
+public enum OutboxStatus { NEW, PUBLISHED, FAILED, DEAD }

--- a/tenant-events/src/main/java/com/lms/tenant/events/publisher/KafkaPublisher.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/publisher/KafkaPublisher.java
@@ -1,0 +1,38 @@
+package com.lms.tenant.events.publisher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lms.tenant.events.config.EventsProperties;
+import com.lms.tenant.events.core.OutboxEvent;
+import com.lms.tenant.events.core.OutboxStatus;
+import com.lms.tenant.events.support.JsonSupport;
+import com.lms.tenant.events.support.TenantHeaderSupplier;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Instant;
+
+/** Publishes outbox events to Kafka using shared/spring Kafka template. */
+public class KafkaPublisher {
+  private final KafkaTemplate<String, String> template;
+  private final EventsProperties props;
+  private final TenantHeaderSupplier tenantHeaderSupplier;
+  private final ObjectMapper om = JsonSupport.mapper();
+
+  public KafkaPublisher(KafkaTemplate<String, String> template, EventsProperties props, TenantHeaderSupplier tenantHeaderSupplier) {
+    this.template = template; this.props = props; this.tenantHeaderSupplier = tenantHeaderSupplier;
+  }
+
+  public void publish(OutboxEvent e) throws Exception {
+    String topic = props.getTopicPrefix() + "." + e.getEventType();
+    String key = e.getAggregateId().toString();
+    var record = new ProducerRecord<String, String>(topic, key, e.getPayloadJson());
+    // add headers
+    tenantHeaderSupplier.headers().forEach((k,v) -> record.headers().add(k, String.valueOf(v).getBytes()));
+    record.headers().add("event_id", e.getEventId().toString().getBytes());
+    record.headers().add("occurred_at", e.getOccurredAt().toString().getBytes());
+
+    template.send(record).get(); // block for simplicity; switch to callback if needed
+    e.setStatus(OutboxStatus.PUBLISHED);
+    e.setPublishedAt(Instant.now());
+  }
+}

--- a/tenant-events/src/main/java/com/lms/tenant/events/publisher/LogPublisher.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/publisher/LogPublisher.java
@@ -1,0 +1,29 @@
+package com.lms.tenant.events.publisher;
+
+import com.lms.tenant.events.config.EventsProperties;
+import com.lms.tenant.events.core.OutboxEvent;
+import com.lms.tenant.events.core.OutboxStatus;
+import com.lms.tenant.events.support.TenantHeaderSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+
+/** Fallback publisher if Kafka is not on the classpath. */
+public class LogPublisher {
+  private static final Logger log = LoggerFactory.getLogger(LogPublisher.class);
+  private final EventsProperties props;
+  private final TenantHeaderSupplier tenantHeaderSupplier;
+
+  public LogPublisher(EventsProperties props, TenantHeaderSupplier tenantHeaderSupplier) {
+    this.props = props; this.tenantHeaderSupplier = tenantHeaderSupplier;
+  }
+
+  public void publish(OutboxEvent e) {
+    log.info("[OUTBOX->LOG] topic={} key={} eventId={} type={} payload={} headers={}",
+        props.getTopicPrefix() + "." + e.getEventType(), e.getAggregateId(), e.getEventId(), e.getEventType(),
+        e.getPayloadJson(), tenantHeaderSupplier.headers());
+    e.setStatus(OutboxStatus.PUBLISHED);
+    e.setPublishedAt(Instant.now());
+  }
+}

--- a/tenant-events/src/main/java/com/lms/tenant/events/publisher/OutboxPublisher.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/publisher/OutboxPublisher.java
@@ -1,0 +1,71 @@
+package com.lms.tenant.events.publisher;
+
+import com.lms.tenant.events.config.EventsProperties;
+import com.lms.tenant.events.core.OutboxEvent;
+import com.lms.tenant.events.core.OutboxStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** Periodically reads from outbox using SKIP LOCKED and publishes. */
+public class OutboxPublisher {
+  private static final Logger log = LoggerFactory.getLogger(OutboxPublisher.class);
+  private final OutboxService outboxService;
+  private final EventsProperties props;
+  private final KafkaPublisher kafka; // may be null
+  private final LogPublisher logPublisher; // may be null
+  private final NamedParameterJdbcTemplate jdbc;
+
+  public OutboxPublisher(OutboxService outboxService, EventsProperties props, KafkaPublisher kafka, LogPublisher logPublisher) {
+    this.outboxService = outboxService; this.props = props; this.kafka = kafka; this.logPublisher = logPublisher;
+    this.jdbc = outboxService.getJdbc();
+  }
+
+  private List<OutboxEvent> lockBatch(int n) {
+    String sql = "select * from outbox_event where status in ('NEW','FAILED') order by occurred_at for update skip locked limit :n";
+    return jdbc.query(sql, new MapSqlParameterSource().addValue("n", n), (rs, i) -> {
+      var e = new OutboxEvent();
+      e.setEventId(java.util.UUID.fromString(rs.getString("event_id")));
+      e.setEventType(rs.getString("event_type"));
+      e.setAggregateType(rs.getString("aggregate_type"));
+      e.setAggregateId(java.util.UUID.fromString(rs.getString("aggregate_id")));
+      e.setOccurredAt(rs.getTimestamp("occurred_at").toInstant());
+      e.setPayloadJson(rs.getString("payload"));
+      e.setHeadersJson(rs.getString("headers"));
+      e.setStatus(OutboxStatus.valueOf(rs.getString("status")));
+      e.setAttempts(rs.getInt("attempts"));
+      return e;
+    });
+  }
+
+  @Scheduled(fixedDelayString = "${lms.events.schedule:PT1S}")
+  @Transactional
+  public void publish() {
+    int batch = props.getBatchSize();
+    List<OutboxEvent> events = lockBatch(batch);
+    if (events.isEmpty()) return;
+
+    for (OutboxEvent e : events) {
+      try {
+        if (kafka != null) kafka.publish(e); else if (logPublisher != null) logPublisher.publish(e);
+        updateStatus(e, OutboxStatus.PUBLISHED, null);
+      } catch (Exception ex) {
+        int attempts = e.getAttempts() + 1;
+        e.setAttempts(attempts);
+        var newStatus = attempts >= props.getMaxAttempts() ? OutboxStatus.DEAD : OutboxStatus.FAILED;
+        updateStatus(e, newStatus, ex);
+      }
+    }
+  }
+
+  private void updateStatus(OutboxEvent e, OutboxStatus status, Exception ex) {
+    String sql = "update outbox_event set status=:s, attempts=:a, published_at = case when :s='PUBLISHED' then now() else published_at end where event_id=:id";
+    jdbc.update(sql, new MapSqlParameterSource().addValue("s", status.name()).addValue("a", e.getAttempts()).addValue("id", e.getEventId()));
+    if (ex != null) log.warn("Failed to publish event {} attempt {} => {}", e.getEventId(), e.getAttempts(), ex.toString());
+  }
+}

--- a/tenant-events/src/main/java/com/lms/tenant/events/publisher/OutboxService.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/publisher/OutboxService.java
@@ -1,0 +1,48 @@
+package com.lms.tenant.events.publisher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lms.tenant.events.core.DomainEvent;
+import com.lms.tenant.events.support.JsonSupport;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/** Minimal JDBC-based outbox writer; avoids JPA session constraints in calling services. */
+public class OutboxService {
+  private final NamedParameterJdbcTemplate jdbc;
+  private final ObjectMapper om = JsonSupport.mapper();
+
+  public OutboxService(JdbcTemplate jdbc) { this.jdbc = new NamedParameterJdbcTemplate(jdbc); }
+
+  @Transactional
+  public UUID append(DomainEvent evt, Map<String,Object> headers) {
+    try {
+      UUID id = UUID.randomUUID();
+      String payload = om.writeValueAsString(evt);
+      String headersJson = om.writeValueAsString(headers);
+      var sql = """
+        insert into outbox_event(event_id,event_type,aggregate_type,aggregate_id,occurred_at,payload,headers,status,attempts)
+        values(:id,:etype,:atype,:aid,:ts, cast(:payload as jsonb), cast(:headers as jsonb),'NEW',0)
+      """;
+      var ps = new MapSqlParameterSource()
+          .addValue("id", id)
+          .addValue("etype", evt.eventType())
+          .addValue("atype", evt.aggregateType())
+          .addValue("aid", evt.aggregateId())
+          .addValue("ts", evt.occurredAt()==null? Instant.now(): evt.occurredAt())
+          .addValue("payload", payload)
+          .addValue("headers", headersJson);
+      jdbc.update(sql, ps);
+      return id;
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to append to outbox", e);
+    }
+  }
+
+  NamedParameterJdbcTemplate getJdbc() { return jdbc; }
+}

--- a/tenant-events/src/main/java/com/lms/tenant/events/support/JsonSupport.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/support/JsonSupport.java
@@ -1,0 +1,14 @@
+package com.lms.tenant.events.support;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public final class JsonSupport {
+  private JsonSupport() {}
+  public static ObjectMapper mapper() {
+    return new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
+}

--- a/tenant-events/src/main/java/com/lms/tenant/events/support/TenantHeaderSupplier.java
+++ b/tenant-events/src/main/java/com/lms/tenant/events/support/TenantHeaderSupplier.java
@@ -1,0 +1,29 @@
+package com.lms.tenant.events.support;
+
+import org.slf4j.MDC;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Supplies cross-cutting headers (tenant_id, trace_id). Default uses MDC + optional TenantContext if present. */
+public interface TenantHeaderSupplier {
+  Map<String, Object> headers();
+
+  class Default implements TenantHeaderSupplier {
+    @Override public Map<String, Object> headers() {
+      Map<String,Object> h = new HashMap<>();
+      String tid = MDC.get("tenant_id");
+      if (tid == null) {
+        try {
+          Class<?> ctx = Class.forName("com.lms.tenant.config.TenantContext");
+          String val = (String) ctx.getMethod("get").invoke(null);
+          if (val != null) tid = val;
+        } catch (Throwable ignored) {}
+      }
+      if (tid != null) h.put("tenant_id", tid);
+      String trace = MDC.get("trace_id");
+      if (trace != null) h.put("trace_id", trace);
+      return h;
+    }
+  }
+}

--- a/tenant-events/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tenant-events/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.lms.tenant.events.config.EventsAutoConfiguration

--- a/tenant-events/src/test/java/com/lms/tenant/events/OutboxServiceTest.java
+++ b/tenant-events/src/test/java/com/lms/tenant/events/OutboxServiceTest.java
@@ -1,0 +1,32 @@
+package com.lms.tenant.events;
+
+import com.lms.tenant.events.core.DomainEvent;
+import com.lms.tenant.events.publisher.OutboxService;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OutboxServiceTest {
+  record TEvent(UUID id) implements DomainEvent {
+    @Override public String eventType() { return "TenantCreated"; }
+    @Override public UUID aggregateId() { return id; }
+    @Override public String aggregateType() { return "tenant"; }
+    @Override public Instant occurredAt() { return Instant.now(); }
+  }
+
+  @Test
+  void append_serializes() {
+    var ds = new DriverManagerDataSource("jdbc:h2:mem:test;MODE=PostgreSQL", "sa", "");
+    var jdbc = new JdbcTemplate(ds);
+    jdbc.execute("create table outbox_event(event_id uuid, event_type varchar, aggregate_type varchar, aggregate_id uuid, occurred_at timestamp, payload json, headers json, status varchar, attempts int, published_at timestamp)");
+    var svc = new OutboxService(jdbc);
+    UUID id = svc.append(new TEvent(UUID.randomUUID()), Map.of("x","y"));
+    assertThat(id).isNotNull();
+  }
+}


### PR DESCRIPTION
## Summary
- provide reusable `tenant-events` library for recording and publishing domain events
- include JDBC-based outbox service and scheduled publisher with Kafka or log publisher
- add tenant-aware headers for messages

## Testing
- `mvn -q -ntp test` *(fails: Non-resolvable import POM: spring-boot-dependencies:3.5.2, com.shared:shared-bom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b60a9a1b1c832fae2f2227a63094c8