### PR TITLE
Fix H2 incompatibility in tenant outbox migration

### DIFF
--- a/tenant-platform/tenant-events/src/main/resources/db/migration/common/V7__create_tenant_outbox.sql
+++ b/tenant-platform/tenant-events/src/main/resources/db/migration/common/V7__create_tenant_outbox.sql
@@ -4,10 +4,10 @@ CREATE TABLE IF NOT EXISTS tenant_outbox (
     tenant_id VARCHAR(64),
     type TEXT NOT NULL,
     payload JSONB NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
     version BIGINT NOT NULL,
-    available_at TIMESTAMPTZ NOT NULL,
+    available_at TIMESTAMP WITH TIME ZONE NOT NULL,
     attempts INTEGER NOT NULL DEFAULT 0,
     status TEXT NOT NULL
 );


### PR DESCRIPTION
## Summary
- replace TIMESTAMPTZ columns with TIMESTAMP WITH TIME ZONE in tenant_outbox migration

## Testing
- `mvn -q -o test` *(fails: Non-resolvable import POM and dependency version errors)*

------
https://chatgpt.com/codex/tasks/task_e_68baf48bda28832f87101407552b8c01