### PR TITLE
Add Micrometer dependency to tenant events module

### DIFF
--- a/tenant-platform/tenant-events/pom.xml
+++ b/tenant-platform/tenant-events/pom.xml
@@ -31,6 +31,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <!-- Micrometer core required by PerformanceConfig in starter-core -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
## Summary
- Include `micrometer-core` dependency in tenant-events module to satisfy `PerformanceConfig` requirements from shared starter

## Testing
- `mvn -q -pl tenant-events -am test` *(fails: Non-resolvable import POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a3ff41c0832f9a87961e5e4447c6