### PR TITLE
Add tenant overage patch endpoint and event

### DIFF
--- a/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantOverageToggledEvent.java
+++ b/tenant-platform/tenant-events/src/main/java/com/lms/tenant/events/TenantOverageToggledEvent.java
@@ -1,0 +1,11 @@
+package com.lms.tenant.events;
+
+import java.util.UUID;
+
+/**
+ * Event published when a tenant's overage setting is toggled.
+ *
+ * @param tenantId       the tenant identifier
+ * @param overageEnabled whether overage was enabled after the toggle
+ */
+public record TenantOverageToggledEvent(UUID tenantId, boolean overageEnabled) {}

--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>tenant-config</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.lms.tenant</groupId>
+      <artifactId>tenant-events</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.lms</groupId>
       <artifactId>starter-openapi</artifactId>
     </dependency>

--- a/tenant-platform/tenant-service/src/main/java/com/lms/tenant/service/TenantService.java
+++ b/tenant-platform/tenant-service/src/main/java/com/lms/tenant/service/TenantService.java
@@ -7,6 +7,8 @@ import com.lms.tenant.persistence.entity.enums.KeyStatus;
 import com.lms.tenant.persistence.entity.enums.TenantStatus;
 import com.lms.tenant.persistence.repository.TenantIntegrationKeyRepository;
 import com.lms.tenant.persistence.repository.TenantRepository;
+import com.lms.tenant.events.TenantOverageToggledEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -16,13 +18,16 @@ public class TenantService {
     private final TenantRepository tenantRepository;
     private final TenantIntegrationKeyRepository keyRepository;
     private final TenantSettingsPort settingsPort;
+    private final ApplicationEventPublisher eventPublisher;
 
     public TenantService(TenantRepository tenantRepository,
                          TenantIntegrationKeyRepository keyRepository,
-                         TenantSettingsPort settingsPort) {
+                         TenantSettingsPort settingsPort,
+                         ApplicationEventPublisher eventPublisher) {
         this.tenantRepository = tenantRepository;
         this.keyRepository = keyRepository;
         this.settingsPort = settingsPort;
+        this.eventPublisher = eventPublisher;
     }
 
     public Tenant createTenant(String slug, String name) {
@@ -59,5 +64,6 @@ public class TenantService {
 
     public void setOverage(UUID tenantId, boolean enabled) {
         settingsPort.setOverageEnabled(tenantId, enabled);
+        eventPublisher.publishEvent(new TenantOverageToggledEvent(tenantId, enabled));
     }
 }

--- a/tenant-platform/tenant-service/src/main/java/com/lms/tenant/service/web/TenantController.java
+++ b/tenant-platform/tenant-service/src/main/java/com/lms/tenant/service/web/TenantController.java
@@ -12,7 +12,7 @@ import java.net.URI;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/tenants")
+@RequestMapping("/api/tenants")
 public class TenantController {
     private final TenantService tenantService;
 
@@ -24,7 +24,7 @@ public class TenantController {
     public ResponseEntity<TenantResponse> create(@RequestBody CreateTenantRequest request) {
         Tenant tenant = tenantService.createTenant(request.slug(), request.name());
         TenantResponse response = new TenantResponse(tenant.getId(), tenant.getSlug(), tenant.getName(), tenant.isOverageEnabled());
-        return ResponseEntity.created(URI.create("/tenants/" + tenant.getId())).body(response);
+        return ResponseEntity.created(URI.create("/api/tenants/" + tenant.getId())).body(response);
     }
 
     @GetMapping("/{tenantId}")
@@ -37,7 +37,7 @@ public class TenantController {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/{tenantId}/overage-enabled")
+    @PatchMapping("/{tenantId}/overage")
     public ResponseEntity<Void> toggleOverage(@PathVariable UUID tenantId, @RequestBody ToggleOverageRequest request) {
         tenantService.setOverage(tenantId, request.enabled());
         return ResponseEntity.accepted().build();

--- a/tenant-platform/tenant-service/src/test/java/com/lms/tenant/service/TenantControllerIT.java
+++ b/tenant-platform/tenant-service/src/test/java/com/lms/tenant/service/TenantControllerIT.java
@@ -41,7 +41,7 @@ class TenantControllerIT {
     @Test
     void toggleOverageFlag() {
         CreateTenantRequest create = new CreateTenantRequest("acme", "Acme Corp");
-        ResponseEntity<TenantResponse> createResp = restTemplate.postForEntity(url("/tenants"), create, TenantResponse.class);
+        ResponseEntity<TenantResponse> createResp = restTemplate.postForEntity(url("/api/tenants"), create, TenantResponse.class);
         assertThat(createResp.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         UUID tenantId = createResp.getBody().id();
 
@@ -49,10 +49,10 @@ class TenantControllerIT {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<ToggleOverageRequest> toggleEntity = new HttpEntity<>(toggle, headers);
-        ResponseEntity<Void> toggleResp = restTemplate.exchange(url("/tenants/" + tenantId + "/overage-enabled"), HttpMethod.PUT, toggleEntity, Void.class);
+        ResponseEntity<Void> toggleResp = restTemplate.exchange(url("/api/tenants/" + tenantId + "/overage"), HttpMethod.PATCH, toggleEntity, Void.class);
         assertThat(toggleResp.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
 
-        ResponseEntity<TenantResponse> getResp = restTemplate.getForEntity(url("/tenants/" + tenantId), TenantResponse.class);
+        ResponseEntity<TenantResponse> getResp = restTemplate.getForEntity(url("/api/tenants/" + tenantId), TenantResponse.class);
         assertThat(getResp.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(getResp.getBody().overageEnabled()).isTrue();
     }


### PR DESCRIPTION
## Summary
- add TenantOverageToggledEvent in tenant-events module
- expose PATCH /api/tenants/{id}/overage endpoint and publish toggle event
- wire tenant-service with ApplicationEventPublisher and update tests

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl tenant-service -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7352621c0832fbb50d9a1e5c137c6