### PR TITLE
Enable tenant filter in TenantConfig test

### DIFF
--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConfigAutoConfiguration.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConfigAutoConfiguration.java
@@ -27,7 +27,7 @@ public class TenantConfigAutoConfiguration {
     }
 
     @Bean
-    public BeanPostProcessor tenantDataSourcePostProcessor() {
+    public static BeanPostProcessor tenantDataSourcePostProcessor() {
         return new BeanPostProcessor() {
             @Override
             public Object postProcessAfterInitialization(Object bean, String beanName) {

--- a/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
+++ b/tenant-platform/tenant-config/src/test/java/com/lms/tenant/config/TenantConfigAutoConfigurationTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -23,7 +24,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootTest(classes = {TenantConfigAutoConfiguration.class, TenantConfigAutoConfigurationTest.TestController.class})
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc(addFilters = true)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class TenantConfigAutoConfigurationTest {
 
@@ -49,6 +50,7 @@ class TenantConfigAutoConfigurationTest {
     private MockMvc mockMvc;
 
     @Test
+    @WithMockUser
     void setsCurrentTenant() throws Exception {
         String tenantId = UUID.randomUUID().toString();
         mockMvc.perform(get("/current-tenant").header(TenantResolver.TENANT_HEADER, tenantId))


### PR DESCRIPTION
## Summary
- Register tenant data source post-processor as a static bean so connections apply current tenant
- Enable servlet filters and mock a user in `TenantConfigAutoConfigurationTest` so tenant context is set during tests

## Testing
- `mvn -pl tenant-config test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b63b893b78832f8860ec9018d7250f