### PR TITLE
Add policy-service HTTP facade with usage and overage handling

### DIFF
--- a/tenant-platform/policy-service/pom.xml
+++ b/tenant-platform/policy-service/pom.xml
@@ -17,5 +17,47 @@
       <groupId>com.shared</groupId>
       <artifactId>shared-starter-security</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.shared</groupId>
+      <artifactId>shared-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>2.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.lms.tenant</groupId>
+      <artifactId>tenant-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.lms.tenant</groupId>
+      <artifactId>tenant-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.lms.tenant</groupId>
+      <artifactId>billing-service</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.lms.tenant</groupId>
+      <artifactId>catalog-service</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.lms.tenant</groupId>
+      <artifactId>subscription-service</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.lms.tenant</groupId>
+      <artifactId>tenant-service</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/tenant-platform/policy-service/src/main/java/com/lms/policy/JdbcUsageReader.java
+++ b/tenant-platform/policy-service/src/main/java/com/lms/policy/JdbcUsageReader.java
@@ -1,0 +1,26 @@
+package com.lms.policy;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Component
+public class JdbcUsageReader implements UsageReader {
+    private final JdbcTemplate jdbcTemplate;
+
+    public JdbcUsageReader(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public long currentUsage(UUID tenantId, String featureKey, Instant periodStart, Instant periodEnd) {
+        // Dummy example query; real implementation would depend on schema
+        return jdbcTemplate.queryForObject(
+                "select coalesce(sum(delta),0) from usage where tenant_id=? and feature_key=?",
+                new Object[]{tenantId, featureKey},
+                Long.class
+        );
+    }
+}

--- a/tenant-platform/policy-service/src/main/java/com/lms/policy/PolicyController.java
+++ b/tenant-platform/policy-service/src/main/java/com/lms/policy/PolicyController.java
@@ -1,0 +1,52 @@
+package com.lms.policy;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/tenants/{tenantId}/policy")
+@Tag(name = "Policy")
+public class PolicyController {
+
+    private final PolicyService policyService;
+    private final UsageReader usageReader;
+
+    public PolicyController(PolicyService policyService, UsageReader usageReader) {
+        this.policyService = policyService;
+        this.usageReader = usageReader;
+    }
+
+    @PostMapping("/consume")
+    @Operation(summary = "Consume feature usage and record overage if needed")
+    public ConsumeResponse consume(@PathVariable UUID tenantId, @RequestBody ConsumeRequest request) {
+        long usedBefore = usageReader.currentUsage(tenantId, request.featureKey(), request.periodStart(), request.periodEnd());
+        long total = usedBefore + request.delta();
+        var result = policyService.consumeOrOverage(tenantId, request.featureKey(), total);
+        boolean overageRecorded = result.overageId() != null;
+        boolean allowed = total <= result.limit() || overageRecorded;
+        return new ConsumeResponse(allowed, request.featureKey(), result.limit(), usedBefore,
+                request.delta(), overageRecorded, result.overageId());
+    }
+
+    public record ConsumeRequest(String featureKey,
+                                 long delta,
+                                 Instant periodStart,
+                                 Instant periodEnd,
+                                 String idempotencyKey) { }
+
+    public record ConsumeResponse(boolean allowed,
+                                  String featureKey,
+                                  long limit,
+                                  long usedBefore,
+                                  long requestedDelta,
+                                  boolean overageRecorded,
+                                  UUID overageId) { }
+}

--- a/tenant-platform/policy-service/src/main/java/com/lms/policy/PolicyServiceApplication.java
+++ b/tenant-platform/policy-service/src/main/java/com/lms/policy/PolicyServiceApplication.java
@@ -1,0 +1,13 @@
+package com.lms.policy;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+
+@SpringBootApplication
+@OpenAPIDefinition
+public class PolicyServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(PolicyServiceApplication.class, args);
+    }
+}

--- a/tenant-platform/policy-service/src/main/java/com/lms/policy/UsageReader.java
+++ b/tenant-platform/policy-service/src/main/java/com/lms/policy/UsageReader.java
@@ -1,0 +1,9 @@
+package com.lms.policy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@FunctionalInterface
+public interface UsageReader {
+    long currentUsage(UUID tenantId, String featureKey, Instant periodStart, Instant periodEnd);
+}

--- a/tenant-platform/policy-service/src/test/java/com/lms/policy/PolicyControllerTest.java
+++ b/tenant-platform/policy-service/src/test/java/com/lms/policy/PolicyControllerTest.java
@@ -1,0 +1,60 @@
+package com.lms.policy;
+
+import com.lms.billing.core.OveragePort;
+import com.lms.catalog.core.FeaturePolicyPort;
+import com.lms.subscription.core.SubscriptionQueryPort;
+import com.lms.tenant.core.TenantSettingsPort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PolicyControllerTest {
+
+    @Mock
+    TenantSettingsPort tenantSettings;
+    @Mock
+    SubscriptionQueryPort subscriptionQuery;
+    @Mock
+    FeaturePolicyPort featurePolicy;
+    @Mock
+    OveragePort overagePort;
+    @Mock
+    UsageReader usageReader;
+
+    @Test
+    void recordsOverageWhenLimitExceeded() {
+        var service = new PolicyService(tenantSettings, subscriptionQuery, featurePolicy, overagePort);
+        var controller = new PolicyController(service, usageReader);
+
+        UUID tenantId = UUID.randomUUID();
+        when(usageReader.currentUsage(eq(tenantId), eq("emails"), any(), any())).thenReturn(95L);
+        when(tenantSettings.isOverageEnabled(tenantId)).thenReturn(true);
+        var sub = new SubscriptionQueryPort.ActiveSubscription(UUID.randomUUID(), "basic", Instant.now(), Instant.now());
+        when(subscriptionQuery.loadActive(tenantId)).thenReturn(sub);
+        var eff = new FeaturePolicyPort.EffectiveFeature(true, 100L, true, 1L, "USD");
+        when(featurePolicy.effective("basic", tenantId, "emails")).thenReturn(eff);
+        UUID overageId = UUID.randomUUID();
+        when(overagePort.recordOverage(eq(tenantId), eq(sub.subscriptionId()), eq("emails"), eq(15L), any(), eq("USD"), any(), any(), isNull()))
+                .thenReturn(overageId);
+
+        var request = new PolicyController.ConsumeRequest("emails", 20L, null, null, null);
+        var response = controller.consume(tenantId, request);
+
+        assertTrue(response.allowed());
+        assertEquals("emails", response.featureKey());
+        assertEquals(100L, response.limit());
+        assertEquals(95L, response.usedBefore());
+        assertEquals(20L, response.requestedDelta());
+        assertTrue(response.overageRecorded());
+        assertEquals(overageId, response.overageId());
+    }
+}


### PR DESCRIPTION
## Summary
- expose `/tenants/{tenantId}/policy/consume` REST endpoint with OpenAPI support
- add pluggable `UsageReader` SPI with JDBC example
- record overage via updated `PolicyService`

## Testing
- `mvn -q -pl policy-service -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6226fe2b8832f9a983081cafe48f3