### PR TITLE
Ensure tenant integration index creation is idempotent

### DIFF
--- a/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V2__indexes_and_seed.sql
+++ b/tenant-platform/tenant-persistence/src/main/resources/db/migration/common/V2__indexes_and_seed.sql
@@ -1,9 +1,9 @@
-CREATE INDEX IF NOT EXISTS idx_tenant_integration_key_tenant_id ON tenant_core.tenant_integration_key (tenant_id);
+-- Ensure the lookup index exists without failing if it is already present
+CREATE INDEX IF NOT EXISTS tenant_core.idx_tenant_integration_key_tenant_id
+    ON tenant_core.tenant_integration_key (tenant_id);
 
--- optional demo seed
+-- Optional demo seed
 INSERT INTO tenant_core.tenant (id, name, status, overage_enabled)
-SELECT '00000000-0000-0000-0000-000000000001', 'Demo Tenant', 'ACTIVE', FALSE
-WHERE NOT EXISTS (
-    SELECT 1 FROM tenant_core.tenant WHERE id = '00000000-0000-0000-0000-000000000001'
-);
+VALUES ('00000000-0000-0000-0000-000000000001', 'Demo Tenant', 'ACTIVE', FALSE)
+ON CONFLICT (id) DO NOTHING;
 


### PR DESCRIPTION
## Summary
- Fully qualify tenant integration key index and guard with `IF NOT EXISTS`
- Seed demo tenant using `ON CONFLICT DO NOTHING` for idempotence

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d42f665c832fbb70563f390ae5ad