### PR TITLE
chore: address checkstyle warnings in addon dtos

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/dto/AddonCreateReq.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/dto/AddonCreateReq.java
@@ -2,7 +2,8 @@ package com.ejada.catalog.dto;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Schema(name = "AddonCreateReq", description = "Create a new addon")
 public record AddonCreateReq(
@@ -27,4 +28,4 @@ public record AddonCreateReq(
 
         @Schema(description = "Active flag; defaults to true if null")
         Boolean isActive
-) {}
+) { }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/dto/AddonFeatureCreateReq.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/dto/AddonFeatureCreateReq.java
@@ -5,17 +5,17 @@ import com.ejada.catalog.model.LimitWindow;
 import com.ejada.catalog.model.MeasureUnit;
 
 public record AddonFeatureCreateReq(
-	    Integer addonId,
-	    Integer featureId,
-	    Boolean enabled,
-	    Enforcement enforcement,
-	    BigDecimal softLimit,
-	    BigDecimal hardLimit,
-	    LimitWindow limitWindow,
-	    MeasureUnit measureUnit,
-	    String resetCron,
-	    Boolean overageEnabled,
-	    BigDecimal overageUnitPrice,
-	    String overageCurrency,
-	    String meta
-	) {}
+        Integer addonId,
+        Integer featureId,
+        Boolean enabled,
+        Enforcement enforcement,
+        BigDecimal softLimit,
+        BigDecimal hardLimit,
+        LimitWindow limitWindow,
+        MeasureUnit measureUnit,
+        String resetCron,
+        Boolean overageEnabled,
+        BigDecimal overageUnitPrice,
+        String overageCurrency,
+        String meta
+) { }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/dto/AddonUpdateReq.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/dto/AddonUpdateReq.java
@@ -1,29 +1,35 @@
 package com.ejada.catalog.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.Size;
 
 @Schema(name = "AddonUpdateReq", description = "Patch/update an existing addon")
 public record AddonUpdateReq(
-        @Size(max = 64)
+        @Size(max = CODE_MAX)
         @Schema(description = "Unique addon code", example = "EXTRA_SEATS")
         String addonCd,
 
-        @Size(max = 128)
+        @Size(max = EN_NAME_MAX)
         @Schema(description = "English name", example = "Extra Seats")
         String addonEnNm,
 
-        @Size(max = 128)
+        @Size(max = AR_NAME_MAX)
         @Schema(description = "Arabic name", example = "مقاعد إضافية")
         String addonArNm,
 
         @Schema(description = "Detailed description")
         String description,
 
-        @Size(max = 64)
+        @Size(max = CATEGORY_MAX)
         @Schema(description = "Optional category for UI grouping", example = "SEATS")
         String category,
 
         @Schema(description = "Active flag")
         Boolean isActive
-) {}
+) {
+    public static final int CODE_MAX = 64;
+    public static final int EN_NAME_MAX = 128;
+    public static final int AR_NAME_MAX = 128;
+    public static final int CATEGORY_MAX = 64;
+}
+


### PR DESCRIPTION
## Summary
- replace wildcard imports with explicit imports in addon DTOs
- remove tabs, add spaces, and add missing whitespace around braces
- extract magic numbers to constants in AddonUpdateReq

## Testing
- `mvn -q checkstyle:check` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4234f1ec832fafca111b60c9a3ef