### PR TITLE
refactor: centralize mapstruct configuration

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
@@ -4,13 +4,15 @@ import com.ejada.tenant.dto.*;
 import com.ejada.tenant.model.Tenant;
 import com.ejada.tenant.model.TenantIntegrationKey;
 import com.ejada.tenant.model.TenantIntegrationKey.Status;
+import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
 
 import java.time.OffsetDateTime;
 
-@Mapper(componentModel = "spring",
-        imports = { Tenant.class, TenantIntegrationKey.class, OffsetDateTime.class },
-        unmappedTargetPolicy = ReportingPolicy.ERROR)
+@Mapper(
+    config = SharedMapstructConfig.class,
+    imports = {Tenant.class, TenantIntegrationKey.class, OffsetDateTime.class}
+)
 public interface TenantIntegrationKeyMapper {
 
     // ---------- Create ----------

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
@@ -2,12 +2,10 @@ package com.ejada.tenant.mapper;
 
 import com.ejada.tenant.dto.*;
 import com.ejada.tenant.model.Tenant;
+import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
 
-import java.time.OffsetDateTime;
-
-@Mapper(componentModel = "spring",
-        unmappedTargetPolicy = ReportingPolicy.ERROR)
+@Mapper(config = SharedMapstructConfig.class)
 public interface TenantMapper {
 
     // ---------- Create ----------


### PR DESCRIPTION
## Summary
- centralize MapStruct configuration in tenant-service by using SharedMapstructConfig in all mappers to disable Lombok builders and enforce consistent rules

## Testing
- `mvn -q -pl tenant-service test` *(fails: Non-resolvable parent POM)*


------
https://chatgpt.com/codex/tasks/task_e_68bc394367e8832fa30fdedcfefd5709