### PR TITLE
fix: correct Flyway ignore migration patterns

### DIFF
--- a/tenant-platform/billing-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-dev.yaml
@@ -12,7 +12,7 @@ spring:
     enabled: true
     default-schema: entity
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    ignore-migration-patterns: 1:ignored
+    ignore-migration-patterns: "versioned:1"
 server:
   port: 8080
 shared:

--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
     enabled: true
     default-schema: entity
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    ignore-migration-patterns: 1:ignored
+    ignore-migration-patterns: "versioned:1"
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
## Summary
- fix Flyway ignore-migration-patterns syntax in billing-service configs

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b97c528884832f893e50f9082c656e