### PR TITLE
refactor: address checkstyle warnings in catalog services

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/TierAddonService.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/TierAddonService.java
@@ -1,6 +1,8 @@
 package com.ejada.catalog.service;
 
-import com.ejada.catalog.dto.*;
+import com.ejada.catalog.dto.TierAddonCreateReq;
+import com.ejada.catalog.dto.TierAddonRes;
+import com.ejada.catalog.dto.TierAddonUpdateReq;
 import com.ejada.common.dto.BaseResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/TierFeatureService.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/TierFeatureService.java
@@ -1,6 +1,8 @@
 package com.ejada.catalog.service;
 
-import com.ejada.catalog.dto.*;
+import com.ejada.catalog.dto.TierFeatureCreateReq;
+import com.ejada.catalog.dto.TierFeatureRes;
+import com.ejada.catalog.dto.TierFeatureUpdateReq;
 import com.ejada.common.dto.BaseResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/TierService.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/TierService.java
@@ -1,6 +1,8 @@
 package com.ejada.catalog.service;
 
-import com.ejada.catalog.dto.*;
+import com.ejada.catalog.dto.TierCreateReq;
+import com.ejada.catalog.dto.TierRes;
+import com.ejada.catalog.dto.TierUpdateReq;
 import com.ejada.common.dto.BaseResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/FeatureServiceImpl.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/FeatureServiceImpl.java
@@ -1,6 +1,8 @@
 package com.ejada.catalog.service.impl;
 
-import com.ejada.catalog.dto.*;
+import com.ejada.catalog.dto.FeatureCreateReq;
+import com.ejada.catalog.dto.FeatureRes;
+import com.ejada.catalog.dto.FeatureUpdateReq;
 import com.ejada.catalog.mapper.FeatureMapper;
 import com.ejada.catalog.model.Feature;
 import com.ejada.catalog.repository.FeatureRepository;
@@ -17,13 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class FeatureServiceImpl implements FeatureService {
+public final class FeatureServiceImpl implements FeatureService {
 
     private final FeatureRepository repo;
     private final FeatureMapper mapper;
 
     @Override
-    public BaseResponse<FeatureRes> create(FeatureCreateReq req) {
+    public BaseResponse<FeatureRes> create(final FeatureCreateReq req) {
         if (repo.existsByFeatureKey(req.featureKey())) {
             throw new IllegalStateException("featureKey already exists: " + req.featureKey());
         }
@@ -32,7 +34,7 @@ public class FeatureServiceImpl implements FeatureService {
     }
 
     @Override
-    public BaseResponse<FeatureRes> update(Integer id, FeatureUpdateReq req) {
+    public BaseResponse<FeatureRes> update(final Integer id, final FeatureUpdateReq req) {
         Feature e = repo.findById(id).orElseThrow(() -> new EntityNotFoundException("Feature " + id));
         mapper.update(e, req);
         return BaseResponse.success("Feature updated", mapper.toRes(e));
@@ -40,7 +42,7 @@ public class FeatureServiceImpl implements FeatureService {
 
     @Override
     @Transactional(readOnly = true)
-    public BaseResponse<FeatureRes> get(Integer id) {
+    public BaseResponse<FeatureRes> get(final Integer id) {
         Feature feature = repo.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Feature", String.valueOf(id)));
         return BaseResponse.success("OK", mapper.toRes(feature));
@@ -48,7 +50,7 @@ public class FeatureServiceImpl implements FeatureService {
 
     @Override
     @Transactional(readOnly = true)
-    public BaseResponse<Page<FeatureRes>> list(String category, Pageable pageable) {
+    public BaseResponse<Page<FeatureRes>> list(final String category, final Pageable pageable) {
         Page<FeatureRes> page;
         if (category == null || category.isBlank()) {
             page = repo.findByIsDeletedFalse(pageable).map(mapper::toRes);
@@ -59,7 +61,7 @@ public class FeatureServiceImpl implements FeatureService {
     }
 
     @Override
-    public BaseResponse<Void> softDelete(Integer id) {
+    public BaseResponse<Void> softDelete(final Integer id) {
         Feature e = repo.findById(id).orElseThrow(() -> new EntityNotFoundException("Feature " + id));
         e.setIsDeleted(true);
         return BaseResponse.success("Feature deleted", null);

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/TierAddonServiceImpl.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/TierAddonServiceImpl.java
@@ -1,8 +1,10 @@
 package com.ejada.catalog.service.impl;
 
-import com.ejada.catalog.dto.*;
+import com.ejada.catalog.dto.TierAddonCreateReq;
+import com.ejada.catalog.dto.TierAddonRes;
+import com.ejada.catalog.dto.TierAddonUpdateReq;
 import com.ejada.catalog.mapper.TierAddonMapper;
-import com.ejada.catalog.model.*;
+import com.ejada.catalog.model.TierAddon;
 import com.ejada.catalog.repository.AddonRepository;
 import com.ejada.catalog.repository.TierAddonRepository;
 import com.ejada.catalog.repository.TierRepository;
@@ -18,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class TierAddonServiceImpl implements TierAddonService {
+public final class TierAddonServiceImpl implements TierAddonService {
 
     private final TierAddonRepository repo;
     private final TierRepository tierRepo;
@@ -26,7 +28,7 @@ public class TierAddonServiceImpl implements TierAddonService {
     private final TierAddonMapper mapper;
 
     @Override
-    public BaseResponse<TierAddonRes> allow(TierAddonCreateReq req) {
+    public BaseResponse<TierAddonRes> allow(final TierAddonCreateReq req) {
         tierRepo.findById(req.tierId()).orElseThrow(() -> new EntityNotFoundException("Tier " + req.tierId()));
         addonRepo.findById(req.addonId()).orElseThrow(() -> new EntityNotFoundException("Addon " + req.addonId()));
 
@@ -38,14 +40,14 @@ public class TierAddonServiceImpl implements TierAddonService {
     }
 
     @Override
-    public BaseResponse<TierAddonRes> update(Integer id, TierAddonUpdateReq req) {
+    public BaseResponse<TierAddonRes> update(final Integer id, final TierAddonUpdateReq req) {
         TierAddon e = repo.findById(id).orElseThrow(() -> new EntityNotFoundException("TierAddon " + id));
         mapper.update(e, req);
         return BaseResponse.success("Tier addon updated", mapper.toRes(e));
     }
 
     @Override
-    public BaseResponse<Void> remove(Integer id) {
+    public BaseResponse<Void> remove(final Integer id) {
         TierAddon e = repo.findById(id).orElseThrow(() -> new EntityNotFoundException("TierAddon " + id));
         e.setIsDeleted(true);
         return BaseResponse.success("Tier addon removed", null);
@@ -53,7 +55,7 @@ public class TierAddonServiceImpl implements TierAddonService {
 
     @Override
     @Transactional(readOnly = true)
-    public BaseResponse<Page<TierAddonRes>> listByTier(Integer tierId, Pageable pageable) {
+    public BaseResponse<Page<TierAddonRes>> listByTier(final Integer tierId, final Pageable pageable) {
         tierRepo.findById(tierId).orElseThrow(() -> new EntityNotFoundException("Tier " + tierId));
         Page<TierAddonRes> page = repo.findByTier_TierIdAndIsDeletedFalse(tierId, pageable).map(mapper::toRes);
         return BaseResponse.success("Tier addon page", page);

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/TierFeatureServiceImpl.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/TierFeatureServiceImpl.java
@@ -1,8 +1,10 @@
 package com.ejada.catalog.service.impl;
 
-import com.ejada.catalog.dto.*;
+import com.ejada.catalog.dto.TierFeatureCreateReq;
+import com.ejada.catalog.dto.TierFeatureRes;
+import com.ejada.catalog.dto.TierFeatureUpdateReq;
 import com.ejada.catalog.mapper.TierFeatureMapper;
-import com.ejada.catalog.model.*;
+import com.ejada.catalog.model.TierFeature;
 import com.ejada.catalog.repository.FeatureRepository;
 import com.ejada.catalog.repository.TierFeatureRepository;
 import com.ejada.catalog.repository.TierRepository;
@@ -18,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class TierFeatureServiceImpl implements TierFeatureService {
+public final class TierFeatureServiceImpl implements TierFeatureService {
 
     private final TierFeatureRepository repo;
     private final TierRepository tierRepo;
@@ -26,7 +28,7 @@ public class TierFeatureServiceImpl implements TierFeatureService {
     private final TierFeatureMapper mapper;
 
     @Override
-    public BaseResponse<TierFeatureRes> attach(TierFeatureCreateReq req) {
+    public BaseResponse<TierFeatureRes> attach(final TierFeatureCreateReq req) {
         // validate existence
         tierRepo.findById(req.tierId()).orElseThrow(() -> new EntityNotFoundException("Tier " + req.tierId()));
         featureRepo.findById(req.featureId()).orElseThrow(() -> new EntityNotFoundException("Feature " + req.featureId()));
@@ -39,14 +41,14 @@ public class TierFeatureServiceImpl implements TierFeatureService {
     }
 
     @Override
-    public BaseResponse<TierFeatureRes> update(Integer id, TierFeatureUpdateReq req) {
+    public BaseResponse<TierFeatureRes> update(final Integer id, final TierFeatureUpdateReq req) {
         TierFeature e = repo.findById(id).orElseThrow(() -> new EntityNotFoundException("TierFeature " + id));
         mapper.update(e, req);
         return BaseResponse.success("Tier feature updated", mapper.toRes(e));
     }
 
     @Override
-    public BaseResponse<Void> detach(Integer id) {
+    public BaseResponse<Void> detach(final Integer id) {
         TierFeature e = repo.findById(id).orElseThrow(() -> new EntityNotFoundException("TierFeature " + id));
         e.setIsDeleted(true);
         return BaseResponse.success("Tier feature detached", null);
@@ -54,7 +56,7 @@ public class TierFeatureServiceImpl implements TierFeatureService {
 
     @Override
     @Transactional(readOnly = true)
-    public BaseResponse<Page<TierFeatureRes>> listByTier(Integer tierId, Pageable pageable) {
+    public BaseResponse<Page<TierFeatureRes>> listByTier(final Integer tierId, final Pageable pageable) {
         tierRepo.findById(tierId).orElseThrow(() -> new EntityNotFoundException("Tier " + tierId));
         Page<TierFeatureRes> page = repo.findByTier_TierIdAndIsDeletedFalse(tierId, pageable).map(mapper::toRes);
         return BaseResponse.success("Tier feature page", page);

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/TierServiceImpl.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/TierServiceImpl.java
@@ -1,6 +1,8 @@
 package com.ejada.catalog.service.impl;
 
-import com.ejada.catalog.dto.*;
+import com.ejada.catalog.dto.TierCreateReq;
+import com.ejada.catalog.dto.TierRes;
+import com.ejada.catalog.dto.TierUpdateReq;
 import com.ejada.catalog.mapper.TierMapper;
 import com.ejada.catalog.model.Tier;
 import com.ejada.catalog.repository.TierRepository;
@@ -16,13 +18,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class TierServiceImpl implements TierService {
+public final class TierServiceImpl implements TierService {
 
     private final TierRepository repo;
     private final TierMapper mapper;
 
     @Override
-    public BaseResponse<TierRes> create(TierCreateReq req) {
+    public BaseResponse<TierRes> create(final TierCreateReq req) {
         if (repo.existsByTierCd(req.tierCd())) {
             throw new IllegalStateException("tierCd already exists: " + req.tierCd());
         }
@@ -31,7 +33,7 @@ public class TierServiceImpl implements TierService {
     }
 
     @Override
-    public BaseResponse<TierRes> update(Integer id, TierUpdateReq req) {
+    public BaseResponse<TierRes> update(final Integer id, final TierUpdateReq req) {
         Tier entity = repo.findById(id).orElseThrow(() -> new EntityNotFoundException("Tier " + id));
         mapper.update(entity, req);
         return BaseResponse.success("Tier updated", mapper.toRes(entity));
@@ -39,7 +41,7 @@ public class TierServiceImpl implements TierService {
 
     @Override
     @Transactional(readOnly = true)
-    public BaseResponse<TierRes> get(Integer id) {
+    public BaseResponse<TierRes> get(final Integer id) {
         return BaseResponse.success(
             "OK",
             mapper.toRes(repo.findById(id).orElseThrow(() -> new EntityNotFoundException("Tier " + id)))
@@ -48,7 +50,7 @@ public class TierServiceImpl implements TierService {
 
     @Override
     @Transactional(readOnly = true)
-    public BaseResponse<Page<TierRes>> list(Boolean active, Pageable pageable) {
+    public BaseResponse<Page<TierRes>> list(final Boolean active, final Pageable pageable) {
         Page<TierRes> page;
         if (active == null) {
             page = repo.findByIsDeletedFalse(pageable).map(mapper::toRes);
@@ -59,7 +61,7 @@ public class TierServiceImpl implements TierService {
     }
 
     @Override
-    public BaseResponse<Void> softDelete(Integer id) {
+    public BaseResponse<Void> softDelete(final Integer id) {
         Tier e = repo.findById(id).orElseThrow(() -> new EntityNotFoundException("Tier " + id));
         e.setIsDeleted(true);
         return BaseResponse.success("Tier deleted", null);


### PR DESCRIPTION
## Summary
- mark catalog service implementations as final and use explicit imports to satisfy checkstyle
- add final modifiers to method parameters for immutability

## Testing
- `mvn -q -pl catalog-service test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3e0afe74832fbccb489d4c04de3e