### PR TITLE
Relax dev security settings and apply Lombok in Redis starter

### DIFF
--- a/lms-setup/src/main/java/com/ejada/setup/web/GlobalExceptionHandler.java
+++ b/lms-setup/src/main/java/com/ejada/setup/web/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.ejada.setup.web;
+
+import com.ejada.common.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Module-level exception handler that converts common exceptions into
+ * standardized {@link ErrorResponse} payloads. This compliments the
+ * global handler provided by starter-core and demonstrates how modules
+ * can hook in additional logic.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  /**
+   * Handle simple {@link IllegalArgumentException}s thrown by controllers
+   * or services.
+   *
+   * @param ex the offending exception
+   * @return standardized error response with HTTP 400 status
+   */
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
+    log.error("Invalid request", ex);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ErrorResponse.of("ERR-400", ex.getMessage()));
+  }
+}
+

--- a/lms-setup/src/main/resources/application-dev.yaml
+++ b/lms-setup/src/main/resources/application-dev.yaml
@@ -56,7 +56,7 @@ management:
     web:
       base-path: /actuator
       exposure:
-        include: health,info,metrics,prometheus,beans,conditions,configprops,loggers,threaddump
+        include: "*"
   endpoint:
     health:
       show-details: always
@@ -89,9 +89,12 @@ shared:
       echo-response-header: true
     cors:
       enabled: true
-      allowed-origins: http://localhost:3000
-      allowed-methods: GET,POST,PUT,DELETE,OPTIONS
+      allowed-origins: "*"
+      allowed-methods: "*"
       allowed-headers: "*"
+    security:
+      resource-server:
+        disable-csrf: true
   headers:
     enabled: true
     correlation:

--- a/shared-lib/shared-starters/starter-redis/pom.xml
+++ b/shared-lib/shared-starters/starter-redis/pom.xml
@@ -63,6 +63,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Lombok for boilerplate reduction -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Observability (opt-in) -->
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/shared-lib/shared-starters/starter-redis/src/main/java/com/ejada/redis/starter/props/RedisProperties.java
+++ b/shared-lib/shared-starters/starter-redis/src/main/java/com/ejada/redis/starter/props/RedisProperties.java
@@ -1,10 +1,17 @@
 package com.ejada.redis.starter.props;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import java.time.Duration;
 import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @ConfigurationProperties(prefix = "shared.redis")
 public class RedisProperties {
   private String url;                 // redis://user:pass@host:6379/0 or rediss://...
@@ -14,50 +21,24 @@ public class RedisProperties {
   private int database = 0;
   private boolean ssl = false;
   private String clientName;
+  @Builder.Default
   private Duration timeout = Duration.ofSeconds(5);
 
   private String keyPrefix = "shared";
+  @Builder.Default
   private Duration defaultTtl = Duration.ofMinutes(10);
   private Boolean reactive = false;
 
   private Map<String, CacheSpec> caches;
 
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
   public static class CacheSpec {
     private Duration ttl;
+    @Builder.Default
     private Boolean cacheNulls = true;         // Spring Data Redis 3.x caches nulls by default
     private String keyPrefixOverride;
-    // getters/setters
-    public Duration getTtl() { return ttl; }
-    public void setTtl(Duration ttl) { this.ttl = ttl; }
-    public Boolean getCacheNulls() { return cacheNulls; }
-    public void setCacheNulls(Boolean cacheNulls) { this.cacheNulls = cacheNulls; }
-    public String getKeyPrefixOverride() { return keyPrefixOverride; }
-    public void setKeyPrefixOverride(String v) { this.keyPrefixOverride = v; }
   }
-
-  // getters/setters for all fields ...
-  public String getUrl() { return url; }
-  public void setUrl(String url) { this.url = url; }
-  public String getHost() { return host; }
-  public void setHost(String host) { this.host = host; }
-  public int getPort() { return port; }
-  public void setPort(int port) { this.port = port; }
-  public String getPassword() { return password; }
-  public void setPassword(String password) { this.password = password; }
-  public int getDatabase() { return database; }
-  public void setDatabase(int database) { this.database = database; }
-  public boolean isSsl() { return ssl; }
-  public void setSsl(boolean ssl) { this.ssl = ssl; }
-  public String getClientName() { return clientName; }
-  public void setClientName(String clientName) { this.clientName = clientName; }
-  public Duration getTimeout() { return timeout; }
-  public void setTimeout(Duration timeout) { this.timeout = timeout; }
-  public String getKeyPrefix() { return keyPrefix; }
-  public void setKeyPrefix(String keyPrefix) { this.keyPrefix = keyPrefix; }
-  public Duration getDefaultTtl() { return defaultTtl; }
-  public void setDefaultTtl(Duration defaultTtl) { this.defaultTtl = defaultTtl; }
-  public Boolean getReactive() { return reactive; }
-  public void setReactive(Boolean reactive) { this.reactive = reactive; }
-  public Map<String, CacheSpec> getCaches() { return caches; }
-  public void setCaches(Map<String, CacheSpec> caches) { this.caches = caches; }
 }

--- a/shared-lib/shared-starters/starter-redis/src/test/java/com/ejada/redis/starter/props/RedisPropertiesTest.java
+++ b/shared-lib/shared-starters/starter-redis/src/test/java/com/ejada/redis/starter/props/RedisPropertiesTest.java
@@ -1,0 +1,23 @@
+package com.ejada.redis.starter.props;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Basic sanity tests for the Lombok-backed {@link RedisProperties} class.
+ */
+class RedisPropertiesTest {
+
+  @Test
+  void builderSetsValues() {
+    RedisProperties props = RedisProperties.builder()
+        .host("example.com")
+        .port(1234)
+        .build();
+
+    assertEquals("example.com", props.getHost());
+    assertEquals(1234, props.getPort());
+  }
+}
+


### PR DESCRIPTION
## Summary
- allow all origins and methods for dev CORS and expose all actuator endpoints while disabling CSRF
- adopt Lombok in RedisProperties and add a basic builder test
- add module-level exception handler for IllegalArgumentException

## Testing
- `mvn -q clean install` *(fails: Non-resolvable import POM: Network is unreachable)*
- `mvn -q test` in starter-redis *(fails: Non-resolvable import POM: Network is unreachable)*
- `mvn -q test` in lms-setup *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bad7d69014832fbd3d6faba98be34d