### PR TITLE
Disable observability starter in catalog service

### DIFF
--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -55,10 +55,15 @@
       <groupId>com.ejada</groupId>
       <artifactId>starter-security</artifactId>
     </dependency>
+    <!-- Observability starter temporarily disabled: logback configuration
+         in this starter requires OpenTelemetry libraries that are not
+         currently on the classpath, causing startup failures. -->
+    <!--
     <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-observability</artifactId>
     </dependency>
+    -->
     <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-resilience</artifactId>


### PR DESCRIPTION
## Summary
- comment out observability starter in catalog-service to avoid missing OpenTelemetry appender

## Testing
- `mvn -q -pl catalog-service -am test` *(failed: Non-resolvable parent POM for com.ejada.tenant:tenant-platform:1.0.0-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ed7a8e68832fafd3ae21c2dacb44