### PR TITLE
refine tenant platform models for flexible testing

### DIFF
--- a/lms-setup/src/main/java/com/ejada/setup/model/Country.java
+++ b/lms-setup/src/main/java/com/ejada/setup/model/Country.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Size;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.UpdateTimestamp;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -88,14 +89,17 @@ public class Country implements Serializable {
 
     @Version
     @Column(name = "version", nullable = false)
+    @Setter(AccessLevel.NONE)
     private Long version;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
     @Column(name = "updated_at")
+    @Setter(AccessLevel.NONE)
     private LocalDateTime updatedAt;
 
     @PrePersist @PreUpdate
@@ -110,7 +114,4 @@ public class Country implements Serializable {
         if (isActive == null) isActive = Boolean.TRUE;
     }
 
-    public Long getVersion() { return version; }
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    public LocalDateTime getUpdatedAt() { return updatedAt; }
 }

--- a/lms-setup/src/main/java/com/ejada/setup/model/Resource.java
+++ b/lms-setup/src/main/java/com/ejada/setup/model/Resource.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Size;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.UpdateTimestamp;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -85,14 +86,17 @@ public class Resource implements Serializable {
 
     @Version
     @Column(name = "version", nullable = false)
+    @Setter(AccessLevel.NONE)
     private Long version;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
     @Column(name = "updated_at")
+    @Setter(AccessLevel.NONE)
     private LocalDateTime updatedAt;
 
     @PrePersist @PreUpdate
@@ -106,7 +110,4 @@ public class Resource implements Serializable {
         if (isActive == null) isActive = Boolean.TRUE;
     }
 
-    public Long getVersion() { return version; }
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    public LocalDateTime getUpdatedAt() { return updatedAt; }
 }

--- a/lms-setup/src/main/resources/application-dev.yaml
+++ b/lms-setup/src/main/resources/application-dev.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:lms}?currentSchema=catalog}"
     username: ${DB_USERNAME:postgres}

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/entity/TenantOverage.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/entity/TenantOverage.java
@@ -5,10 +5,16 @@ import java.time.Instant;
 import java.util.UUID;
 
 import com.ejada.billing.enums.OverageStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * JPA entity representing an overage recorded for a tenant.
  */
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "tenant_overage")
 public class TenantOverage {
@@ -53,114 +59,5 @@ public class TenantOverage {
 
     @Column(name = "metadata", columnDefinition = "jsonb")
     private String metadataJson;
-
-    public TenantOverage() {
-    }
-
-    // Getters and setters
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public UUID getTenantId() {
-        return tenantId;
-    }
-
-    public void setTenantId(UUID tenantId) {
-        this.tenantId = tenantId;
-    }
-
-    public UUID getSubscriptionId() {
-        return subscriptionId;
-    }
-
-    public void setSubscriptionId(UUID subscriptionId) {
-        this.subscriptionId = subscriptionId;
-    }
-
-    public String getFeatureKey() {
-        return featureKey;
-    }
-
-    public void setFeatureKey(String featureKey) {
-        this.featureKey = featureKey;
-    }
-
-    public long getQuantity() {
-        return quantity;
-    }
-
-    public void setQuantity(long quantity) {
-        this.quantity = quantity;
-    }
-
-    public long getUnitPriceMinor() {
-        return unitPriceMinor;
-    }
-
-    public void setUnitPriceMinor(long unitPriceMinor) {
-        this.unitPriceMinor = unitPriceMinor;
-    }
-
-    public String getCurrency() {
-        return currency;
-    }
-
-    public void setCurrency(String currency) {
-        this.currency = currency;
-    }
-
-    public Instant getOccurredAt() {
-        return occurredAt;
-    }
-
-    public void setOccurredAt(Instant occurredAt) {
-        this.occurredAt = occurredAt;
-    }
-
-    public Instant getPeriodStart() {
-        return periodStart;
-    }
-
-    public void setPeriodStart(Instant periodStart) {
-        this.periodStart = periodStart;
-    }
-
-    public Instant getPeriodEnd() {
-        return periodEnd;
-    }
-
-    public void setPeriodEnd(Instant periodEnd) {
-        this.periodEnd = periodEnd;
-    }
-
-    public OverageStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(OverageStatus status) {
-        this.status = status;
-    }
-
-    public String getIdempotencyKey() {
-        return idempotencyKey;
-    }
-
-    public void setIdempotencyKey(String idempotencyKey) {
-        this.idempotencyKey = idempotencyKey;
-    }
-
-    public String getMetadataJson() {
-        return metadataJson;
-    }
-
-    public void setMetadataJson(String metadataJson) {
-        this.metadataJson = metadataJson;
-    }
 }
 

--- a/tenant-platform/billing-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-dev.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     url: jdbc:postgresql://localhost:5432/lms?currentSchema=tenant_billing
     username: postgres

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -35,6 +35,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
       <scope>test</scope>

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/entity/TenantFeatureOverrideEntity.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/entity/TenantFeatureOverrideEntity.java
@@ -4,7 +4,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "tenant_feature_override")
 public class TenantFeatureOverrideEntity {
@@ -26,52 +32,4 @@ public class TenantFeatureOverrideEntity {
 
     @Column(name = "overage_currency_override")
     private String overageCurrencyOverride;
-
-    public TenantFeatureOverrideId getId() {
-        return id;
-    }
-
-    public void setId(TenantFeatureOverrideId id) {
-        this.id = id;
-    }
-
-    public Boolean getEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(Boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public Long getLimitValue() {
-        return limitValue;
-    }
-
-    public void setLimitValue(Long limitValue) {
-        this.limitValue = limitValue;
-    }
-
-    public Boolean getAllowOverageOverride() {
-        return allowOverageOverride;
-    }
-
-    public void setAllowOverageOverride(Boolean allowOverageOverride) {
-        this.allowOverageOverride = allowOverageOverride;
-    }
-
-    public Long getOverageUnitPriceMinorOverride() {
-        return overageUnitPriceMinorOverride;
-    }
-
-    public void setOverageUnitPriceMinorOverride(Long overageUnitPriceMinorOverride) {
-        this.overageUnitPriceMinorOverride = overageUnitPriceMinorOverride;
-    }
-
-    public String getOverageCurrencyOverride() {
-        return overageCurrencyOverride;
-    }
-
-    public void setOverageCurrencyOverride(String overageCurrencyOverride) {
-        this.overageCurrencyOverride = overageCurrencyOverride;
-    }
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/entity/TenantFeatureOverrideId.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/entity/TenantFeatureOverrideId.java
@@ -1,48 +1,16 @@
 package com.ejada.catalog.entity;
 
 import java.io.Serializable;
-import java.util.Objects;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class TenantFeatureOverrideId implements Serializable {
 
     private UUID tenantId;
     private String featureKey;
-
-    public TenantFeatureOverrideId() {
-    }
-
-    public TenantFeatureOverrideId(UUID tenantId, String featureKey) {
-        this.tenantId = tenantId;
-        this.featureKey = featureKey;
-    }
-
-    public UUID getTenantId() {
-        return tenantId;
-    }
-
-    public void setTenantId(UUID tenantId) {
-        this.tenantId = tenantId;
-    }
-
-    public String getFeatureKey() {
-        return featureKey;
-    }
-
-    public void setFeatureKey(String featureKey) {
-        this.featureKey = featureKey;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        TenantFeatureOverrideId that = (TenantFeatureOverrideId) o;
-        return Objects.equals(tenantId, that.tenantId) && Objects.equals(featureKey, that.featureKey);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(tenantId, featureKey);
-    }
 }

--- a/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     url: jdbc:postgresql://localhost:5432/lms?currentSchema=tenant_catalog
     username: postgres

--- a/tenant-platform/policy-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/policy-service/src/main/resources/application-dev.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     url: jdbc:postgresql://localhost:5432/lms?currentSchema=tenant_policy
     username: postgres

--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     url: jdbc:postgresql://localhost:5432/lms?currentSchema=tenant_subscription
     username: postgres

--- a/tenant-platform/tenant-api/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-api/src/main/resources/application-dev.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     url: jdbc:postgresql://localhost:5432/lms?currentSchema=tenant_core
     username: postgres

--- a/tenant-platform/tenant-events/pom.xml
+++ b/tenant-platform/tenant-events/pom.xml
@@ -50,6 +50,11 @@
       <artifactId>micrometer-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/tenant-platform/tenant-events/src/main/java/com/ejada/tenant/events/TenantEventsProperties.java
+++ b/tenant-platform/tenant-events/src/main/java/com/ejada/tenant/events/TenantEventsProperties.java
@@ -2,7 +2,9 @@ package com.ejada.tenant.events;
 
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import lombok.Data;
 
+@Data
 @ConfigurationProperties(prefix = "tenant.events")
 public class TenantEventsProperties {
     /** Whether tenant events are enabled. */
@@ -11,28 +13,4 @@ public class TenantEventsProperties {
     private Duration pollInterval = Duration.ofSeconds(5);
     /** Batch size for polling. */
     private int batchSize = 10;
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public Duration getPollInterval() {
-        return pollInterval;
-    }
-
-    public void setPollInterval(Duration pollInterval) {
-        this.pollInterval = pollInterval;
-    }
-
-    public int getBatchSize() {
-        return batchSize;
-    }
-
-    public void setBatchSize(int batchSize) {
-        this.batchSize = batchSize;
-    }
 }

--- a/tenant-platform/tenant-events/src/main/java/com/ejada/tenant/events/entity/TenantOutboxEvent.java
+++ b/tenant-platform/tenant-events/src/main/java/com/ejada/tenant/events/entity/TenantOutboxEvent.java
@@ -7,10 +7,14 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * JPA entity representing a pending tenant event stored in the outbox.
  */
+@Getter
+@Setter
 @Entity
 @Table(name = "tenant_outbox",schema = "tenant_core")
 public class TenantOutboxEvent extends TenantBaseEntity {
@@ -32,44 +36,4 @@ public class TenantOutboxEvent extends TenantBaseEntity {
     private Status status = Status.NEW;
 
     public enum Status { NEW, SENT }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public String getPayload() {
-        return payload;
-    }
-
-    public void setPayload(String payload) {
-        this.payload = payload;
-    }
-
-    public Instant getAvailableAt() {
-        return availableAt;
-    }
-
-    public void setAvailableAt(Instant availableAt) {
-        this.availableAt = availableAt;
-    }
-
-    public int getAttempts() {
-        return attempts;
-    }
-
-    public void setAttempts(int attempts) {
-        this.attempts = attempts;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
-    }
 }

--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     url: jdbc:postgresql://localhost:5432/lms?currentSchema=tenant_core
     username: postgres


### PR DESCRIPTION
## Summary
- replace manual boilerplate in tenant-platform entities with Lombok
- allow bean definition overriding across tenant-platform dev configs

## Testing
- `mvn -q test` in `tenant-platform/catalog-service` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q test` in `tenant-platform/tenant-events` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bad6b759e4832fa25712d9dc0879d3