### PR TITLE
Specify versions for internal and test dependencies

### DIFF
--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -115,19 +115,22 @@
         <artifactId>tenant-api</artifactId>
         <version>${project.version}</version>
       </dependency>
-       <dependency>
-      <groupId>com.ejada</groupId>
-      <artifactId>starter-openapi</artifactId>
-    </dependency>
-     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-     <dependency>
-      <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-    </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-openapi</artifactId>
+        <version>${ejada.starters.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <version>${spring-boot.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        <version>${springdoc.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Summary
- specify versions for custom openapi starter, spring boot test starter, and springdoc dependencies in tenant-platform parent pom

## Testing
- `mvn -q -f tenant-platform/pom.xml test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baea329e20832f8b0eefafeb09021e