### PR TITLE
Ensure feature policy validators run on entity lifecycle

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/AddonFeature.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/AddonFeature.java
@@ -116,9 +116,6 @@ public class AddonFeature {
         this.isDeleted       = isDeleted != null ? isDeleted : Boolean.FALSE;
     }
 
-    @PrePersist
-    @PreUpdate
-    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "JPA lifecycle callback")
     private void validatePolicy() {
         if (enforcement == Enforcement.BLOCK && hardLimit == null) {
             throw new IllegalStateException("hardLimit is required when enforcement=BLOCK");
@@ -129,5 +126,11 @@ public class AddonFeature {
         if (softLimit != null && hardLimit != null && hardLimit.compareTo(softLimit) < 0) {
             throw new IllegalStateException("hardLimit must be >= softLimit");
         }
+    }
+
+    @PrePersist
+    @PreUpdate
+    private void jpaValidate() {
+        validatePolicy();
     }
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierFeature.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierFeature.java
@@ -132,9 +132,6 @@ public class TierFeature {
 
     /* --- Optional guard methods (domain validation) --- */
 
-    @PrePersist
-    @PreUpdate
-    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "JPA lifecycle callback")
     private void validatePolicy() {
         if (enforcement == Enforcement.BLOCK && hardLimit == null) {
             throw new IllegalStateException("hardLimit is required when enforcement=BLOCK");
@@ -145,5 +142,11 @@ public class TierFeature {
         if (softLimit != null && hardLimit != null && hardLimit.compareTo(softLimit) < 0) {
             throw new IllegalStateException("hardLimit must be >= softLimit");
         }
+    }
+
+    @PrePersist
+    @PreUpdate
+    private void jpaValidate() {
+        validatePolicy();
     }
 }


### PR DESCRIPTION
## Summary
- Invoke AddonFeature policy validation during JPA lifecycle
- Invoke TierFeature policy validation during JPA lifecycle

## Testing
- `mvn -f tenant-platform/pom.xml -pl catalog-service -am test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3d3351a8832fa05fbf9614e646f7