### PR TITLE
Add Spring Security Test dependency

### DIFF
--- a/lms-setup/pom.xml
+++ b/lms-setup/pom.xml
@@ -107,6 +107,11 @@
       <version>4.8.6</version>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>shared-test-support</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## Summary
- add missing Spring Security test dependency so test classes compiling WithMockUser annotation compile

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baff9fcdb8832fb4a7b75bc7f90571