### PR TITLE
Explicitly map boolean fields in catalog mappers

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
@@ -36,5 +36,6 @@ public interface AddonFeatureMapper {
 
     @Mapping(target = "addonId", source = "addon.addonId")
     @Mapping(target = "featureId", source = "feature.featureId")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     AddonFeatureRes toRes(@NonNull AddonFeature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
@@ -34,5 +34,7 @@ public interface AddonMapper {
     // ---------- Response ----------
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "isActive", source = "isActive")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     AddonRes toRes(@NonNull Addon entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/FeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/FeatureMapper.java
@@ -25,5 +25,8 @@ public interface FeatureMapper {
     @Mapping(target = "featureKey", ignore = true)
     void update(@MappingTarget @NonNull Feature entity, @NonNull FeatureUpdateReq req);
 
+    @Mapping(target = "isMetered", source = "isMetered")
+    @Mapping(target = "isActive", source = "isActive")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     FeatureRes toRes(@NonNull Feature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
@@ -10,6 +10,7 @@ import org.springframework.lang.NonNull;
         imports = {Tier.class, Addon.class})
 public interface TierAddonMapper {
 
+    @BeanMapping(ignoreUnmappedSourceProperties = {"tierId", "addonId"})
     @Mapping(target = "tierAddonId", ignore = true)
     @Mapping(target = "tier", expression = "java(Tier.ref(req.tierId()))")
     @Mapping(target = "addon", expression = "java(Addon.ref(req.addonId()))")
@@ -28,5 +29,6 @@ public interface TierAddonMapper {
 
     @Mapping(target = "tierId", source = "tier.tierId")
     @Mapping(target = "addonId", source = "addon.addonId")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     TierAddonRes toRes(@NonNull TierAddon entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
@@ -36,5 +36,6 @@ public interface TierFeatureMapper {
 
     @Mapping(target = "tierId", source = "tier.tierId")
     @Mapping(target = "featureId", source = "feature.featureId")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     TierFeatureRes toRes(@NonNull TierFeature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierMapper.java
@@ -24,5 +24,7 @@ public interface TierMapper {
     @Mapping(target = "tierCd", ignore = true)
     void update(@MappingTarget @NonNull Tier entity, @NonNull TierUpdateReq req);
 
+    @Mapping(target = "isActive", source = "isActive")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     TierRes toRes(@NonNull Tier entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/Addon.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/Addon.java
@@ -50,6 +50,7 @@ public class Addon {
     public boolean isActive()  { return Boolean.TRUE.equals(isActive); }
     public boolean isDeleted() { return Boolean.TRUE.equals(isDeleted); }
 
+
     /** id-only reference helper */
     public static Addon ref(final Integer id) {
         if (id == null) return null;

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/AddonFeature.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/AddonFeature.java
@@ -79,9 +79,8 @@ public class AddonFeature {
 
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = Boolean.FALSE;
-
-    public boolean isEnabled()        { return Boolean.TRUE.equals(enabled); }
     public boolean isDeleted()        { return Boolean.TRUE.equals(isDeleted); }
+    public boolean isEnabled()        { return Boolean.TRUE.equals(enabled); }
     public boolean isOverageEnabled() { return Boolean.TRUE.equals(overageEnabled); }
 
     /** id-only helpers for builder ergonomics */

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/Feature.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/Feature.java
@@ -48,9 +48,10 @@ public class Feature {
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = Boolean.FALSE;
 
+    public boolean isMetered() { return Boolean.TRUE.equals(isMetered); }
     public boolean isActive()  { return Boolean.TRUE.equals(isActive); }
     public boolean isDeleted() { return Boolean.TRUE.equals(isDeleted); }
-    public boolean isMetered() { return Boolean.TRUE.equals(isMetered); }
+
 
     public static Feature ref(final Integer id) {
         if (id == null) return null;

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/Tier.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/Tier.java
@@ -53,8 +53,9 @@ public class Tier {
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = Boolean.FALSE;
 
-    public boolean isActive() { return Boolean.TRUE.equals(isActive); }
+    public boolean isActive()  { return Boolean.TRUE.equals(isActive); }
     public boolean isDeleted() { return Boolean.TRUE.equals(isDeleted); }
+
 
     public static Tier ref(final Integer id) {
         if (id == null) return null;

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierAddon.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierAddon.java
@@ -54,9 +54,8 @@ public class TierAddon {
 
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = Boolean.FALSE;
-
+    public boolean isDeleted() { return Boolean.TRUE.equals(isDeleted); }
     public boolean isIncluded() { return Boolean.TRUE.equals(included); }
-    public boolean isDeleted()  { return Boolean.TRUE.equals(isDeleted); }
 
     /** id-only helpers */
     public static TierAddon ref(final Integer id) {

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierFeature.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierFeature.java
@@ -87,9 +87,8 @@ public class TierFeature {
 
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = Boolean.FALSE;
-
-    public boolean isEnabled()         { return Boolean.TRUE.equals(enabled); }
     public boolean isDeleted()         { return Boolean.TRUE.equals(isDeleted); }
+    public boolean isEnabled()         { return Boolean.TRUE.equals(enabled); }
     public boolean isOverageEnabled()  { return Boolean.TRUE.equals(overageEnabled); }
 
     @Builder


### PR DESCRIPTION
## Summary
- restore boolean helper methods on catalog entities instead of relying on field access
- map `isActive`, `isDeleted`, and other boolean flags explicitly in MapStruct mappers to suppress warnings

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl catalog-service -am compile` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4220b104832fb1b8262fc3dcd537