### PR TITLE
Add primary MVC ObjectMapper

### DIFF
--- a/setup-service/src/main/java/com/ejada/setup/config/JacksonConfig.java
+++ b/setup-service/src/main/java/com/ejada/setup/config/JacksonConfig.java
@@ -1,0 +1,18 @@
+package com.ejada.setup.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration
+public class JacksonConfig {
+
+    // ObjectMapper default for web (HTTP)
+    @Bean
+    @Primary
+    public ObjectMapper httpObjectMapper(Jackson2ObjectMapperBuilder builder) {
+        return builder.build();
+    }
+}


### PR DESCRIPTION
## Summary
- add MVC-specific ObjectMapper bean with `@Primary`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.ejada:setup-service:1.0.0: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb29ecd8a8832f9f3a5d5202dc07a8