### PR TITLE
Add JSON starter to tenant-events module

### DIFF
--- a/tenant-platform/tenant-events/pom.xml
+++ b/tenant-platform/tenant-events/pom.xml
@@ -21,15 +21,15 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jdbc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
     </dependency>
     <!-- Micrometer core required by PerformanceConfig in starter-core -->
     <dependency>


### PR DESCRIPTION
## Summary
- Include `spring-boot-starter-json` to supply ObjectMapper support in tenant-events module
- Drop direct jackson-databind dependency

## Testing
- `mvn -q -pl tenant-events test` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:pom:3.5.2 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6af42c23c832fac73157d9f1ef195