### PR TITLE
Fix test configuration for tenant-events

### DIFF
--- a/tenant-platform/tenant-events/src/test/java/com/lms/tenant/events/TenantEventPublisherTests.java
+++ b/tenant-platform/tenant-events/src/test/java/com/lms/tenant/events/TenantEventPublisherTests.java
@@ -8,15 +8,19 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest(classes = TenantEventsAutoConfiguration.class)
+@SpringBootTest(classes = TenantEventPublisherTests.TestApplication.class)
 @TestPropertySource(properties = {
     "spring.datasource.url=jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
     "spring.task.scheduling.enabled=false"
 })
 class TenantEventPublisherTests {
+
+    @SpringBootApplication
+    static class TestApplication {}
 
     @Autowired
     TenantEventWriter writer;


### PR DESCRIPTION
## Summary
- ensure `TenantEventPublisherTests` boots a minimal Spring application so JPA and other autoconfigurations run

## Testing
- `mvn -pl tenant-events test` *(fails: Non-resolvable import POM: ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b64106cbf8832fa87bded2ceada579