### PR TITLE
Include validation starter in tenant-events module

### DIFF
--- a/tenant-platform/tenant-events/pom.xml
+++ b/tenant-platform/tenant-events/pom.xml
@@ -28,6 +28,10 @@
       <artifactId>spring-boot-starter-jdbc</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary
- add `spring-boot-starter-validation` dependency to tenant-events module so GlobalExceptionHandler can resolve `ConstraintViolationException`

## Testing
- `mvn -pl tenant-events test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c7283b54832fb6e18065f74b8407