### PR TITLE
Fix poll interval bean reference in tenant event publisher

### DIFF
--- a/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantEventPublisher.java
+++ b/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantEventPublisher.java
@@ -31,7 +31,7 @@ public class TenantEventPublisher {
         this.properties = properties;
     }
 
-    @Scheduled(fixedDelayString = "#{@tenantEventsProperties.pollInterval.toMillis()}")
+    @Scheduled(fixedDelayString = "${tenant.events.poll-interval:5s}")
     @Transactional
     public void publish() {
         List<TenantOutboxEvent> rows = repository.findByStatusAndAvailableAtLessThanEqualOrderById(


### PR DESCRIPTION
## Summary
- use property placeholder for tenant event poll interval to avoid missing bean errors

## Testing
- `mvn -q -pl tenant-events test` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:pom:3.5.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c9a14c20832fbaef85f06531a534