### PR TITLE
feat: add tenant API module with shared DTOs

### DIFF
--- a/tenant-platform/tenant-api/pom.xml
+++ b/tenant-platform/tenant-api/pom.xml
@@ -2,32 +2,19 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent><groupId>com.lms.tenant</groupId><artifactId>tenant-platform</artifactId><version>1.0.0-SNAPSHOT</version></parent>
+  <parent>
+    <groupId>com.lms.tenant</groupId>
+    <artifactId>tenant-platform</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
   <artifactId>tenant-api</artifactId>
+  <packaging>jar</packaging>
+
   <dependencies>
+    <!-- Spring annotations for declarative HTTP clients -->
     <dependency>
-      <groupId>com.lms.tenant</groupId>
-      <artifactId>tenant-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.lms.tenant</groupId>
-      <artifactId>tenant-config</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.shared</groupId>
-      <artifactId>shared-starter-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.shared</groupId>
-      <artifactId>shared-starter-openapi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-validation</artifactId>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/client/BillingClient.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/client/BillingClient.java
@@ -1,0 +1,22 @@
+package com.lms.tenant.api.client;
+
+import com.lms.tenant.api.dto.OverageDto;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+/**
+ * Declarative HTTP client for interacting with the billing service.
+ */
+@HttpExchange("/billing")
+public interface BillingClient {
+
+  /**
+   * Report an overage to the billing system.
+   *
+   * @param overage details of the overage
+   */
+  @PostExchange("/overages")
+  void reportOverage(@RequestBody OverageDto overage);
+}
+

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/client/CatalogClient.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/client/CatalogClient.java
@@ -1,0 +1,24 @@
+package com.lms.tenant.api.client;
+
+import com.lms.tenant.api.dto.EffectiveFeatureDto;
+import java.util.List;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+/**
+ * Declarative HTTP client for interacting with the catalog service.
+ */
+@HttpExchange("/catalog")
+public interface CatalogClient {
+
+  /**
+   * Retrieve features available for a particular plan.
+   *
+   * @param planId identifier of the plan
+   * @return list of features exposed by the plan
+   */
+  @GetExchange("/plans/{planId}/features")
+  List<EffectiveFeatureDto> featuresForPlan(@PathVariable("planId") String planId);
+}
+

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/client/PolicyClient.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/client/PolicyClient.java
@@ -1,0 +1,24 @@
+package com.lms.tenant.api.client;
+
+import com.lms.tenant.api.dto.EnforcementResultDto;
+import com.lms.tenant.api.dto.SubscriptionDto;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+/**
+ * Declarative HTTP client for interacting with the policy service.
+ */
+@HttpExchange("/policy")
+public interface PolicyClient {
+
+  /**
+   * Request policy enforcement for a subscription.
+   *
+   * @param subscription subscription data for enforcement
+   * @return result of the enforcement check
+   */
+  @PostExchange("/enforce")
+  EnforcementResultDto enforce(@RequestBody SubscriptionDto subscription);
+}
+

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/client/SubscriptionClient.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/client/SubscriptionClient.java
@@ -1,0 +1,24 @@
+package com.lms.tenant.api.client;
+
+import com.lms.tenant.api.dto.SubscriptionDto;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+/**
+ * Declarative HTTP client for interacting with the subscription service.
+ */
+@HttpExchange("/subscriptions")
+public interface SubscriptionClient {
+
+  /**
+   * Retrieve subscription information for a tenant.
+   *
+   * @param tenantId identifier of the tenant
+   * @return the tenant's subscription details
+   */
+  @GetExchange("/{tenantId}")
+  SubscriptionDto findByTenant(@PathVariable("tenantId") UUID tenantId);
+}
+

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/dto/EffectiveFeatureDto.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/dto/EffectiveFeatureDto.java
@@ -1,0 +1,13 @@
+package com.lms.tenant.api.dto;
+
+/**
+ * Represents the effective configuration of a feature for a tenant after
+ * all policies and subscriptions have been evaluated.
+ *
+ * @param featureCode identifier for the feature
+ * @param enabled     whether the feature is enabled
+ * @param limit       optional limit for the feature (null if unlimited)
+ */
+public record EffectiveFeatureDto(String featureCode, boolean enabled, Long limit) {
+}
+

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/dto/EnforcementResultDto.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/dto/EnforcementResultDto.java
@@ -1,0 +1,12 @@
+package com.lms.tenant.api.dto;
+
+/**
+ * Outcome of enforcing feature usage against policy constraints.
+ *
+ * @param allowed whether the action is permitted
+ * @param message optional explanatory message
+ * @param overage details about any overage that occurred
+ */
+public record EnforcementResultDto(boolean allowed, String message, OverageDto overage) {
+}
+

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/dto/OverageDto.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/dto/OverageDto.java
@@ -1,0 +1,13 @@
+package com.lms.tenant.api.dto;
+
+/**
+ * Represents usage that exceeded an allotted limit for a feature.
+ *
+ * @param featureCode identifier for the feature
+ * @param allowed     quota allowed for the feature
+ * @param used        amount actually used
+ * @param overage     amount over the allowed quota
+ */
+public record OverageDto(String featureCode, long allowed, long used, long overage) {
+}
+

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/dto/SubscriptionDto.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/dto/SubscriptionDto.java
@@ -1,0 +1,24 @@
+package com.lms.tenant.api.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Represents a tenant's subscription plan.
+ *
+ * @param id        subscription identifier
+ * @param plan      name of the subscribed plan
+ * @param startDate date the subscription became active
+ * @param endDate   optional end date (null if active)
+ * @param features  features included with the subscription
+ */
+public record SubscriptionDto(
+    UUID id,
+    String plan,
+    LocalDate startDate,
+    LocalDate endDate,
+    List<EffectiveFeatureDto> features
+) {
+}
+

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/dto/TenantDto.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/dto/TenantDto.java
@@ -1,0 +1,14 @@
+package com.lms.tenant.api.dto;
+
+import java.util.UUID;
+
+/**
+ * Lightweight representation of a tenant in the system.
+ *
+ * @param id            tenant identifier
+ * @param name          tenant display name
+ * @param subscription  subscription currently associated with the tenant
+ */
+public record TenantDto(UUID id, String name, SubscriptionDto subscription) {
+}
+


### PR DESCRIPTION
## Summary
- introduce plain `tenant-api` module for shared DTOs and HTTP clients
- provide tenant, subscription and policy DTOs and HTTP interfaces

## Testing
- `mvn -q -pl tenant-api -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b622816f40832fbdda3440d0a535aa