### PR TITLE
Remove Spring Boot plugin from persistence module

### DIFF
--- a/tenant-platform/tenant-persistence/pom.xml
+++ b/tenant-platform/tenant-persistence/pom.xml
@@ -25,13 +25,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
## Summary
- remove spring-boot-maven-plugin from tenant-persistence module to avoid repackage failures

## Testing
- `mvn -pl :tenant-persistence -am clean package` *(fails: network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68b801cc0ac0832fb218b5aed2c51796