### PR TITLE
Add missing validation dependency for setup tests

### DIFF
--- a/lms-setup/pom.xml
+++ b/lms-setup/pom.xml
@@ -66,6 +66,10 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-security</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary
- add `spring-boot-starter-validation` to setup module so that bean validation is available during tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact spring-boot-starter-parent: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb043dcca0832fbba8f6ec280ac18c