### PR TITLE
Fix tenant-events module by adding JPA and test dependencies

### DIFF
--- a/tenant-platform/tenant-events/pom.xml
+++ b/tenant-platform/tenant-events/pom.xml
@@ -8,6 +8,14 @@
   <artifactId>tenant-events</artifactId>
   <dependencies>
     <dependency>
+      <groupId>com.lms</groupId>
+      <artifactId>starter-data</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
@@ -26,6 +34,11 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Summary
- add starter-data and JPA dependencies for tenant events
- include H2 for tests

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b62fa713c8832f897c30e8f34e6e14