### PR TITLE
Implement overage persistence and API

### DIFF
--- a/tenant-platform/billing-service/pom.xml
+++ b/tenant-platform/billing-service/pom.xml
@@ -23,7 +23,20 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jdbc</artifactId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/tenant-platform/billing-service/src/main/java/com/lms/billing/BillingServiceApplication.java
+++ b/tenant-platform/billing-service/src/main/java/com/lms/billing/BillingServiceApplication.java
@@ -1,9 +1,11 @@
 package com.lms.billing;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@OpenAPIDefinition
 public class BillingServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(BillingServiceApplication.class, args);

--- a/tenant-platform/billing-service/src/main/java/com/lms/billing/core/BillingService.java
+++ b/tenant-platform/billing-service/src/main/java/com/lms/billing/core/BillingService.java
@@ -1,8 +1,9 @@
 package com.lms.billing.core;
 
+import com.shared.billing.api.OverageResponse;
+import com.shared.billing.api.RecordOverageRequest;
 import org.springframework.stereotype.Service;
 
-import java.time.Instant;
 import java.util.UUID;
 
 @Service
@@ -14,8 +15,7 @@ public class BillingService {
         this.port = port;
     }
 
-    public UUID record(UUID tenantId, UUID subscriptionId, String feature, long qty,
-                       Long price, String currency, Instant start, Instant end, String idemKey) {
-        return port.recordOverage(tenantId, subscriptionId, feature, qty, price, currency, start, end, idemKey);
+    public OverageResponse record(UUID tenantId, UUID subscriptionId, RecordOverageRequest request) {
+        return port.recordOverage(tenantId, subscriptionId, request);
     }
 }

--- a/tenant-platform/billing-service/src/main/java/com/lms/billing/core/OveragePort.java
+++ b/tenant-platform/billing-service/src/main/java/com/lms/billing/core/OveragePort.java
@@ -1,10 +1,14 @@
 package com.lms.billing.core;
 
-import java.time.Instant;
+import com.shared.billing.api.OverageResponse;
+import com.shared.billing.api.RecordOverageRequest;
+
 import java.util.UUID;
 
+/**
+ * Port for persisting overage records.
+ */
 public interface OveragePort {
-    UUID recordOverage(UUID tenantId, UUID subscriptionId, String featureKey, long quantity,
-                       Long unitPriceMinor, String currency, Instant periodStart, Instant periodEnd,
-                       String idempotencyKey);
+
+    OverageResponse recordOverage(UUID tenantId, UUID subscriptionId, RecordOverageRequest request);
 }

--- a/tenant-platform/billing-service/src/main/java/com/lms/billing/persistence/JpaOverageAdapter.java
+++ b/tenant-platform/billing-service/src/main/java/com/lms/billing/persistence/JpaOverageAdapter.java
@@ -1,0 +1,81 @@
+package com.lms.billing.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lms.billing.core.OveragePort;
+import com.lms.billing.persistence.entity.OverageStatus;
+import com.lms.billing.persistence.entity.TenantOverage;
+import com.lms.billing.persistence.repo.TenantOverageRepository;
+import com.shared.billing.api.OverageResponse;
+import com.shared.billing.api.RecordOverageRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * JPA implementation of {@link OveragePort}.
+ */
+@Component
+public class JpaOverageAdapter implements OveragePort {
+
+    private final TenantOverageRepository repo;
+    private final ObjectMapper objectMapper;
+
+    public JpaOverageAdapter(TenantOverageRepository repo, ObjectMapper objectMapper) {
+        this.repo = repo;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    @Transactional
+    public OverageResponse recordOverage(UUID tenantId, UUID subscriptionId, RecordOverageRequest request) {
+        if (request.idempotencyKey() != null) {
+            return repo.findByTenantIdAndIdempotencyKey(tenantId, request.idempotencyKey())
+                    .map(this::toResponse)
+                    .orElseGet(() -> saveNew(tenantId, subscriptionId, request));
+        }
+        return saveNew(tenantId, subscriptionId, request);
+    }
+
+    private OverageResponse saveNew(UUID tenantId, UUID subscriptionId, RecordOverageRequest req) {
+        TenantOverage o = new TenantOverage();
+        o.setId(UUID.randomUUID());
+        o.setTenantId(tenantId);
+        o.setSubscriptionId(subscriptionId);
+        o.setFeatureKey(req.featureKey());
+        o.setQuantity(req.quantity());
+        o.setUnitPriceMinor(req.unitPriceMinor() == null ? 0L : req.unitPriceMinor());
+        o.setCurrency(req.currency() == null ? "USD" : req.currency());
+        o.setOccurredAt(req.occurredAt() == null ? Instant.now() : req.occurredAt());
+        o.setPeriodStart(req.periodStart());
+        o.setPeriodEnd(req.periodEnd());
+        o.setStatus(OverageStatus.RECORDED);
+        o.setIdempotencyKey(req.idempotencyKey());
+        try {
+            o.setMetadataJson(objectMapper.writeValueAsString(req.metadata() == null ? Map.of() : req.metadata()));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        TenantOverage saved = repo.save(o);
+        return toResponse(saved);
+    }
+
+    private OverageResponse toResponse(TenantOverage o) {
+        return new OverageResponse(
+                o.getId(),
+                o.getTenantId(),
+                o.getFeatureKey(),
+                o.getQuantity(),
+                o.getUnitPriceMinor(),
+                o.getCurrency(),
+                o.getOccurredAt(),
+                o.getPeriodStart(),
+                o.getPeriodEnd(),
+                o.getStatus().name()
+        );
+    }
+}
+

--- a/tenant-platform/billing-service/src/main/java/com/lms/billing/persistence/entity/OverageStatus.java
+++ b/tenant-platform/billing-service/src/main/java/com/lms/billing/persistence/entity/OverageStatus.java
@@ -1,0 +1,11 @@
+package com.lms.billing.persistence.entity;
+
+/**
+ * Status of an overage record.
+ */
+public enum OverageStatus {
+    RECORDED,
+    INVOICED,
+    CANCELED
+}
+

--- a/tenant-platform/billing-service/src/main/java/com/lms/billing/persistence/entity/TenantOverage.java
+++ b/tenant-platform/billing-service/src/main/java/com/lms/billing/persistence/entity/TenantOverage.java
@@ -1,0 +1,164 @@
+package com.lms.billing.persistence.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * JPA entity representing an overage recorded for a tenant.
+ */
+@Entity
+@Table(name = "tenant_overage")
+public class TenantOverage {
+
+    @Id
+    @Column(name = "overage_id")
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @Column(name = "subscription_id")
+    private UUID subscriptionId;
+
+    @Column(name = "feature_key", nullable = false)
+    private String featureKey;
+
+    @Column(name = "quantity", nullable = false)
+    private long quantity;
+
+    @Column(name = "unit_price_minor", nullable = false)
+    private long unitPriceMinor;
+
+    @Column(name = "currency", nullable = false)
+    private String currency;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    @Column(name = "period_start", nullable = false)
+    private Instant periodStart;
+
+    @Column(name = "period_end", nullable = false)
+    private Instant periodEnd;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private OverageStatus status;
+
+    @Column(name = "idempotency_key")
+    private String idempotencyKey;
+
+    @Column(name = "metadata", columnDefinition = "jsonb")
+    private String metadataJson;
+
+    public TenantOverage() {
+    }
+
+    // Getters and setters
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(UUID tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public UUID getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    public void setSubscriptionId(UUID subscriptionId) {
+        this.subscriptionId = subscriptionId;
+    }
+
+    public String getFeatureKey() {
+        return featureKey;
+    }
+
+    public void setFeatureKey(String featureKey) {
+        this.featureKey = featureKey;
+    }
+
+    public long getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(long quantity) {
+        this.quantity = quantity;
+    }
+
+    public long getUnitPriceMinor() {
+        return unitPriceMinor;
+    }
+
+    public void setUnitPriceMinor(long unitPriceMinor) {
+        this.unitPriceMinor = unitPriceMinor;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public Instant getOccurredAt() {
+        return occurredAt;
+    }
+
+    public void setOccurredAt(Instant occurredAt) {
+        this.occurredAt = occurredAt;
+    }
+
+    public Instant getPeriodStart() {
+        return periodStart;
+    }
+
+    public void setPeriodStart(Instant periodStart) {
+        this.periodStart = periodStart;
+    }
+
+    public Instant getPeriodEnd() {
+        return periodEnd;
+    }
+
+    public void setPeriodEnd(Instant periodEnd) {
+        this.periodEnd = periodEnd;
+    }
+
+    public OverageStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OverageStatus status) {
+        this.status = status;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public void setIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public String getMetadataJson() {
+        return metadataJson;
+    }
+
+    public void setMetadataJson(String metadataJson) {
+        this.metadataJson = metadataJson;
+    }
+}
+

--- a/tenant-platform/billing-service/src/main/java/com/lms/billing/persistence/repo/TenantOverageRepository.java
+++ b/tenant-platform/billing-service/src/main/java/com/lms/billing/persistence/repo/TenantOverageRepository.java
@@ -1,0 +1,16 @@
+package com.lms.billing.persistence.repo;
+
+import com.lms.billing.persistence.entity.TenantOverage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository for {@link TenantOverage}.
+ */
+public interface TenantOverageRepository extends JpaRepository<TenantOverage, UUID> {
+
+    Optional<TenantOverage> findByTenantIdAndIdempotencyKey(UUID tenantId, String idempotencyKey);
+}
+

--- a/tenant-platform/billing-service/src/main/java/com/lms/billing/web/OverageController.java
+++ b/tenant-platform/billing-service/src/main/java/com/lms/billing/web/OverageController.java
@@ -1,16 +1,15 @@
 package com.lms.billing.web;
 
 import com.lms.billing.core.BillingService;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import com.shared.billing.api.OverageResponse;
+import com.shared.billing.api.OverageService;
+import com.shared.billing.api.RecordOverageRequest;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.time.Instant;
-import java.util.Map;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/tenants/{tenantId}/overages")
-public class OverageController {
+public class OverageController implements OverageService {
 
     private final BillingService service;
 
@@ -18,20 +17,8 @@ public class OverageController {
         this.service = service;
     }
 
-    @PostMapping
-    public ResponseEntity<UUID> record(@PathVariable UUID tenantId,
-                                       @RequestParam(required = false) UUID subscriptionId,
-                                       @RequestBody Map<String, Object> body) {
-        UUID id = service.record(
-                tenantId,
-                subscriptionId,
-                (String) body.get("featureKey"),
-                ((Number) body.get("quantity")).longValue(),
-                body.get("unitPriceMinor") == null ? null : ((Number) body.get("unitPriceMinor")).longValue(),
-                (String) body.getOrDefault("currency", "USD"),
-                Instant.parse((String) body.get("periodStart")),
-                Instant.parse((String) body.get("periodEnd")),
-                (String) body.get("idempotencyKey"));
-        return ResponseEntity.ok(id);
+    @Override
+    public OverageResponse record(UUID tenantId, UUID subscriptionId, RecordOverageRequest request) {
+        return service.record(tenantId, subscriptionId, request);
     }
 }

--- a/tenant-platform/billing-service/src/main/java/com/shared/billing/api/OverageResponse.java
+++ b/tenant-platform/billing-service/src/main/java/com/shared/billing/api/OverageResponse.java
@@ -1,0 +1,22 @@
+package com.shared.billing.api;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Response payload returned after recording an overage.
+ */
+public record OverageResponse(
+        UUID overageId,
+        UUID tenantId,
+        String featureKey,
+        long quantity,
+        long unitPriceMinor,
+        String currency,
+        Instant occurredAt,
+        Instant periodStart,
+        Instant periodEnd,
+        String status
+) {
+}
+

--- a/tenant-platform/billing-service/src/main/java/com/shared/billing/api/OverageService.java
+++ b/tenant-platform/billing-service/src/main/java/com/shared/billing/api/OverageService.java
@@ -1,0 +1,27 @@
+package com.shared.billing.api;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.UUID;
+
+/**
+ * API contract for recording tenant overages.
+ */
+@RequestMapping("/tenants/{tenantId}/billing/overages")
+public interface OverageService {
+
+    /**
+     * Record an overage for a tenant. If an idempotency key is supplied and a record exists,
+     * the existing overage is returned.
+     */
+    @PostMapping
+    OverageResponse record(
+            @PathVariable UUID tenantId,
+            @RequestParam(required = false) UUID subscriptionId,
+            @RequestBody RecordOverageRequest request);
+}
+

--- a/tenant-platform/billing-service/src/main/java/com/shared/billing/api/RecordOverageRequest.java
+++ b/tenant-platform/billing-service/src/main/java/com/shared/billing/api/RecordOverageRequest.java
@@ -1,0 +1,21 @@
+package com.shared.billing.api;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Request payload for recording an overage.
+ */
+public record RecordOverageRequest(
+        String featureKey,
+        long quantity,
+        Long unitPriceMinor,
+        String currency,
+        Instant occurredAt,
+        Instant periodStart,
+        Instant periodEnd,
+        String idempotencyKey,
+        Map<String, Object> metadata
+) {
+}
+

--- a/tenant-platform/billing-service/src/test/java/com/lms/billing/web/OverageControllerTest.java
+++ b/tenant-platform/billing-service/src/test/java/com/lms/billing/web/OverageControllerTest.java
@@ -1,0 +1,79 @@
+package com.lms.billing.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lms.billing.persistence.repo.TenantOverageRepository;
+import com.shared.billing.api.RecordOverageRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class OverageControllerTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    TenantOverageRepository repo;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Test
+    void idempotentRequestsCreateSingleRow() throws Exception {
+        UUID tenantId = UUID.randomUUID();
+        String idem = UUID.randomUUID().toString();
+
+        RecordOverageRequest req = new RecordOverageRequest(
+                "feature", 5L, 10L, "USD", Instant.now(),
+                Instant.now().minusSeconds(60), Instant.now(), idem, Map.of("k", "v"));
+
+        String json = mapper.writeValueAsString(req);
+
+        String url = "/tenants/" + tenantId + "/billing/overages";
+
+        var first = mvc.perform(post(url).contentType(MediaType.APPLICATION_JSON).content(json))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        var second = mvc.perform(post(url).contentType(MediaType.APPLICATION_JSON).content(json))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertThat(first).isEqualTo(second);
+        assertThat(repo.count()).isEqualTo(1);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Spring Boot billing-service for recording tenant overages
- persist overages with idempotency key and expose shared API
- enable OpenAPI and add integration test skeleton

## Testing
- `mvn -e -pl billing-service -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6225d26e4832fbf0d0a1d59cc8b3c