### PR TITLE
Add JPA and Resilience4j dependencies to catalog-service

### DIFF
--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -39,11 +39,19 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
+      <artifactId>starter-resilience</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
       <artifactId>starter-redis</artifactId>
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springdoc</groupId>


### PR DESCRIPTION
## Summary
- enable Resilience4j retries via `starter-resilience`
- include JPA support through `spring-boot-starter-data-jpa`

## Testing
- `mvn -pl catalog-service -am package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baf2e75478832f941472ec3bf522da