### PR TITLE
Specify application class for subscription service tests

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/SubscriptionServiceApplicationTests.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/SubscriptionServiceApplicationTests.java
@@ -1,5 +1,6 @@
 package com.ejada.subscription;
 
+import com.ejada.tenant.subscription.SubscriptionServiceApplication;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -12,7 +13,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * Simple smoke test that verifies the Spring context can start. The application
  * requires a PostgreSQL database, so we supply one using Testcontainers.
  */
-@SpringBootTest
+@SpringBootTest(classes = SubscriptionServiceApplication.class)
 @Testcontainers(disabledWithoutDocker = false)
 class SubscriptionServiceApplicationTests {
 


### PR DESCRIPTION
## Summary
- ensure SubscriptionServiceApplicationTests explicitly loads SubscriptionServiceApplication class

## Testing
- `mvn -q -pl subscription-service test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b5fa5900832f9e4f22fb47501480