### PR TITLE
fix: enable executable jar for setup module

### DIFF
--- a/lms-setup/pom.xml
+++ b/lms-setup/pom.xml
@@ -347,6 +347,17 @@
         </execution>
       </executions>
     </plugin>
+    <plugin>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-maven-plugin</artifactId>
+      <executions>
+        <execution>
+          <goals>
+            <goal>repackage</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
   </plugins>
 </build>
 </project>


### PR DESCRIPTION
## Summary
- add Spring Boot Maven plugin to package lms-setup as executable jar

## Testing
- `mvn -f lms-setup/pom.xml -q package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d8d22884832fa10f505dd587db77