### PR TITLE
Guard MVC-specific exception handler

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/common/starter/core/exception/CoreExceptionAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/common/starter/core/exception/CoreExceptionAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.common.starter.core.exception;
 
 import com.shared.starter_core.web.GlobalExceptionHandler;
+import com.shared.starter_core.web.NoResourceFoundHandlerConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -12,6 +13,6 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(name = "org.springframework.http.HttpStatusCode")
-@Import(GlobalExceptionHandler.class)
+@Import({GlobalExceptionHandler.class, NoResourceFoundHandlerConfiguration.class})
 public class CoreExceptionAutoConfiguration {
 }

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/GlobalExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/GlobalExceptionHandler.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
-import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -105,13 +104,6 @@ public class GlobalExceptionHandler {
         log.error("Data integrity violation: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(BaseResponse.error("ERR_DATA_CONFLICT", "Data conflict occurred"));
-    }
-
-    @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<BaseResponse<?>> handleNoResourceFound(NoResourceFoundException ex, WebRequest request) {
-        log.warn("No resource found: {}", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(BaseResponse.error("ERR_RESOURCE_NOT_FOUND", ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/NoResourceFoundExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/NoResourceFoundExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.shared.starter_core.web;
+
+import com.common.dto.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+/**
+ * Handles {@link NoResourceFoundException} when Spring MVC is available.
+ */
+@Slf4j
+@RestControllerAdvice
+public class NoResourceFoundExceptionHandler {
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<BaseResponse<?>> handleNoResourceFound(NoResourceFoundException ex, WebRequest request) {
+        log.warn("No resource found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(BaseResponse.error("ERR_RESOURCE_NOT_FOUND", ex.getMessage()));
+    }
+}

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/NoResourceFoundHandlerConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/NoResourceFoundHandlerConfiguration.java
@@ -1,0 +1,15 @@
+package com.shared.starter_core.web;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Registers {@link NoResourceFoundExceptionHandler} only when the MVC-specific
+ * {@code NoResourceFoundException} is present on the classpath.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(name = "org.springframework.web.servlet.resource.NoResourceFoundException")
+@Import(NoResourceFoundExceptionHandler.class)
+class NoResourceFoundHandlerConfiguration {
+}


### PR DESCRIPTION
## Summary
- avoid always loading Spring MVC's `NoResourceFoundException`
- add conditional advice that only registers when MVC is present

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl tenant-events -am test` *(fails: Non-resolvable import POM: ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b99832a8832faae16a606bcd8392