### PR TITLE
Fix tenant config test configuration

### DIFF
--- a/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
+++ b/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@SpringBootTest
+@SpringBootTest(classes = {TenantConfigAutoConfiguration.class, TenantConfigAutoConfigurationTest.TestController.class})
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class TenantConfigAutoConfigurationTest {


### PR DESCRIPTION
## Summary
- specify TenantConfig auto configuration in `TenantConfigAutoConfigurationTest` to supply Spring Boot configuration

## Testing
- `mvn -f tenant-platform/pom.xml -pl tenant-config -am test` *(fails: Non-resolvable import POM: Could not transfer artifacts due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b63742d9f0832f98da90f97772440c