### PR TITLE
Enable JPA auto configuration for billing service tests

### DIFF
--- a/tenant-platform/billing-service/pom.xml
+++ b/tenant-platform/billing-service/pom.xml
@@ -65,6 +65,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
       <scope>test</scope>

--- a/tenant-platform/billing-service/src/test/java/com/ejada/billing/BillingServiceApplicationTests.java
+++ b/tenant-platform/billing-service/src/test/java/com/ejada/billing/BillingServiceApplicationTests.java
@@ -2,31 +2,14 @@ package com.ejada.billing;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-
-import com.ejada.billing.repository.TenantOverageRepository;
 
 /**
- * Verifies that the Spring application context can start without requiring
- * external infrastructure such as the PostgreSQL database. The various data
- * source related auto configurations are disabled and the JPA repository is
- * mocked so the context loads in isolation.
+ * Verifies that the Spring application context can start with the full JPA
+ * infrastructure configured. If the context fails to load, this test will
+ * fail.
  */
-@SpringBootTest(properties = {
-        "spring.autoconfigure.exclude=" +
-                "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration," +
-                "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration," +
-                "org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration," +
-                "org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration"
-})
+@SpringBootTest
 class BillingServiceApplicationTests {
-
-    /**
-     * Mock the JPA repository so that components depending on it can be created
-     * without an actual database.
-     */
-    @MockBean
-    TenantOverageRepository repository;
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
## Summary
- Remove JPA auto-configuration exclusions so tests load full context
- Add JPA and H2 test dependencies for in-memory database testing

## Testing
- ❌ `mvn -pl billing-service test` *(failed: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d4fe6340832fa0dd7a8466b7af17