### PR TITLE
Ensure tenant database exists in docker compose

### DIFF
--- a/tenant-platform/docker-compose.yml
+++ b/tenant-platform/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   postgres:
     image: postgres:16
     environment:
+      POSTGRES_DB: tenant
+      POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports: [ "5432:5432" ]
   redis:


### PR DESCRIPTION
## Summary
- create tenant database for Postgres in tenant-platform's docker-compose so services can start

## Testing
- `mvn -f tenant-platform/pom.xml test` *(fails: Non-resolvable import POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b80ddb1ed0832f85e93864b34ba962