### PR TITLE
test: update country controller test for new security auto-config

### DIFF
--- a/lms-setup/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
+++ b/lms-setup/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.method.MethodSecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -42,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @WithMockUser(roles = {"ADMIN", "USER"})
 @Import(CountryControllerTest.TestSecurityConfig.class)
-@ImportAutoConfiguration({AopAutoConfiguration.class, MethodSecurityAutoConfiguration.class})
+@ImportAutoConfiguration(AopAutoConfiguration.class)
 class CountryControllerTest {
 
     private static final String BASE_URL = "/setup/countries";


### PR DESCRIPTION
## Summary
- remove outdated MethodSecurityAutoConfiguration import from CountryControllerTest
- rely on AopAutoConfiguration for method security setup in tests

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(failed: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bce4a2d8832f8892d90abf17e68c