### PR TITLE
Fix dependency versions in parent POM

### DIFF
--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -115,19 +115,22 @@
         <artifactId>tenant-api</artifactId>
         <version>${project.version}</version>
       </dependency>
-       <dependency>
-      <groupId>com.ejada</groupId>
-      <artifactId>starter-openapi</artifactId>
-    </dependency>
-     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-     <dependency>
-      <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-    </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-openapi</artifactId>
+        <version>${ejada.starters.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <version>${spring-boot.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        <version>${springdoc.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Summary
- specify version properties for starter-openapi, springdoc, and spring-boot-starter-test in tenant platform parent POM

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baea453258832f8b773c65c2f1b96a