### PR TITLE
Fix MapStruct annotation processor resolution

### DIFF
--- a/shared-lib/shared-starters/starter-mapstruct/pom.xml
+++ b/shared-lib/shared-starters/starter-mapstruct/pom.xml
@@ -72,14 +72,17 @@
             <path>
               <groupId>org.mapstruct</groupId>
               <artifactId>mapstruct-processor</artifactId>
+              <version>${mapstruct.version}</version>
             </path>
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
             </path>
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok-mapstruct-binding</artifactId>
+              <version>${lombokMapstruct.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>


### PR DESCRIPTION
## Summary
- specify explicit versions for MapStruct, Lombok, and Lombok MapStruct binding annotation processors in `starter-mapstruct`

## Testing
- `mvn -f shared-lib/pom.xml -pl shared-starters/starter-mapstruct -am compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8df05107c832fb8aceebdbaff1ab0