### PR TITLE
fix: ignore plain secret helper in mapper

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
@@ -66,6 +66,7 @@ public interface TenantIntegrationKeyMapper {
     @Mapping(target = "scopes", source = "scopes", qualifiedByName = "toList")
     @Mapping(target = "status", source = "status", qualifiedByName = "toDtoStatus")
     @Mapping(target = "plainSecret", expression = "java(null)")
+    @Mapping(target = "withPlainSecret", ignore = true)
     TenantIntegrationKeyRes toRes(@NonNull TenantIntegrationKey entity);
 
     // ---------- Enum & collection converters ----------


### PR DESCRIPTION
## Summary
- avoid MapStruct mapping failure by ignoring helper method `withPlainSecret`

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bc93f46f2c832f8e42d22546fdfbb8