### PR TITLE
Add web and OpenAPI dependencies to tenant-api module

### DIFF
--- a/tenant-platform/tenant-api/pom.xml
+++ b/tenant-platform/tenant-api/pom.xml
@@ -25,12 +25,23 @@
     <dependency>
       <groupId>com.ejada.tenant</groupId>
       <artifactId>tenant-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
-    <!-- Validation annotations for DTOs -->
+    <!-- Web & validation support for controllers -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+
+    <!-- OpenAPI documentation -->
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
     </dependency>
 
     <!-- Lombok for DTOs/builders -->


### PR DESCRIPTION
## Summary
- add Spring Web and validation starter to tenant-api
- include SpringDoc OpenAPI starter
- declare tenant-core version explicitly

## Testing
- `mvn -q -pl tenant-api -am test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68baea546cb8832f8d5929cc41344eb6