### PR TITLE
Prevent concurrent updates in tenant event publisher

### DIFF
--- a/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/repo/TenantOutboxEventRepository.java
+++ b/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/repo/TenantOutboxEventRepository.java
@@ -6,10 +6,13 @@ import java.time.Instant;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import jakarta.persistence.LockModeType;
 
 /** Repository for pending tenant events. */
 public interface TenantOutboxEventRepository extends JpaRepository<TenantOutboxEvent, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<TenantOutboxEvent> findByStatusAndAvailableAtLessThanEqualOrderById(
             Status status, Instant availableAt, Pageable pageable);
 }


### PR DESCRIPTION
## Summary
- lock outbox events with `PESSIMISTIC_WRITE` when fetching them for publication

## Testing
- `mvn -q -pl tenant-events test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e586cc58832fb8412d8c5c3b62ac