### PR TITLE
Make index creation idempotent in Flyway migration

### DIFF
--- a/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V2__indexes_and_seed.sql
+++ b/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V2__indexes_and_seed.sql
@@ -1,4 +1,4 @@
-CREATE INDEX idx_tenant_integration_key_tenant_id ON tenant_core.tenant_integration_key (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_tenant_integration_key_tenant_id ON tenant_core.tenant_integration_key (tenant_id);
 
 -- optional demo seed
 INSERT INTO tenant_core.tenant (id, name, status, overage_enabled)


### PR DESCRIPTION
## Summary
- ensure tenant_integration_key index creation uses IF NOT EXISTS for idempotent migrations

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl tenant-persistence test` *(fails: Non-resolvable import POM: Could not transfer artifacts, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d295d114832fba015c320f7d3313