### PR TITLE
fix: support postgres 16 with flyway plugin

### DIFF
--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -27,6 +27,11 @@
       <version>${flyway.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+      <version>${flyway.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>

--- a/tenant-platform/tenant-persistence/pom.xml
+++ b/tenant-platform/tenant-persistence/pom.xml
@@ -8,6 +8,7 @@
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-data-jpa</artifactId></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-jdbc</artifactId></dependency>
     <dependency><groupId>org.flywaydb</groupId><artifactId>flyway-core</artifactId></dependency>
+    <dependency><groupId>org.flywaydb</groupId><artifactId>flyway-database-postgresql</artifactId><version>${flyway.version}</version></dependency>
     <dependency><groupId>org.postgresql</groupId><artifactId>postgresql</artifactId></dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- add Flyway PostgreSQL plugin to persistence layer
- add Flyway PostgreSQL plugin to catalog service

## Testing
- `mvn -q -pl tenant-persistence,catalog-service -am test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d712fa38832fb46b52df502f3ef0