### PR TITLE
Add spring-security-test dependency for tenant-config tests

### DIFF
--- a/tenant-platform/tenant-config/pom.xml
+++ b/tenant-platform/tenant-config/pom.xml
@@ -39,6 +39,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.zonky.test</groupId>
       <artifactId>embedded-postgres</artifactId>
       <version>2.0.3</version>


### PR DESCRIPTION
## Summary
- fix tenant-config tests by adding missing `spring-security-test` dependency

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.2 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b63f3149b0832f9f005dc810119c98