### PR TITLE
Fix TenantIntegrationKey update mapping

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
@@ -47,6 +47,15 @@ public interface TenantIntegrationKeyMapper {
 
     // ---------- Update (PATCH/PUT with IGNORE nulls) ----------
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "tikId", ignore = true)
+    @Mapping(target = "tenant", ignore = true)
+    @Mapping(target = "keyId", ignore = true)
+    @Mapping(target = "keySecret", ignore = true)
+    @Mapping(target = "lastUsedAt", ignore = true)
+    @Mapping(target = "useCount", ignore = true)
+    @Mapping(target = "isDeleted", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
     @Mapping(target = "scopes", source = "scopes", qualifiedByName = "toArray")
     @Mapping(target = "status", source = "status", qualifiedByName = "toEntityStatus")
     void update(@MappingTarget TenantIntegrationKey entity, TenantIntegrationKeyUpdateReq req);


### PR DESCRIPTION
## Summary
- ignore non-updatable fields in `TenantIntegrationKeyMapper#update` to resolve MapStruct unmapped target errors

## Testing
- `mvn -q -pl tenant-service -am test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c41c804832f84d7a716e8925d3e