### PR TITLE
feat: update flyway to support postgres 16

### DIFF
--- a/tenant-platform/billing-service/pom.xml
+++ b/tenant-platform/billing-service/pom.xml
@@ -34,6 +34,11 @@
       <artifactId>flyway-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+      <version>${flyway.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
     </dependency>

--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -22,6 +22,7 @@
     <java.version>21</java.version>
     <spring-boot.version>3.5.2</spring-boot.version>
     <mapstruct.version>1.6.3</mapstruct.version>
+    <flyway.version>11.11.2</flyway.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
## Summary
- set Flyway version to 11.11.2 across tenant platform
- add PostgreSQL-specific Flyway support in billing service

## Testing
- `mvn -q -pl billing-service test` *(fails: Non-resolvable import POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b823ae54d0832f8c3a97ce291d5669