### PR TITLE
Silence MapStruct warnings

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
@@ -9,6 +9,7 @@ import org.mapstruct.*;
         imports = {Addon.class, Feature.class, Enforcement.class})
 public interface AddonFeatureMapper {
 
+    @BeanMapping(ignoreUnmappedSourceProperties = {"addonId", "featureId"})
     @Mapping(target = "addonFeatureId", ignore = true)
     @Mapping(target = "addon", expression = "java(Addon.ref(req.addonId()))")
     @Mapping(target = "feature", expression = "java(Feature.ref(req.featureId()))")

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
@@ -9,6 +9,7 @@ import org.mapstruct.*;
         imports = {Tier.class, Addon.class})
 public interface TierAddonMapper {
 
+    @BeanMapping(ignoreUnmappedSourceProperties = {"tierId", "addonId"})
     @Mapping(target = "tierAddonId", ignore = true)
     @Mapping(target = "tier", expression = "java(Tier.ref(req.tierId()))")
     @Mapping(target = "addon", expression = "java(Addon.ref(req.addonId()))")
@@ -19,7 +20,8 @@ public interface TierAddonMapper {
     @Mapping(target = "isDeleted", constant = "false")
     TierAddon toEntity(TierAddonCreateReq req);
 
-    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+                ignoreUnmappedSourceProperties = {"tierId", "addonId"})
     @Mapping(target = "tierAddonId", ignore = true)
     @Mapping(target = "tier", ignore = true)
     @Mapping(target = "addon", ignore = true)

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
@@ -9,6 +9,7 @@ import org.mapstruct.*;
         imports = {Tier.class, Feature.class, Enforcement.class})
 public interface TierFeatureMapper {
 
+    @BeanMapping(ignoreUnmappedSourceProperties = {"tierId", "featureId"})
     @Mapping(target = "tierFeatureId", ignore = true)
     @Mapping(target = "tier", expression = "java(Tier.ref(req.tierId()))")
     @Mapping(target = "feature", expression = "java(Feature.ref(req.featureId()))")

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
@@ -14,6 +14,7 @@ import java.time.OffsetDateTime;
 public interface TenantIntegrationKeyMapper {
 
     // ---------- Create ----------
+    @BeanMapping(ignoreUnmappedSourceProperties = "tenantId")
     @Mapping(target = "tikId", ignore = true)
     @Mapping(target = "tenant", expression = "java(Tenant.ref(req.tenantId()))")
     @Mapping(target = "keyId", source = "keyId")

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
@@ -28,6 +28,10 @@ public interface TenantMapper {
 
     // ---------- Update (PATCH/PUT with IGNORE nulls) ----------
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "isDeleted", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
     void update(@MappingTarget Tenant entity, TenantUpdateReq req);
 
     // ---------- Response ----------


### PR DESCRIPTION
## Summary
- Ignore non-updatable fields in `TenantMapper` update method
- Suppress MapStruct source warnings for identifier fields in catalog mappers
- Mark tenant ID as intentionally unused in `TenantIntegrationKeyMapper`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68bc332d8dc0832f8b4cb815cf8fecaa