### PR TITLE
Add explicit JPA dependency and test placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository houses several components:
 
 - **shared-lib** – a collection of reusable Spring Boot starter modules and utilities.
 - **lms-setup** – a Spring Boot microservice for reference lookups and tenant/platform configuration.
-- **tenant-persistence** – central JPA entities, repositories, and Flyway migrations for the tenant domain.
+- **tenant-persistence** – central JPA entities, repositories, and Flyway migrations for the tenant domain. Requires `spring-boot-starter-data-jpa` for JPA and repository support.
 
 ## Getting Started
 

--- a/tenant-platform/README.md
+++ b/tenant-platform/README.md
@@ -24,6 +24,13 @@ Each service follows a standard Maven layout and provides an
 mvn -T4 clean verify
 ```
 
+### Persistence module dependencies
+
+The `tenant-persistence` module now explicitly depends on
+`spring-boot-starter-data-jpa` to provide JPA annotations and Spring Data
+repository support. Ensure this dependency is available when building or
+running the platform.
+
 ## Run locally
 ```bash
 docker-compose up --build

--- a/tenant-platform/tenant-persistence/pom.xml
+++ b/tenant-platform/tenant-persistence/pom.xml
@@ -27,6 +27,12 @@
       <artifactId>starter-data</artifactId>
     </dependency>
 
+    <!-- Explicit JPA dependency to provide Entity annotations and Spring Data repositories -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+
     <!-- Lombok for entities/DTOs/builders -->
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/tenant-platform/tenant-persistence/src/test/java/com/ejada/tenant/persistence/repository/TenantRepositoryTest.java
+++ b/tenant-platform/tenant-persistence/src/test/java/com/ejada/tenant/persistence/repository/TenantRepositoryTest.java
@@ -1,0 +1,11 @@
+package com.ejada.tenant.persistence.repository;
+
+import org.junit.jupiter.api.Test;
+
+class TenantRepositoryTest {
+
+    @Test
+    void placeholder() {
+        // TODO implement repository unit tests
+    }
+}

--- a/tenant-platform/tenant-persistence/src/test/java/com/ejada/tenant/persistence/service/TenantServiceTest.java
+++ b/tenant-platform/tenant-persistence/src/test/java/com/ejada/tenant/persistence/service/TenantServiceTest.java
@@ -1,0 +1,11 @@
+package com.ejada.tenant.persistence.service;
+
+import org.junit.jupiter.api.Test;
+
+class TenantServiceTest {
+
+    @Test
+    void placeholder() {
+        // TODO implement service layer tests
+    }
+}


### PR DESCRIPTION
## Summary
- ensure tenant-persistence declares spring-boot-starter-data-jpa so JPA annotations and Spring Data repositories compile
- document the new dependency in README files
- add placeholder tests for service and repository layers

## Testing
- `mvn -pl tenant-persistence test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baee18c4ec832fbd87868313e8325f