### PR TITLE
Add missing JPA and audit dependencies

### DIFF
--- a/lms-setup/pom.xml
+++ b/lms-setup/pom.xml
@@ -62,6 +62,10 @@
       <artifactId>starter-data</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-security</artifactId>
     </dependency>
@@ -87,11 +91,20 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
+      <artifactId>starter-audit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
       <artifactId>starter-mapstruct</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>4.8.6</version>
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>


### PR DESCRIPTION
## Summary
- include Spring Data JPA starter for persistence APIs
- add audit starter and SpotBugs annotations dependencies

## Testing
- `mvn -f lms-setup/pom.xml -q test` *(fails: Non-resolvable parent POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bafd7018fc832f9ee6fa2e23dd9620