### PR TITLE
fix tenant config test to instantiate JdbcTemplate from DataSource

### DIFF
--- a/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
+++ b/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -59,8 +60,8 @@ class TenantConfigAutoConfigurationTest {
     static class TestController {
         private final JdbcTemplate jdbcTemplate;
 
-        TestController(JdbcTemplate jdbcTemplate) {
-            this.jdbcTemplate = jdbcTemplate;
+        TestController(DataSource dataSource) {
+            this.jdbcTemplate = new JdbcTemplate(dataSource);
         }
 
         @GetMapping("/current-tenant")


### PR DESCRIPTION
## Summary
- construct JdbcTemplate manually in `TenantConfigAutoConfigurationTest` to avoid missing bean

## Testing
- `mvn -q -pl tenant-config test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b638402be8832fb6777298a86ed819