### PR TITLE
Add tenant status count method and service tests

### DIFF
--- a/tenant-platform/tenant-persistence/src/main/java/com/lms/tenant/persistence/repository/TenantRepository.java
+++ b/tenant-platform/tenant-persistence/src/main/java/com/lms/tenant/persistence/repository/TenantRepository.java
@@ -1,6 +1,7 @@
 package com.lms.tenant.persistence.repository;
 
 import com.lms.tenant.persistence.entity.Tenant;
+import com.lms.tenant.persistence.entity.enums.TenantStatus;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,5 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * Repository for {@link Tenant} entities.
  */
 public interface TenantRepository extends JpaRepository<Tenant, UUID> {
+
+    long countByStatus(TenantStatus status);
 }
 

--- a/tenant-platform/tenant-service/src/main/java/com/lms/tenant/service/TenantService.java
+++ b/tenant-platform/tenant-service/src/main/java/com/lms/tenant/service/TenantService.java
@@ -53,6 +53,10 @@ public class TenantService {
         return tenantRepository.findById(tenantId).orElse(null);
     }
 
+    public long getTotalTenantsByStatus(TenantStatus status) {
+        return tenantRepository.countByStatus(status);
+    }
+
     public void setOverage(UUID tenantId, boolean enabled) {
         settingsPort.setOverageEnabled(tenantId, enabled);
     }

--- a/tenant-platform/tenant-service/src/test/java/com/lms/tenant/service/TenantServiceTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/lms/tenant/service/TenantServiceTest.java
@@ -1,0 +1,59 @@
+package com.lms.tenant.service;
+
+import com.lms.tenant.persistence.entity.Tenant;
+import com.lms.tenant.persistence.entity.enums.TenantStatus;
+import com.lms.tenant.persistence.repository.TenantIntegrationKeyRepository;
+import com.lms.tenant.persistence.repository.TenantRepository;
+import com.lms.tenant.service.TenantSettingsPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class TenantServiceTest {
+
+    @Autowired
+    TenantRepository tenantRepository;
+
+    @Autowired
+    TenantIntegrationKeyRepository keyRepository;
+
+    TenantService tenantService;
+
+    @BeforeEach
+    void setUp() {
+        tenantService = new TenantService(tenantRepository, keyRepository, Mockito.mock(TenantSettingsPort.class));
+    }
+
+    @Test
+    void getTotalTenantsByStatusReturnsCount() {
+        Tenant t1 = new Tenant();
+        t1.setId(UUID.randomUUID());
+        t1.setSlug("foo");
+        t1.setName("Foo");
+        t1.setStatus(TenantStatus.ACTIVE);
+        tenantRepository.save(t1);
+
+        Tenant t2 = new Tenant();
+        t2.setId(UUID.randomUUID());
+        t2.setSlug("bar");
+        t2.setName("Bar");
+        t2.setStatus(TenantStatus.ACTIVE);
+        tenantRepository.save(t2);
+
+        long total = tenantService.getTotalTenantsByStatus(TenantStatus.ACTIVE);
+        assertThat(total).isEqualTo(2);
+    }
+
+    @Test
+    void getTotalTenantsByStatusReturnsZeroWhenNone() {
+        long total = tenantService.getTotalTenantsByStatus(TenantStatus.INACTIVE);
+        assertThat(total).isZero();
+    }
+}


### PR DESCRIPTION
## Summary
- extend tenant repository with `countByStatus`
- expose `getTotalTenantsByStatus` in tenant service
- cover tenant service status counting with JPA tests

## Testing
- `mvn -q -pl tenant-persistence -f tenant-platform/pom.xml test` *(fails: Non-resolvable import POM)*
- `mvn -q -pl tenant-service -f tenant-platform/pom.xml test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b63e0f3254832f9c83b7a9ec8e6103