### PR TITLE
Make resilience auto-configuration conditional on WebClient

### DIFF
--- a/shared-lib/shared-starters/starter-resilience/src/main/java/com/ejada/shared_starter_resilience/ResilienceAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-resilience/src/main/java/com/ejada/shared_starter_resilience/ResilienceAutoConfiguration.java
@@ -13,11 +13,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 import java.time.Duration;
 
 @AutoConfiguration
+@ConditionalOnClass(WebClient.Builder.class)
 @EnableConfigurationProperties(SharedResilienceProps.class)
 public class ResilienceAutoConfiguration {
 
   @Bean
-  @ConditionalOnClass({WebClient.class, HttpClient.class, ReactorClientHttpConnector.class})
+  @ConditionalOnClass({HttpClient.class, ReactorClientHttpConnector.class})
   @ConditionalOnMissingBean(WebClient.Builder.class)
   public WebClient.Builder resilientWebClientBuilder(SharedResilienceProps props) {
     HttpClient client = HttpClient.create()


### PR DESCRIPTION
## Summary
- Only enable Resilience auto-configuration when WebClient.Builder is on the classpath
- Preserve existing WebClient builder bean with conditional Reactor Netty support

## Testing
- `mvn test` *(fails: Non-resolvable import POM and missing dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fc79b704832fa0a5f6d9661448bc