### PR TITLE
Add tenant persistence module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Learning Management System (LMS)
 
-This repository houses two primary components:
+This repository houses several components:
 
 - **shared-lib** – a collection of reusable Spring Boot starter modules and utilities.
 - **lms-setup** – a Spring Boot microservice for reference lookups and tenant/platform configuration.
+- **tenant-persistence** – central JPA entities, repositories, and Flyway migrations for the tenant domain.
 
 ## Getting Started
 

--- a/tenant-persistence/README.md
+++ b/tenant-persistence/README.md
@@ -1,0 +1,33 @@
+# tenant-persistence (com.lms.tenant.persistence)
+
+Central JPA entities + repositories + Flyway migrations for the tenant domain.
+
+## Add to a service
+```xml
+<dependency>
+  <groupId>com.lms.tenant</groupId>
+  <artifactId>tenant-persistence</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+</dependency>
+```
+
+Ensure your service config includes:
+
+```yaml
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate.jdbc.time_zone: UTC
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+```
+
+## Notes
+
+* PostgreSQL **RLS** is enabled/forced on `tenant_integration_key`; the service should set `app.current_tenant` (see tenant-config module).
+* Arrays are mapped via Hibernate 6 `@JdbcTypeCode(SqlTypes.ARRAY)` to a `text[]` column.
+* DDL is **idempotent** and safe for multiple deployments.
+

--- a/tenant-persistence/pom.xml
+++ b/tenant-persistence/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.lms.tenant</groupId>
+  <artifactId>tenant-persistence</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>tenant-persistence</name>
+  <description>Shared JPA entities, repositories, and Flyway migrations for tenant domain</description>
+  <packaging>jar</packaging>
+
+  <properties>
+    <java.version>21</java.version>
+    <spring-boot.version>3.5.2</spring-boot.version>
+    <testcontainers.version>1.20.2</testcontainers.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-data-jpa</artifactId></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-jdbc</artifactId></dependency>
+    <dependency><groupId>org.flywaydb</groupId><artifactId>flyway-core</artifactId></dependency>
+    <dependency><groupId>org.postgresql</groupId><artifactId>postgresql</artifactId></dependency>
+
+    <!-- Test -->
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
+    <dependency><groupId>org.testcontainers</groupId><artifactId>junit-jupiter</artifactId><version>${testcontainers.version}</version><scope>test</scope></dependency>
+    <dependency><groupId>org.testcontainers</groupId><artifactId>postgresql</artifactId><version>${testcontainers.version}</version><scope>test</scope></dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <parameters>true</parameters>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tenant-persistence/src/main/java/com/lms/tenant/persistence/config/JpaAuditingConfig.java
+++ b/tenant-persistence/src/main/java/com/lms/tenant/persistence/config/JpaAuditingConfig.java
@@ -1,0 +1,8 @@
+package com.lms.tenant.persistence.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig { }

--- a/tenant-persistence/src/main/java/com/lms/tenant/persistence/config/PersistenceAutoConfiguration.java
+++ b/tenant-persistence/src/main/java/com/lms/tenant/persistence/config/PersistenceAutoConfiguration.java
@@ -1,0 +1,10 @@
+package com.lms.tenant.persistence.config;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@AutoConfiguration
+@Configuration
+@EnableJpaRepositories(basePackages = "com.lms.tenant.persistence.repo")
+public class PersistenceAutoConfiguration { }

--- a/tenant-persistence/src/main/java/com/lms/tenant/persistence/entity/KeyStatus.java
+++ b/tenant-persistence/src/main/java/com/lms/tenant/persistence/entity/KeyStatus.java
@@ -1,0 +1,2 @@
+package com.lms.tenant.persistence.entity;
+public enum KeyStatus { ACTIVE, REVOKED }

--- a/tenant-persistence/src/main/java/com/lms/tenant/persistence/entity/Tenant.java
+++ b/tenant-persistence/src/main/java/com/lms/tenant/persistence/entity/Tenant.java
@@ -1,0 +1,82 @@
+package com.lms.tenant.persistence.entity;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "tenant", uniqueConstraints = @UniqueConstraint(name = "uq_tenant_slug", columnNames = "tenant_slug"))
+public class Tenant {
+  @Id
+  @Column(name = "tenant_id", nullable = false)
+  private UUID id;
+
+  @Column(name = "tenant_slug", nullable = false)
+  private String slug;
+
+  @Column(name = "name", nullable = false)
+  private String name;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private TenantStatus status = TenantStatus.ACTIVE;
+
+  @Column(name = "tier_id")
+  private String tierId;
+
+  @Column(name = "timezone")
+  private String timezone = "UTC";
+
+  @Column(name = "locale")
+  private String locale = "en";
+
+  @JdbcTypeCode(SqlTypes.ARRAY)
+  @Column(name = "domains", columnDefinition = "text[]")
+  private String[] domains = new String[0];
+
+  @Column(name = "overage_enabled", nullable = false)
+  private boolean overageEnabled = false;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @PrePersist
+  public void prePersist() {
+    if (id == null) id = UUID.randomUUID();
+    if (createdAt == null) createdAt = Instant.now();
+    if (updatedAt == null) updatedAt = createdAt;
+  }
+
+  @PreUpdate
+  public void preUpdate() { this.updatedAt = Instant.now(); }
+
+  // getters/setters
+  public UUID getId() { return id; }
+  public void setId(UUID id) { this.id = id; }
+  public String getSlug() { return slug; }
+  public void setSlug(String slug) { this.slug = slug; }
+  public String getName() { return name; }
+  public void setName(String name) { this.name = name; }
+  public TenantStatus getStatus() { return status; }
+  public void setStatus(TenantStatus status) { this.status = status; }
+  public String getTierId() { return tierId; }
+  public void setTierId(String tierId) { this.tierId = tierId; }
+  public String getTimezone() { return timezone; }
+  public void setTimezone(String timezone) { this.timezone = timezone; }
+  public String getLocale() { return locale; }
+  public void setLocale(String locale) { this.locale = locale; }
+  public String[] getDomains() { return domains; }
+  public void setDomains(String[] domains) { this.domains = domains; }
+  public boolean isOverageEnabled() { return overageEnabled; }
+  public void setOverageEnabled(boolean overageEnabled) { this.overageEnabled = overageEnabled; }
+  public Instant getCreatedAt() { return createdAt; }
+  public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+  public Instant getUpdatedAt() { return updatedAt; }
+  public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/tenant-persistence/src/main/java/com/lms/tenant/persistence/entity/TenantIntegrationKey.java
+++ b/tenant-persistence/src/main/java/com/lms/tenant/persistence/entity/TenantIntegrationKey.java
@@ -1,0 +1,38 @@
+package com.lms.tenant.persistence.entity;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "tenant_integration_key",
+    uniqueConstraints = @UniqueConstraint(name="uq_key_prefix", columnNames = {"tenant_id","key_prefix"}))
+public class TenantIntegrationKey {
+  @Id @Column(name = "key_id", nullable = false) private UUID id;
+  @Column(name = "tenant_id", nullable = false) private UUID tenantId;
+  @Column(name = "key_prefix", nullable = false) private String keyPrefix;
+  @Lob @Column(name = "key_hash", nullable = false) private byte[] keyHash;
+  @Column(name = "name") private String name;
+  @Column(name = "scopes", columnDefinition = "text[]") private String[] scopes;
+  @Column(name = "rate_limit_per_min") private Integer rateLimitPerMin;
+  @Column(name = "created_at", nullable = false) private Instant createdAt;
+  @Column(name = "last_used_at") private Instant lastUsedAt;
+  @Column(name = "expires_at") private Instant expiresAt;
+  @Enumerated(EnumType.STRING) @Column(name = "status", nullable = false) private KeyStatus status = KeyStatus.ACTIVE;
+
+  @PrePersist public void prePersist(){ if(id==null) id=UUID.randomUUID(); if(createdAt==null) createdAt=Instant.now(); }
+
+  // getters/setters
+  public UUID getId(){return id;} public void setId(UUID id){this.id=id;}
+  public UUID getTenantId(){return tenantId;} public void setTenantId(UUID tenantId){this.tenantId=tenantId;}
+  public String getKeyPrefix(){return keyPrefix;} public void setKeyPrefix(String keyPrefix){this.keyPrefix=keyPrefix;}
+  public byte[] getKeyHash(){return keyHash;} public void setKeyHash(byte[] keyHash){this.keyHash=keyHash;}
+  public String getName(){return name;} public void setName(String name){this.name=name;}
+  public String[] getScopes(){return scopes;} public void setScopes(String[] scopes){this.scopes=scopes;}
+  public Integer getRateLimitPerMin(){return rateLimitPerMin;} public void setRateLimitPerMin(Integer v){this.rateLimitPerMin=v;}
+  public Instant getCreatedAt(){return createdAt;} public void setCreatedAt(Instant createdAt){this.createdAt=createdAt;}
+  public Instant getLastUsedAt(){return lastUsedAt;} public void setLastUsedAt(Instant v){this.lastUsedAt=v;}
+  public Instant getExpiresAt(){return expiresAt;} public void setExpiresAt(Instant v){this.expiresAt=v;}
+  public KeyStatus getStatus(){return status;} public void setStatus(KeyStatus status){this.status=status;}
+}

--- a/tenant-persistence/src/main/java/com/lms/tenant/persistence/entity/TenantStatus.java
+++ b/tenant-persistence/src/main/java/com/lms/tenant/persistence/entity/TenantStatus.java
@@ -1,0 +1,2 @@
+package com.lms.tenant.persistence.entity;
+public enum TenantStatus { ACTIVE, SUSPENDED, ARCHIVED }

--- a/tenant-persistence/src/main/java/com/lms/tenant/persistence/repo/TenantIntegrationKeyRepository.java
+++ b/tenant-persistence/src/main/java/com/lms/tenant/persistence/repo/TenantIntegrationKeyRepository.java
@@ -1,0 +1,8 @@
+package com.lms.tenant.persistence.repo;
+
+import com.lms.tenant.persistence.entity.TenantIntegrationKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface TenantIntegrationKeyRepository extends JpaRepository<TenantIntegrationKey, UUID> { }

--- a/tenant-persistence/src/main/java/com/lms/tenant/persistence/repo/TenantRepository.java
+++ b/tenant-persistence/src/main/java/com/lms/tenant/persistence/repo/TenantRepository.java
@@ -1,0 +1,13 @@
+package com.lms.tenant.persistence.repo;
+
+import com.lms.tenant.persistence.entity.Tenant;
+import com.lms.tenant.persistence.entity.TenantStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TenantRepository extends JpaRepository<Tenant, UUID> {
+  Optional<Tenant> findBySlug(String slug);
+  long countByStatus(TenantStatus status);
+}

--- a/tenant-persistence/src/main/resources/db/migration/V1__tenant_baseline.sql
+++ b/tenant-persistence/src/main/resources/db/migration/V1__tenant_baseline.sql
@@ -1,0 +1,53 @@
+create extension if not exists pgcrypto;
+
+do $$ begin
+  if not exists (select 1 from pg_type where typname='tenant_status') then
+    create type tenant_status as enum ('ACTIVE','SUSPENDED','ARCHIVED');
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from information_schema.tables where table_name = 'tenant') then
+    create table tenant (
+      tenant_id uuid primary key default gen_random_uuid(),
+      tenant_slug text not null unique,
+      name text not null,
+      status tenant_status not null default 'ACTIVE',
+      tier_id text,
+      timezone text not null default 'UTC',
+      locale text not null default 'en',
+      domains text[] not null default '{}',
+      overage_enabled boolean not null default false,
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now()
+    );
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_type where typname='key_status') then
+    create type key_status as enum ('ACTIVE','REVOKED');
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from information_schema.tables where table_name = 'tenant_integration_key') then
+    create table tenant_integration_key (
+      key_id uuid primary key default gen_random_uuid(),
+      tenant_id uuid not null references tenant(tenant_id) on delete cascade,
+      key_prefix text not null,
+      key_hash bytea not null,
+      name text,
+      scopes text[] not null default '{"*"}',
+      rate_limit_per_min integer,
+      created_at timestamptz not null default now(),
+      last_used_at timestamptz,
+      expires_at timestamptz,
+      status key_status not null default 'ACTIVE',
+      unique (tenant_id, key_prefix)
+    );
+  end if;
+end $$;
+
+create index if not exists ix_tenant_slug on tenant(tenant_slug);
+create index if not exists ix_tenant_status on tenant(status);

--- a/tenant-persistence/src/main/resources/db/migration/V2__rls_and_policies.sql
+++ b/tenant-persistence/src/main/resources/db/migration/V2__rls_and_policies.sql
@@ -1,0 +1,8 @@
+-- Enable RLS on tenant-scoped tables (integration keys). The tenant table is admin-only in most cases.
+alter table if exists tenant_integration_key enable row level security;
+
+create policy if not exists p_key_by_tenant on tenant_integration_key
+  using (tenant_id = current_setting('app.current_tenant', true)::uuid)
+  with check (tenant_id = current_setting('app.current_tenant', true)::uuid);
+
+alter table if exists tenant_integration_key force row level security;

--- a/tenant-persistence/src/main/resources/db/migration/V3__indexes_and_seed.sql
+++ b/tenant-persistence/src/main/resources/db/migration/V3__indexes_and_seed.sql
@@ -1,0 +1,6 @@
+-- Helpful indexes and seed
+create index if not exists ix_key_tenant_prefix on tenant_integration_key(tenant_id, key_prefix);
+
+insert into tenant(tenant_slug, name)
+values ('demo', 'Demo Tenant')
+on conflict (tenant_slug) do nothing;

--- a/tenant-persistence/src/test/java/com/lms/tenant/persistence/TenantPersistenceIT.java
+++ b/tenant-persistence/src/test/java/com/lms/tenant/persistence/TenantPersistenceIT.java
@@ -1,0 +1,38 @@
+package com.lms.tenant.persistence;
+
+import com.lms.tenant.persistence.entity.Tenant;
+import com.lms.tenant.persistence.repo.TenantRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class TenantPersistenceIT {
+  static PostgreSQLContainer<?> pg = new PostgreSQLContainer<>("postgres:16");
+
+  @SpringBootApplication(scanBasePackages = "com.lms.tenant.persistence")
+  static class TestApp { }
+
+  @BeforeAll static void init() { pg.start(); System.setProperty("spring.datasource.url", pg.getJdbcUrl()); System.setProperty("spring.datasource.username", pg.getUsername()); System.setProperty("spring.datasource.password", pg.getPassword()); System.setProperty("spring.flyway.locations", "classpath:db/migration"); }
+  @AfterAll static void stop() { pg.stop(); }
+
+  @Autowired TenantRepository repo;
+
+  @Test
+  void canPersistTenant() {
+    Tenant t = new Tenant();
+    t.setSlug("it-tenant");
+    t.setName("IT");
+    t = repo.save(t);
+    assertThat(t.getId()).isNotNull();
+    assertThat(repo.findBySlug("it-tenant")).isPresent();
+  }
+}


### PR DESCRIPTION
## Summary
- add tenant-persistence module with JPA entities, repositories, and Flyway migrations for tenant data
- expose auto-configuration with JPA auditing and repository scanning
- document and register the module in the main README

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b60c8f0164832fad47291ca4f5c980