### PR TITLE
Standardize package names in billing and catalog services

### DIFF
--- a/tenant-platform/billing-service/README.md
+++ b/tenant-platform/billing-service/README.md
@@ -19,3 +19,10 @@
 ## Events
 - **Publishes:** UsageRecorded, OverageRecorded, DailyUsageSummaryReady.
 - **Consumes:** SubscriptionChanged (align periods), PolicyChanged (optional, price context).
+
+## Folder Conventions
+- `adapter` – outbound integrations (e.g., JPA implementations).
+- `controller` – REST controllers and API contracts.
+- `repository` – Spring Data repositories.
+- `dto`, `entity`, `service`, `enums` – domain models and logic.
+- Tests mirror the same package structure under `src/test/java` and use `src/test/resources` for configuration.

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/adapter/JpaOverageAdapter.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/adapter/JpaOverageAdapter.java
@@ -1,10 +1,10 @@
-package com.ejada.billing.adapters;
+package com.ejada.billing.adapter;
 
 import com.ejada.billing.dto.OverageResponse;
 import com.ejada.billing.dto.RecordOverageRequest;
 import com.ejada.billing.entity.TenantOverage;
 import com.ejada.billing.enums.OverageStatus;
-import com.ejada.billing.repo.TenantOverageRepository;
+import com.ejada.billing.repository.TenantOverageRepository;
 import com.ejada.billing.service.OveragePort;
 import com.ejada.common.exception.JsonSerializationException;
 import com.ejada.common.json.JsonUtils;
@@ -21,17 +21,17 @@ import java.util.UUID;
 @Component
 public class JpaOverageAdapter implements OveragePort {
 
-    private final TenantOverageRepository repo;
+    private final TenantOverageRepository repository;
 
-    public JpaOverageAdapter(TenantOverageRepository repo) {
-        this.repo = repo;
+    public JpaOverageAdapter(TenantOverageRepository repository) {
+        this.repository = repository;
     }
 
     @Override
     @Transactional
     public OverageResponse recordOverage(UUID tenantId, UUID subscriptionId, RecordOverageRequest request) {
         if (request.idempotencyKey() != null) {
-            return repo.findByTenantIdAndIdempotencyKey(tenantId, request.idempotencyKey())
+            return repository.findByTenantIdAndIdempotencyKey(tenantId, request.idempotencyKey())
                     .map(this::toResponse)
                     .orElseGet(() -> saveNew(tenantId, subscriptionId, request));
         }
@@ -57,7 +57,7 @@ public class JpaOverageAdapter implements OveragePort {
         } catch (JsonSerializationException e) {
             throw new RuntimeException(e);
         }
-        TenantOverage saved = repo.save(o);
+        TenantOverage saved = repository.save(o);
         return toResponse(saved);
     }
 

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/repository/TenantOverageRepository.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/repository/TenantOverageRepository.java
@@ -1,4 +1,4 @@
-package com.ejada.billing.repo;
+package com.ejada.billing.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/tenant-platform/billing-service/src/test/java/com/ejada/billing/BillingServiceApplicationTests.java
+++ b/tenant-platform/billing-service/src/test/java/com/ejada/billing/BillingServiceApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-import com.ejada.billing.repo.TenantOverageRepository;
+import com.ejada.billing.repository.TenantOverageRepository;
 
 /**
  * Verifies that the Spring application context can start without requiring
@@ -26,7 +26,7 @@ class BillingServiceApplicationTests {
      * without an actual database.
      */
     @MockBean
-    TenantOverageRepository repo;
+    TenantOverageRepository repository;
 
     @Test
     void contextLoads() {

--- a/tenant-platform/billing-service/src/test/java/com/ejada/billing/controller/OverageControllerTest.java
+++ b/tenant-platform/billing-service/src/test/java/com/ejada/billing/controller/OverageControllerTest.java
@@ -1,4 +1,4 @@
-package com.ejada.billing.web;
+package com.ejada.billing.controller;
 
 import com.ejada.billing.controller.OverageController;
 import com.ejada.billing.dto.OverageResponse;

--- a/tenant-platform/billing-service/src/test/resources/application.properties
+++ b/tenant-platform/billing-service/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+# Test-specific properties
+# (Intentionally left blank for now)

--- a/tenant-platform/catalog-service/README.md
+++ b/tenant-platform/catalog-service/README.md
@@ -15,3 +15,10 @@
 ## Events
 - **Publishes:** PolicyChanged (base or override changes).
 - **Consumes:** TenantCreated (optional: seed defaults).
+
+## Folder Conventions
+- `adapter` – inbound/outbound adapters.
+- `controller` – REST API controllers.
+- `repository` – Spring Data repositories.
+- `entity`, `service` – core domain logic.
+- Tests mirror this structure under `src/test/java` and store config in `src/test/resources`.

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/FeatureRepository.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/FeatureRepository.java
@@ -1,4 +1,4 @@
-package com.ejada.catalog.repo;
+package com.ejada.catalog.repository;
 
 import com.ejada.catalog.entity.FeatureEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/ProductTierRepository.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/ProductTierRepository.java
@@ -1,4 +1,4 @@
-package com.ejada.catalog.repo;
+package com.ejada.catalog.repository;
 
 import com.ejada.catalog.entity.ProductTierEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/TenantFeatureOverrideRepository.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/TenantFeatureOverrideRepository.java
@@ -1,4 +1,4 @@
-package com.ejada.catalog.repo;
+package com.ejada.catalog.repository;
 
 import com.ejada.catalog.entity.TenantFeatureOverrideEntity;
 import com.ejada.catalog.entity.TenantFeatureOverrideId;

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/TierFeatureLimitRepository.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/TierFeatureLimitRepository.java
@@ -1,4 +1,4 @@
-package com.ejada.catalog.repo;
+package com.ejada.catalog.repository;
 
 import com.ejada.catalog.entity.TierFeatureLimitEntity;
 import com.ejada.catalog.entity.TierFeatureLimitId;


### PR DESCRIPTION
## Summary
- Use singular `adapter` and full `repository` package names in billing and catalog services
- Align controller test packages and add billing test resources
- Document folder structure conventions for both services

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM / Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b76a0db174832fbd9420d7a4e5119f