### PR TITLE
Add servlet API dependency for controller tests

### DIFF
--- a/lms-setup/pom.xml
+++ b/lms-setup/pom.xml
@@ -107,6 +107,11 @@
       <version>4.8.6</version>
     </dependency>
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## Summary
- fix controller tests by adding jakarta servlet API dependency

## Testing
- `mvn -Djava.net.preferIPv4Stack=true test -q` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68bb00911bc4832fb0df505131db20cf