### PR TITLE
fix: make flyway migration h2 compatible

### DIFF
--- a/tenant-platform/tenant-persistence/src/main/resources/db/migration/V2__rls_and_policies.sql
+++ b/tenant-platform/tenant-persistence/src/main/resources/db/migration/V2__rls_and_policies.sql
@@ -1,6 +1,2 @@
-ALTER TABLE tenant_integration_key ENABLE ROW LEVEL SECURITY;
-
-CREATE POLICY tenant_integration_key_tenant_isolation
-    ON tenant_integration_key
-    USING (tenant_id = current_setting('app.current_tenant', true)::uuid);
-
+-- No-op migration for databases without row-level security support (e.g., H2)
+-- PostgreSQL-specific version located in V2__rls_and_policies__postgresql.sql

--- a/tenant-platform/tenant-persistence/src/main/resources/db/migration/V2__rls_and_policies__postgresql.sql
+++ b/tenant-platform/tenant-persistence/src/main/resources/db/migration/V2__rls_and_policies__postgresql.sql
@@ -1,0 +1,6 @@
+ALTER TABLE tenant_integration_key ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_integration_key_tenant_isolation
+    ON tenant_integration_key
+    USING (tenant_id = current_setting('app.current_tenant', true)::uuid);
+


### PR DESCRIPTION
## Summary
- rename Postgres row-level security migration to `V2__rls_and_policies__postgresql.sql`
- add no-op `V2__rls_and_policies.sql` for databases without RLS support

## Testing
- `mvn -q -pl tenant-service -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d4a189e8832fa8bb827a3ad77caf