### PR TITLE
feat: guard global exception handler import on web presence

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/common/starter/core/exception/CoreExceptionAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/common/starter/core/exception/CoreExceptionAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.common.starter.core.exception;
 
 import com.shared.starter_core.web.GlobalExceptionHandler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Import;
  * consistent exception mapping across applications.
  */
 @Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(name = "org.springframework.http.HttpStatusCode")
 @Import(GlobalExceptionHandler.class)
 public class CoreExceptionAutoConfiguration {
 }


### PR DESCRIPTION
## Summary
- only import GlobalExceptionHandler when `HttpStatusCode` is available

## Testing
- `mvn -q -f shared-lib/pom.xml -pl shared-starters/starter-core test` *(fails: Network is unreachable)*
- `mvn -q -f tenant-platform/pom.xml -pl tenant-events test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a9ab5710832f9aeac4db4c8b507f