### PR TITLE
test: use isolated profile for catalog service

### DIFF
--- a/tenant-platform/catalog-service/src/test/java/com/ejada/catalog/CatalogServiceApplicationTests.java
+++ b/tenant-platform/catalog-service/src/test/java/com/ejada/catalog/CatalogServiceApplicationTests.java
@@ -3,7 +3,10 @@ package com.ejada.catalog;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import org.springframework.test.context.ActiveProfiles;
+
 @SpringBootTest
+@ActiveProfiles("test")
 class CatalogServiceApplicationTests {
 
     @Test

--- a/tenant-platform/catalog-service/src/test/resources/application-test.properties
+++ b/tenant-platform/catalog-service/src/test/resources/application-test.properties
@@ -2,3 +2,4 @@ spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALS
 spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
+spring.flyway.enabled=false


### PR DESCRIPTION
## Summary
- use dedicated test profile for catalog service tests
- disable Flyway and configure in-memory H2 for tests

## Testing
- `mvn -q -pl catalog-service test` *(fails: Non-resolvable import POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b8b796fc832f93fc098d854c5aee