### PR TITLE
Fix tests and overage controller

### DIFF
--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -100,6 +100,13 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
   <build>
     <pluginManagement>
       <plugins>

--- a/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/OverageController.java
+++ b/tenant-platform/tenant-api/src/main/java/com/lms/tenant/api/OverageController.java
@@ -25,6 +25,13 @@ public class OverageController {
             @PathVariable UUID tenantId,
             @RequestParam(required = false) UUID subscriptionId,
             @Valid @RequestBody RecordOverageRequest req) {
-        return ResponseEntity.ok(service.record(tenantId, subscriptionId, req));
+        long unitPrice = req.unitPriceMinor() == null ? 0L : req.unitPriceMinor();
+        var id = service.record(tenantId, subscriptionId, req.featureKey(),
+                req.quantity(), unitPrice, req.currency(),
+                req.periodStart(), req.periodEnd(), req.idempotencyKey());
+        var res = new OverageResponse(id, tenantId, req.featureKey(), req.quantity(),
+                unitPrice, req.currency(), req.occurredAt(),
+                req.periodStart(), req.periodEnd(), "RECORDED");
+        return ResponseEntity.ok(res);
     }
 }

--- a/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
+++ b/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
@@ -31,7 +31,7 @@ class TenantConfigAutoConfigurationTest {
     @DynamicPropertySource
     static void postgresProperties(DynamicPropertyRegistry registry) throws IOException {
         postgres = EmbeddedPostgres.start();
-        registry.add("spring.datasource.url", () -> postgres.getJdbcUrl());
+        registry.add("spring.datasource.url", () -> postgres.getJdbcUrl("postgres", "postgres"));
         registry.add("spring.datasource.username", () -> "postgres");
         registry.add("spring.datasource.password", () -> "postgres");
         registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");


### PR DESCRIPTION
## Summary
- add Spring Boot test dependency for tenant-platform modules
- handle RecordOverageRequest fields individually in OverageController
- use EmbeddedPostgres.getJdbcUrl with parameters in TenantConfigAutoConfigurationTest

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:pom:3.5.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b634923810832fb74c9ac953966ad0