### PR TITLE
Use shared exception types in subscription service

### DIFF
--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -38,6 +38,10 @@
       <artifactId>starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>shared-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary
- throw `BusinessRuleException` with tenant-specific details if active subscription exists
- replace `NotFoundException` with `ResourceNotFoundException` in cancellation path
- include `shared-common` dependency for shared exception types

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.ejada.tenant:tenant-platform:1.0.0-SNAPSHOT: Could not transfer org.springframework.boot:spring-boot-starter-parent:pom:3.5.5: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bad2a9d18c832f9302e78094feb8b2