### PR TITLE
Manage starter dependencies for tenant platform

### DIFF
--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -39,6 +39,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.lms</groupId>
+        <artifactId>shared-starter</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
 
       <!-- Manage versions for internal modules so children can omit them -->
       <dependency>

--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -38,10 +38,6 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.lms</groupId>
-      <artifactId>starter-openapi</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## Summary
- Import `shared-starter` BOM in tenant platform so starter modules have managed versions
- Remove duplicate `starter-openapi` dependency from subscription-service module

## Testing
- `mvn -q -e -f tenant-platform/pom.xml test -DskipTests` *(fails: Non-resolvable import POMs due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b62f48af1c832faff3449cd120fb9a