### PR TITLE
Guard micrometer metrics auto config

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/config/CoreExtrasAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/config/CoreExtrasAutoConfiguration.java
@@ -4,6 +4,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import({EnvironmentLogger.class, PerformanceConfig.class})
+@Import(EnvironmentLogger.class)
 public class CoreExtrasAutoConfiguration {
 }

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/config/PerformanceConfig.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/config/PerformanceConfig.java
@@ -10,9 +10,19 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 
 @Configuration
 @EnableAspectJAutoProxy
+@ConditionalOnClass(name = {
+        "io.micrometer.core.instrument.MeterRegistry",
+        "io.micrometer.core.aop.TimedAspect",
+        "io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics",
+        "io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics",
+        "io.micrometer.core.instrument.binder.jvm.JvmGcMetrics",
+        "io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics",
+        "io.micrometer.core.instrument.binder.system.ProcessorMetrics"
+})
 public class PerformanceConfig {
 
     @Bean

--- a/shared-lib/shared-starters/starter-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/shared-lib/shared-starters/starter-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 com.common.starter.core.exception.CoreExceptionAutoConfiguration
 com.shared.starter_core.config.CoreExtrasAutoConfiguration
+com.shared.starter_core.config.PerformanceConfig


### PR DESCRIPTION
## Summary
- Avoid loading performance metrics configuration unless Micrometer JVM metrics are present
- Import EnvironmentLogger without forcing PerformanceConfig
- Register PerformanceConfig separately in auto configuration imports

## Testing
- `mvn -f tenant-platform/pom.xml -pl tenant-events test -DskipTests=false` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6436904d8832f8b3ed3b8305097fa