### PR TITLE
Make security exception handling optional

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/exception/CoreExceptionAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/exception/CoreExceptionAutoConfiguration.java
@@ -14,6 +14,14 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(name = "org.springframework.http.HttpStatusCode")
-@Import({GlobalExceptionHandler.class, NoResourceFoundHandlerConfiguration.class, SecurityExceptionHandler.class})
+@Import({GlobalExceptionHandler.class, NoResourceFoundHandlerConfiguration.class})
 public class CoreExceptionAutoConfiguration {
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(name = {
+            "org.springframework.security.access.AccessDeniedException",
+            "org.springframework.security.authorization.AuthorizationDeniedException"})
+    @Import(SecurityExceptionHandler.class)
+    static class SecurityHandlerConfiguration {
+    }
 }

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -105,13 +104,6 @@ public class GlobalExceptionHandler {
         log.error("Data integrity violation: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(BaseResponse.error("ERR_DATA_CONFLICT", "Data conflict occurred"));
-    }
-
-    @ExceptionHandler(AuthorizationDeniedException.class)
-    public ResponseEntity<BaseResponse<?>> handleAccessDenied(AuthorizationDeniedException ex, WebRequest request) {
-        log.warn("Access denied: {}", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(BaseResponse.error("ERR_ACCESS_DENIED", "Access is denied"));
     }
 
     @ExceptionHandler(Exception.class)

--- a/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/GlobalExceptionHandlerTest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/GlobalExceptionHandlerTest.java
@@ -3,7 +3,6 @@ package com.ejada.starter_core.web;
 import com.ejada.common.dto.BaseResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authorization.AuthorizationDeniedException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -18,11 +17,4 @@ class GlobalExceptionHandlerTest {
         assertEquals("ERR_INTERNAL", resp.getBody().getCode());
     }
 
-    @Test
-    void handleAccessDeniedReturnsForbidden() {
-        AuthorizationDeniedException ex = new AuthorizationDeniedException("denied");
-        ResponseEntity<BaseResponse<?>> resp = handler.handleAccessDenied(ex, null);
-        assertEquals(403, resp.getStatusCode().value());
-        assertEquals("ERR_ACCESS_DENIED", resp.getBody().getCode());
-    }
 }


### PR DESCRIPTION
## Summary
- Remove hard dependency on Spring Security from `GlobalExceptionHandler`
- Import `SecurityExceptionHandler` only when security classes are present
- Drop obsolete access-denied test for `GlobalExceptionHandler`

## Testing
- `mvn -q -f pom.xml -pl shared-starters/starter-core -am test` *(failed: Non-resolvable import POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b986b53bfc832f89818edd6ae6fb4c