### PR TITLE
Fix demo tenant seed for H2 compatibility

### DIFF
--- a/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V3__indexes_and_seed.sql
+++ b/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V3__indexes_and_seed.sql
@@ -2,6 +2,8 @@ CREATE INDEX idx_tenant_integration_key_tenant_id ON tenant_integration_key (ten
 
 -- optional demo seed
 INSERT INTO tenant (id, name, status, overage_enabled)
-VALUES ('00000000-0000-0000-0000-000000000001', 'Demo Tenant', 'ACTIVE', FALSE)
-ON CONFLICT DO NOTHING;
+SELECT '00000000-0000-0000-0000-000000000001', 'Demo Tenant', 'ACTIVE', FALSE
+WHERE NOT EXISTS (
+    SELECT 1 FROM tenant WHERE id = '00000000-0000-0000-0000-000000000001'
+);
 


### PR DESCRIPTION
## Summary
- use portable `INSERT ... SELECT WHERE NOT EXISTS` instead of `ON CONFLICT DO NOTHING` for tenant seed

## Testing
- `mvn -q -pl tenant-service -am test` *(fails: Non-resolvable import POM: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7049d73e8832fbdb4b271a370f9d8