### PR TITLE
build: install shared libraries before platform build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+      - name: Build shared libraries
+        run: mvn -B -DskipTests=false install -f shared-lib/pom.xml
       - name: Build tenant platform
         run: mvn -B -DskipTests=false verify -f tenant-platform/pom.xml
       - name: Build setup service


### PR DESCRIPTION
## Summary
- install shared-lib in CI before building tenant services

## Testing
- `mvn -q -f shared-lib/pom.xml test` *(fails: Network is unreachable)*
- `mvn -q -f tenant-platform/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6357fe034832f8cca7341277376d9