### PR TITLE
Enable shared OpenAPI docs for tenant API

### DIFF
--- a/tenant-platform/tenant-api/pom.xml
+++ b/tenant-platform/tenant-api/pom.xml
@@ -32,6 +32,10 @@
       <artifactId>starter-openapi</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-actuator</artifactId>
     </dependency>

--- a/tenant-platform/tenant-api/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application-dev.yaml
@@ -14,3 +14,7 @@ spring:
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080
+shared:
+  openapi:
+    title: Tenant API
+    description: Admin gateway APIs

--- a/tenant-platform/tenant-api/src/main/resources/application-qa.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application-qa.yaml
@@ -14,3 +14,7 @@ spring:
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080
+shared:
+  openapi:
+    title: Tenant API
+    description: Admin gateway APIs

--- a/tenant-platform/tenant-api/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application.yaml
@@ -10,3 +10,7 @@ spring:
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 server:
   port: 8080
+shared:
+  openapi:
+    title: Tenant API
+    description: Admin gateway APIs


### PR DESCRIPTION
## Summary
- expose OpenAPI UI for tenant API using shared configuration
- document gateway endpoints via shared OpenAPI properties

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl tenant-api -am test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e8595e58832f8a1b9b7980c1e5a5