### PR TITLE
Add JPA dependency to subscription-service

### DIFF
--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -22,6 +22,10 @@
       <artifactId>starter-data</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-security</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary
- include `spring-boot-starter-data-jpa` so subscription-service can use JPA repositories and entities

## Testing
- `mvn -q -pl subscription-service -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baf21b1564832f93089d7f27be861e