### PR TITLE
Align tenant services with tenant_core schema

### DIFF
--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -6,6 +6,9 @@ spring:
     enabled: true
     default-schema: tenant_billing
     schemas: tenant_billing
+    baseline-on-migrate: true
+    validate-on-migrate: true
+    clean-disabled: true
 
   jpa:
     hibernate:

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -5,6 +5,9 @@ spring:
     enabled: true
     default-schema: tenant_catalog
     schemas: tenant_catalog
+    baseline-on-migrate: true
+    validate-on-migrate: true
+    clean-disabled: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
   jpa:
     hibernate:

--- a/tenant-platform/policy-service/src/main/resources/application.yaml
+++ b/tenant-platform/policy-service/src/main/resources/application.yaml
@@ -6,6 +6,9 @@ spring:
     enabled: true
     default-schema: tenant_policy
     schemas: tenant_policy
+    baseline-on-migrate: true
+    validate-on-migrate: true
+    clean-disabled: true
 server:
   port: 8080
 shared:

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -5,6 +5,9 @@ spring:
     enabled: true
     default-schema: tenant_subscription
     schemas: tenant_subscription
+    baseline-on-migrate: true
+    validate-on-migrate: true
+    clean-disabled: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
   jpa:
     hibernate:

--- a/tenant-platform/tenant-api/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application-dev.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=entity
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_core
     username: postgres
     password: postgres
   redis:
@@ -10,7 +10,7 @@ spring:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_core
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/tenant-api/src/main/resources/application-qa.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application-qa.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_core
     username: app_user
     password: postgres
   redis:
@@ -10,7 +10,7 @@ spring:
     bootstrap-servers: 127.0.0.1:9092
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_core
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/tenant-api/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application.yaml
@@ -3,7 +3,10 @@ spring:
     active: dev
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_core
+    baseline-on-migrate: true
+    validate-on-migrate: true
+    clean-disabled: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -1,11 +1,11 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=entity
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_core
     username: postgres
     password: postgres
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_core
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
@@ -1,11 +1,11 @@
 spring:
   datasource:
-    url: jdbc:postgresql://127.0.0.1:5432/lms
+    url: jdbc:postgresql://127.0.0.1:5432/lms?currentSchema=tenant_core
     username: postgres
     password: postgres
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_core
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -3,7 +3,10 @@ spring:
     active: dev
   flyway:
     enabled: true
-    default-schema: entity
+    default-schema: tenant_core
+    baseline-on-migrate: true
+    validate-on-migrate: true
+    clean-disabled: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
   jpa:
     hibernate:


### PR DESCRIPTION
## Summary
- enforce Flyway baseline and validation in tenant service configs
- prevent accidental schema wipes by disabling Flyway clean
- point tenant-service and tenant-api to `tenant_core` schema rather than missing `entity`

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c422ca90832f8ce3758a6b948037