### PR TITLE
Normalize Flyway indentation in YAML configs

### DIFF
--- a/tenant-platform/billing-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-dev.yaml
@@ -9,9 +9,9 @@ spring:
   kafka:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
-	enabled: true
-		default-schema: entity
-		locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    enabled: true
+    default-schema: entity
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080
 shared:

--- a/tenant-platform/billing-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-qa.yaml
@@ -9,9 +9,9 @@ spring:
   kafka:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
-	enabled: true
-		default-schema: entity
-		    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    enabled: true
+    default-schema: entity
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080
 shared:

--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -2,8 +2,8 @@ spring:
   profiles:
     active: dev
   flyway:
-	enabled: true
-	default-schema: entity
+    enabled: true
+    default-schema: entity
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
   jpa:
     hibernate:

--- a/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
@@ -9,9 +9,9 @@ spring:
   kafka:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
-	enabled: true
-		default-schema: entity
-		    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    enabled: true
+    default-schema: entity
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080
 shared:

--- a/tenant-platform/catalog-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-qa.yaml
@@ -9,9 +9,9 @@ spring:
   kafka:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
-	enabled: true
-		default-schema: entity
-		    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    enabled: true
+    default-schema: entity
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080
 shared:

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -2,8 +2,8 @@ spring:
   profiles:
     active: dev
   flyway:
-	enabled: true
-		default-schema: entity
+    enabled: true
+    default-schema: entity
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
   jpa:
     hibernate:

--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -9,9 +9,9 @@ spring:
   kafka:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
-	enabled: true
-		default-schema: entity
-		    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    enabled: true
+    default-schema: entity
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080
 shared:

--- a/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
@@ -9,9 +9,9 @@ spring:
   kafka:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
-	enabled: true
-		default-schema: entity
-		    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    enabled: true
+    default-schema: entity
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080
 shared:

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -2,8 +2,8 @@ spring:
   profiles:
     active: dev
   flyway:
-	enabled: true
-		default-schema: entity
+    enabled: true
+    default-schema: entity
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
   jpa:
     hibernate:

--- a/tenant-platform/tenant-api/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application-dev.yaml
@@ -9,8 +9,8 @@ spring:
   kafka:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
-	enabled: true
-		default-schema: entity
-		    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    enabled: true
+    default-schema: entity
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/tenant-api/src/main/resources/application-qa.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application-qa.yaml
@@ -9,8 +9,8 @@ spring:
   kafka:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
-	enabled: true
-		default-schema: entity
-		    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    enabled: true
+    default-schema: entity
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/tenant-api/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application.yaml
@@ -2,8 +2,8 @@ spring:
   profiles:
     active: dev
   flyway:
-	enabled: true
-		default-schema: entity
-		    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    enabled: true
+    default-schema: entity
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -4,9 +4,9 @@ spring:
     username: postgres
     password: postgres
   flyway:
-	enabled: true
-		default-schema: entity
-		    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    enabled: true
+    default-schema: entity
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080
 shared:

--- a/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
@@ -4,9 +4,9 @@ spring:
     username: postgres
     password: postgres
   flyway:
-	enabled: true
-		default-schema: entity
-		    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    enabled: true
+    default-schema: entity
+    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080
 shared:

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -2,8 +2,8 @@ spring:
   profiles:
     active: dev
   flyway:
-	enabled: true
-		default-schema: entity
+    enabled: true
+    default-schema: entity
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
   jpa:
     hibernate:


### PR DESCRIPTION
## Summary
- normalize flyway configuration indentation in tenant-service
- normalize flyway configuration indentation in catalog-service, billing-service, subscription-service, tenant-api
- align dev/qa environment YAML files with the corrected structure

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dec71624832f85dc119a98e0b3ef