### PR TITLE
Fix MapStruct mapper configuration

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
@@ -2,11 +2,11 @@ package com.ejada.catalog.mapper;
 
 import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.*;
+import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
 
-@Mapper(componentModel = "spring",
-        imports = {Addon.class, Feature.class},
-        unmappedTargetPolicy = ReportingPolicy.ERROR)
+@Mapper(config = SharedMapstructConfig.class,
+        imports = {Addon.class, Feature.class, Enforcement.class})
 public interface AddonFeatureMapper {
 
     @Mapping(target = "addonFeatureId", ignore = true)
@@ -27,6 +27,9 @@ public interface AddonFeatureMapper {
     AddonFeature toEntity(AddonFeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "addonFeatureId", ignore = true)
+    @Mapping(target = "addon", ignore = true)
+    @Mapping(target = "feature", ignore = true)
     void update(@MappingTarget AddonFeature entity, AddonFeatureUpdateReq req);
 
     @Mapping(target = "addonId", source = "addon.addonId")

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
@@ -1,10 +1,10 @@
 package com.ejada.catalog.mapper;
 import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.Addon;
+import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
 
-@Mapper(componentModel = "spring",
-        unmappedTargetPolicy = ReportingPolicy.ERROR)
+@Mapper(config = SharedMapstructConfig.class)
 public interface AddonMapper {
 
     // ---------- Create ----------
@@ -26,8 +26,12 @@ public interface AddonMapper {
 
     // ---------- Update ----------
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "addonId", ignore = true)
+    @Mapping(target = "isDeleted", ignore = true)
     void update(@MappingTarget Addon entity, AddonUpdateReq req);
 
     // ---------- Response ----------
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
     AddonRes toRes(Addon entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/FeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/FeatureMapper.java
@@ -2,10 +2,10 @@ package com.ejada.catalog.mapper;
 
 import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.*;
+import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
 
-@Mapper(componentModel = "spring",
-        unmappedTargetPolicy = ReportingPolicy.ERROR)
+@Mapper(config = SharedMapstructConfig.class)
 public interface FeatureMapper {
 
     @Mapping(target = "featureId", ignore = true)
@@ -20,6 +20,8 @@ public interface FeatureMapper {
     Feature toEntity(FeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "featureId", ignore = true)
+    @Mapping(target = "featureKey", ignore = true)
     void update(@MappingTarget Feature entity, FeatureUpdateReq req);
 
     FeatureRes toRes(Feature entity);

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
@@ -2,11 +2,11 @@ package com.ejada.catalog.mapper;
 
 import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.*;
+import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
 
-@Mapper(componentModel = "spring",
-        imports = {Tier.class, Addon.class},
-        unmappedTargetPolicy = ReportingPolicy.ERROR)
+@Mapper(config = SharedMapstructConfig.class,
+        imports = {Tier.class, Addon.class})
 public interface TierAddonMapper {
 
     @Mapping(target = "tierAddonId", ignore = true)
@@ -20,6 +20,9 @@ public interface TierAddonMapper {
     TierAddon toEntity(TierAddonCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "tierAddonId", ignore = true)
+    @Mapping(target = "tier", ignore = true)
+    @Mapping(target = "addon", ignore = true)
     void update(@MappingTarget TierAddon entity, TierAddonUpdateReq req);
 
     @Mapping(target = "tierId", source = "tier.tierId")

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
@@ -2,11 +2,11 @@ package com.ejada.catalog.mapper;
 
 import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.*;
+import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
 
-@Mapper(componentModel = "spring",
-        imports = {Tier.class, Feature.class},
-        unmappedTargetPolicy = ReportingPolicy.ERROR)
+@Mapper(config = SharedMapstructConfig.class,
+        imports = {Tier.class, Feature.class, Enforcement.class})
 public interface TierFeatureMapper {
 
     @Mapping(target = "tierFeatureId", ignore = true)
@@ -27,6 +27,9 @@ public interface TierFeatureMapper {
     TierFeature toEntity(TierFeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "tierFeatureId", ignore = true)
+    @Mapping(target = "tier", ignore = true)
+    @Mapping(target = "feature", ignore = true)
     void update(@MappingTarget TierFeature entity, TierFeatureUpdateReq req);
 
     @Mapping(target = "tierId", source = "tier.tierId")

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierMapper.java
@@ -2,10 +2,10 @@ package com.ejada.catalog.mapper;
 
 import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.*;
+import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
 
-@Mapper(componentModel = "spring",
-        unmappedTargetPolicy = ReportingPolicy.ERROR)
+@Mapper(config = SharedMapstructConfig.class)
 public interface TierMapper {
 
     @Mapping(target = "tierId", ignore = true)
@@ -19,6 +19,8 @@ public interface TierMapper {
     Tier toEntity(TierCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "tierId", ignore = true)
+    @Mapping(target = "tierCd", ignore = true)
     void update(@MappingTarget Tier entity, TierUpdateReq req);
 
     TierRes toRes(Tier entity);


### PR DESCRIPTION
## Summary
- centralize MapStruct defaults via shared `SharedMapstructConfig`
- update catalog-service mappers to use shared config and explicit id-based association mapping

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_68bc23e9aee8832f9c207aad06396d48