### PR TITLE
Add Flyway PostgreSQL extension to tenant service

### DIFF
--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -31,6 +31,15 @@
       <artifactId>postgresql</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+      <version>${flyway.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.ejada.tenant</groupId>
       <artifactId>tenant-persistence</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary
- add flyway-core and database specific flyway-database-postgresql dependencies to tenant-service

## Testing
- `mvn -pl tenant-service -am -o test` *(fails: Non-resolvable import POM: Cannot access central in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d868df20832fbbec53270ad4c462