### PR TITLE
Exclude Kafka auto config in event publisher test

### DIFF
--- a/tenant-platform/tenant-events/src/test/java/com/ejada/tenant/events/TenantEventPublisherTests.java
+++ b/tenant-platform/tenant-events/src/test/java/com/ejada/tenant/events/TenantEventPublisherTests.java
@@ -4,22 +4,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ejada.tenant.events.entity.TenantOutboxEvent;
 import com.ejada.tenant.events.repo.TenantOutboxEventRepository;
+import com.ejada.tenant.events.OutboxPublisher;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(classes = TenantEventPublisherTests.TestApplication.class)
 @TestPropertySource(properties = {
     "spring.datasource.url=jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
-    "spring.task.scheduling.enabled=false"
+    "spring.task.scheduling.enabled=false",
+    "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration,com.ejada.kafka_starter.config.KafkaAutoConfiguration"
 })
 class TenantEventPublisherTests {
 
     @SpringBootApplication
+    @ComponentScan(excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = OutboxPublisher.class))
     static class TestApplication {}
 
     @Autowired


### PR DESCRIPTION
## Summary
- prevent Spring's Kafka auto configuration and custom Kafka config from loading during `TenantEventPublisherTests`
- exclude `OutboxPublisher` component so the test doesn't try to send Kafka messages

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl tenant-events -am test` *(fails: Non-resolvable import POM: The following artifacts could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b2a6fcbc832f9eb98cec4e58b5b1