### PR TITLE
Add Spring Web starter to tenant API module

### DIFF
--- a/tenant-platform/tenant-api/pom.xml
+++ b/tenant-platform/tenant-api/pom.xml
@@ -33,6 +33,12 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
 
+    <!-- Spring MVC & HTTP abstractions for controllers and clients -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
     <!-- Lombok for DTOs/builders -->
     <dependency>
       <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Summary
- add Spring Boot Web starter to tenant API module so HTTP and web annotations resolve

## Testing
- `mvn -f tenant-platform/pom.xml -pl tenant-api -am test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baea5c15cc832f9ae39151849e28b6