### PR TITLE
Avoid duplicate hmac signer bean in crypto auto-config

### DIFF
--- a/shared-lib/shared-starters/starter-crypto/src/main/java/com/ejada/crypto/starter/CryptoAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-crypto/src/main/java/com/ejada/crypto/starter/CryptoAutoConfiguration.java
@@ -81,9 +81,16 @@ public class CryptoAutoConfiguration {
     return facade;
   }
 
-  /** Convenience HMAC signer bean (shared lib), if someone wants to inject it directly. */
+  /** Convenience HMAC signer bean (shared lib), if someone wants to inject it directly.
+   *
+   * <p>This bean is only created when no other {@code HmacSigner} is present and no
+   * {@link InMemoryKeyProviderAutoConfiguration.KeyProvider} is registered. When the
+   * in-memory key provider is active, a more advanced signer is supplied there and this
+   * fallback should be skipped to avoid bean name collisions.</p>
+   */
   @Bean
-  @ConditionalOnMissingBean
+  @ConditionalOnMissingBean(HmacSigner.class)
+  @ConditionalOnMissingBean(InMemoryKeyProviderAutoConfiguration.KeyProvider.class)
   public HmacSigner hmacSigner() {
     return new HmacSigner(); // HmacSHA256 helper for legacy usage
   }


### PR DESCRIPTION
## Summary
- prevent `CryptoAutoConfiguration` from registering a fallback `hmacSigner` when the in-memory key provider is active

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM; missing dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f500bc8c832fa378d6642d036ae5