### PR TITLE
Fix Checkstyle suppressions file path

### DIFF
--- a/shared-lib/shared-quality/checkstyle.xml
+++ b/shared-lib/shared-quality/checkstyle.xml
@@ -7,7 +7,7 @@
   
   <!-- Exclude generated files -->
   <module name="SuppressionFilter">
-    <property name="file" value="suppressions.xml"/>
+    <property name="file" value="${suppressionsFile}"/>
   </module>
   
   <!-- File length -->

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -208,6 +208,9 @@
         <configLocation>../../shared-lib/shared-quality/checkstyle.xml</configLocation>
         <consoleOutput>true</consoleOutput>
         <failOnViolation>false</failOnViolation>
+        <propertyExpansion>
+          <suppressionsFile>${project.basedir}/../../shared-lib/shared-quality/suppressions.xml</suppressionsFile>
+        </propertyExpansion>
       </configuration>
       <executions>
         <execution>

--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -205,11 +205,13 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.5.0</version>
       <configuration>
-        <configLocation>../shared-lib/shared-quality/checkstyle.xml</configLocation>
+        <configLocation>../../shared-lib/shared-quality/checkstyle.xml</configLocation>
         <consoleOutput>true</consoleOutput>
         <encoding>${project.build.sourceEncoding}</encoding>
         <failOnViolation>false</failOnViolation>
-        <propertyExpansion>config_loc=${project.basedir}/../shared-lib/shared-quality</propertyExpansion>
+        <propertyExpansion>
+          <suppressionsFile>${project.basedir}/../../shared-lib/shared-quality/suppressions.xml</suppressionsFile>
+        </propertyExpansion>
       </configuration>
       <executions>
         <execution>


### PR DESCRIPTION
## Summary
- Load Checkstyle suppressions file via property for shared configuration
- Point catalog-service and tenant-service Checkstyle plugins to shared suppressions file

## Testing
- `mvn -q -f tenant-platform/pom.xml verify` *(fails: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_68bc2db7c538832fa925d3c7050542f1