### PR TITLE
fix: correct flyway migrations

### DIFF
--- a/tenant-platform/catalog-service/src/main/resources/db/migration/postgresql/V1__init.sql
+++ b/tenant-platform/catalog-service/src/main/resources/db/migration/postgresql/V1__init.sql
@@ -16,7 +16,7 @@ create table if not exists tenant_catalog.product_tier (
   updated_at timestamptz default now()
 );
 
-create table if not exists tier_feature_limit (
+create table if not exists tenant_catalog.tier_feature_limit (
   tier_id text references tenant_catalog.product_tier(tier_id),
   feature_key text references tenant_catalog.feature(feature_key),
   enabled boolean,

--- a/tenant-platform/subscription-service/src/main/resources/db/migration/V1__init.sql
+++ b/tenant-platform/subscription-service/src/main/resources/db/migration/V1__init.sql
@@ -35,4 +35,3 @@ alter table tenant_subscription.subscription_item enable row level security;
 create policy tenant_sub_policy on tenant_subscription.subscription using (tenant_id = current_setting('app.current_tenant', true)::uuid);
 create policy tenant_sub_item_policy on tenant_subscription.subscription_item using (subscription_id in (select subscription_id from tenant_subscription.subscription where tenant_id = current_setting('app.current_tenant', true)::uuid));
 
-create unique index if not exists ux_active_subscription on tenant_subscription.subscription (tenant_id) where active;


### PR DESCRIPTION
## Summary
- fix migration for catalog service to create tier feature limits table under tenant_catalog schema
- remove duplicate unique index from subscription service init migration to rely on dedicated partial index

## Testing
- `mvn -q -pl catalog-service,subscription-service -am test` *(failed: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d0311798832fa8e9c7223d657391