### PR TITLE
Handle missing tenant and optional Kafka publisher

### DIFF
--- a/tenant-platform/tenant-events/src/main/java/com/ejada/tenant/events/OutboxPublisher.java
+++ b/tenant-platform/tenant-events/src/main/java/com/ejada/tenant/events/OutboxPublisher.java
@@ -3,6 +3,7 @@ package com.ejada.tenant.events;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.support.MessageBuilder;
@@ -14,22 +15,31 @@ import java.util.UUID;
 @Component
 public class OutboxPublisher {
     private static final Logger log = LoggerFactory.getLogger(OutboxPublisher.class);
-    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectProvider<KafkaTemplate<String, String>> kafkaProvider;
 
-    public OutboxPublisher(KafkaTemplate<String, String> kafkaTemplate) {
-        this.kafkaTemplate = kafkaTemplate;
+    public OutboxPublisher(ObjectProvider<KafkaTemplate<String, String>> kafkaProvider) {
+        this.kafkaProvider = kafkaProvider;
     }
 
     @Scheduled(fixedDelayString = "PT1S")
     public void publish() {
+        KafkaTemplate<String, String> kafka = kafkaProvider.getIfAvailable();
+        if (kafka == null) {
+            log.debug("Kafka template not available, skipping tenant event publish");
+            return;
+        }
         String tenantId = UUID.randomUUID().toString();
         try (MDC.MDCCloseable ignored = MDC.putCloseable("tenantId", tenantId)) {
             var message = MessageBuilder.withPayload("{}")
                     .setHeader(KafkaHeaders.TOPIC, "tenant.events")
                     .setHeader("X-Tenant-Id", tenantId)
                     .build();
-            kafkaTemplate.send(message);
-            log.info("published tenant event");
+            try {
+                kafka.send(message);
+                log.info("published tenant event");
+            } catch (Exception ex) {
+                log.warn("Failed to publish tenant event", ex);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- prevent filter from throwing when tenant header is missing, returning 400 instead
- skip tenant event publishing when KafkaTemplate is unavailable to avoid timeouts

## Testing
- `mvn -q -pl tenant-config,tenant-events -am test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bacc540a84832faf2f5706cbffdea3