### PR TITLE
feat: add tenant service endpoints

### DIFF
--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantResolverFilter.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantResolverFilter.java
@@ -20,6 +20,10 @@ public class TenantResolverFilter extends OncePerRequestFilter {
     try { jdbc.execute("select set_config('app.current_tenant', '" + tid + "', true)"); chain.doFilter(req, res); }
     finally { TenantContext.clear(); MDC.remove("tenant_id"); }
   }
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest req) {
+    return "POST".equalsIgnoreCase(req.getMethod()) && "/tenants".equals(req.getRequestURI());
+  }
   private String extract(HttpServletRequest req) {
     String host = req.getHeader("host");
     if (host != null) { Matcher m = SUBDOMAIN.matcher(host); if (m.find()) return m.group(1); }

--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -43,6 +43,14 @@
       <artifactId>shared-starter-redis</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.lms.tenant</groupId>
+      <artifactId>tenant-persistence</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.lms.tenant</groupId>
+      <artifactId>tenant-config</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
     </dependency>

--- a/tenant-platform/tenant-service/src/main/java/com/lms/tenant/core/TenantService.java
+++ b/tenant-platform/tenant-service/src/main/java/com/lms/tenant/core/TenantService.java
@@ -1,16 +1,43 @@
 package com.lms.tenant.core;
 
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
 import java.util.UUID;
 
 @Service
 public class TenantService {
 
     private final TenantSettingsPort settingsPort;
+    private final NamedParameterJdbcTemplate jdbc;
 
-    public TenantService(TenantSettingsPort settingsPort) {
+    public record Tenant(UUID id, String slug, String name, boolean overageEnabled) {}
+
+    public TenantService(TenantSettingsPort settingsPort, NamedParameterJdbcTemplate jdbc) {
         this.settingsPort = settingsPort;
+        this.jdbc = jdbc;
+    }
+
+    public Tenant createTenant(String slug, String name) {
+        UUID id = UUID.randomUUID();
+        jdbc.update(
+                "insert into tenant (tenant_id, tenant_slug, name, status) values (:id,:slug,:name,'ACTIVE')",
+                Map.of("id", id, "slug", slug, "name", name));
+        // ensure RLS context for integration-key operations
+        jdbc.getJdbcOperations().execute("select set_config('app.current_tenant', '" + id + "', true)");
+        return new Tenant(id, slug, name, false);
+    }
+
+    public Tenant findTenant(UUID id) {
+        return jdbc.query(
+                "select tenant_id, tenant_slug, name, overage_enabled from tenant where tenant_id = :id",
+                Map.of("id", id),
+                rs -> rs.next() ? new Tenant(
+                        (UUID) rs.getObject("tenant_id"),
+                        rs.getString("tenant_slug"),
+                        rs.getString("name"),
+                        rs.getBoolean("overage_enabled")) : null);
     }
 
     public void toggleOverage(UUID tenantId, boolean enabled) {

--- a/tenant-platform/tenant-service/src/main/java/com/lms/tenant/web/CreateTenantRequest.java
+++ b/tenant-platform/tenant-service/src/main/java/com/lms/tenant/web/CreateTenantRequest.java
@@ -1,0 +1,3 @@
+package com.lms.tenant.web;
+
+public record CreateTenantRequest(String slug, String name) {}

--- a/tenant-platform/tenant-service/src/main/java/com/lms/tenant/web/TenantResponse.java
+++ b/tenant-platform/tenant-service/src/main/java/com/lms/tenant/web/TenantResponse.java
@@ -1,0 +1,5 @@
+package com.lms.tenant.web;
+
+import java.util.UUID;
+
+public record TenantResponse(UUID id, String slug, String name, boolean overageEnabled) {}

--- a/tenant-platform/tenant-service/src/main/java/com/lms/tenant/web/ToggleOverageRequest.java
+++ b/tenant-platform/tenant-service/src/main/java/com/lms/tenant/web/ToggleOverageRequest.java
@@ -1,0 +1,3 @@
+package com.lms.tenant.web;
+
+public record ToggleOverageRequest(boolean enabled) {}

--- a/tenant-platform/tenant-service/src/test/java/com/lms/tenant/TenantControllerTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/lms/tenant/TenantControllerTest.java
@@ -1,0 +1,60 @@
+package com.lms.tenant;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.flyway.enabled=false"
+})
+class TenantControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    NamedParameterJdbcTemplate jdbc;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @BeforeEach
+    void setup() {
+        jdbc.getJdbcOperations().execute("drop table if exists tenant");
+        jdbc.getJdbcOperations().execute("create table tenant (tenant_id uuid primary key, tenant_slug text, name text, status text, overage_enabled boolean not null)");
+    }
+
+    @Test
+    void togglesOverageAndReadsBack() throws Exception {
+        UUID id = UUID.randomUUID();
+        jdbc.update("insert into tenant (tenant_id, tenant_slug, name, status, overage_enabled) values (:id,:slug,:name,'ACTIVE',false)",
+                Map.of("id", id, "slug", "acme", "name", "Acme"));
+
+        mockMvc.perform(put("/tenants/" + id + "/overage-enabled")
+                        .header("X-Tenant-ID", "acme")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(Map.of("enabled", true))))
+                .andExpect(status().isAccepted());
+
+        mockMvc.perform(get("/tenants/" + id).header("X-Tenant-ID", "acme"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.overageEnabled").value(true));
+    }
+}


### PR DESCRIPTION
## Summary
- implement tenant creation, read, and overage toggle endpoints
- respect RLS for integration key operations and skip tenant filter for creation
- add module dependencies and integration test scaffold

## Testing
- `mvn -q -pl tenant-service -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6227924b8832fac8b9c1de54e9b6a