### PR TITLE
Fix overage controller parameter binding

### DIFF
--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/service/OverageService.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/service/OverageService.java
@@ -23,8 +23,8 @@ public interface OverageService {
      */
     @PostMapping
     OverageResponse record(
-            @PathVariable UUID tenantId,
-            @RequestParam(required = false) UUID subscriptionId,
+            @PathVariable("tenantId") UUID tenantId,
+            @RequestParam(value = "subscriptionId", required = false) UUID subscriptionId,
             @RequestBody RecordOverageRequest request);
 }
 


### PR DESCRIPTION
## Summary
- explicitly name record endpoint parameters in `OverageService`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b767c09870832f92649e22fa916b58