### PR TITLE
Add Spring Boot plugin to service modules

### DIFF
--- a/tenant-platform/billing-service/pom.xml
+++ b/tenant-platform/billing-service/pom.xml
@@ -66,4 +66,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -62,4 +62,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -57,4 +57,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -71,4 +71,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
## Summary
- make Spring Boot services executable by enabling `spring-boot-maven-plugin`

## Testing
- `mvn -q -pl billing-service,tenant-service,subscription-service,catalog-service -am package` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f9b72b68832fa926a3b442200c55