### PR TITLE
Handle access denied

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -104,6 +105,13 @@ public class GlobalExceptionHandler {
         log.error("Data integrity violation: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(BaseResponse.error("ERR_DATA_CONFLICT", "Data conflict occurred"));
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<BaseResponse<?>> handleAccessDenied(AuthorizationDeniedException ex, WebRequest request) {
+        log.warn("Access denied: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(BaseResponse.error("ERR_ACCESS_DENIED", "Access is denied"));
     }
 
     @ExceptionHandler(Exception.class)

--- a/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/GlobalExceptionHandlerTest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/GlobalExceptionHandlerTest.java
@@ -3,6 +3,7 @@ package com.ejada.starter_core.web;
 import com.ejada.common.dto.BaseResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -15,5 +16,13 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<BaseResponse<?>> resp = handler.handleGeneric(new RuntimeException("boom"), null);
         assertEquals(500, resp.getStatusCode().value());
         assertEquals("ERR_INTERNAL", resp.getBody().getCode());
+    }
+
+    @Test
+    void handleAccessDeniedReturnsForbidden() {
+        AuthorizationDeniedException ex = new AuthorizationDeniedException("denied");
+        ResponseEntity<BaseResponse<?>> resp = handler.handleAccessDenied(ex, null);
+        assertEquals(403, resp.getStatusCode().value());
+        assertEquals("ERR_ACCESS_DENIED", resp.getBody().getCode());
     }
 }


### PR DESCRIPTION
## Summary
- return 403 Access Denied via GlobalExceptionHandler
- test forbidden handling in GlobalExceptionHandlerTest

## Testing
- `mvn -q -f lms-setup/pom.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d5043e30832f8318248b8f03bd6b