### PR TITLE
fix: specify checkstyle suppressions

### DIFF
--- a/setup-service/pom.xml
+++ b/setup-service/pom.xml
@@ -206,6 +206,7 @@
         <version>3.5.0</version>
       <configuration>
         <configLocation>../shared-lib/shared-quality/checkstyle.xml</configLocation>
+        <suppressionsLocation>../shared-lib/shared-quality/suppressions.xml</suppressionsLocation>
         <consoleOutput>true</consoleOutput>
         <encoding>${project.build.sourceEncoding}</encoding>
         <failOnViolation>false</failOnViolation>

--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -185,6 +185,7 @@
           <version>3.5.0</version>
           <configuration>
             <configLocation>shared-quality/checkstyle.xml</configLocation>
+            <suppressionsLocation>shared-quality/suppressions.xml</suppressionsLocation>
             <encoding>${project.build.sourceEncoding}</encoding>
             <consoleOutput>true</consoleOutput>
             <failOnViolation>false</failOnViolation>

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -206,6 +206,7 @@
         <version>3.5.0</version>
       <configuration>
         <configLocation>../../shared-lib/shared-quality/checkstyle.xml</configLocation>
+        <suppressionsLocation>../../shared-lib/shared-quality/suppressions.xml</suppressionsLocation>
         <consoleOutput>true</consoleOutput>
         <failOnViolation>false</failOnViolation>
       </configuration>

--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -206,6 +206,7 @@
         <version>3.5.0</version>
       <configuration>
         <configLocation>../../shared-lib/shared-quality/checkstyle.xml</configLocation>
+        <suppressionsLocation>../../shared-lib/shared-quality/suppressions.xml</suppressionsLocation>
         <consoleOutput>true</consoleOutput>
         <failOnViolation>false</failOnViolation>
       </configuration>


### PR DESCRIPTION
## Summary
- configure shared suppressions for Checkstyle across modules

## Testing
- `mvn -q -f shared-lib/pom.xml verify` *(fails: Non-resolvable import POM due to network is unreachable)*
- `mvn -q -f setup-service/pom.xml verify` *(fails: Non-resolvable parent POM due to network is unreachable)*
- `mvn -q -f tenant-platform/pom.xml verify` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2f801904832f8f139802061bbf00