### PR TITLE
Suppress SpotBugs warnings for catalog service

### DIFF
--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -226,6 +226,7 @@
       <configuration>
         <effort>Max</effort>
         <threshold>Low</threshold>
+        <excludeFilterFile>${project.basedir}/spotbugs-exclude.xml</excludeFilterFile>
       </configuration>
       <executions>
         <execution>

--- a/tenant-platform/catalog-service/spotbugs-exclude.xml
+++ b/tenant-platform/catalog-service/spotbugs-exclude.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match>
+    <Class name="~com\.ejada\.catalog\.mapper\..*Impl"/>
+  </Match>
+</FindBugsFilter>

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/TierAddonController.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/TierAddonController.java
@@ -4,6 +4,7 @@ import com.ejada.catalog.dto.*;
 import com.ejada.catalog.security.CatalogAuthorized;
 import com.ejada.catalog.service.TierAddonService;
 import com.ejada.common.dto.BaseResponse;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,7 +27,7 @@ import org.springframework.web.bind.annotation.*;
 @Validated
 @Tag(name = "Tier Addon Management", description = "APIs for managing addons allowed for tiers")
 public class TierAddonController {
-
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Injected service is managed by Spring")
     private final TierAddonService service;
 
     @PostMapping

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/AddonFeature.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/AddonFeature.java
@@ -116,7 +116,9 @@ public class AddonFeature {
         this.isDeleted       = isDeleted != null ? isDeleted : Boolean.FALSE;
     }
 
-    @PrePersist @PreUpdate
+    @PrePersist
+    @PreUpdate
+    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "JPA lifecycle callback")
     private void validatePolicy() {
         if (enforcement == Enforcement.BLOCK && hardLimit == null) {
             throw new IllegalStateException("hardLimit is required when enforcement=BLOCK");

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierFeature.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierFeature.java
@@ -132,7 +132,9 @@ public class TierFeature {
 
     /* --- Optional guard methods (domain validation) --- */
 
-    @PrePersist @PreUpdate
+    @PrePersist
+    @PreUpdate
+    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "JPA lifecycle callback")
     private void validatePolicy() {
         if (enforcement == Enforcement.BLOCK && hardLimit == null) {
             throw new IllegalStateException("hardLimit is required when enforcement=BLOCK");


### PR DESCRIPTION
## Summary
- exclude MapStruct-generated mapper implementations from SpotBugs analysis
- suppress false positives in TierAddonController and entity validation hooks

## Testing
- `mvn -q -pl catalog-service -am verify` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3ac168d8832f84ebdaa9be83a974