### PR TITLE
fix: rename integration key column

### DIFF
--- a/tenant-platform/tenant-persistence/src/main/java/com/lms/tenant/persistence/entity/TenantIntegrationKey.java
+++ b/tenant-platform/tenant-persistence/src/main/java/com/lms/tenant/persistence/entity/TenantIntegrationKey.java
@@ -30,7 +30,7 @@ public class TenantIntegrationKey {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(name = "key_value", nullable = false)
     private String key;
 
     @Enumerated(EnumType.STRING)

--- a/tenant-platform/tenant-persistence/src/main/resources/db/migration/V1__tenant_baseline.sql
+++ b/tenant-platform/tenant-persistence/src/main/resources/db/migration/V1__tenant_baseline.sql
@@ -13,7 +13,7 @@ CREATE TABLE tenant_integration_key (
     id UUID PRIMARY KEY,
     tenant_id UUID NOT NULL REFERENCES tenant(id),
     name VARCHAR(255) NOT NULL,
-    key VARCHAR(255) NOT NULL,
+    key_value VARCHAR(255) NOT NULL,
     status key_status NOT NULL DEFAULT 'ACTIVE'
 );
 


### PR DESCRIPTION
## Summary
- rename `key` column in tenant integration key table to `key_value`
- map entity field to new column name to avoid SQL reserved word conflict

## Testing
- `mvn -q -pl tenant-service -am test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d39b0864832f90d32b05f08bda27