### PR TITLE
Disable security filters in tenant-config test

### DIFF
--- a/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
+++ b/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootTest(classes = {TenantConfigAutoConfiguration.class, TenantConfigAutoConfigurationTest.TestController.class})
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class TenantConfigAutoConfigurationTest {
 


### PR DESCRIPTION
## Summary
- Disable Spring Security filters for tenant-config tests to allow unauthenticated requests

## Testing
- `mvn -f tenant-platform/pom.xml -pl tenant-config test` *(fails: Non-resolvable import POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b639cb7fac832fab95310ebe6754d4