### PR TITLE
Handle AuthorizationDeniedException with 403 response

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/SecurityExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/SecurityExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
@@ -15,11 +16,11 @@ import org.springframework.web.context.request.WebRequest;
  */
 @Slf4j
 @RestControllerAdvice
-@ConditionalOnClass(AccessDeniedException.class)
+@ConditionalOnClass({AccessDeniedException.class, AuthorizationDeniedException.class})
 public class SecurityExceptionHandler {
 
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<BaseResponse<?>> handleAccessDenied(AccessDeniedException ex, WebRequest request) {
+    @ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})
+    public ResponseEntity<BaseResponse<?>> handleAccessDenied(Exception ex, WebRequest request) {
         log.warn("Access denied: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(BaseResponse.error("ERR_ACCESS_DENIED", "Access denied"));

--- a/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/SecurityExceptionHandlerTest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/SecurityExceptionHandlerTest.java
@@ -1,0 +1,28 @@
+package com.ejada.starter_core.web;
+
+import com.ejada.common.dto.BaseResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SecurityExceptionHandlerTest {
+
+    private final SecurityExceptionHandler handler = new SecurityExceptionHandler();
+
+    @Test
+    void handleAccessDeniedReturnsForbidden() {
+        ResponseEntity<BaseResponse<?>> resp = handler.handleAccessDenied(new AccessDeniedException("denied"), null);
+        assertEquals(403, resp.getStatusCode().value());
+        assertEquals("ERR_ACCESS_DENIED", resp.getBody().getCode());
+    }
+
+    @Test
+    void handleAuthorizationDeniedReturnsForbidden() {
+        ResponseEntity<BaseResponse<?>> resp = handler.handleAccessDenied(new AuthorizationDeniedException("denied"), null);
+        assertEquals(403, resp.getStatusCode().value());
+        assertEquals("ERR_ACCESS_DENIED", resp.getBody().getCode());
+    }
+}


### PR DESCRIPTION
## Summary
- treat AuthorizationDeniedException and AccessDeniedException consistently in security handler
- test that security handler returns 403 for both exception types

## Testing
- `mvn -q -f shared-lib/pom.xml -pl shared-starters/starter-core -am test` *(fails: Network is unreachable)*
- `mvn -q -f lms-setup/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c62a6ad4832fb188f59c0ef9e7c9