### PR TITLE
Add test logback configuration to bypass missing OpenTelemetry appender

### DIFF
--- a/lms-setup/src/test/resources/logback-test.xml
+++ b/lms-setup/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+      <providers>
+        <timestamp/>
+        <logLevel/>
+        <loggerName/>
+        <threadName/>
+        <pattern>
+          <pattern>{"message":"%message","X-Correlation-Id":"%X{X-Correlation-Id}"}</pattern>
+        </pattern>
+        <mdc/>
+      </providers>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+</configuration>


### PR DESCRIPTION
## Summary
- add a `logback-test.xml` to avoid requiring OpenTelemetry appender during tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb01a1c1b4832f837cdbcb80b78793