### PR TITLE
Enable billing JPA repository scanning

### DIFF
--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/config/BillingJpaConfig.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/config/BillingJpaConfig.java
@@ -1,0 +1,21 @@
+package com.ejada.billing.config;
+
+import com.ejada.billing.entity.TenantOverage;
+import com.ejada.billing.repository.TenantOverageRepository;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+/**
+ * Configures JPA components for the billing service.
+ *
+ * <p>Adds package scanning for billing entities and repositories so that
+ * {@link TenantOverageRepository} is registered alongside repositories
+ * imported by other modules.</p>
+ */
+@Configuration
+@EnableJpaRepositories(basePackageClasses = TenantOverageRepository.class)
+@EntityScan(basePackageClasses = TenantOverage.class)
+public class BillingJpaConfig {
+}
+


### PR DESCRIPTION
## Summary
- add BillingJpaConfig to scan billing entities and repositories

## Testing
- `mvn -q -pl billing-service -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b82854fab8832f82b16e3325161c5d