### PR TITLE
refine domain models for cleaner configuration

### DIFF
--- a/lms-setup/src/main/java/com/ejada/setup/model/Country.java
+++ b/lms-setup/src/main/java/com/ejada/setup/model/Country.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Size;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.UpdateTimestamp;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -88,14 +89,17 @@ public class Country implements Serializable {
 
     @Version
     @Column(name = "version", nullable = false)
+    @Setter(AccessLevel.NONE)
     private Long version;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
     @Column(name = "updated_at")
+    @Setter(AccessLevel.NONE)
     private LocalDateTime updatedAt;
 
     @PrePersist @PreUpdate
@@ -110,7 +114,4 @@ public class Country implements Serializable {
         if (isActive == null) isActive = Boolean.TRUE;
     }
 
-    public Long getVersion() { return version; }
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    public LocalDateTime getUpdatedAt() { return updatedAt; }
 }

--- a/lms-setup/src/main/java/com/ejada/setup/model/Resource.java
+++ b/lms-setup/src/main/java/com/ejada/setup/model/Resource.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Size;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.UpdateTimestamp;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -85,14 +86,17 @@ public class Resource implements Serializable {
 
     @Version
     @Column(name = "version", nullable = false)
+    @Setter(AccessLevel.NONE)
     private Long version;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
     @Column(name = "updated_at")
+    @Setter(AccessLevel.NONE)
     private LocalDateTime updatedAt;
 
     @PrePersist @PreUpdate
@@ -106,7 +110,4 @@ public class Resource implements Serializable {
         if (isActive == null) isActive = Boolean.TRUE;
     }
 
-    public Long getVersion() { return version; }
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    public LocalDateTime getUpdatedAt() { return updatedAt; }
 }

--- a/lms-setup/src/main/resources/application-dev.yaml
+++ b/lms-setup/src/main/resources/application-dev.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:lms}?currentSchema=catalog}"
     username: ${DB_USERNAME:postgres}


### PR DESCRIPTION
## Summary
- prevent setters on audit fields in `Resource` and `Country` using Lombok
- allow bean overriding in `application-dev.yaml` to simplify testing

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bad6b759e4832fa25712d9dc0879d3