### PR TITLE
Enable dev profile for tenant services

### DIFF
--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: dev
   datasource:
     url: jdbc:postgresql://${POSTGRES_HOST:postgres}:5432/tenant
     username: ${POSTGRES_USER:postgres}

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: dev
   datasource:
     url: jdbc:postgresql://${POSTGRES_HOST:postgres}:5432/tenant
     username: ${POSTGRES_USER:postgres}

--- a/tenant-platform/policy-service/src/main/resources/application.yaml
+++ b/tenant-platform/policy-service/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: dev
   datasource:
     url: jdbc:postgresql://${POSTGRES_HOST:postgres}:5432/tenant
     username: ${POSTGRES_USER:postgres}

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: dev
   datasource:
     url: jdbc:postgresql://${POSTGRES_HOST:postgres}:5432/tenant
     username: ${POSTGRES_USER:postgres}

--- a/tenant-platform/tenant-api/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: dev
   datasource:
     url: jdbc:postgresql://${POSTGRES_HOST:postgres}:5432/tenant
     username: ${POSTGRES_USER:postgres}

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: dev
   datasource:
     url: jdbc:postgresql://${POSTGRES_HOST:postgres}:5432/tenant
     username: ${POSTGRES_USER:postgres}


### PR DESCRIPTION
## Summary
- activate dev profile in tenant service configurations so application-dev.yaml is loaded

## Testing
- `mvn -q -f tenant-platform/pom.xml test` *(fails: Network is unreachable)*
- `mvn -q -f lms-setup/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8150aa0b0832fbecd5f87d4763264