### PR TITLE
Fix tenant-platform module parents and OpenAPI dependency

### DIFF
--- a/tenant-platform/billing-service/pom.xml
+++ b/tenant-platform/billing-service/pom.xml
@@ -8,7 +8,7 @@
   <groupId>com.ejada.tenant</groupId>
   <artifactId>tenant-platform</artifactId>
   <version>1.0.0-SNAPSHOT</version>
-  <relativePath>..</relativePath>
+  <relativePath>../pom.xml</relativePath>
 </parent>
 
   <artifactId>billing-service</artifactId>

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.ejada.tenant</groupId>
     <artifactId>tenant-platform</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>catalog-service</artifactId>

--- a/tenant-platform/policy-service/pom.xml
+++ b/tenant-platform/policy-service/pom.xml
@@ -8,7 +8,7 @@
   <groupId>com.ejada.tenant</groupId>
   <artifactId>tenant-platform</artifactId>
   <version>1.0.0-SNAPSHOT</version>
-  <relativePath>..</relativePath>
+  <relativePath>../pom.xml</relativePath>
 </parent>
 
   <artifactId>policy-service</artifactId>

--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -8,7 +8,7 @@
   <groupId>com.ejada.tenant</groupId>
   <artifactId>tenant-platform</artifactId>
   <version>1.0.0-SNAPSHOT</version>
-  <relativePath>..</relativePath>
+  <relativePath>../pom.xml</relativePath>
 </parent>
 
   <artifactId>subscription-service</artifactId>

--- a/tenant-platform/tenant-api/pom.xml
+++ b/tenant-platform/tenant-api/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.ejada.tenant</groupId>
   <artifactId>tenant-platform</artifactId>
   <version>1.0.0-SNAPSHOT</version>
-  <relativePath>..</relativePath>
+  <relativePath>../pom.xml</relativePath>
 </parent>
 
   <artifactId>tenant-api</artifactId>
@@ -25,6 +25,12 @@
     <dependency>
       <groupId>com.ejada.tenant</groupId>
       <artifactId>tenant-core</artifactId>
+    </dependency>
+
+    <!-- OpenAPI types used in configuration -->
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-openapi</artifactId>
     </dependency>
 
     <!-- Validation annotations for DTOs -->

--- a/tenant-platform/tenant-config/pom.xml
+++ b/tenant-platform/tenant-config/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.ejada.tenant</groupId>
     <artifactId>tenant-platform</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>tenant-config</artifactId>

--- a/tenant-platform/tenant-core/pom.xml
+++ b/tenant-platform/tenant-core/pom.xml
@@ -8,7 +8,7 @@
   <groupId>com.ejada.tenant</groupId>
   <artifactId>tenant-platform</artifactId>
   <version>1.0.0-SNAPSHOT</version>
-  <relativePath>..</relativePath>
+  <relativePath>../pom.xml</relativePath>
 </parent>
 
   <artifactId>tenant-core</artifactId>

--- a/tenant-platform/tenant-events/pom.xml
+++ b/tenant-platform/tenant-events/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.ejada.tenant</groupId>
   <artifactId>tenant-platform</artifactId>
   <version>1.0.0-SNAPSHOT</version>
-  <relativePath>..</relativePath>
+  <relativePath>../pom.xml</relativePath>
 </parent>
 
   <artifactId>tenant-events</artifactId>

--- a/tenant-platform/tenant-persistence/pom.xml
+++ b/tenant-platform/tenant-persistence/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.ejada.tenant</groupId>
   <artifactId>tenant-platform</artifactId>
   <version>1.0.0-SNAPSHOT</version>
-  <relativePath>..</relativePath>
+  <relativePath>../pom.xml</relativePath>
 </parent>
 
   <artifactId>tenant-persistence</artifactId>

--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -8,7 +8,7 @@
   <groupId>com.ejada.tenant</groupId>
   <artifactId>tenant-platform</artifactId>
   <version>1.0.0-SNAPSHOT</version>
-  <relativePath>..</relativePath>
+  <relativePath>../pom.xml</relativePath>
 </parent>
 
   <artifactId>tenant-service</artifactId>


### PR DESCRIPTION
## Summary
- point tenant-platform child modules to parent `pom.xml`
- add `starter-openapi` dependency to tenant-api to resolve missing `Components` type

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl tenant-api -am test` *(fails: Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68baea2676a8832fb4b65fd298442221