### PR TITLE
fix: correct checkstyle config paths

### DIFF
--- a/shared-lib/shared-quality/checkstyle.xml
+++ b/shared-lib/shared-quality/checkstyle.xml
@@ -7,7 +7,7 @@
   
   <!-- Exclude generated files -->
   <module name="SuppressionFilter">
-    <property name="file" value="${config_loc}/suppressions.xml"/>
+    <property name="file" value="suppressions.xml"/>
   </module>
   
   <!-- File length -->

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -205,11 +205,9 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.5.0</version>
       <configuration>
-        <configLocation>../shared-lib/shared-quality/checkstyle.xml</configLocation>
+        <configLocation>../../shared-lib/shared-quality/checkstyle.xml</configLocation>
         <consoleOutput>true</consoleOutput>
-        <encoding>${project.build.sourceEncoding}</encoding>
         <failOnViolation>false</failOnViolation>
-        <propertyExpansion>config_loc=${project.basedir}/../shared-lib/shared-quality</propertyExpansion>
       </configuration>
       <executions>
         <execution>

--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -205,11 +205,9 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.5.0</version>
       <configuration>
-        <configLocation>../shared-lib/shared-quality/checkstyle.xml</configLocation>
+        <configLocation>../../shared-lib/shared-quality/checkstyle.xml</configLocation>
         <consoleOutput>true</consoleOutput>
-        <encoding>${project.build.sourceEncoding}</encoding>
         <failOnViolation>false</failOnViolation>
-        <propertyExpansion>config_loc=${project.basedir}/../shared-lib/shared-quality</propertyExpansion>
       </configuration>
       <executions>
         <execution>


### PR DESCRIPTION
## Summary
- fix Checkstyle plugin paths for catalog-service and tenant-service
- reference suppressions.xml directly in shared Checkstyle config

## Testing
- `mvn -q -f tenant-platform/catalog-service/pom.xml -DskipTests checkstyle:check` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q -f tenant-platform/tenant-service/pom.xml -DskipTests checkstyle:check` *(fails: Network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2a7f03ec832f9fdff72f42fb15ce