### PR TITLE
Skip subscription tests when Docker unavailable

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/SubscriptionServiceApplicationTests.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/SubscriptionServiceApplicationTests.java
@@ -13,7 +13,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * requires a PostgreSQL database, so we supply one using Testcontainers.
  */
 @SpringBootTest
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 class SubscriptionServiceApplicationTests {
 
     @Container


### PR DESCRIPTION
## Summary
- skip subscription service context-load test when Docker isn't available

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM from central, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b76f61ee00832fbd4990c34429b8a8