### PR TITLE
chore(ci): skip unit tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,8 +16,8 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Build shared libraries
-        run: mvn -B -DskipTests=false install -f shared-lib/pom.xml
+        run: mvn -B -DskipTests=true install -f shared-lib/pom.xml
       - name: Build tenant platform
-        run: mvn -B -DskipTests=false verify -f tenant-platform/pom.xml
+        run: mvn -B -DskipTests=true verify -f tenant-platform/pom.xml
       - name: Build setup service
-        run: mvn -B -DskipTests=false verify -f lms-setup/pom.xml
+        run: mvn -B -DskipTests=true verify -f lms-setup/pom.xml


### PR DESCRIPTION
## Summary
- skip unit tests in the Maven CI workflow

## Testing
- `mvn -B -DskipTests=true install -f shared-lib/pom.xml` *(fails: Network is unreachable)*
- `mvn -B -DskipTests=true verify -f tenant-platform/pom.xml` *(fails: Network is unreachable)*
- `mvn -B -DskipTests=true verify -f lms-setup/pom.xml` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b80b8a0cd4832fbe7b1c2c4a641acc