### PR TITLE
Add versions for shared starters in BOM

### DIFF
--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -219,11 +219,70 @@
         <artifactId>cache-api</artifactId>
         <version>${cache.api.version}</version>
       </dependency>
-<dependency>
-    <groupId>org.apache.kafka</groupId>
-    <artifactId>kafka-clients</artifactId>
-    <version>${kafka.clients.version}</version>
-</dependency>
+    <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${kafka.clients.version}</version>
+    </dependency>
+
+      <!-- Ejada shared starters -->
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-config</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-data</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-security</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-actuator</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-observability</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-openapi</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-redis</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-kafka</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>starter-mapstruct</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <!-- Test utilities -->
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>shared-test-support</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Summary
- declare versions for Ejada starters and test support in shared BOM

## Testing
- `mvn -q install` *(fails: Network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68baf7f53654832fb397fefa03e3dabc