### PR TITLE
fix: remove duplicate JPA test dependency

### DIFF
--- a/tenant-platform/billing-service/pom.xml
+++ b/tenant-platform/billing-service/pom.xml
@@ -65,11 +65,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## Summary
- remove redundant test-scoped `spring-boot-starter-data-jpa` dependency to restore JPA classes on the compile classpath

## Testing
- `mvn -pl billing-service -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e3984170832fbf5e6160aa76c2be