### PR TITLE
Disable filters in CountryControllerTest to prevent context errors

### DIFF
--- a/lms-setup/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
+++ b/lms-setup/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
@@ -38,7 +38,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = CountryController.class)
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 @WithMockUser(roles = {"ADMIN", "USER"})
 @Import({CountryControllerTest.TestSecurityConfig.class, SecurityExceptionHandler.class})


### PR DESCRIPTION
## Summary
- disable Spring Security filters in CountryControllerTest by adding `addFilters = false`

## Testing
- `mvn -q -Dtest=CountryControllerTest test` *(fails: Non-resolvable parent POM for com.ejada:lms-setup:1.0.0: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb02fad0f0832f8bf1efe9c0d2b0b1