### PR TITLE
fix: remove duplicate security annotations

### DIFF
--- a/lms-setup/src/main/java/com/ejada/setup/controller/CountryController.java
+++ b/lms-setup/src/main/java/com/ejada/setup/controller/CountryController.java
@@ -42,7 +42,6 @@ public class CountryController {
     }
 
     @PostMapping
-    @SetupAuthorized
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create a new country", description = "Creates a new country with the provided details")
     @ApiResponses(value = {
@@ -57,7 +56,6 @@ public class CountryController {
     }
 
     @PutMapping("/{countryId}")
-    @SetupAuthorized
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update an existing country", description = "Updates the country with the specified ID")
     @ApiResponses(value = {


### PR DESCRIPTION
## Summary
- ensure country controller has a single pre-authorization rule per endpoint by removing redundant `@SetupAuthorized` from create and update methods

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.5.5 due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c1c62e04832fb177d43e663b39d6