### PR TITLE
Fix BOM version for tests

### DIFF
--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -105,6 +105,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring-boot.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Summary
- specify Spring Boot version for test dependency in tenant-platform POM

## Testing
- `mvn -q test` *(failed: 'dependencies.dependency.version' for org.springframework.boot:spring-boot-starter-web:jar is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e18e3bac832f85fc80e28717763a