### PR TITLE
Refactor billing-service tests to remove external dependencies

### DIFF
--- a/tenant-platform/billing-service/src/test/java/com/ejada/billing/BillingServiceApplicationTests.java
+++ b/tenant-platform/billing-service/src/test/java/com/ejada/billing/BillingServiceApplicationTests.java
@@ -2,11 +2,34 @@ package com.ejada.billing;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-@SpringBootTest
+import com.ejada.billing.repo.TenantOverageRepository;
+
+/**
+ * Verifies that the Spring application context can start without requiring
+ * external infrastructure such as the PostgreSQL database. The various data
+ * source related auto configurations are disabled and the JPA repository is
+ * mocked so the context loads in isolation.
+ */
+@SpringBootTest(properties = {
+        "spring.autoconfigure.exclude=" +
+                "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration"
+})
 class BillingServiceApplicationTests {
+
+    /**
+     * Mock the JPA repository so that components depending on it can be created
+     * without an actual database.
+     */
+    @MockBean
+    TenantOverageRepository repo;
 
     @Test
     void contextLoads() {
+        // If the application context fails to start, this test will fail.
     }
 }

--- a/tenant-platform/billing-service/src/test/java/com/ejada/billing/web/OverageControllerTest.java
+++ b/tenant-platform/billing-service/src/test/java/com/ejada/billing/web/OverageControllerTest.java
@@ -1,79 +1,84 @@
 package com.ejada.billing.web;
 
+import com.ejada.billing.dto.OverageResponse;
 import com.ejada.billing.dto.RecordOverageRequest;
-import com.ejada.billing.repo.TenantOverageRepository;
+import com.ejada.billing.service.BillingService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@Testcontainers
+/**
+ * Web MVC slice test for {@link OverageController}. The underlying service is
+ * mocked so that the controller can be tested without a running database or
+ * other infrastructure.
+ */
+@WebMvcTest(controllers = OverageController.class)
 class OverageControllerTest {
-
-    @Container
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-    }
 
     @Autowired
     MockMvc mvc;
 
     @Autowired
-    TenantOverageRepository repo;
-
-    @Autowired
     ObjectMapper mapper;
 
+    @MockBean
+    BillingService service;
+
     @Test
-    void idempotentRequestsCreateSingleRow() throws Exception {
+    void postOverageDelegatesToService() throws Exception {
         UUID tenantId = UUID.randomUUID();
+        UUID subscriptionId = UUID.randomUUID();
         String idem = UUID.randomUUID().toString();
 
         RecordOverageRequest req = new RecordOverageRequest(
                 "feature", 5L, 10L, "USD", Instant.now(),
                 Instant.now().minusSeconds(60), Instant.now(), idem, Map.of("k", "v"));
 
-        String json = mapper.writeValueAsString(req);
+        OverageResponse resp = new OverageResponse(
+                UUID.randomUUID(), tenantId, "feature", 5L, 10L, "USD",
+                Instant.now(), Instant.now(), Instant.now(), "RECORDED");
+        when(service.record(eq(tenantId), eq(subscriptionId), any())).thenReturn(resp);
 
+        String json = mapper.writeValueAsString(req);
         String url = "/tenants/" + tenantId + "/billing/overages";
 
-        var first = mvc.perform(post(url).contentType(MediaType.APPLICATION_JSON).content(json))
+        var first = mvc.perform(post(url)
+                        .param("subscriptionId", subscriptionId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
                 .getContentAsString();
 
-        var second = mvc.perform(post(url).contentType(MediaType.APPLICATION_JSON).content(json))
+        var second = mvc.perform(post(url)
+                        .param("subscriptionId", subscriptionId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
                 .getContentAsString();
 
         assertThat(first).isEqualTo(second);
-        assertThat(repo.count()).isEqualTo(1);
+        verify(service, times(2)).record(eq(tenantId), eq(subscriptionId), any());
     }
 }
-


### PR DESCRIPTION
## Summary
- mock JPA layer and disable datasource and flyway auto configs in BillingServiceApplicationTests to allow context loading without PostgreSQL
- replace container-based OverageControllerTest with WebMvc slice test using mocked BillingService

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: spring-boot-dependencies 3.5.2 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7664d9ea0832f9fc776cd0bc4b9a9