### PR TITLE
fix: correct checkstyle config path

### DIFF
--- a/shared-lib/shared-quality/checkstyle.xml
+++ b/shared-lib/shared-quality/checkstyle.xml
@@ -7,7 +7,7 @@
   
   <!-- Exclude generated files -->
   <module name="SuppressionFilter">
-    <property name="file" value="${config_loc}/suppressions.xml"/>
+    <property name="file" value="suppressions.xml"/>
   </module>
   
   <!-- File length -->

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -207,9 +207,7 @@
       <configuration>
         <configLocation>../../shared-lib/shared-quality/checkstyle.xml</configLocation>
         <consoleOutput>true</consoleOutput>
-        <encoding>${project.build.sourceEncoding}</encoding>
         <failOnViolation>false</failOnViolation>
-        <propertyExpansion>config_loc=${project.basedir}/../../shared-lib/shared-quality</propertyExpansion>
       </configuration>
       <executions>
         <execution>


### PR DESCRIPTION
## Summary
- fix Checkstyle plugin path for catalog-service

## Testing
- `mvn -q -f tenant-platform/catalog-service/pom.xml -DskipTests checkstyle:check` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2a7f03ec832f9fdff72f42fb15ce