### PR TITLE
Ensure Micrometer metrics dependency is available

### DIFF
--- a/shared-lib/shared-starters/starter-core/pom.xml
+++ b/shared-lib/shared-starters/starter-core/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
       <optional>true</optional>
     </dependency>
+    <!-- Core Micrometer APIs used by PerformanceConfig -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
 
     <!-- Jackson JavaTime (opt-in) -->
     <dependency>


### PR DESCRIPTION
## Summary
- include Micrometer core so PerformanceConfig's JvmThreadMetrics is available

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl tenant-events -am test` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:pom:3.5.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b64201a010832fa0c73a2aac7d3386