### PR TITLE
Fix CityMapper builder mapping

### DIFF
--- a/lms-setup/src/main/java/com/ejada/setup/mapper/CityMapper.java
+++ b/lms-setup/src/main/java/com/ejada/setup/mapper/CityMapper.java
@@ -2,9 +2,7 @@ package com.ejada.setup.mapper;
 
 import com.ejada.setup.dto.CityDto;
 import com.ejada.setup.model.City;
-import com.ejada.setup.model.Country;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.data.domain.Page;
@@ -24,8 +22,12 @@ public interface CityMapper {
   @Mapping(source = "country.countryId", target = "countryId")
   CityDto toDto(City entity);
 
-  @InheritInverseConfiguration(name = "toDto")
-  @Mapping(target = "country", expression = "java(toCountry(dto.getCountryId()))")
+  @Mapping(source = "id",        target = "cityId")
+  @Mapping(source = "cityCd",    target = "cityCd")
+  @Mapping(source = "cityEnNm",  target = "cityEnNm")
+  @Mapping(source = "cityArNm",  target = "cityArNm")
+  @Mapping(source = "isActive",  target = "isActive")
+  @Mapping(source = "countryId", target = "countryId")
   City toEntity(CityDto dto);
 
   //  Add this so MapStruct generates the iterable mapper
@@ -33,13 +35,6 @@ public interface CityMapper {
 
   // (optional, if you ever need reverse list mapping)
   // List<City> toEntityList(List<CityDto> dtos);
-
-  default Country toCountry(Integer id) {
-    if (id == null) return null;
-    Country c = new Country();
-    c.setCountryId(id);
-    return c;
-  }
 
   // Uses the list mapper above
   default Page<CityDto> toDtoPage(Page<City> page) {


### PR DESCRIPTION
## Summary
- fix MapStruct mapping to use City builder's countryId instead of country property

## Testing
- `mvn -q test` (fails: Non-resolvable parent POM for com.ejada:lms-setup:1.0.0)


------
https://chatgpt.com/codex/tasks/task_e_68bb08068378832fae5b4ec7c460c451