### PR TITLE
Handle Flyway migration mismatches in billing service

### DIFF
--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/config/FlywayRepairStrategy.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/config/FlywayRepairStrategy.java
@@ -1,0 +1,41 @@
+package com.ejada.billing.config;
+
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Customizes Flyway to automatically repair the schema history table before
+ * applying migrations. This updates checksums when migration scripts change
+ * without requiring manual intervention.
+ */
+@Configuration
+public class FlywayRepairStrategy {
+
+    /**
+     * Repairs the Flyway schema history table and then runs migrations.
+     *
+     * @return strategy that repairs then migrates
+     */
+    @Bean
+    public FlywayMigrationStrategy repairThenMigrateStrategy() {
+        return (Flyway flyway) -> {
+            flyway.repair();
+            flyway.migrate();
+        };
+    }
+
+    /**
+     * Ignores missing historical migrations to allow systems with existing
+     * schemas to start even if early migrations were renumbered.
+     *
+     * @return configuration customizer adding ignore pattern
+     */
+    @Bean
+    public FlywayConfigurationCustomizer ignoreMissingMigrationsCustomizer() {
+        return configuration -> configuration.ignoreMigrationPatterns("1:ignored");
+    }
+}
+

--- a/tenant-platform/billing-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-dev.yaml
@@ -12,6 +12,7 @@ spring:
     enabled: true
     default-schema: entity
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    ignore-migration-patterns: 1:ignored
 server:
   port: 8080
 shared:

--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -5,6 +5,7 @@ spring:
     enabled: true
     default-schema: entity
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    ignore-migration-patterns: 1:ignored
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
## Summary
- repair Flyway schema history before migrations
- ignore missing initial migration to avoid startup failures

## Testing
- `mvn -q -pl billing-service test` *(fails: Could not resolve artifacts from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68b97a9b5cbc832fb6837eb840724197