### PR TITLE
Ensure tenant-config includes shared-common dependency

### DIFF
--- a/tenant-platform/tenant-config/pom.xml
+++ b/tenant-platform/tenant-config/pom.xml
@@ -10,6 +10,10 @@
   <dependencies>
     <dependency><groupId>com.lms</groupId><artifactId>starter-core</artifactId></dependency>
     <dependency><groupId>com.lms</groupId><artifactId>starter-headers</artifactId></dependency>
+    <dependency>
+      <groupId>com.lms</groupId>
+      <artifactId>shared-common</artifactId>
+    </dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-jdbc</artifactId></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-cache</artifactId></dependency>


### PR DESCRIPTION
## Summary
- add shared-common library to tenant-config module to resolve TenantContext references

## Testing
- `mvn -q -f shared-lib/pom.xml install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b633332864832f858e7bf3819d4568