### PR TITLE
Include security handler in exception auto-config

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/exception/CoreExceptionAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/exception/CoreExceptionAutoConfiguration.java
@@ -2,6 +2,7 @@ package com.ejada.starter_core.exception;
 
 import com.ejada.starter_core.web.GlobalExceptionHandler;
 import com.ejada.starter_core.web.NoResourceFoundHandlerConfiguration;
+import com.ejada.starter_core.web.SecurityExceptionHandler;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -13,6 +14,6 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(name = "org.springframework.http.HttpStatusCode")
-@Import({GlobalExceptionHandler.class, NoResourceFoundHandlerConfiguration.class})
+@Import({GlobalExceptionHandler.class, NoResourceFoundHandlerConfiguration.class, SecurityExceptionHandler.class})
 public class CoreExceptionAutoConfiguration {
 }


### PR DESCRIPTION
## Summary
- include SecurityExceptionHandler in CoreExceptionAutoConfiguration to ensure access-denied exceptions map to HTTP 403

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cd1d26cc832fac8e6e332d71f438