### PR TITLE
Guard TimedAspect creation on MeterRegistry presence

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/config/PerformanceConfig.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/shared/starter_core/config/PerformanceConfig.java
@@ -7,10 +7,11 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 
 @Configuration
 @EnableAspectJAutoProxy
@@ -26,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 public class PerformanceConfig {
 
     @Bean
+    @ConditionalOnBean(MeterRegistry.class)
     public TimedAspect timedAspect(MeterRegistry registry) {
         return new TimedAspect(registry);
     }


### PR DESCRIPTION
## Summary
- avoid failing autoconfiguration when no MeterRegistry is defined by only creating `TimedAspect` if a registry bean exists

## Testing
- `mvn -q -f shared-lib/pom.xml -pl shared-starters/starter-core -am test` *(fails: Non-resolvable import POM: Network is unreachable)*
- `mvn -q -f tenant-platform/pom.xml -pl tenant-events -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d07e8b78832fba6092cc1159353d