### PR TITLE
Enable Kafka audit sink and use spring bootstrap servers

### DIFF
--- a/setup-service/src/main/resources/application-dev.yaml
+++ b/setup-service/src/main/resources/application-dev.yaml
@@ -155,7 +155,8 @@ shared:
         schema: setup
         table: audit_logs
       kafka:
-        enabled: false
+        enabled: true
+        topic: audit_logs
       otlp:
         enabled: false
       outbox:

--- a/setup-service/src/main/resources/application-qa.yaml
+++ b/setup-service/src/main/resources/application-qa.yaml
@@ -155,7 +155,8 @@ shared:
         schema: setup
         table: audit_logs
       kafka:
-        enabled: false
+        enabled: true
+        topic: audit_logs
       otlp:
         enabled: false
       outbox:

--- a/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
@@ -155,7 +155,8 @@ shared:
         schema: setup
         table: audit_logs
       kafka:
-        enabled: false
+        enabled: true
+        topic: audit_logs
       otlp:
         enabled: false
       outbox:

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/config/AuditAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/config/AuditAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -208,9 +209,12 @@ public class AuditAutoConfiguration {
   @Bean
   @ConditionalOnProperty(prefix = "shared.audit.sinks.kafka", name = "enabled", havingValue = "true")
   @ConditionalOnClass(name = "com.ejada.audit.starter.core.dispatch.sinks.KafkaSink")
-  public Sink kafkaSink(AuditProperties props) {
+  public Sink kafkaSink(AuditProperties props, Environment env) {
     Object k = props.getSinks().getKafka();
-    String bootstrap = optionalString(k, "getBootstrapServers", "localhost:9092");
+    String bootstrap = optionalString(k, "getBootstrapServers", null);
+    if (bootstrap == null || bootstrap.isBlank()) {
+      bootstrap = env.getProperty("spring.kafka.bootstrap-servers", "localhost:9092");
+    }
     String topic = optionalString(k, "getTopic", "audit.events.v1");
     String acks = optionalString(k, "getAcks", "all");
     String compression = optionalString(k, "getCompression", "zstd");


### PR DESCRIPTION
## Summary
- allow audit Kafka sink to fall back to `spring.kafka.bootstrap-servers`
- enable Kafka audit sink in shared and setup-service configs

## Testing
- `mvn -q -f shared-lib/pom.xml -pl shared-config,shared-starters/starter-audit -am install` *(fails: Non-resolvable import POM: Network is unreachable)*
- `mvn -q -f setup-service/pom.xml -o test` *(fails: Non-resolvable parent POM: cannot access central in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2dc0348c832fbf81f365bdf27da0