### PR TITLE
fix: remove unsupported ignore from TierAddonMapper

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
@@ -9,7 +9,6 @@ import org.mapstruct.*;
         imports = {Tier.class, Addon.class})
 public interface TierAddonMapper {
 
-    @BeanMapping(ignoreUnmappedSourceProperties = {"tierId", "addonId"})
     @Mapping(target = "tierAddonId", ignore = true)
     @Mapping(target = "tier", expression = "java(Tier.ref(req.tierId()))")
     @Mapping(target = "addon", expression = "java(Addon.ref(req.addonId()))")
@@ -20,8 +19,7 @@ public interface TierAddonMapper {
     @Mapping(target = "isDeleted", constant = "false")
     TierAddon toEntity(TierAddonCreateReq req);
 
-    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
-                ignoreUnmappedSourceProperties = {"tierId", "addonId"})
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "tierAddonId", ignore = true)
     @Mapping(target = "tier", ignore = true)
     @Mapping(target = "addon", ignore = true)


### PR DESCRIPTION
## Summary
- remove unsupported ignoreUnmappedSourceProperties from TierAddonMapper to resolve MapStruct compilation error

## Testing
- `mvn -f tenant-platform/pom.xml clean test` *(fails: Non-resolvable parent POM for com.ejada.tenant:tenant-platform:1.0.0-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3898d628832fb8abbe52903da0c0