### PR TITLE
Handle AccessDeniedException only when Spring Security is present

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/GlobalExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/GlobalExceptionHandler.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -113,13 +112,6 @@ public class GlobalExceptionHandler {
         log.warn("No resource found: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(BaseResponse.error("ERR_RESOURCE_NOT_FOUND", ex.getMessage()));
-    }
-
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<BaseResponse<?>> handleAccessDenied(AccessDeniedException ex, WebRequest request) {
-        log.warn("Access denied: {}", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(BaseResponse.error("ERR_ACCESS_DENIED", "Access denied"));
     }
 
     @ExceptionHandler(Exception.class)

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/SecurityExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/SecurityExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.shared.starter_core.web;
+
+import com.common.dto.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+/**
+ * Handles security-related exceptions if Spring Security is present.
+ */
+@Slf4j
+@RestControllerAdvice
+@ConditionalOnClass(AccessDeniedException.class)
+public class SecurityExceptionHandler {
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<BaseResponse<?>> handleAccessDenied(AccessDeniedException ex, WebRequest request) {
+        log.warn("Access denied: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(BaseResponse.error("ERR_ACCESS_DENIED", "Access denied"));
+    }
+}


### PR DESCRIPTION
## Summary
- Remove direct AccessDeniedException handling from global handler
- Add dedicated SecurityExceptionHandler with Spring Security conditional

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl tenant-events test` *(fails: Non-resolvable import POM - Could not transfer artifact due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b4d7a830832fae6a5865a7f2ef56