### PR TITLE
Refactor policy service to use core ports

### DIFF
--- a/tenant-platform/policy-service/pom.xml
+++ b/tenant-platform/policy-service/pom.xml
@@ -44,26 +44,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.ejada.tenant</groupId>
-      <artifactId>billing-service</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ejada.tenant</groupId>
-      <artifactId>catalog-service</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ejada.tenant</groupId>
-      <artifactId>subscription-service</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ejada.tenant</groupId>
-      <artifactId>tenant-service</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/tenant-platform/policy-service/src/main/java/com/ejada/policy/PolicyService.java
+++ b/tenant-platform/policy-service/src/main/java/com/ejada/policy/PolicyService.java
@@ -1,10 +1,9 @@
 package com.ejada.policy;
 
-import com.ejada.subscription.core.SubscriptionQueryPort;
+import com.ejada.tenant.core.SubscriptionPort;
 import com.ejada.tenant.core.TenantSettingsPort;
-import com.ejada.billing.dto.RecordOverageRequest;
-import com.ejada.billing.service.OveragePort;
-import com.ejada.catalog.service.FeaturePolicyPort;
+import com.ejada.tenant.core.OveragePort;
+import com.ejada.tenant.core.FeaturePolicyPort;
 
 import org.springframework.stereotype.Service;
 
@@ -15,22 +14,22 @@ import java.util.UUID;
 public class PolicyService {
 
     private final TenantSettingsPort tenantSettings;
-    private final SubscriptionQueryPort subscriptionQuery;
+    private final SubscriptionPort subscriptionPort;
     private final FeaturePolicyPort featurePolicy;
     private final OveragePort overagePort;
 
     public PolicyService(TenantSettingsPort tenantSettings,
-                         SubscriptionQueryPort subscriptionQuery,
+                         SubscriptionPort subscriptionPort,
                          FeaturePolicyPort featurePolicy,
                          OveragePort overagePort) {
         this.tenantSettings = tenantSettings;
-        this.subscriptionQuery = subscriptionQuery;
+        this.subscriptionPort = subscriptionPort;
         this.featurePolicy = featurePolicy;
         this.overagePort = overagePort;
     }
 
     public PolicyResult consumeOrOverage(UUID tenantId, String feature, long totalUsage) {
-        var sub = subscriptionQuery.loadActive(tenantId);
+        var sub = subscriptionPort.activeSubscription(tenantId);
         var eff = featurePolicy.effective(sub.tierId(), tenantId, feature);
 
         if (!eff.enabled()) {
@@ -48,18 +47,17 @@ public class PolicyService {
 
         long exceeded = totalUsage - limit;
         long price = eff.overageUnitPriceMinor() == null ? 0 : eff.overageUnitPriceMinor();
-        var req = new RecordOverageRequest(
+        var overageId = overagePort.recordOverage(
+                tenantId,
+                sub.subscriptionId(),
                 feature,
                 exceeded,
                 price,
                 eff.overageCurrency(),
                 Instant.now(),
                 Instant.now(),
-                Instant.now(),
-                null,
                 null);
-        var response = overagePort.recordOverage(tenantId, sub.subscriptionId(), req);
-        return new PolicyResult(limit, response.overageId());
+        return new PolicyResult(limit, overageId);
     }
 
     public record PolicyResult(long limit, UUID overageId) {}


### PR DESCRIPTION
## Summary
- update PolicyService to rely on tenant-core ports for subscriptions, feature policies, and overage recording
- remove cross-service module dependencies from policy-service pom

## Testing
- `MAVEN_OPTS="-Djava.net.preferIPv4Stack=true" mvn -q -pl policy-service -am test` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies 3.5.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b808fcc744832fbcede2fc00136f13