### PR TITLE
Add tenant context and datasource interception module

### DIFF
--- a/tenant-platform/tenant-config/README.md
+++ b/tenant-platform/tenant-config/README.md
@@ -1,0 +1,16 @@
+# tenant-config
+
+Spring Boot starter providing request-scoped tenant resolution and PostgreSQL GUC propagation.
+
+## Configuration
+
+Add typical datasource properties to enable PostgreSQL:
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/app
+    username: user
+    password: pass
+```
+```

--- a/tenant-platform/tenant-config/pom.xml
+++ b/tenant-platform/tenant-config/pom.xml
@@ -14,5 +14,36 @@
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-jdbc</artifactId></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-cache</artifactId></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-data-redis</artifactId></dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-resource-server</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-jose</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zonky.test</groupId>
+      <artifactId>embedded-postgres</artifactId>
+      <version>2.0.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConfigAutoConfiguration.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConfigAutoConfiguration.java
@@ -1,0 +1,41 @@
+package com.lms.tenant.config;
+
+import javax.sql.DataSource;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.core.Ordered;
+import org.springframework.jdbc.datasource.DelegatingDataSource;
+
+/**
+ * Auto configuration wiring tenant resolution and datasource interception.
+ */
+@AutoConfiguration
+public class TenantConfigAutoConfiguration {
+
+    @Bean
+    public TenantResolver tenantResolver() {
+        return new TenantResolver();
+    }
+
+    @Bean
+    public FilterRegistrationBean<TenantFilter> tenantFilter(TenantResolver tenantResolver) {
+        FilterRegistrationBean<TenantFilter> registration = new FilterRegistrationBean<>(new TenantFilter(tenantResolver));
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
+
+    @Bean
+    public BeanPostProcessor tenantDataSourcePostProcessor() {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) {
+                if (bean instanceof DataSource dataSource && !(dataSource instanceof DelegatingDataSource)) {
+                    return new TenantConnectionInterceptor(dataSource);
+                }
+                return bean;
+            }
+        };
+    }
+}

--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConnectionInterceptor.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConnectionInterceptor.java
@@ -1,0 +1,43 @@
+package com.lms.tenant.config;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.springframework.jdbc.datasource.DelegatingDataSource;
+
+/**
+ * Wraps {@link DataSource} connections to apply the current tenant using a PostgreSQL GUC variable.
+ */
+public class TenantConnectionInterceptor extends DelegatingDataSource {
+
+    public TenantConnectionInterceptor(DataSource targetDataSource) {
+        super(targetDataSource);
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        Connection connection = super.getConnection();
+        applyTenant(connection);
+        return connection;
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        Connection connection = super.getConnection(username, password);
+        applyTenant(connection);
+        return connection;
+    }
+
+    private void applyTenant(Connection connection) throws SQLException {
+        if (connection == null) {
+            return;
+        }
+        var tenantId = TenantContext.getTenantId();
+        if (tenantId.isPresent()) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("SET LOCAL app.current_tenant = '" + tenantId.get() + "'");
+            }
+        }
+    }
+}

--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantContext.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantContext.java
@@ -1,8 +1,40 @@
 package com.lms.tenant.config;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Holds the tenant identifier for the current request using {@link ThreadLocal} storage.
+ */
 public final class TenantContext {
-  private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
-  private TenantContext() {}
-  public static void set(String tenantId) { CURRENT.set(tenantId); }
-  public static String get() { return CURRENT.get(); }
-  public static void clear() { CURRENT.remove(); }
+
+    private static final ThreadLocal<UUID> CURRENT_TENANT = new ThreadLocal<>();
+
+    private TenantContext() {
+    }
+
+    /**
+     * Set the tenant identifier for the current thread.
+     *
+     * @param tenantId tenant identifier
+     */
+    public static void setTenantId(UUID tenantId) {
+        CURRENT_TENANT.set(tenantId);
+    }
+
+    /**
+     * Retrieve the tenant identifier for the current thread.
+     *
+     * @return optional tenant identifier
+     */
+    public static Optional<UUID> getTenantId() {
+        return Optional.ofNullable(CURRENT_TENANT.get());
+    }
+
+    /**
+     * Clear the tenant information from the current thread.
+     */
+    public static void clear() {
+        CURRENT_TENANT.remove();
+    }
 }

--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantFilter.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantFilter.java
@@ -1,0 +1,39 @@
+package com.lms.tenant.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Servlet filter that populates {@link TenantContext} for each request.
+ */
+public class TenantFilter extends OncePerRequestFilter {
+
+    private final TenantResolver tenantResolver;
+
+    public TenantFilter(TenantResolver tenantResolver) {
+        this.tenantResolver = tenantResolver;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        Optional<UUID> tenantId = tenantResolver.resolveTenant(request);
+        tenantId.ifPresent(id -> {
+            TenantContext.setTenantId(id);
+            MDC.put("tenantId", id.toString());
+        });
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            TenantContext.clear();
+            MDC.remove("tenantId");
+        }
+    }
+}

--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantResolver.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantResolver.java
@@ -1,0 +1,58 @@
+package com.lms.tenant.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.util.StringUtils;
+
+/**
+ * Resolves tenant identifiers from incoming requests.
+ */
+public class TenantResolver {
+
+    public static final String TENANT_HEADER = "X-Tenant-Id";
+    private static final String TENANT_CLAIM = "tenant_id";
+
+    /**
+     * Resolve the tenant identifier from the request or security context.
+     *
+     * @param request incoming request
+     * @return optional tenant identifier
+     */
+    public Optional<UUID> resolveTenant(HttpServletRequest request) {
+        String headerValue = request.getHeader(TENANT_HEADER);
+        if (StringUtils.hasText(headerValue)) {
+            return parse(headerValue);
+        }
+        try {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication instanceof JwtAuthenticationToken jwtAuthenticationToken) {
+                String claim = jwtAuthenticationToken.getToken().getClaimAsString(TENANT_CLAIM);
+                if (StringUtils.hasText(claim)) {
+                    return parse(claim);
+                }
+            }
+            if (authentication != null && authentication.getPrincipal() instanceof Jwt jwt) {
+                String claim = jwt.getClaimAsString(TENANT_CLAIM);
+                if (StringUtils.hasText(claim)) {
+                    return parse(claim);
+                }
+            }
+        } catch (NoClassDefFoundError ignored) {
+            // Spring Security not present
+        }
+        return Optional.empty();
+    }
+
+    private Optional<UUID> parse(String raw) {
+        try {
+            return Optional.of(UUID.fromString(raw));
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+    }
+}

--- a/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
+++ b/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
@@ -1,0 +1,72 @@
+package com.lms.tenant.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class TenantConfigAutoConfigurationTest {
+
+    private static EmbeddedPostgres postgres;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) throws IOException {
+        postgres = EmbeddedPostgres.start();
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", () -> "postgres");
+        registry.add("spring.datasource.password", () -> "postgres");
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    }
+
+    @AfterAll
+    static void stop() throws IOException {
+        if (postgres != null) {
+            postgres.close();
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void setsCurrentTenant() throws Exception {
+        String tenantId = UUID.randomUUID().toString();
+        mockMvc.perform(get("/current-tenant").header(TenantResolver.TENANT_HEADER, tenantId))
+                .andExpect(status().isOk())
+                .andExpect(content().string(tenantId));
+    }
+
+    @RestController
+    static class TestController {
+        private final JdbcTemplate jdbcTemplate;
+
+        TestController(JdbcTemplate jdbcTemplate) {
+            this.jdbcTemplate = jdbcTemplate;
+        }
+
+        @GetMapping("/current-tenant")
+        @Transactional
+        String currentTenant() {
+            return jdbcTemplate.queryForObject("select current_setting('app.current_tenant', true)", String.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tenant-config module with request-scoped TenantContext and resolver
- inject servlet filter and datasource interceptor via auto-configuration
- document datasource properties

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable import POM: spring-boot-dependencies:3.5.2, shared-bom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b62216fa80832fbf5c44fd4ffcf1c5