### PR TITLE
Handle default values and suppress resource leak warning

### DIFF
--- a/setup-service/src/main/java/com/ejada/setup/model/Country.java
+++ b/setup-service/src/main/java/com/ejada/setup/model/Country.java
@@ -80,6 +80,7 @@ public class Country implements Serializable {
     @Column(name = "nationality_ar", length = 256)
     private String nationalityAr;
 
+    @Builder.Default
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = Boolean.TRUE;
 

--- a/setup-service/src/main/java/com/ejada/setup/model/Resource.java
+++ b/setup-service/src/main/java/com/ejada/setup/model/Resource.java
@@ -77,6 +77,7 @@ public class Resource implements Serializable {
     @Column(name = "parent_resource_id")
     private Integer parentResourceId;
 
+    @Builder.Default
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = Boolean.TRUE;
 

--- a/setup-service/src/main/java/com/ejada/setup/model/SystemParameter.java
+++ b/setup-service/src/main/java/com/ejada/setup/model/SystemParameter.java
@@ -39,6 +39,7 @@ public class SystemParameter {
     @Column(name = "group_code", length = 150)
     private String paramGroup;
 
+    @Builder.Default
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = Boolean.TRUE;
 

--- a/shared-lib/shared-starters/starter-redis/src/main/java/com/ejada/redis/starter/props/RedisProperties.java
+++ b/shared-lib/shared-starters/starter-redis/src/main/java/com/ejada/redis/starter/props/RedisProperties.java
@@ -15,18 +15,24 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "shared.redis")
 public class RedisProperties {
   private String url;                 // redis://user:pass@host:6379/0 or rediss://...
+  @Builder.Default
   private String host = "localhost";
+  @Builder.Default
   private int port = 6379;
   private String password;
+  @Builder.Default
   private int database = 0;
+  @Builder.Default
   private boolean ssl = false;
   private String clientName;
   @Builder.Default
   private Duration timeout = Duration.ofSeconds(5);
 
+  @Builder.Default
   private String keyPrefix = "shared";
   @Builder.Default
   private Duration defaultTtl = Duration.ofMinutes(10);
+  @Builder.Default
   private Boolean reactive = false;
 
   private Map<String, CacheSpec> caches;

--- a/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/IntegrationTestSupport.java
+++ b/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/IntegrationTestSupport.java
@@ -23,6 +23,7 @@ public abstract class IntegrationTestSupport {
 
     /** Lightweight Redis container. */
     @Container
+    @SuppressWarnings("resource")
     protected static final GenericContainer<?> REDIS =
             new GenericContainer<>("redis:7").withExposedPorts(6379);
 


### PR DESCRIPTION
## Summary
- Ensure builder respects default fields in models and Redis properties
- Suppress false positive resource leak warning in integration test support

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.ejada:setup-service:1.0.0)*
- `mvn -q test` *(fails: dependency version missing for org.springframework.boot:spring-boot-starter)*
- `mvn -q test` *(fails: Non-resolvable import POM com.ejada:shared-bom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc43b05694832fa9c4acc6986a0f21