### PR TITLE
chore: suppress SpotBugs warning for City country reference

### DIFF
--- a/lms-setup/src/main/java/com/ejada/setup/model/City.java
+++ b/lms-setup/src/main/java/com/ejada/setup/model/City.java
@@ -7,6 +7,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @Entity
 @Table(
@@ -42,6 +43,8 @@ public class City {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "country_id", nullable = false)
+    @Getter(onMethod_ = @__(@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Country is a JPA entity")))
+    @Setter(onMethod_ = @__(@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Country is a JPA entity")))
     private Country country;
 
     @Column(name = "is_active", nullable = false)


### PR DESCRIPTION
## Summary
- suppress SpotBugs `EI_EXPOSE_REP` and `EI_EXPOSE_REP2` on City.country via Lombok annotations

## Testing
- `mvn -q verify` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb09bf2a70832fa3515237e5b1d56d