### PR TITLE
chore: mark mapper parameters non-null

### DIFF
--- a/setup-service/src/main/java/com/ejada/setup/mapper/CityMapper.java
+++ b/setup-service/src/main/java/com/ejada/setup/mapper/CityMapper.java
@@ -7,6 +7,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.lang.NonNull;
 
 import java.util.List;
 
@@ -20,7 +21,7 @@ public interface CityMapper {
   @Mapping(source = "cityArNm",          target = "cityArNm")
   @Mapping(source = "isActive",          target = "isActive")
   @Mapping(source = "country.countryId", target = "countryId")
-  CityDto toDto(City entity);
+  CityDto toDto(@NonNull City entity);
 
   @Mapping(source = "id",        target = "cityId")
   @Mapping(source = "cityCd",    target = "cityCd")
@@ -28,10 +29,10 @@ public interface CityMapper {
   @Mapping(source = "cityArNm",  target = "cityArNm")
   @Mapping(source = "isActive",  target = "isActive")
   @Mapping(source = "countryId", target = "countryId")
-  City toEntity(CityDto dto);
+  City toEntity(@NonNull CityDto dto);
 
   //  Add this so MapStruct generates the iterable mapper
-  List<CityDto> toDtoList(List<City> entities);
+  List<CityDto> toDtoList(@NonNull List<City> entities);
 
   // (optional, if you ever need reverse list mapping)
   // List<City> toEntityList(List<CityDto> dtos);

--- a/setup-service/src/main/java/com/ejada/setup/mapper/ResourceMapper.java
+++ b/setup-service/src/main/java/com/ejada/setup/mapper/ResourceMapper.java
@@ -7,18 +7,19 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.lang.NonNull;
 
 import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface ResourceMapper {
     @Mapping(source = "resourceId", target = "id")
-    ResourceDto toDto(Resource entity);
+    ResourceDto toDto(@NonNull Resource entity);
 
     @InheritInverseConfiguration(name = "toDto")
-    Resource toEntity(ResourceDto dto);
+    Resource toEntity(@NonNull ResourceDto dto);
 
-    List<ResourceDto> toDtoList(List<Resource> entities);
+    List<ResourceDto> toDtoList(@NonNull List<Resource> entities);
 
     default Page<ResourceDto> toDtoPage(Page<Resource> page) {
         if (page == null) return Page.empty();

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
@@ -4,6 +4,7 @@ import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.*;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
+import org.springframework.lang.NonNull;
 
 @Mapper(config = SharedMapstructConfig.class,
         imports = {Addon.class, Feature.class, Enforcement.class})
@@ -25,15 +26,15 @@ public interface AddonFeatureMapper {
     @Mapping(target = "overageCurrency", source = "overageCurrency", defaultValue = "SAR")
     @Mapping(target = "meta", source = "meta")
     @Mapping(target = "isDeleted", constant = "false")
-    AddonFeature toEntity(AddonFeatureCreateReq req);
+    AddonFeature toEntity(@NonNull AddonFeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "addonFeatureId", ignore = true)
     @Mapping(target = "addon", ignore = true)
     @Mapping(target = "feature", ignore = true)
-    void update(@MappingTarget AddonFeature entity, AddonFeatureUpdateReq req);
+    void update(@MappingTarget @NonNull AddonFeature entity, @NonNull AddonFeatureUpdateReq req);
 
     @Mapping(target = "addonId", source = "addon.addonId")
     @Mapping(target = "featureId", source = "feature.featureId")
-    AddonFeatureRes toRes(AddonFeature entity);
+    AddonFeatureRes toRes(@NonNull AddonFeature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
@@ -3,6 +3,7 @@ import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.Addon;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
+import org.springframework.lang.NonNull;
 
 @Mapper(config = SharedMapstructConfig.class)
 public interface AddonMapper {
@@ -16,7 +17,7 @@ public interface AddonMapper {
     @Mapping(target = "category", source = "category")
     @Mapping(target = "isActive", source = "isActive")
     @Mapping(target = "isDeleted", constant = "false")
-    Addon toEntity(AddonCreateReq req);
+    Addon toEntity(@NonNull AddonCreateReq req);
 
     @AfterMapping
     default void defaults(@MappingTarget Addon e, AddonCreateReq req) {
@@ -28,10 +29,10 @@ public interface AddonMapper {
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "addonId", ignore = true)
     @Mapping(target = "isDeleted", ignore = true)
-    void update(@MappingTarget Addon entity, AddonUpdateReq req);
+    void update(@MappingTarget @NonNull Addon entity, @NonNull AddonUpdateReq req);
 
     // ---------- Response ----------
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    AddonRes toRes(Addon entity);
+    AddonRes toRes(@NonNull Addon entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/FeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/FeatureMapper.java
@@ -4,6 +4,7 @@ import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.*;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
+import org.springframework.lang.NonNull;
 
 @Mapper(config = SharedMapstructConfig.class)
 public interface FeatureMapper {
@@ -17,12 +18,12 @@ public interface FeatureMapper {
     @Mapping(target = "isMetered", source = "isMetered", defaultValue = "false")
     @Mapping(target = "isActive", source = "isActive", defaultValue = "true")
     @Mapping(target = "isDeleted", constant = "false")
-    Feature toEntity(FeatureCreateReq req);
+    Feature toEntity(@NonNull FeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "featureId", ignore = true)
     @Mapping(target = "featureKey", ignore = true)
-    void update(@MappingTarget Feature entity, FeatureUpdateReq req);
+    void update(@MappingTarget @NonNull Feature entity, @NonNull FeatureUpdateReq req);
 
-    FeatureRes toRes(Feature entity);
+    FeatureRes toRes(@NonNull Feature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
@@ -4,6 +4,7 @@ import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.*;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
+import org.springframework.lang.NonNull;
 
 @Mapper(config = SharedMapstructConfig.class,
         imports = {Tier.class, Addon.class})
@@ -17,15 +18,15 @@ public interface TierAddonMapper {
     @Mapping(target = "basePrice", source = "basePrice")
     @Mapping(target = "currency", source = "currency")
     @Mapping(target = "isDeleted", constant = "false")
-    TierAddon toEntity(TierAddonCreateReq req);
+    TierAddon toEntity(@NonNull TierAddonCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "tierAddonId", ignore = true)
     @Mapping(target = "tier", ignore = true)
     @Mapping(target = "addon", ignore = true)
-    void update(@MappingTarget TierAddon entity, TierAddonUpdateReq req);
+    void update(@MappingTarget @NonNull TierAddon entity, @NonNull TierAddonUpdateReq req);
 
     @Mapping(target = "tierId", source = "tier.tierId")
     @Mapping(target = "addonId", source = "addon.addonId")
-    TierAddonRes toRes(TierAddon entity);
+    TierAddonRes toRes(@NonNull TierAddon entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
@@ -4,6 +4,7 @@ import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.*;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
+import org.springframework.lang.NonNull;
 
 @Mapper(config = SharedMapstructConfig.class,
         imports = {Tier.class, Feature.class, Enforcement.class})
@@ -25,15 +26,15 @@ public interface TierFeatureMapper {
     @Mapping(target = "overageCurrency", source = "overageCurrency", defaultValue = "SAR")
     @Mapping(target = "meta", source = "meta")
     @Mapping(target = "isDeleted", constant = "false")
-    TierFeature toEntity(TierFeatureCreateReq req);
+    TierFeature toEntity(@NonNull TierFeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "tierFeatureId", ignore = true)
     @Mapping(target = "tier", ignore = true)
     @Mapping(target = "feature", ignore = true)
-    void update(@MappingTarget TierFeature entity, TierFeatureUpdateReq req);
+    void update(@MappingTarget @NonNull TierFeature entity, @NonNull TierFeatureUpdateReq req);
 
     @Mapping(target = "tierId", source = "tier.tierId")
     @Mapping(target = "featureId", source = "feature.featureId")
-    TierFeatureRes toRes(TierFeature entity);
+    TierFeatureRes toRes(@NonNull TierFeature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierMapper.java
@@ -4,6 +4,7 @@ import com.ejada.catalog.dto.*;
 import com.ejada.catalog.model.*;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
+import org.springframework.lang.NonNull;
 
 @Mapper(config = SharedMapstructConfig.class)
 public interface TierMapper {
@@ -16,12 +17,12 @@ public interface TierMapper {
     @Mapping(target = "rankOrder", source = "rankOrder", defaultValue = "0")
     @Mapping(target = "isActive", source = "isActive", defaultValue = "true")
     @Mapping(target = "isDeleted", constant = "false")
-    Tier toEntity(TierCreateReq req);
+    Tier toEntity(@NonNull TierCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "tierId", ignore = true)
     @Mapping(target = "tierCd", ignore = true)
-    void update(@MappingTarget Tier entity, TierUpdateReq req);
+    void update(@MappingTarget @NonNull Tier entity, @NonNull TierUpdateReq req);
 
-    TierRes toRes(Tier entity);
+    TierRes toRes(@NonNull Tier entity);
 }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
@@ -6,6 +6,7 @@ import com.ejada.tenant.model.TenantIntegrationKey;
 import com.ejada.tenant.model.TenantIntegrationKey.Status;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
+import org.springframework.lang.NonNull;
 
 import java.time.OffsetDateTime;
 
@@ -35,7 +36,7 @@ public interface TenantIntegrationKeyMapper {
     // DB-managed timestamps
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    TenantIntegrationKey toEntity(TenantIntegrationKeyCreateReq req);
+    TenantIntegrationKey toEntity(@NonNull TenantIntegrationKeyCreateReq req);
 
     @AfterMapping
     default void setDefaults(@MappingTarget TenantIntegrationKey e, TenantIntegrationKeyCreateReq req) {
@@ -58,13 +59,13 @@ public interface TenantIntegrationKeyMapper {
     @Mapping(target = "updatedAt", ignore = true)
     @Mapping(target = "scopes", source = "scopes", qualifiedByName = "toArray")
     @Mapping(target = "status", source = "status", qualifiedByName = "toEntityStatus")
-    void update(@MappingTarget TenantIntegrationKey entity, TenantIntegrationKeyUpdateReq req);
+    void update(@MappingTarget @NonNull TenantIntegrationKey entity, @NonNull TenantIntegrationKeyUpdateReq req);
 
     // ---------- Response ----------
     @Mapping(target = "tenantId", source = "tenant.id")
     @Mapping(target = "scopes", source = "scopes", qualifiedByName = "toList")
     @Mapping(target = "status", source = "status", qualifiedByName = "toDtoStatus")
-    TenantIntegrationKeyRes toRes(TenantIntegrationKey entity);
+    TenantIntegrationKeyRes toRes(@NonNull TenantIntegrationKey entity);
 
     // ---------- Enum & collection converters ----------
     @Named("toEntityStatus")

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
@@ -4,6 +4,7 @@ import com.ejada.tenant.dto.*;
 import com.ejada.tenant.model.Tenant;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
+import org.springframework.lang.NonNull;
 
 @Mapper(config = SharedMapstructConfig.class)
 public interface TenantMapper {
@@ -15,7 +16,7 @@ public interface TenantMapper {
     // DB-managed timestamps
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    Tenant toEntity(TenantCreateReq req);
+    Tenant toEntity(@NonNull TenantCreateReq req);
 
     // Post-process defaults
     @AfterMapping
@@ -30,10 +31,10 @@ public interface TenantMapper {
     @Mapping(target = "isDeleted", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    void update(@MappingTarget Tenant entity, TenantUpdateReq req);
+    void update(@MappingTarget @NonNull Tenant entity, @NonNull TenantUpdateReq req);
 
     // ---------- Response ----------
-    TenantRes toRes(Tenant entity);
+    TenantRes toRes(@NonNull Tenant entity);
 
     // ---------- Helpers ----------
     static Tenant ref(Integer id) { return Tenant.ref(id); }


### PR DESCRIPTION
## Summary
- annotate MapStruct mapper method parameters with `@NonNull` to aid static analysis and reduce SpotBugs noise

## Testing
- `mvn -q -f setup-service/pom.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q -f tenant-platform/pom.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3d4b8cf8832fb1ba4c86224da205