### PR TITLE
Enable method security in CountryControllerTest

### DIFF
--- a/lms-setup/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
+++ b/lms-setup/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
@@ -7,6 +7,9 @@ import com.ejada.setup.service.CountryService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.method.MethodSecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -43,6 +46,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @WithMockUser(roles = {"ADMIN", "USER"})
 @Import(CountryControllerTest.TestSecurityConfig.class)
+@ImportAutoConfiguration({AopAutoConfiguration.class, MethodSecurityAutoConfiguration.class})
 class CountryControllerTest {
 
     private static final String BASE_URL = "/setup/countries";


### PR DESCRIPTION
## Summary
- enable AOP and method-security auto configurations in CountryControllerTest to ensure `@SetupAuthorized` checks

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b76c2040832fb8c2fa16d92f96a1