### PR TITLE
feat(security): expose csrf token header

### DIFF
--- a/shared-lib/shared-starters/starter-security/README.md
+++ b/shared-lib/shared-starters/starter-security/README.md
@@ -12,9 +12,17 @@ shared:
     resource-server:
       enabled: true
       permit-all: /actuator/health
-      disable-csrf: true
+      disable-csrf: true  # set to false to enable CSRF with X-CSRF-Token header
       stateless: true
 ```
+
+When `disable-csrf` is set to `false`, the starter:
+
+* stores the token in a readable cookie (`XSRF-TOKEN`)
+* echoes the token in the `X-CSRF-Token` response header
+
+Clients must capture the header/cookie on the first request and send the token
+back on subsequent modifying requests via the same header.
 
 ## Usage
 Add the dependency:

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/CsrfHeaderFilter.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/CsrfHeaderFilter.java
@@ -1,0 +1,30 @@
+package com.ejada.starter_security;
+
+import com.ejada.common.constants.HeaderNames;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Exposes the CSRF token value via {@code X-CSRF-Token} header so that
+ * JavaScript clients can read it on the first request and echo it back in
+ * subsequent state changing requests.
+ */
+class CsrfHeaderFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+        CsrfToken token = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+        if (token != null) {
+            response.setHeader(HeaderNames.CSRF_TOKEN, token.getToken());
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
@@ -33,6 +33,8 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsConfiguration;
@@ -173,6 +175,9 @@ public class SecurityAutoConfiguration {
 
     if (rs.isDisableCsrf()) {
       http.csrf(AbstractHttpConfigurer::disable);
+    } else {
+      http.csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()));
+      http.addFilterAfter(new CsrfHeaderFilter(), CsrfFilter.class);
     }
     if (rs.isStateless()) {
       http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
@@ -235,8 +240,12 @@ public class SecurityAutoConfiguration {
         HeaderNames.CONTENT_TYPE,
         "X-Requested-With",
         HeaderNames.CORRELATION_ID,
-        HeaderNames.X_TENANT_ID));
-    configuration.setExposedHeaders(Arrays.asList(HeaderNames.CORRELATION_ID, HeaderNames.X_TENANT_ID));
+        HeaderNames.X_TENANT_ID,
+        HeaderNames.CSRF_TOKEN));
+    configuration.setExposedHeaders(Arrays.asList(
+        HeaderNames.CORRELATION_ID,
+        HeaderNames.X_TENANT_ID,
+        HeaderNames.CSRF_TOKEN));
     configuration.setAllowCredentials(false);
     configuration.setMaxAge(3600L);
 

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/CsrfHeaderFilterTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/CsrfHeaderFilterTest.java
@@ -1,0 +1,40 @@
+package com.ejada.starter_security;
+
+import com.ejada.common.constants.HeaderNames;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CsrfHeaderFilterTest {
+
+    @Test
+    void copiesTokenToHeader() throws ServletException, IOException {
+        CsrfToken token = new DefaultCsrfToken("X-CSRF-Token", "_csrf", "abc123");
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setAttribute(CsrfToken.class.getName(), token);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        FilterChain chain = (request, response) -> {};
+        new CsrfHeaderFilter().doFilter(req, res, chain);
+
+        assertEquals("abc123", res.getHeader(HeaderNames.CSRF_TOKEN));
+    }
+
+    @Test
+    void skipsWhenNoToken() throws ServletException, IOException {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        FilterChain chain = (request, response) -> {};
+        new CsrfHeaderFilter().doFilter(req, res, chain);
+
+        assertNull(res.getHeader(HeaderNames.CSRF_TOKEN));
+    }
+}


### PR DESCRIPTION
## Summary
- add CsrfHeaderFilter to echo CSRF token in X-CSRF-Token header
- configure security auto-configuration to register CookieCsrfTokenRepository and filter when CSRF is enabled
- expose CSRF header through CORS and document usage

## Testing
- `mvn -q -pl shared-starters/starter-security -am test` *(failed: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba09a50040832fa1e3815eef87ad64