### PR TITLE
Manage tenant platform dependency versions

### DIFF
--- a/tenant-platform/billing-service/pom.xml
+++ b/tenant-platform/billing-service/pom.xml
@@ -15,7 +15,7 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
-      <artifactId>starter-config</artifactId>
+      <artifactId>shared-config</artifactId>
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -15,7 +15,7 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
-      <artifactId>starter-config</artifactId>
+      <artifactId>shared-config</artifactId>
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>

--- a/tenant-platform/policy-service/pom.xml
+++ b/tenant-platform/policy-service/pom.xml
@@ -15,7 +15,7 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
-      <artifactId>starter-config</artifactId>
+      <artifactId>shared-config</artifactId>
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>

--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -37,6 +37,48 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>shared-starter</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>shared-common</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>shared-config</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>shared-test-support</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada.tenant</groupId>
+        <artifactId>tenant-persistence</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada.tenant</groupId>
+        <artifactId>tenant-config</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada.tenant</groupId>
+        <artifactId>tenant-events</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada.tenant</groupId>
+        <artifactId>tenant-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -15,7 +15,7 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
-      <artifactId>starter-config</artifactId>
+      <artifactId>shared-config</artifactId>
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>

--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -16,7 +16,7 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
-      <artifactId>starter-config</artifactId>
+      <artifactId>shared-config</artifactId>
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>


### PR DESCRIPTION
## Summary
- Import shared starter and internal modules into tenant platform dependency management
- Use shared-config instead of starter-config in tenant service modules

## Testing
- `mvn -q -f shared-lib/pom.xml install -DskipTests` *(failed: Network is unreachable)*
- `mvn -q -f tenant-platform/pom.xml test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baf04bb420832fb3fd380fa6f698d7