### PR TITLE
Add explicit versions for internal tenant-service dependencies

### DIFF
--- a/tenant-platform/policy-service/pom.xml
+++ b/tenant-platform/policy-service/pom.xml
@@ -36,26 +36,32 @@
     <dependency>
       <groupId>com.ejada.tenant</groupId>
       <artifactId>tenant-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.ejada.tenant</groupId>
       <artifactId>tenant-config</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.ejada.tenant</groupId>
       <artifactId>billing-service</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.ejada.tenant</groupId>
       <artifactId>catalog-service</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.ejada.tenant</groupId>
       <artifactId>subscription-service</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.ejada.tenant</groupId>
       <artifactId>tenant-service</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- specify module versions for policy-service's internal tenant dependencies to ensure correct resolution

## Testing
- `mvn -pl policy-service -am -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b805672dd4832f9b48e7d01164fd17