### PR TITLE
Refactor policy and overage handling

### DIFF
--- a/tenant-platform/billing-service/pom.xml
+++ b/tenant-platform/billing-service/pom.xml
@@ -56,5 +56,10 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/tenant-platform/billing-service/src/main/java/com/lms/billing/web/OverageController.java
+++ b/tenant-platform/billing-service/src/main/java/com/lms/billing/web/OverageController.java
@@ -1,16 +1,17 @@
 package com.lms.billing.web;
 
 import com.lms.billing.core.BillingService;
-import org.springframework.http.ResponseEntity;
+import com.shared.billing.api.OverageResponse;
+import com.shared.billing.api.OverageService;
+import com.shared.billing.api.RecordOverageRequest;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/tenants/{tenantId}/overages")
 @Validated
-public class OverageController {
+public class OverageController implements OverageService {
 
     private final BillingService service;
 

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -43,5 +43,10 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/tenant-platform/policy-service/src/test/java/com/lms/policy/PolicyControllerTest.java
+++ b/tenant-platform/policy-service/src/test/java/com/lms/policy/PolicyControllerTest.java
@@ -4,6 +4,8 @@ import com.lms.billing.core.OveragePort;
 import com.lms.catalog.core.FeaturePolicyPort;
 import com.lms.subscription.core.SubscriptionQueryPort;
 import com.lms.tenant.core.TenantSettingsPort;
+import com.shared.billing.api.OverageResponse;
+import com.shared.billing.api.RecordOverageRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -43,10 +45,11 @@ class PolicyControllerTest {
         var eff = new FeaturePolicyPort.EffectiveFeature(true, 100L, true, 1L, "USD");
         when(featurePolicy.effective("basic", tenantId, "emails")).thenReturn(eff);
         UUID overageId = UUID.randomUUID();
-        when(overagePort.recordOverage(eq(tenantId), eq(sub.subscriptionId()), eq("emails"), eq(15L), any(), eq("USD"), any(), any(), isNull()))
-                .thenReturn(overageId);
+        when(overagePort.recordOverage(eq(tenantId), eq(sub.subscriptionId()), any(RecordOverageRequest.class)))
+                .thenReturn(new OverageResponse(overageId, tenantId, "emails", 15L, 1L, "USD",
+                        Instant.now(), Instant.now(), Instant.now(), "RECORDED"));
 
-        var request = new PolicyController.ConsumeRequest("emails", 20L, null, null, null);
+        var request = new PolicyController.ConsumeRequest("emails", 20L, Instant.now().minusSeconds(60), Instant.now(), null);
         var response = controller.consume(tenantId, request);
 
         assertTrue(response.allowed());

--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -47,5 +47,10 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/PolicyController.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/PolicyController.java
@@ -6,10 +6,8 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
-import java.time.Instant;
 import java.util.UUID;
 
 @RestController
@@ -22,11 +20,6 @@ public class PolicyController {
     this.service = service;
   }
 
-  @GetMapping("/entitlements")
-  public ResponseEntity<PolicyService.Entitlements> entitlements(@PathVariable UUID tenantId) {
-    return ResponseEntity.ok(service.effective(tenantId));
-  }
-
   @PostMapping("/features/{featureKey}/consume")
   public ResponseEntity<PolicyService.EnforcementResult> consume(
       @PathVariable UUID tenantId,
@@ -36,8 +29,6 @@ public class PolicyController {
         tenantId,
         featureKey,
         req.delta(),
-        req.periodStart(),
-        req.periodEnd(),
         () -> req.currentUsage(),
         req.idempotencyKey());
     return ResponseEntity.ok(result);
@@ -46,7 +37,5 @@ public class PolicyController {
   public record ConsumeRequest(
       @Positive long delta,
       @PositiveOrZero long currentUsage,
-      @NotNull Instant periodStart,
-      @NotNull Instant periodEnd,
       String idempotencyKey) {}
 }

--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConnectionInterceptor.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConnectionInterceptor.java
@@ -1,5 +1,6 @@
 package com.lms.tenant.config;
 
+import com.common.context.TenantContext;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -33,7 +34,7 @@ public class TenantConnectionInterceptor extends DelegatingDataSource {
         if (connection == null) {
             return;
         }
-        var tenantId = TenantContext.getTenantId();
+        var tenantId = TenantContext.get();
         if (tenantId.isPresent()) {
             try (Statement statement = connection.createStatement()) {
                 statement.execute("SET LOCAL app.current_tenant = '" + tenantId.get() + "'");

--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantFilter.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantFilter.java
@@ -1,5 +1,6 @@
 package com.lms.tenant.config;
 
+import com.common.context.TenantContext;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,7 +27,7 @@ public class TenantFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         Optional<UUID> tenantId = tenantResolver.resolveTenant(request);
         tenantId.ifPresent(id -> {
-            TenantContext.setTenantId(id);
+            TenantContext.set(id);
             MDC.put("tenantId", id.toString());
         });
         try {

--- a/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
+++ b/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
@@ -11,15 +11,15 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -31,7 +31,7 @@ class TenantConfigAutoConfigurationTest {
     @DynamicPropertySource
     static void postgresProperties(DynamicPropertyRegistry registry) throws IOException {
         postgres = EmbeddedPostgres.start();
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.url", () -> postgres.getJdbcUrl());
         registry.add("spring.datasource.username", () -> "postgres");
         registry.add("spring.datasource.password", () -> "postgres");
         registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");

--- a/tenant-platform/tenant-core/src/main/java/com/lms/tenant/core/dto/OverageResponse.java
+++ b/tenant-platform/tenant-core/src/main/java/com/lms/tenant/core/dto/OverageResponse.java
@@ -1,0 +1,17 @@
+package com.lms.tenant.core.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record OverageResponse(
+        UUID overageId,
+        UUID tenantId,
+        String featureKey,
+        long quantity,
+        long unitPriceMinor,
+        String currency,
+        Instant occurredAt,
+        Instant periodStart,
+        Instant periodEnd,
+        String status) {
+}

--- a/tenant-platform/tenant-core/src/main/java/com/lms/tenant/core/dto/RecordOverageRequest.java
+++ b/tenant-platform/tenant-core/src/main/java/com/lms/tenant/core/dto/RecordOverageRequest.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.time.Instant;
 import java.util.Map;
-import java.util.UUID;
 
 public record RecordOverageRequest(
         @NotBlank String featureKey,
@@ -18,17 +17,4 @@ public record RecordOverageRequest(
         @NotNull Instant periodEnd,
         String idempotencyKey,
         Map<String, Object> metadata) {
-}
-
-public record OverageResponse(
-        UUID overageId,
-        UUID tenantId,
-        String featureKey,
-        long quantity,
-        long unitPriceMinor,
-        String currency,
-        Instant occurredAt,
-        Instant periodStart,
-        Instant periodEnd,
-        String status) {
 }

--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -57,6 +57,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>

--- a/tenant-platform/tenant-service/src/main/java/com/lms/tenant/service/TenantService.java
+++ b/tenant-platform/tenant-service/src/main/java/com/lms/tenant/service/TenantService.java
@@ -1,6 +1,6 @@
 package com.lms.tenant.service;
 
-import com.lms.tenant.config.TenantContext;
+import com.common.context.TenantContext;
 import com.lms.tenant.persistence.entity.Tenant;
 import com.lms.tenant.persistence.entity.TenantIntegrationKey;
 import com.lms.tenant.persistence.entity.enums.KeyStatus;
@@ -34,7 +34,7 @@ public class TenantService {
         tenantRepository.save(tenant);
 
         // create default integration key respecting RLS
-        TenantContext.setTenantId(tenant.getId());
+        TenantContext.set(tenant.getId());
         try {
             TenantIntegrationKey key = new TenantIntegrationKey();
             key.setId(UUID.randomUUID());


### PR DESCRIPTION
## Summary
- split overage request/response into separate DTOs
- update policy service and API to use new DTO and streamlined consume endpoint
- align tenant config with shared TenantContext and add Testcontainers JUnit support

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b631162660832f9573f4666855b687