### PR TITLE
Use shared library in tenant API and add dev config

### DIFF
--- a/tenant-platform/tenant-api/pom.xml
+++ b/tenant-platform/tenant-api/pom.xml
@@ -16,6 +16,10 @@
       <artifactId>tenant-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.lms</groupId>
+      <artifactId>starter-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
@@ -24,8 +28,8 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <groupId>com.lms</groupId>
+      <artifactId>starter-openapi</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/tenant-platform/tenant-api/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application-dev.yaml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/lms
+    username: app_user
+    password: postgres
+  redis:
+    host: localhost
+    port: 6379
+  kafka:
+    bootstrap-servers: localhost:9092
+  flyway:
+    enabled: true
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+server:
+  port: 8080


### PR DESCRIPTION
## Summary
- Use shared core and OpenAPI starters in tenant-api module
- Add `application-dev.yaml` for local development configuration

## Testing
- `mvn -f tenant-platform/pom.xml -pl tenant-api -am test` *(fails: Non-resolvable import POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7341306b4832f82272a8a9685d98d