### PR TITLE
Ensure tenant id applied when retrieving connection

### DIFF
--- a/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConnectionInterceptor.java
+++ b/tenant-platform/tenant-config/src/main/java/com/lms/tenant/config/TenantConnectionInterceptor.java
@@ -38,7 +38,11 @@ public class TenantConnectionInterceptor extends DelegatingDataSource {
         var tenantId = TenantContext.get();
         if (tenantId.isPresent()) {
             try (Statement statement = connection.createStatement()) {
-                statement.execute("SET LOCAL app.current_tenant = '" + tenantId.get() + "'");
+                // Use a regular SET to ensure the tenant identifier persists for the
+                // lifetime of the connection. This avoids issues where SET LOCAL could
+                // be cleared before a transaction starts (e.g. with auto-commit
+                // connections) which resulted in the tenant not being propagated.
+                statement.execute("SET app.current_tenant = '" + tenantId.get() + "'");
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure tenant identifier persists on connections by using SET instead of SET LOCAL
- avoid losing tenant context before transactions begin

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b63ffcb59c832f9b4aa224e094a3dc