### PR TITLE
Suppress SpotBugs warnings for JPA callbacks

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/AddonFeature.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/AddonFeature.java
@@ -130,6 +130,8 @@ public class AddonFeature {
 
     @PrePersist
     @PreUpdate
+    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD",
+                        justification = "Invoked by JPA via reflection")
     private void jpaValidate() {
         validatePolicy();
     }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierFeature.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierFeature.java
@@ -146,6 +146,8 @@ public class TierFeature {
 
     @PrePersist
     @PreUpdate
+    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD",
+                        justification = "Invoked by JPA via reflection")
     private void jpaValidate() {
         validatePolicy();
     }


### PR DESCRIPTION
## Summary
- suppress UPM_UNCALLED_PRIVATE_METHOD warning for AddonFeature.jpaValidate invoked by JPA
- suppress UPM_UNCALLED_PRIVATE_METHOD warning for TierFeature.jpaValidate invoked by JPA

## Testing
- `mvn -q -pl catalog-service -am verify` *(failed: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3f519d9c832f83142874b8335c8a