### PR TITLE
Assign dedicated schemas to platform services

### DIFF
--- a/tenant-platform/billing-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-dev.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=entity
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_billing
     username: postgres
     password: postgres
 
@@ -13,7 +13,8 @@ spring:
 
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_billing
+    schemas: tenant_billing
     create-schemas: true
     baseline-on-migrate: true
     validate-on-migrate: true

--- a/tenant-platform/billing-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-qa.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_billing
     username: postgres
     password: postgres
   redis:
@@ -10,7 +10,8 @@ spring:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_billing
+    schemas: tenant_billing
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -2,6 +2,11 @@ spring:
   profiles:
     active: dev
 
+  flyway:
+    enabled: true
+    default-schema: tenant_billing
+    schemas: tenant_billing
+
   jpa:
     hibernate:
       ddl-auto: none

--- a/tenant-platform/billing-service/src/main/resources/db/migration/V1__init.sql
+++ b/tenant-platform/billing-service/src/main/resources/db/migration/V1__init.sql
@@ -1,4 +1,6 @@
-create table if not exists tenant_overage (
+create schema if not exists tenant_billing;
+
+create table if not exists tenant_billing.tenant_overage (
   overage_id uuid primary key default gen_random_uuid(),
   tenant_id uuid not null,
   subscription_id uuid,
@@ -14,9 +16,9 @@ create table if not exists tenant_overage (
   metadata jsonb not null default '{}'::jsonb
 );
 
-create index if not exists idx_overage_tenant_time on tenant_overage(tenant_id, occurred_at desc);
-create index if not exists idx_overage_tenant_feature on tenant_overage(tenant_id, feature_key);
-create unique index if not exists idx_overage_idem on tenant_overage(tenant_id, idempotency_key) where idempotency_key is not null;
+create index if not exists idx_overage_tenant_time on tenant_billing.tenant_overage(tenant_id, occurred_at desc);
+create index if not exists idx_overage_tenant_feature on tenant_billing.tenant_overage(tenant_id, feature_key);
+create unique index if not exists idx_overage_idem on tenant_billing.tenant_overage(tenant_id, idempotency_key) where idempotency_key is not null;
 
-alter table tenant_overage enable row level security;
-create policy tenant_overage_policy on tenant_overage using (tenant_id = current_setting('app.current_tenant', true)::uuid);
+alter table tenant_billing.tenant_overage enable row level security;
+create policy tenant_overage_policy on tenant_billing.tenant_overage using (tenant_id = current_setting('app.current_tenant', true)::uuid);

--- a/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=entity
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_catalog
     username: postgres
     password: postgres
   redis:
@@ -10,7 +10,8 @@ spring:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_catalog
+    schemas: tenant_catalog
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/catalog-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-qa.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_catalog
     username: postgres
     password: postgres
   redis:
@@ -10,7 +10,8 @@ spring:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_catalog
+    schemas: tenant_catalog
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -3,7 +3,8 @@ spring:
     active: dev
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_catalog
+    schemas: tenant_catalog
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
   jpa:
     hibernate:

--- a/tenant-platform/catalog-service/src/main/resources/db/migration/postgresql/V1__init.sql
+++ b/tenant-platform/catalog-service/src/main/resources/db/migration/postgresql/V1__init.sql
@@ -1,9 +1,11 @@
-create table if not exists feature (
+create schema if not exists tenant_catalog;
+
+create table if not exists tenant_catalog.feature (
   feature_key text primary key,
   description text
 );
 
-create table if not exists product_tier (
+create table if not exists tenant_catalog.product_tier (
   tier_id text primary key,
   name text,
   description text,
@@ -15,8 +17,8 @@ create table if not exists product_tier (
 );
 
 create table if not exists tier_feature_limit (
-  tier_id text references product_tier(tier_id),
-  feature_key text references feature(feature_key),
+  tier_id text references tenant_catalog.product_tier(tier_id),
+  feature_key text references tenant_catalog.feature(feature_key),
   enabled boolean,
   limit_value bigint,
   allow_overage boolean default false,
@@ -25,7 +27,7 @@ create table if not exists tier_feature_limit (
   primary key (tier_id, feature_key)
 );
 
-create table if not exists tenant_feature_override (
+create table if not exists tenant_catalog.tenant_feature_override (
   tenant_id uuid,
   feature_key text,
   enabled boolean,
@@ -36,5 +38,5 @@ create table if not exists tenant_feature_override (
   primary key (tenant_id, feature_key)
 );
 
-alter table tenant_feature_override enable row level security;
-create policy tenant_override_policy on tenant_feature_override using (tenant_id = current_setting('app.current_tenant', true)::uuid);
+alter table tenant_catalog.tenant_feature_override enable row level security;
+create policy tenant_override_policy on tenant_catalog.tenant_feature_override using (tenant_id = current_setting('app.current_tenant', true)::uuid);

--- a/tenant-platform/policy-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/policy-service/src/main/resources/application-dev.yaml
@@ -1,8 +1,12 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=entity
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_policy
     username: postgres
     password: postgres
+  flyway:
+    enabled: true
+    default-schema: tenant_policy
+    schemas: tenant_policy
 server:
   port: 8080
 shared:

--- a/tenant-platform/policy-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/policy-service/src/main/resources/application-qa.yaml
@@ -1,8 +1,12 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_policy
     username: postgres
     password: postgres
+  flyway:
+    enabled: true
+    default-schema: tenant_policy
+    schemas: tenant_policy
 server:
   port: 8080
 shared:

--- a/tenant-platform/policy-service/src/main/resources/application.yaml
+++ b/tenant-platform/policy-service/src/main/resources/application.yaml
@@ -1,6 +1,11 @@
 spring:
   profiles:
     active: dev
+
+  flyway:
+    enabled: true
+    default-schema: tenant_policy
+    schemas: tenant_policy
 server:
   port: 8080
 shared:

--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=entity
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_subscription
     username: postgres
     password: postgres
   redis:
@@ -10,7 +10,8 @@ spring:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_subscription
+    schemas: tenant_subscription
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_subscription
     username: postgres
     password: postgres
   redis:
@@ -10,7 +10,8 @@ spring:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_subscription
+    schemas: tenant_subscription
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -3,7 +3,8 @@ spring:
     active: dev
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_subscription
+    schemas: tenant_subscription
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
   jpa:
     hibernate:

--- a/tenant-platform/subscription-service/src/main/resources/db/migration/V1__init.sql
+++ b/tenant-platform/subscription-service/src/main/resources/db/migration/V1__init.sql
@@ -1,4 +1,6 @@
-create table if not exists tenant_subscription (
+create schema if not exists tenant_subscription;
+
+create table if not exists tenant_subscription.subscription (
   subscription_id uuid primary key,
   tenant_id uuid not null,
   tier_id text,
@@ -19,18 +21,18 @@ create table if not exists tenant_subscription (
   updated_at timestamptz default now()
 );
 
-create table if not exists subscription_item (
+create table if not exists tenant_subscription.subscription_item (
   item_id uuid primary key,
-  subscription_id uuid references tenant_subscription(subscription_id),
+  subscription_id uuid references tenant_subscription.subscription(subscription_id),
   feature_key text,
   quantity bigint,
   unique(subscription_id, feature_key)
 );
 
-alter table tenant_subscription enable row level security;
-alter table subscription_item enable row level security;
+alter table tenant_subscription.subscription enable row level security;
+alter table tenant_subscription.subscription_item enable row level security;
 
-create policy tenant_sub_policy on tenant_subscription using (tenant_id = current_setting('app.current_tenant', true)::uuid);
-create policy tenant_sub_item_policy on subscription_item using (subscription_id in (select subscription_id from tenant_subscription where tenant_id = current_setting('app.current_tenant', true)::uuid));
+create policy tenant_sub_policy on tenant_subscription.subscription using (tenant_id = current_setting('app.current_tenant', true)::uuid);
+create policy tenant_sub_item_policy on tenant_subscription.subscription_item using (subscription_id in (select subscription_id from tenant_subscription.subscription where tenant_id = current_setting('app.current_tenant', true)::uuid));
 
-create unique index if not exists ux_active_subscription on tenant_subscription (tenant_id) where active;
+create unique index if not exists ux_active_subscription on tenant_subscription.subscription (tenant_id) where active;

--- a/tenant-platform/subscription-service/src/main/resources/db/migration/V2__tenant_subscription_partial_unique_idx.sql
+++ b/tenant-platform/subscription-service/src/main/resources/db/migration/V2__tenant_subscription_partial_unique_idx.sql
@@ -1,3 +1,3 @@
 create unique index if not exists ux_tenant_subscription_active
-    on tenant_subscription (tenant_id)
+    on tenant_subscription.subscription (tenant_id)
     where status in ('TRIALING','ACTIVE','PAST_DUE');

--- a/tenant-platform/tenant-events/src/main/resources/db/migration/V1__create_tenant_outbox.sql
+++ b/tenant-platform/tenant-events/src/main/resources/db/migration/V1__create_tenant_outbox.sql
@@ -1,4 +1,6 @@
-CREATE TABLE IF NOT EXISTS tenant_outbox (
+CREATE SCHEMA IF NOT EXISTS tenant_events;
+
+CREATE TABLE IF NOT EXISTS tenant_events.tenant_outbox (
     id BIGSERIAL PRIMARY KEY,
     tenant_id VARCHAR(64),
     type TEXT NOT NULL,
@@ -11,4 +13,4 @@ CREATE TABLE IF NOT EXISTS tenant_outbox (
     status TEXT NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS tenant_outbox_status_idx ON tenant_outbox(status, available_at);
+CREATE INDEX IF NOT EXISTS tenant_outbox_status_idx ON tenant_events.tenant_outbox(status, available_at);

--- a/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V2__tenant_baseline.sql
+++ b/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V2__tenant_baseline.sql
@@ -1,17 +1,19 @@
+CREATE SCHEMA IF NOT EXISTS tenant_core;
+
 CREATE TYPE tenant_status AS ENUM ('ACTIVE', 'INACTIVE');
 
 CREATE TYPE key_status AS ENUM ('ACTIVE', 'REVOKED');
 
-CREATE TABLE tenant (
+CREATE TABLE tenant_core.tenant (
     id UUID PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     status tenant_status NOT NULL DEFAULT 'ACTIVE',
     overage_enabled BOOLEAN NOT NULL DEFAULT FALSE
 );
 
-CREATE TABLE tenant_integration_key (
+CREATE TABLE tenant_core.tenant_integration_key (
     id UUID PRIMARY KEY,
-    tenant_id UUID NOT NULL REFERENCES tenant(id),
+    tenant_id UUID NOT NULL REFERENCES tenant_core.tenant(id),
     name VARCHAR(255) NOT NULL,
     key_value VARCHAR(255) NOT NULL,
     status key_status NOT NULL DEFAULT 'ACTIVE'

--- a/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V3__indexes_and_seed.sql
+++ b/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V3__indexes_and_seed.sql
@@ -1,9 +1,9 @@
-CREATE INDEX idx_tenant_integration_key_tenant_id ON tenant_integration_key (tenant_id);
+CREATE INDEX idx_tenant_integration_key_tenant_id ON tenant_core.tenant_integration_key (tenant_id);
 
 -- optional demo seed
-INSERT INTO tenant (id, name, status, overage_enabled)
+INSERT INTO tenant_core.tenant (id, name, status, overage_enabled)
 SELECT '00000000-0000-0000-0000-000000000001', 'Demo Tenant', 'ACTIVE', FALSE
 WHERE NOT EXISTS (
-    SELECT 1 FROM tenant WHERE id = '00000000-0000-0000-0000-000000000001'
+    SELECT 1 FROM tenant_core.tenant WHERE id = '00000000-0000-0000-0000-000000000001'
 );
 

--- a/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V4__add_tenant_slug.sql
+++ b/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V4__add_tenant_slug.sql
@@ -1,4 +1,4 @@
-ALTER TABLE tenant ADD COLUMN tenant_slug VARCHAR(255);
-UPDATE tenant SET tenant_slug = id::text;
-ALTER TABLE tenant ALTER COLUMN tenant_slug SET NOT NULL;
-ALTER TABLE tenant ADD CONSTRAINT uq_tenant_slug UNIQUE (tenant_slug);
+ALTER TABLE tenant_core.tenant ADD COLUMN tenant_slug VARCHAR(255);
+UPDATE tenant_core.tenant SET tenant_slug = id::text;
+ALTER TABLE tenant_core.tenant ALTER COLUMN tenant_slug SET NOT NULL;
+ALTER TABLE tenant_core.tenant ADD CONSTRAINT uq_tenant_slug UNIQUE (tenant_slug);

--- a/tenant-platform/tenant-persistence/src/main/resources/db/migration/postgresql/V1__rls_and_policies.sql
+++ b/tenant-platform/tenant-persistence/src/main/resources/db/migration/postgresql/V1__rls_and_policies.sql
@@ -1,6 +1,6 @@
-ALTER TABLE tenant_integration_key ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenant_core.tenant_integration_key ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY tenant_integration_key_tenant_isolation
-    ON tenant_integration_key
+    ON tenant_core.tenant_integration_key
     USING (tenant_id = current_setting('app.current_tenant', true)::uuid);
 


### PR DESCRIPTION
## Summary
- scope Flyway migrations for subscription, billing, catalog and policy services to dedicated schemas
- qualify tenant persistence and events migrations with their own schema names

## Testing
- `mvn -q -pl tenant-persistence,subscription-service,billing-service,catalog-service,policy-service,tenant-events -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a2914fa4832fb7555420d8c4a930