### PR TITLE
fix: use valid flyway ignore pattern

### DIFF
--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/config/FlywayRepairStrategy.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/config/FlywayRepairStrategy.java
@@ -35,7 +35,12 @@ public class FlywayRepairStrategy {
      */
     @Bean
     public FlywayConfigurationCustomizer ignoreMissingMigrationsCustomizer() {
-        return configuration -> configuration.ignoreMigrationPatterns("1:ignored");
+        // Ignore migrations that exist in the schema history table but are
+        // no longer present on disk (e.g. when early migrations were
+        // renumbered). Flyway expects the pattern format
+        // "<type>:<state>", so "*:missing" ignores all migration types
+        // that are marked as missing.
+        return configuration -> configuration.ignoreMigrationPatterns("*:missing");
     }
 }
 


### PR DESCRIPTION
## Summary
- ignore missing migrations using `*:missing` pattern
- document valid pattern format in `FlywayRepairStrategy`

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b97e5ee414832fb63c0f18a808342f