### PR TITLE
Add setup-service to docker compose

### DIFF
--- a/tenant-platform/docker-compose.yml
+++ b/tenant-platform/docker-compose.yml
@@ -57,6 +57,27 @@ services:
       timeout: 5s
       retries: 20
 
+  setup-service:
+    build: ../lms-setup
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    environment:
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: lms
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      SHARED_REDIS_HOST: redis
+      SHARED_REDIS_PORT: 6379
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+    ports:
+      - "8085:8080"
+
   tenant-service:
     build: ./tenant-service
     depends_on:


### PR DESCRIPTION
## Summary
- add setup-service to docker compose with database, cache and Kafka connections

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b8447cadf8832faf844f03b6cd948c