### PR TITLE
Add JDBC adapters for tenant settings and directory

### DIFF
--- a/lms-platform/tenant-service/pom.xml
+++ b/lms-platform/tenant-service/pom.xml
@@ -56,5 +56,10 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/lms-platform/tenant-service/src/main/java/com/lms/tenant/adapter/JdbcTenantDirectoryAdapter.java
+++ b/lms-platform/tenant-service/src/main/java/com/lms/tenant/adapter/JdbcTenantDirectoryAdapter.java
@@ -1,0 +1,26 @@
+package com.lms.tenant.adapter;
+
+import com.lms.tenant.core.TenantDirectoryPort;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Repository
+public class JdbcTenantDirectoryAdapter implements TenantDirectoryPort {
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public JdbcTenantDirectoryAdapter(NamedParameterJdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public UUID resolveTenantIdBySlugOrDomain(String key) {
+        return jdbc.query(
+                "select tenant_id from tenant where tenant_slug = :key or :key = any(domains)",
+                Map.of("key", key),
+                rs -> rs.next() ? UUID.fromString(rs.getString(1)) : null
+        );
+    }
+}

--- a/lms-platform/tenant-service/src/main/java/com/lms/tenant/adapter/JdbcTenantSettingsAdapter.java
+++ b/lms-platform/tenant-service/src/main/java/com/lms/tenant/adapter/JdbcTenantSettingsAdapter.java
@@ -1,0 +1,38 @@
+package com.lms.tenant.adapter;
+
+import com.lms.tenant.core.TenantSettingsPort;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Repository
+public class JdbcTenantSettingsAdapter implements TenantSettingsPort {
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public JdbcTenantSettingsAdapter(NamedParameterJdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public boolean isOverageEnabled(UUID tenantId) {
+        Boolean result = jdbc.queryForObject(
+                "select overage_enabled from tenant where tenant_id = :id",
+                Map.of("id", tenantId),
+                Boolean.class);
+        return Boolean.TRUE.equals(result);
+    }
+
+    @Override
+    public void setOverageEnabled(UUID tenantId, boolean enabled) {
+        int updated = jdbc.update(
+                "update tenant set overage_enabled = :enabled, updated_at = now() where tenant_id = :id",
+                Map.of("id", tenantId, "enabled", enabled));
+        if (updated == 0) {
+            jdbc.update(
+                    "insert into tenant (tenant_id, overage_enabled) values (:id, :enabled)",
+                    Map.of("id", tenantId, "enabled", enabled));
+        }
+    }
+}

--- a/lms-platform/tenant-service/src/test/java/com/lms/tenant/adapter/JdbcTenantDirectoryAdapterTest.java
+++ b/lms-platform/tenant-service/src/test/java/com/lms/tenant/adapter/JdbcTenantDirectoryAdapterTest.java
@@ -1,0 +1,49 @@
+package com.lms.tenant.adapter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JdbcTest
+@Import(JdbcTenantDirectoryAdapter.class)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+        "spring.datasource.driverClassName=org.h2.Driver"
+})
+class JdbcTenantDirectoryAdapterTest {
+
+    @Autowired
+    NamedParameterJdbcTemplate jdbc;
+
+    @Autowired
+    JdbcTenantDirectoryAdapter adapter;
+
+    @BeforeEach
+    void setup() {
+        jdbc.getJdbcOperations().execute("drop table if exists tenant");
+        jdbc.getJdbcOperations().execute("create table tenant (tenant_id uuid primary key, tenant_slug text, domains text[])");
+    }
+
+    @Test
+    void resolvesBySlugOrDomain() {
+        UUID id = UUID.randomUUID();
+        jdbc.update("insert into tenant(tenant_id, tenant_slug, domains) values(:id, :slug, ARRAY['acme.com'])",
+                Map.of("id", id, "slug", "acme"));
+        assertThat(adapter.resolveTenantIdBySlugOrDomain("acme")).isEqualTo(id);
+        assertThat(adapter.resolveTenantIdBySlugOrDomain("acme.com")).isEqualTo(id);
+    }
+
+    @Test
+    void returnsNullWhenNotFound() {
+        assertThat(adapter.resolveTenantIdBySlugOrDomain("missing")).isNull();
+    }
+}

--- a/lms-platform/tenant-service/src/test/java/com/lms/tenant/adapter/JdbcTenantSettingsAdapterTest.java
+++ b/lms-platform/tenant-service/src/test/java/com/lms/tenant/adapter/JdbcTenantSettingsAdapterTest.java
@@ -1,0 +1,52 @@
+package com.lms.tenant.adapter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JdbcTest
+@Import(JdbcTenantSettingsAdapter.class)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+        "spring.datasource.driverClassName=org.h2.Driver"
+})
+class JdbcTenantSettingsAdapterTest {
+
+    @Autowired
+    NamedParameterJdbcTemplate jdbc;
+
+    @Autowired
+    JdbcTenantSettingsAdapter adapter;
+
+    @BeforeEach
+    void setup() {
+        jdbc.getJdbcOperations().execute("drop table if exists tenant");
+        jdbc.getJdbcOperations().execute("create table tenant (tenant_id uuid primary key, overage_enabled boolean not null)");
+    }
+
+    @Test
+    void togglesFlag() {
+        UUID id = UUID.randomUUID();
+        adapter.setOverageEnabled(id, true);
+        assertThat(adapter.isOverageEnabled(id)).isTrue();
+        adapter.setOverageEnabled(id, false);
+        assertThat(adapter.isOverageEnabled(id)).isFalse();
+    }
+
+    @Test
+    void insertsWhenMissing() {
+        UUID id = UUID.randomUUID();
+        adapter.setOverageEnabled(id, true);
+        Integer count = jdbc.queryForObject("select count(*) from tenant where tenant_id=:id", Map.of("id", id), Integer.class);
+        assertThat(count).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement JDBC adapters for TenantSettingsPort and TenantDirectoryPort
- Add unit tests for overage flag toggling and tenant resolution
- Include H2 test dependency for embedded database testing

## Testing
- `mvn -pl tenant-service test` *(fails: Could not resolve com.shared:shared-bom:pom:1.0.0; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6113d8410832fafead3169ea69b85