### PR TITLE
Add subscription lifecycle service

### DIFF
--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -18,12 +18,20 @@
       <artifactId>shared-starter-data</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.shared</groupId>
+      <artifactId>shared-starter-openapi</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jdbc</artifactId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/SubscriptionServiceApplication.java
+++ b/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/SubscriptionServiceApplication.java
@@ -1,0 +1,11 @@
+package com.lms.tenant.subscription;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SubscriptionServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SubscriptionServiceApplication.class, args);
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/adapter/SubscriptionQueryServiceAdapter.java
+++ b/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/adapter/SubscriptionQueryServiceAdapter.java
@@ -1,0 +1,23 @@
+package com.lms.tenant.subscription.adapter;
+
+import com.lms.tenant.subscription.service.SubscriptionService;
+import com.shared.subscription.api.SubscriptionDto;
+import com.shared.subscription.api.SubscriptionQueryService;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SubscriptionQueryServiceAdapter implements SubscriptionQueryService {
+
+    private final SubscriptionService subscriptionService;
+
+    public SubscriptionQueryServiceAdapter(SubscriptionService subscriptionService) {
+        this.subscriptionService = subscriptionService;
+    }
+
+    @Override
+    public Optional<SubscriptionDto> findActiveSubscription(UUID tenantId) {
+        return subscriptionService.findActiveSubscription(tenantId);
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/domain/SubscriptionItem.java
+++ b/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/domain/SubscriptionItem.java
@@ -1,0 +1,47 @@
+package com.lms.tenant.subscription.domain;
+
+import jakarta.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "subscription_item")
+public class SubscriptionItem {
+    @Id
+    @Column(name = "item_id")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subscription_id")
+    private TenantSubscription subscription;
+
+    @Column(name = "feature_key")
+    private String featureKey;
+
+    @Column(name = "quantity")
+    private Long quantity;
+
+    public SubscriptionItem() {}
+
+    public SubscriptionItem(UUID id, TenantSubscription subscription, String featureKey, Long quantity) {
+        this.id = id;
+        this.subscription = subscription;
+        this.featureKey = featureKey;
+        this.quantity = quantity;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public TenantSubscription getSubscription() {
+        return subscription;
+    }
+
+    public String getFeatureKey() {
+        return featureKey;
+    }
+
+    public Long getQuantity() {
+        return quantity;
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/domain/SubscriptionStatus.java
+++ b/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/domain/SubscriptionStatus.java
@@ -1,0 +1,7 @@
+package com.lms.tenant.subscription.domain;
+
+public enum SubscriptionStatus {
+    TRIAL,
+    ACTIVE,
+    CANCELED
+}

--- a/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/domain/TenantSubscription.java
+++ b/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/domain/TenantSubscription.java
@@ -1,0 +1,63 @@
+package com.lms.tenant.subscription.domain;
+
+import jakarta.persistence.*;
+import java.util.*;
+
+@Entity
+@Table(name = "tenant_subscription")
+public class TenantSubscription {
+
+    @Id
+    @Column(name = "subscription_id")
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private SubscriptionStatus status;
+
+    @Column(name = "active")
+    private boolean active;
+
+    @OneToMany(mappedBy = "subscription", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SubscriptionItem> items = new ArrayList<>();
+
+    public TenantSubscription() {}
+
+    public TenantSubscription(UUID id, UUID tenantId, SubscriptionStatus status, boolean active) {
+        this.id = id;
+        this.tenantId = tenantId;
+        this.status = status;
+        this.active = active;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getTenantId() {
+        return tenantId;
+    }
+
+    public SubscriptionStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(SubscriptionStatus status) {
+        this.status = status;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public List<SubscriptionItem> getItems() {
+        return items;
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/repo/TenantSubscriptionRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/repo/TenantSubscriptionRepository.java
@@ -1,0 +1,13 @@
+package com.lms.tenant.subscription.repo;
+
+import com.lms.tenant.subscription.domain.TenantSubscription;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface TenantSubscriptionRepository extends JpaRepository<TenantSubscription, UUID> {
+
+    @Query("select s from TenantSubscription s where s.tenantId = :tenantId and s.active = true")
+    Optional<TenantSubscription> findActiveByTenantId(UUID tenantId);
+}

--- a/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/service/SubscriptionService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/service/SubscriptionService.java
@@ -1,0 +1,58 @@
+package com.lms.tenant.subscription.service;
+
+import com.lms.tenant.subscription.domain.SubscriptionStatus;
+import com.lms.tenant.subscription.domain.TenantSubscription;
+import com.lms.tenant.subscription.repo.TenantSubscriptionRepository;
+import com.shared.subscription.api.SubscriptionDto;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class SubscriptionService {
+
+    private final TenantSubscriptionRepository repository;
+
+    public SubscriptionService(TenantSubscriptionRepository repository) {
+        this.repository = repository;
+    }
+
+    public SubscriptionDto startTrial(UUID tenantId) {
+        repository.findActiveByTenantId(tenantId)
+            .ifPresent(s -> { throw new IllegalStateException("Active subscription exists"); });
+        TenantSubscription sub = new TenantSubscription(UUID.randomUUID(), tenantId, SubscriptionStatus.TRIAL, true);
+        repository.save(sub);
+        return toDto(sub);
+    }
+
+    public SubscriptionDto activate(UUID tenantId) {
+        TenantSubscription sub = repository.findActiveByTenantId(tenantId)
+            .map(existing -> {
+                existing.setStatus(SubscriptionStatus.ACTIVE);
+                return existing;
+            })
+            .orElseGet(() -> new TenantSubscription(UUID.randomUUID(), tenantId, SubscriptionStatus.ACTIVE, true));
+        repository.save(sub);
+        return toDto(sub);
+    }
+
+    public void cancel(UUID tenantId, UUID subscriptionId) {
+        TenantSubscription sub = repository.findById(subscriptionId)
+            .filter(s -> s.getTenantId().equals(tenantId))
+            .orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
+        sub.setActive(false);
+        sub.setStatus(SubscriptionStatus.CANCELED);
+        repository.save(sub);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<SubscriptionDto> findActiveSubscription(UUID tenantId) {
+        return repository.findActiveByTenantId(tenantId).map(this::toDto);
+    }
+
+    SubscriptionDto toDto(TenantSubscription sub) {
+        return new SubscriptionDto(sub.getId(), sub.getTenantId(), sub.getStatus().name());
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/web/SubscriptionController.java
+++ b/tenant-platform/subscription-service/src/main/java/com/lms/tenant/subscription/web/SubscriptionController.java
@@ -1,0 +1,41 @@
+package com.lms.tenant.subscription.web;
+
+import com.lms.tenant.subscription.service.SubscriptionService;
+import com.shared.subscription.api.SubscriptionDto;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/tenants/{tenantId}/subscription")
+public class SubscriptionController {
+
+    private final SubscriptionService service;
+
+    public SubscriptionController(SubscriptionService service) {
+        this.service = service;
+    }
+
+    @PutMapping("/trial")
+    public ResponseEntity<SubscriptionDto> startTrial(@PathVariable UUID tenantId) {
+        return ResponseEntity.ok(service.startTrial(tenantId));
+    }
+
+    @PutMapping
+    public ResponseEntity<SubscriptionDto> activate(@PathVariable UUID tenantId) {
+        return ResponseEntity.ok(service.activate(tenantId));
+    }
+
+    @PutMapping("/{subscriptionId}/cancel")
+    public ResponseEntity<Void> cancel(@PathVariable UUID tenantId, @PathVariable UUID subscriptionId) {
+        service.cancel(tenantId, subscriptionId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/active")
+    public ResponseEntity<SubscriptionDto> active(@PathVariable UUID tenantId) {
+        return service.findActiveSubscription(tenantId)
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/shared/subscription/api/SubscriptionDto.java
+++ b/tenant-platform/subscription-service/src/main/java/com/shared/subscription/api/SubscriptionDto.java
@@ -1,0 +1,5 @@
+package com.shared.subscription.api;
+
+import java.util.UUID;
+
+public record SubscriptionDto(UUID id, UUID tenantId, String status) {}

--- a/tenant-platform/subscription-service/src/main/java/com/shared/subscription/api/SubscriptionQueryService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/shared/subscription/api/SubscriptionQueryService.java
@@ -1,0 +1,8 @@
+package com.shared.subscription.api;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SubscriptionQueryService {
+    Optional<SubscriptionDto> findActiveSubscription(UUID tenantId);
+}

--- a/tenant-platform/subscription-service/src/main/resources/db/migration/V1__init.sql
+++ b/tenant-platform/subscription-service/src/main/resources/db/migration/V1__init.sql
@@ -3,6 +3,7 @@ create table if not exists tenant_subscription (
   tenant_id uuid not null,
   tier_id text,
   status text,
+  active boolean default true,
   seats int,
   currency text,
   period_start timestamptz,
@@ -31,3 +32,5 @@ alter table subscription_item enable row level security;
 
 create policy tenant_sub_policy on tenant_subscription using (tenant_id = current_setting('app.current_tenant', true)::uuid);
 create policy tenant_sub_item_policy on subscription_item using (subscription_id in (select subscription_id from tenant_subscription where tenant_id = current_setting('app.current_tenant', true)::uuid));
+
+create unique index if not exists ux_active_subscription on tenant_subscription (tenant_id) where active;

--- a/tenant-platform/subscription-service/src/test/java/com/lms/tenant/subscription/SubscriptionServiceIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/lms/tenant/subscription/SubscriptionServiceIT.java
@@ -1,0 +1,69 @@
+package com.lms.tenant.subscription;
+
+import com.lms.tenant.subscription.service.SubscriptionService;
+import com.lms.tenant.subscription.repo.TenantSubscriptionRepository;
+import com.shared.subscription.api.SubscriptionDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@SpringBootTest
+@Testcontainers
+@ExtendWith(SpringExtension.class)
+class SubscriptionServiceIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    SubscriptionService service;
+
+    @Autowired
+    TenantSubscriptionRepository repository;
+
+    @Autowired
+    JdbcTemplate jdbc;
+
+    @Test
+    @Transactional
+    void enforcesSingleActiveSubscriptionPerTenant() {
+        UUID tenantId = UUID.randomUUID();
+        jdbc.execute("select set_config('app.current_tenant', '" + tenantId + "', true)");
+        repository.saveAndFlush(new com.lms.tenant.subscription.domain.TenantSubscription(UUID.randomUUID(), tenantId, com.lms.tenant.subscription.domain.SubscriptionStatus.TRIAL, true));
+        assertThatThrownBy(() -> {
+            repository.saveAndFlush(new com.lms.tenant.subscription.domain.TenantSubscription(UUID.randomUUID(), tenantId, com.lms.tenant.subscription.domain.SubscriptionStatus.ACTIVE, true));
+        }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @Transactional
+    void findsActiveSubscription() {
+        UUID tenantId = UUID.randomUUID();
+        jdbc.execute("select set_config('app.current_tenant', '" + tenantId + "', true)");
+        SubscriptionDto dto = service.startTrial(tenantId);
+        assertThat(service.findActiveSubscription(tenantId)).isPresent();
+        service.cancel(tenantId, dto.id());
+        assertThat(service.findActiveSubscription(tenantId)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- implement Spring Boot subscription service with trial, activate, cancel operations
- add Flyway schema with RLS and unique partial index for active subscriptions
- expose REST endpoints and shared SubscriptionQueryService adapter
- include integration tests for unique active per tenant and active lookup

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl subscription-service -am test` *(fails: Non-resolvable import POM: spring-boot-dependencies, shared-bom: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b622523b80832fba3e6e5f034c0361