### PR TITLE
fix TenantServiceTest initialization

### DIFF
--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/TenantServiceTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/TenantServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.UUID;
 
@@ -30,7 +31,12 @@ class TenantServiceTest {
     void setUp() {
         keyRepository.deleteAll();
         tenantRepository.deleteAll();
-        tenantService = new TenantService(tenantRepository, keyRepository, Mockito.mock(TenantSettingsPort.class));
+        tenantService = new TenantService(
+                tenantRepository,
+                keyRepository,
+                Mockito.mock(TenantSettingsPort.class),
+                Mockito.mock(ApplicationEventPublisher.class)
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary
- mock `ApplicationEventPublisher` in `TenantServiceTest`

## Testing
- `MAVEN_OPTS=-Djava.net.preferIPv4Stack=true mvn -q -f shared-lib/pom.xml install` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b76c8c8b1c832fa73f34815e0ebbc5