### PR TITLE
Add dev configs and shared actuator support to tenant platform

### DIFF
--- a/tenant-platform/README.md
+++ b/tenant-platform/README.md
@@ -2,6 +2,13 @@
 
 Combined platform containing shared tenant components and Ejada microservices.
 
+## Structure
+
+The platform is composed of several Spring Boot services that share common
+configuration and starters from the [`shared-lib`](../shared-lib) project.
+Each service follows a standard Maven layout and provides an
+`application-dev.yaml` for local development.
+
 ## Services
 | Service | Description |
 |---------|-------------|
@@ -10,6 +17,7 @@ Combined platform containing shared tenant components and Ejada microservices.
 | [subscription-service](subscription-service/README.md) | Tracks active subscription and billing period. |
 | [billing-service](billing-service/README.md) | Usage and overage tracking with export feeds. |
 | [admin-api-gateway](tenant-api/README.md) | Thin façade aggregating read models for the Admin UI. |
+| [policy-service](policy-service/README.md) | Evaluates access policies across tenant modules. |
 
 ## Build
 ```bash

--- a/tenant-platform/billing-service/pom.xml
+++ b/tenant-platform/billing-service/pom.xml
@@ -47,6 +47,10 @@
       <artifactId>starter-openapi</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-actuator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -38,6 +38,10 @@
       <artifactId>starter-openapi</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-actuator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
@@ -1,0 +1,30 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/tenant
+    username: postgres
+    password: postgres
+  redis:
+    host: localhost
+    port: 6379
+  kafka:
+    bootstrap-servers: localhost:9092
+  flyway:
+    enabled: true
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+server:
+  port: 8080
+shared:
+  core:
+    correlation:
+      header-name: X-Correlation-Id
+      generate-if-missing: true
+      echo-response-header: true
+    tenant:
+      enabled: true
+      header-name: x_tenant_id
+      query-param: tenantId
+      default-policy: OPTIONAL
+      echo-response-header: true
+  openapi:
+    title: Catalog Service
+    description: Feature catalog APIs

--- a/tenant-platform/policy-service/README.md
+++ b/tenant-platform/policy-service/README.md
@@ -1,0 +1,14 @@
+# Policy Service
+
+Service responsible for evaluating access policies across tenant modules.
+
+## Local Development
+
+Configuration for running the service locally is available in `src/main/resources/application-dev.yaml`.
+The service leverages shared starter modules for logging, security and actuator support.
+
+## Build
+
+```bash
+mvn clean verify
+```

--- a/tenant-platform/policy-service/pom.xml
+++ b/tenant-platform/policy-service/pom.xml
@@ -26,9 +26,12 @@
       <artifactId>spring-boot-starter-jdbc</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.5.0</version>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-openapi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-actuator</artifactId>
     </dependency>
     <dependency>
       <groupId>com.ejada.tenant</groupId>

--- a/tenant-platform/policy-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/policy-service/src/main/resources/application-dev.yaml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/tenant
+    username: postgres
+    password: postgres
+server:
+  port: 8080
+shared:
+  core:
+    correlation:
+      header-name: X-Correlation-Id
+      generate-if-missing: true
+      echo-response-header: true
+    tenant:
+      enabled: true
+      header-name: x_tenant_id
+      query-param: tenantId
+      default-policy: OPTIONAL
+      echo-response-header: true

--- a/tenant-platform/policy-service/src/main/resources/application.yaml
+++ b/tenant-platform/policy-service/src/main/resources/application.yaml
@@ -1,0 +1,7 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${POSTGRES_HOST:postgres}:5432/tenant
+    username: ${POSTGRES_USER:postgres}
+    password: ${POSTGRES_PASSWORD:postgres}
+server:
+  port: 8080

--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -26,6 +26,10 @@
       <artifactId>starter-openapi</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-actuator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>

--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -1,0 +1,27 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/tenant
+    username: postgres
+    password: postgres
+  redis:
+    host: localhost
+    port: 6379
+  kafka:
+    bootstrap-servers: localhost:9092
+  flyway:
+    enabled: true
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+server:
+  port: 8080
+shared:
+  core:
+    correlation:
+      header-name: X-Correlation-Id
+      generate-if-missing: true
+      echo-response-header: true
+    tenant:
+      enabled: true
+      header-name: x_tenant_id
+      query-param: tenantId
+      default-policy: OPTIONAL
+      echo-response-header: true

--- a/tenant-platform/tenant-api/pom.xml
+++ b/tenant-platform/tenant-api/pom.xml
@@ -31,5 +31,9 @@
       <groupId>com.ejada</groupId>
       <artifactId>starter-openapi</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-actuator</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/tenant
+    username: postgres
+    password: postgres
+  flyway:
+    enabled: true
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+server:
+  port: 8080
+shared:
+  core:
+    correlation:
+      header-name: X-Correlation-Id
+      generate-if-missing: true
+      echo-response-header: true
+    tenant:
+      enabled: true
+      header-name: x_tenant_id
+      query-param: tenantId
+      default-policy: OPTIONAL
+      echo-response-header: true


### PR DESCRIPTION
## Summary
- document tenant platform structure and policy service
- add application-dev.yaml for catalog, subscription, tenant and policy services
- use shared starter-actuator and starter-openapi in services

## Testing
- `mvn -q -f tenant-platform/pom.xml test` *(fails: Could not transfer artifacts; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b76d6af11c832f829f1a41a2f55c19