### PR TITLE
refactor: organize billing service into layers

### DIFF
--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/application/ports/OveragePort.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/application/ports/OveragePort.java
@@ -1,10 +1,10 @@
-package com.ejada.billing.service;
+package com.ejada.billing.application.ports;
 
 
 import java.util.UUID;
 
-import com.ejada.billing.dto.OverageResponse;
-import com.ejada.billing.dto.RecordOverageRequest;
+import com.ejada.billing.domain.dtos.OverageResponse;
+import com.ejada.billing.domain.dtos.RecordOverageRequest;
 
 /**
  * Port for persisting overage records.

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/application/services/BillingService.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/application/services/BillingService.java
@@ -1,10 +1,11 @@
-package com.ejada.billing.service;
+package com.ejada.billing.application.services;
 
 
 import org.springframework.stereotype.Service;
 
-import com.ejada.billing.dto.OverageResponse;
-import com.ejada.billing.dto.RecordOverageRequest;
+import com.ejada.billing.application.ports.OveragePort;
+import com.ejada.billing.domain.dtos.OverageResponse;
+import com.ejada.billing.domain.dtos.RecordOverageRequest;
 
 import java.util.UUID;
 
@@ -12,7 +13,6 @@ import java.util.UUID;
 public class BillingService {
 
     private final OveragePort port;
-
     public BillingService(OveragePort port) {
         this.port = port;
     }

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/config/package-info.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/config/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Configuration components for the billing service.
+ */
+package com.ejada.billing.config;

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/domain/dtos/OverageResponse.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/domain/dtos/OverageResponse.java
@@ -1,4 +1,4 @@
-package com.ejada.billing.dto;
+package com.ejada.billing.domain.dtos;
 
 import java.time.Instant;
 import java.util.UUID;

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/domain/dtos/RecordOverageRequest.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/domain/dtos/RecordOverageRequest.java
@@ -1,4 +1,4 @@
-package com.ejada.billing.dto;
+package com.ejada.billing.domain.dtos;
 
 import java.time.Instant;
 import java.util.Map;

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/domain/entities/TenantOverage.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/domain/entities/TenantOverage.java
@@ -1,10 +1,10 @@
-package com.ejada.billing.entity;
+package com.ejada.billing.domain.entities;
 
 import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.UUID;
 
-import com.ejada.billing.enums.OverageStatus;
+import com.ejada.billing.domain.enums.OverageStatus;
 
 /**
  * JPA entity representing an overage recorded for a tenant.

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/domain/enums/OverageStatus.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/domain/enums/OverageStatus.java
@@ -1,4 +1,4 @@
-package com.ejada.billing.enums;
+package com.ejada.billing.domain.enums;
 
 /**
  * Status of an overage record.

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/infrastructure/adapters/JpaOverageAdapter.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/infrastructure/adapters/JpaOverageAdapter.java
@@ -1,11 +1,11 @@
-package com.ejada.billing.adapters;
+package com.ejada.billing.infrastructure.adapters;
 
-import com.ejada.billing.dto.OverageResponse;
-import com.ejada.billing.dto.RecordOverageRequest;
-import com.ejada.billing.entity.TenantOverage;
-import com.ejada.billing.enums.OverageStatus;
-import com.ejada.billing.repo.TenantOverageRepository;
-import com.ejada.billing.service.OveragePort;
+import com.ejada.billing.domain.dtos.OverageResponse;
+import com.ejada.billing.domain.dtos.RecordOverageRequest;
+import com.ejada.billing.domain.entities.TenantOverage;
+import com.ejada.billing.domain.enums.OverageStatus;
+import com.ejada.billing.infrastructure.repositories.TenantOverageRepository;
+import com.ejada.billing.application.ports.OveragePort;
 import com.ejada.common.exception.JsonSerializationException;
 import com.ejada.common.json.JsonUtils;
 import org.springframework.stereotype.Component;

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/infrastructure/repositories/TenantOverageRepository.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/infrastructure/repositories/TenantOverageRepository.java
@@ -1,8 +1,8 @@
-package com.ejada.billing.repo;
+package com.ejada.billing.infrastructure.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.ejada.billing.entity.TenantOverage;
+import com.ejada.billing.domain.entities.TenantOverage;
 
 import java.util.Optional;
 import java.util.UUID;

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/web/controllers/OverageController.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/web/controllers/OverageController.java
@@ -1,9 +1,8 @@
-package com.ejada.billing.controller;
+package com.ejada.billing.web.controllers;
 
-import com.ejada.billing.dto.OverageResponse;
-import com.ejada.billing.dto.RecordOverageRequest;
-import com.ejada.billing.service.BillingService;
-import com.ejada.billing.service.OverageService;
+import com.ejada.billing.domain.dtos.OverageResponse;
+import com.ejada.billing.domain.dtos.RecordOverageRequest;
+import com.ejada.billing.application.services.BillingService;
 
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RestController;

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/web/controllers/OverageService.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/web/controllers/OverageService.java
@@ -1,4 +1,4 @@
-package com.ejada.billing.service;
+package com.ejada.billing.web.controllers;
 
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -6,8 +6,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import com.ejada.billing.dto.OverageResponse;
-import com.ejada.billing.dto.RecordOverageRequest;
+import com.ejada.billing.domain.dtos.OverageResponse;
+import com.ejada.billing.domain.dtos.RecordOverageRequest;
 
 import java.util.UUID;
 

--- a/tenant-platform/billing-service/src/test/java/com/ejada/billing/BillingServiceApplicationTests.java
+++ b/tenant-platform/billing-service/src/test/java/com/ejada/billing/BillingServiceApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-import com.ejada.billing.repo.TenantOverageRepository;
+import com.ejada.billing.infrastructure.repositories.TenantOverageRepository;
 
 /**
  * Verifies that the Spring application context can start without requiring

--- a/tenant-platform/billing-service/src/test/java/com/ejada/billing/web/controllers/OverageControllerTest.java
+++ b/tenant-platform/billing-service/src/test/java/com/ejada/billing/web/controllers/OverageControllerTest.java
@@ -1,11 +1,10 @@
-package com.ejada.billing.web;
+package com.ejada.billing.web.controllers;
 
-import com.ejada.billing.dto.OverageResponse;
-import com.ejada.billing.dto.RecordOverageRequest;
-import com.ejada.billing.service.BillingService;
+import com.ejada.billing.domain.dtos.OverageResponse;
+import com.ejada.billing.domain.dtos.RecordOverageRequest;
+import com.ejada.billing.application.services.BillingService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;


### PR DESCRIPTION
## Summary
- restructure billing service into application, domain, infrastructure, and web layers
- rename packages to plural forms and update imports
- mirror layout in tests and add config package

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7676a0ca4832fbff75f239aac2412