### PR TITLE
Ensure unauthorized CountryController requests return 403

### DIFF
--- a/lms-setup/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
+++ b/lms-setup/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.ejada.starter_security.RoleChecker;
 import com.ejada.starter_security.SharedSecurityProps;
+import com.ejada.starter_core.web.SecurityExceptionHandler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -40,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @WithMockUser(roles = {"ADMIN", "USER"})
-@Import(CountryControllerTest.TestSecurityConfig.class)
+@Import({CountryControllerTest.TestSecurityConfig.class, SecurityExceptionHandler.class})
 @ImportAutoConfiguration(AopAutoConfiguration.class)
 class CountryControllerTest {
 


### PR DESCRIPTION
## Summary
- Import `SecurityExceptionHandler` into `CountryControllerTest` so unauthorized users receive 403 instead of 500

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d37ebe60832f9927e34748dd113c