### PR TITLE
Fix failing subscription-service context test by using Postgres Testcontainer

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/lms/subscription/SubscriptionServiceApplicationTests.java
+++ b/tenant-platform/subscription-service/src/test/java/com/lms/subscription/SubscriptionServiceApplicationTests.java
@@ -2,11 +2,32 @@ package com.lms.subscription;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+/**
+ * Simple smoke test that verifies the Spring context can start. The application
+ * requires a PostgreSQL database, so we supply one using Testcontainers.
+ */
 @SpringBootTest
+@Testcontainers
 class SubscriptionServiceApplicationTests {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
 
     @Test
     void contextLoads() {
+        // verifies that the Spring application context loads successfully
     }
 }


### PR DESCRIPTION
## Summary
- start a PostgreSQL Testcontainer so the Spring Boot context loads in tests

## Testing
- `mvn -pl subscription-service test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7115022b8832fb8ea9ead2312c66b