### PR TITLE
feat: add tenant event outbox with scheduled publisher

### DIFF
--- a/tenant-platform/tenant-events/pom.xml
+++ b/tenant-platform/tenant-events/pom.xml
@@ -1,1 +1,39 @@
-<project><modelVersion>4.0.0</modelVersion><parent><groupId>com.lms.tenant</groupId><artifactId>tenant-platform</artifactId><version>1.0.0-SNAPSHOT</version></parent><artifactId>tenant-events</artifactId></project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.lms.tenant</groupId>
+    <artifactId>tenant-platform</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>tenant-events</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantEventPublisher.java
+++ b/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantEventPublisher.java
@@ -1,0 +1,75 @@
+package com.lms.tenant.events;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Polls the outbox table and publishes tenant events. */
+public class TenantEventPublisher {
+    private static final Logger log = LoggerFactory.getLogger(TenantEventPublisher.class);
+
+    private final JdbcTemplate jdbc;
+    private final ObjectProvider<KafkaTemplate<String, String>> kafkaProvider;
+    private final TenantEventsProperties properties;
+
+    public TenantEventPublisher(JdbcTemplate jdbc,
+                                ObjectProvider<KafkaTemplate<String, String>> kafkaProvider,
+                                TenantEventsProperties properties) {
+        this.jdbc = jdbc;
+        this.kafkaProvider = kafkaProvider;
+        this.properties = properties;
+    }
+
+    @Scheduled(fixedDelayString = "#{@tenantEventsProperties.pollInterval.toMillis()}")
+    @Transactional
+    public void publish() {
+        List<OutboxRow> rows = jdbc.query(
+            "SELECT id, tenant_id, type, payload FROM tenant_outbox WHERE status='NEW' AND available_at <= now() ORDER BY id LIMIT ? FOR UPDATE SKIP LOCKED",
+            new OutboxRowMapper(), properties.getBatchSize());
+        KafkaTemplate<String, String> kafka = kafkaProvider.getIfAvailable();
+        for (OutboxRow row : rows) {
+            boolean success = false;
+            try {
+                if (kafka != null) {
+                    ProducerRecord<String, String> record = new ProducerRecord<>(row.type(), row.payload());
+                    record.headers().add("X-Tenant-Id", row.tenantId().toString().getBytes(StandardCharsets.UTF_8));
+                    kafka.send(record);
+                } else {
+                    log.info("Tenant event {}: {}", row.type(), row.payload());
+                }
+                success = true;
+            } catch (Exception ex) {
+                log.warn("Failed to publish tenant event {}", row.id(), ex);
+            }
+            if (success) {
+                jdbc.update("UPDATE tenant_outbox SET status='SENT', attempts = attempts + 1 WHERE id = ?", row.id());
+            } else {
+                jdbc.update("UPDATE tenant_outbox SET attempts = attempts + 1 WHERE id = ?", row.id());
+            }
+        }
+    }
+
+    private record OutboxRow(UUID id, UUID tenantId, String type, String payload) {}
+
+    private static class OutboxRowMapper implements RowMapper<OutboxRow> {
+        @Override
+        public OutboxRow mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new OutboxRow(
+                rs.getObject("id", UUID.class),
+                rs.getObject("tenant_id", UUID.class),
+                rs.getString("type"),
+                rs.getString("payload"));
+        }
+    }
+}

--- a/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantEventWriter.java
+++ b/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantEventWriter.java
@@ -1,0 +1,36 @@
+package com.lms.tenant.events;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/** Writes tenant events to the outbox table using JDBC. */
+public class TenantEventWriter {
+    private final JdbcTemplate jdbc;
+    private final ObjectMapper mapper;
+
+    public TenantEventWriter(JdbcTemplate jdbc, ObjectMapper mapper) {
+        this.jdbc = jdbc;
+        this.mapper = mapper;
+    }
+
+    public void write(UUID tenantId, String type, Object payload) {
+        write(tenantId, type, payload, Instant.now());
+    }
+
+    public void write(UUID tenantId, String type, Object payload, Instant availableAt) {
+        String json;
+        try {
+            json = mapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Unable to serialize payload", e);
+        }
+        jdbc.update(
+            "INSERT INTO tenant_outbox (id, tenant_id, type, payload, created_at, available_at, attempts, status) " +
+            "VALUES (?, ?, ?, cast(? as jsonb), now(), ?, 0, 'NEW')",
+            UUID.randomUUID(), tenantId, type, json, Timestamp.from(availableAt));
+    }
+}

--- a/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantEventsAutoConfiguration.java
+++ b/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantEventsAutoConfiguration.java
@@ -1,0 +1,30 @@
+package com.lms.tenant.events;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@AutoConfiguration
+@EnableConfigurationProperties(TenantEventsProperties.class)
+@EnableScheduling
+@ConditionalOnProperty(prefix = "tenant.events", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class TenantEventsAutoConfiguration {
+
+    @Bean
+    public TenantEventWriter tenantEventWriter(JdbcTemplate jdbcTemplate, ObjectMapper mapper) {
+        return new TenantEventWriter(jdbcTemplate, mapper);
+    }
+
+    @Bean
+    public TenantEventPublisher tenantEventPublisher(JdbcTemplate jdbcTemplate,
+            ObjectProvider<KafkaTemplate<String, String>> kafkaTemplate,
+            TenantEventsProperties properties) {
+        return new TenantEventPublisher(jdbcTemplate, kafkaTemplate, properties);
+    }
+}

--- a/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantEventsProperties.java
+++ b/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantEventsProperties.java
@@ -1,0 +1,38 @@
+package com.lms.tenant.events;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "tenant.events")
+public class TenantEventsProperties {
+    /** Whether tenant events are enabled. */
+    private boolean enabled = true;
+    /** Poll interval for publisher. */
+    private Duration pollInterval = Duration.ofSeconds(5);
+    /** Batch size for polling. */
+    private int batchSize = 10;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Duration getPollInterval() {
+        return pollInterval;
+    }
+
+    public void setPollInterval(Duration pollInterval) {
+        this.pollInterval = pollInterval;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+}

--- a/tenant-platform/tenant-events/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tenant-platform/tenant-events/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.lms.tenant.events.TenantEventsAutoConfiguration

--- a/tenant-platform/tenant-events/src/main/resources/db/migration/V1__create_tenant_outbox.sql
+++ b/tenant-platform/tenant-events/src/main/resources/db/migration/V1__create_tenant_outbox.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS tenant_outbox (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL,
+    type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    available_at TIMESTAMPTZ NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS tenant_outbox_status_idx ON tenant_outbox(status, available_at);

--- a/tenant-platform/tenant-events/src/test/java/com/lms/tenant/events/TenantEventPublisherTests.java
+++ b/tenant-platform/tenant-events/src/test/java/com/lms/tenant/events/TenantEventPublisherTests.java
@@ -1,0 +1,41 @@
+package com.lms.tenant.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest(classes = TenantEventsAutoConfiguration.class)
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.task.scheduling.enabled=false"
+})
+class TenantEventPublisherTests {
+
+    @Autowired
+    TenantEventWriter writer;
+
+    @Autowired
+    TenantEventPublisher publisher;
+
+    @Autowired
+    JdbcTemplate jdbc;
+
+    @Test
+    void insertAndPublishWithoutKafkaMarksSent() {
+        UUID tenantId = UUID.randomUUID();
+        writer.write(tenantId, "test-topic", Map.of("hello", "world"));
+
+        publisher.publish();
+
+        String status = jdbc.queryForObject("select status from tenant_outbox", String.class);
+        Integer attempts = jdbc.queryForObject("select attempts from tenant_outbox", Integer.class);
+        assertThat(status).isEqualTo("SENT");
+        assertThat(attempts).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add tenant-events module with Flyway migration for tenant_outbox
- implement JDBC outbox writer and scheduled publisher with Kafka/log fallback
- expose auto-configuration and properties for tenant event polling

## Testing
- `mvn -q -pl tenant-events test` *(fails: Non-resolvable import POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b62225f610832f9d871f869f597378