### PR TITLE
fix: make NoResourceFoundHandlerConfiguration public

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/NoResourceFoundHandlerConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/web/NoResourceFoundHandlerConfiguration.java
@@ -11,5 +11,5 @@ import org.springframework.context.annotation.Import;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(name = "org.springframework.web.servlet.resource.NoResourceFoundException")
 @Import(NoResourceFoundExceptionHandler.class)
-class NoResourceFoundHandlerConfiguration {
+public class NoResourceFoundHandlerConfiguration {
 }


### PR DESCRIPTION
## Summary
- make `NoResourceFoundHandlerConfiguration` public so it can be imported by other modules

## Testing
- `mvn -pl shared-starters/starter-core -am -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6beda8770832f88fb95253f89c9ea