### PR TITLE
Fix catalog controller test configuration

### DIFF
--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -30,6 +30,10 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-openapi</artifactId>
     </dependency>
@@ -46,6 +50,11 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/CatalogController.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/CatalogController.java
@@ -20,9 +20,10 @@ public class CatalogController {
     }
 
     @GetMapping("/effective")
-    public ResponseEntity<FeaturePolicyPort.EffectiveFeature> effective(@RequestParam String tierId,
-                                                                        @RequestParam UUID tenantId,
-                                                                        @RequestParam String featureKey) {
+    public ResponseEntity<FeaturePolicyPort.EffectiveFeature> effective(
+            @RequestParam("tierId") String tierId,
+            @RequestParam("tenantId") UUID tenantId,
+            @RequestParam("featureKey") String featureKey) {
         return ResponseEntity.ok(service.effective(tierId, tenantId, featureKey));
     }
 }

--- a/tenant-platform/catalog-service/src/test/resources/application.properties
+++ b/tenant-platform/catalog-service/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- specify request parameter names in `CatalogController`
- add validation starter and H2 test dependency
- configure test application properties to use in-memory database

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b7654d9c64832f807673c7f25fc33a