### PR TITLE
Use shared exception types in subscription service

### DIFF
--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -38,6 +38,10 @@
       <artifactId>starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>shared-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/tenant/subscription/service/SubscriptionService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/tenant/subscription/service/SubscriptionService.java
@@ -1,5 +1,7 @@
 package com.ejada.tenant.subscription.service;
 
+import com.ejada.common.exception.BusinessRuleException;
+import com.ejada.common.exception.NotFoundException;
 import com.ejada.tenant.subscription.domain.SubscriptionStatus;
 import com.ejada.tenant.subscription.domain.TenantSubscription;
 import com.ejada.tenant.subscription.repo.TenantSubscriptionRepository;
@@ -21,7 +23,7 @@ public class SubscriptionService {
 
     public SubscriptionDto startTrial(UUID tenantId) {
         repository.findActiveByTenantId(tenantId)
-            .ifPresent(s -> { throw new IllegalStateException("Active subscription exists"); });
+            .ifPresent(s -> { throw new BusinessRuleException("Active subscription exists"); });
         TenantSubscription sub = new TenantSubscription(UUID.randomUUID(), tenantId, SubscriptionStatus.TRIAL, true);
         repository.save(sub);
         return toDto(sub);
@@ -41,7 +43,7 @@ public class SubscriptionService {
     public void cancel(UUID tenantId, UUID subscriptionId) {
         TenantSubscription sub = repository.findById(subscriptionId)
             .filter(s -> s.getTenantId().equals(tenantId))
-            .orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
+            .orElseThrow(() -> new NotFoundException("Subscription not found"));
         sub.setActive(false);
         sub.setStatus(SubscriptionStatus.CANCELED);
         repository.save(sub);


### PR DESCRIPTION
## Summary
- replace generic exceptions with shared `BusinessRuleException` and `NotFoundException`
- add `shared-common` dependency for shared exception types

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.ejada.tenant:tenant-platform:1.0.0-SNAPSHOT: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bad2a9d18c832f9302e78094feb8b2