### PR TITLE
Add missing web and OpenAPI deps to tenant-api module

### DIFF
--- a/tenant-platform/tenant-api/pom.xml
+++ b/tenant-platform/tenant-api/pom.xml
@@ -33,6 +33,19 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
 
+    <!-- Spring MVC annotations and HTTP interface support -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- OpenAPI models and annotations -->
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>${springdoc.version}</version>
+    </dependency>
+
     <!-- Lombok for DTOs/builders -->
     <dependency>
       <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Summary
- include Spring Web starter to supply MVC annotations and HTTP interfaces
- add SpringDoc OpenAPI starter for OpenAPI models and annotations

## Testing
- `mvn -q -pl tenant-api -am test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baea3c8870832f9f409e4650288000