### PR TITLE
Use shared TenantContext

### DIFF
--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConnectionInterceptor.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConnectionInterceptor.java
@@ -5,6 +5,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import javax.sql.DataSource;
 import org.springframework.jdbc.datasource.DelegatingDataSource;
+import com.common.context.TenantContext;
 
 /**
  * Wraps {@link DataSource} connections to apply the current tenant using a PostgreSQL GUC variable.
@@ -33,7 +34,7 @@ public class TenantConnectionInterceptor extends DelegatingDataSource {
         if (connection == null) {
             return;
         }
-        var tenantId = TenantContext.getTenantId();
+        var tenantId = TenantContext.get();
         if (tenantId.isPresent()) {
             try (Statement statement = connection.createStatement()) {
                 statement.execute("SET LOCAL app.current_tenant = '" + tenantId.get() + "'");

--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantFilter.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantFilter.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.MDC;
 import org.springframework.web.filter.OncePerRequestFilter;
+import com.common.context.TenantContext;
 
 /**
  * Servlet filter that populates {@link TenantContext} for each request.
@@ -26,7 +27,7 @@ public class TenantFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         Optional<UUID> tenantId = tenantResolver.resolveTenant(request);
         tenantId.ifPresent(id -> {
-            TenantContext.setTenantId(id);
+            TenantContext.set(id);
             MDC.put("tenantId", id.toString());
         });
         try {

--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantResolverFilter.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantResolverFilter.java
@@ -1,6 +1,5 @@
 package com.lms.tenant.config;
 
-import com.common.context.TenantContext;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,6 +12,7 @@ import org.slf4j.MDC;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import com.common.context.TenantContext;
 
 /**
  * Resolves tenant identifiers from the incoming request and stores them in the

--- a/tenant-platform/tenant-service/src/main/java/com/lms/tenant/service/TenantService.java
+++ b/tenant-platform/tenant-service/src/main/java/com/lms/tenant/service/TenantService.java
@@ -1,6 +1,6 @@
 package com.lms.tenant.service;
 
-import com.lms.tenant.config.TenantContext;
+import com.common.context.TenantContext;
 import com.lms.tenant.persistence.entity.Tenant;
 import com.lms.tenant.persistence.entity.TenantIntegrationKey;
 import com.lms.tenant.persistence.entity.enums.KeyStatus;
@@ -34,7 +34,7 @@ public class TenantService {
         tenantRepository.save(tenant);
 
         // create default integration key respecting RLS
-        TenantContext.setTenantId(tenant.getId());
+        TenantContext.set(tenant.getId());
         try {
             TenantIntegrationKey key = new TenantIntegrationKey();
             key.setId(UUID.randomUUID());


### PR DESCRIPTION
## Summary
- Remove module-specific TenantContext implementation
- Import and use shared `com.common.context.TenantContext` in tenant filters, connection interceptor and service

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl tenant-config,tenant-service -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b63135effc832fb2e5c065fb811828