### PR TITLE
Add dev config and shared json utils to billing service

### DIFF
--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/adapters/JpaOverageAdapter.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/adapters/JpaOverageAdapter.java
@@ -1,13 +1,13 @@
 package com.ejada.billing.adapters;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ejada.billing.dto.OverageResponse;
 import com.ejada.billing.dto.RecordOverageRequest;
 import com.ejada.billing.entity.TenantOverage;
 import com.ejada.billing.enums.OverageStatus;
 import com.ejada.billing.repo.TenantOverageRepository;
 import com.ejada.billing.service.OveragePort;
+import com.ejada.common.exception.JsonSerializationException;
+import com.ejada.common.json.JsonUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,11 +22,9 @@ import java.util.UUID;
 public class JpaOverageAdapter implements OveragePort {
 
     private final TenantOverageRepository repo;
-    private final ObjectMapper objectMapper;
 
-    public JpaOverageAdapter(TenantOverageRepository repo, ObjectMapper objectMapper) {
+    public JpaOverageAdapter(TenantOverageRepository repo) {
         this.repo = repo;
-        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -50,13 +48,13 @@ public class JpaOverageAdapter implements OveragePort {
         o.setUnitPriceMinor(req.unitPriceMinor() == null ? 0L : req.unitPriceMinor());
         o.setCurrency(req.currency() == null ? "USD" : req.currency());
         o.setOccurredAt(req.occurredAt() == null ? Instant.now() : req.occurredAt());
-        o.setPeriodStart(req.periodStart());
-        o.setPeriodEnd(req.periodEnd());
+        o.setPeriodStart(req.periodStart() == null ? Instant.now() : req.periodStart());
+        o.setPeriodEnd(req.periodEnd() == null ? Instant.now() : req.periodEnd());
         o.setStatus(OverageStatus.RECORDED);
         o.setIdempotencyKey(req.idempotencyKey());
         try {
-            o.setMetadataJson(objectMapper.writeValueAsString(req.metadata() == null ? Map.of() : req.metadata()));
-        } catch (JsonProcessingException e) {
+            o.setMetadataJson(JsonUtils.toJson(req.metadata() == null ? Map.of() : req.metadata()));
+        } catch (JsonSerializationException e) {
             throw new RuntimeException(e);
         }
         TenantOverage saved = repo.save(o);

--- a/tenant-platform/billing-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-dev.yaml
@@ -1,0 +1,27 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/tenant
+    username: postgres
+    password: postgres
+  redis:
+    host: localhost
+    port: 6379
+  kafka:
+    bootstrap-servers: localhost:9092
+  flyway:
+    enabled: true
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+server:
+  port: 8080
+shared:
+  core:
+    correlation:
+      header-name: X-Correlation-Id
+      generate-if-missing: true
+      echo-response-header: true
+    tenant:
+      enabled: true
+      header-name: x_tenant_id
+      query-param: tenantId
+      default-policy: OPTIONAL
+      echo-response-header: true


### PR DESCRIPTION
## Summary
- add application-dev.yaml with local datasource and shared correlation config
- use shared JsonUtils in JpaOverageAdapter and default missing periods

## Testing
- `mvn -pl billing-service -am test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7659c0598832f941e5965cc9911bf