### PR TITLE
feat: auto-generate integration key secrets

### DIFF
--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -93,6 +93,10 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
+      <artifactId>starter-crypto</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
       <artifactId>starter-actuator</artifactId>
     </dependency>
        <!--

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyCreateReq.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyCreateReq.java
@@ -14,8 +14,8 @@ public record TenantIntegrationKeyCreateReq(
         @Schema(description = "Public key identifier", example = "SYS_DEFAULT")
         String keyId,
 
-        @Size(min = 12, max = 256)
-        @Schema(description = "Plain secret to be hashed server-side (optional if you auto-generate)", example = "S3cure-Plain-Secret")
+        @Size(max = 256)
+        @Schema(description = "Optional plain secret to be hashed server-side; generated if blank", example = "S3cure-Plain-Secret")
         String plainSecret,
 
         @Size(max = 128)

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyRes.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyRes.java
@@ -21,7 +21,9 @@ public record TenantIntegrationKeyRes(
         String meta,
         Boolean isDeleted,
         OffsetDateTime createdAt,
-        OffsetDateTime updatedAt
+        OffsetDateTime updatedAt,
+        @Schema(description = "Plain secret returned only on creation")
+        String plainSecret
 ) {
     public TenantIntegrationKeyRes {
         scopes = scopes == null ? List.of() : List.copyOf(scopes);
@@ -30,5 +32,11 @@ public record TenantIntegrationKeyRes(
     @Override
     public List<String> scopes() {
         return List.copyOf(scopes);
+    }
+
+    public TenantIntegrationKeyRes withPlainSecret(String secret) {
+        return new TenantIntegrationKeyRes(tikId, tenantId, keyId, label, scopes, status,
+                validFrom, expiresAt, lastUsedAt, useCount, dailyQuota, meta, isDeleted,
+                createdAt, updatedAt, secret);
     }
 }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
@@ -65,6 +65,7 @@ public interface TenantIntegrationKeyMapper {
     @Mapping(target = "tenantId", source = "tenant.id")
     @Mapping(target = "scopes", source = "scopes", qualifiedByName = "toList")
     @Mapping(target = "status", source = "status", qualifiedByName = "toDtoStatus")
+    @Mapping(target = "plainSecret", ignore = true)
     TenantIntegrationKeyRes toRes(@NonNull TenantIntegrationKey entity);
 
     // ---------- Enum & collection converters ----------

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/TenantIntegrationKeyServiceImplTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/TenantIntegrationKeyServiceImplTest.java
@@ -1,0 +1,59 @@
+package com.ejada.tenant.service;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.crypto.CryptoService;
+import com.ejada.tenant.dto.TenantIntegrationKeyCreateReq;
+import com.ejada.tenant.dto.TenantIntegrationKeyRes;
+import com.ejada.tenant.dto.TikStatus;
+import com.ejada.tenant.mapper.TenantIntegrationKeyMapper;
+import com.ejada.tenant.model.Tenant;
+import com.ejada.tenant.model.TenantIntegrationKey;
+import com.ejada.tenant.repository.TenantIntegrationKeyRepository;
+import com.ejada.tenant.repository.TenantRepository;
+import com.ejada.tenant.service.impl.TenantIntegrationKeyServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.mockito.ArgumentCaptor;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class TenantIntegrationKeyServiceImplTest {
+
+    @Test
+    void createGeneratesSecretWhenMissing() throws Exception {
+        TenantIntegrationKeyRepository repo = mock(TenantIntegrationKeyRepository.class);
+        TenantRepository tenantRepo = mock(TenantRepository.class);
+        TenantIntegrationKeyMapper mapper = Mappers.getMapper(TenantIntegrationKeyMapper.class);
+        CryptoService crypto = mock(CryptoService.class);
+
+        Tenant tenant = new Tenant();
+        tenant.setId(1);
+        when(tenantRepo.findByIdAndIsDeletedFalse(1)).thenReturn(Optional.of(tenant));
+        when(repo.existsByTenant_IdAndKeyIdAndIsDeletedFalse(1, "KEY")).thenReturn(false);
+        when(crypto.signToBase64(anyString())).thenReturn("hashed-secret");
+        when(repo.save(any(TenantIntegrationKey.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        TenantIntegrationKeyCreateReq req = new TenantIntegrationKeyCreateReq(
+                1, "KEY", null, "label", List.of(), TikStatus.ACTIVE,
+                null, OffsetDateTime.now().plusDays(1), null, null
+        );
+
+        TenantIntegrationKeyServiceImpl service =
+                new TenantIntegrationKeyServiceImpl(repo, tenantRepo, mapper, crypto);
+
+        BaseResponse<TenantIntegrationKeyRes> resp = service.create(req);
+        assertNotNull(resp.getData().plainSecret());
+        assertFalse(resp.getData().plainSecret().isBlank());
+
+        ArgumentCaptor<TenantIntegrationKey> captor = ArgumentCaptor.forClass(TenantIntegrationKey.class);
+        verify(repo).save(captor.capture());
+        assertEquals("hashed-secret", captor.getValue().getKeySecret());
+    }
+}
+


### PR DESCRIPTION
## Summary
- auto-generate a secret if none is supplied when creating a tenant integration key
- sign secrets using `CryptoService` and return the plain value once in the response
- expose secret field in response DTO, mapper, and tests

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl tenant-service -am test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc434d8780832f9806afd211aa9f06