### PR TITLE
Ensure null plainSecret in TenantIntegrationKeyRes mapping

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
@@ -65,7 +65,7 @@ public interface TenantIntegrationKeyMapper {
     @Mapping(target = "tenantId", source = "tenant.id")
     @Mapping(target = "scopes", source = "scopes", qualifiedByName = "toList")
     @Mapping(target = "status", source = "status", qualifiedByName = "toDtoStatus")
-    @Mapping(target = "plainSecret", ignore = true)
+    @Mapping(target = "plainSecret", expression = "java(null)")
     TenantIntegrationKeyRes toRes(@NonNull TenantIntegrationKey entity);
 
     // ---------- Enum & collection converters ----------


### PR DESCRIPTION
## Summary
- Prevent MapStruct from using outdated constructor by explicitly mapping `plainSecret` to `null` in TenantIntegrationKeyMapper

## Testing
- `mvn -q -pl tenant-service -am test` *(fails: Non-resolvable import POM: Could not transfer artifact org.assertj:assertj-bom:pom:3.27.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc844d7910832f8c1af26be0e7a625