### PR TITLE
chore: centralize spotbugs mapper exclusions

### DIFF
--- a/shared-lib/shared-quality/spotbugs-exclude.xml
+++ b/shared-lib/shared-quality/spotbugs-exclude.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!-- Exclude MapStruct generated mapper implementations -->
+  <Match>
+    <Or>
+      <Class name="~.*\.mapper\..*MapperImpl"/>
+    </Or>
+  </Match>
+</FindBugsFilter>

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -226,7 +226,7 @@
       <configuration>
         <effort>Max</effort>
         <threshold>Low</threshold>
-        <excludeFilterFile>${project.basedir}/spotbugs-exclude.xml</excludeFilterFile>
+        <excludeFilterFile>${project.basedir}/../../shared-lib/shared-quality/spotbugs-exclude.xml</excludeFilterFile>
       </configuration>
       <executions>
         <execution>

--- a/tenant-platform/catalog-service/spotbugs-exclude.xml
+++ b/tenant-platform/catalog-service/spotbugs-exclude.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<FindBugsFilter>
-  <Match>
-    <Class name="~com\.ejada\.catalog\.mapper\..*Impl"/>
-  </Match>
-</FindBugsFilter>

--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -226,6 +226,7 @@
       <configuration>
         <effort>Max</effort>
         <threshold>Low</threshold>
+        <excludeFilterFile>${project.basedir}/../../shared-lib/shared-quality/spotbugs-exclude.xml</excludeFilterFile>
       </configuration>
       <executions>
         <execution>


### PR DESCRIPTION
## Summary
- centralize SpotBugs exclude rules for MapStruct-generated mappers
- apply shared exclusion file in catalog-service and tenant-service builds

## Testing
- `mvn -pl catalog-service -am clean verify` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c66f17c832f877bc13eca472801