### PR TITLE
chore: align MapStruct dependencies

### DIFF
--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -38,7 +38,7 @@
     <springdoc.version>2.7.0</springdoc.version>
    <money.api.version>1.1</money.api.version>
    <moneta.version>1.4.5</moneta.version>
-   <mapstruct.version>1.5.5.Final</mapstruct.version>
+   <mapstruct.version>1.6.2</mapstruct.version>
   <lombok.version>1.18.32</lombok.version>
   <lombokMapstruct.version>0.2.0</lombokMapstruct.version>
   <logstashLogback.version>8.0</logstashLogback.version>

--- a/shared-lib/shared-starters/starter-mapstruct/pom.xml
+++ b/shared-lib/shared-starters/starter-mapstruct/pom.xml
@@ -27,6 +27,7 @@
     <dependency>
       <groupId>org.mapstruct</groupId>
       <artifactId>mapstruct</artifactId>
+      <version>${mapstruct.version}</version>
     </dependency>
 
 		<!-- Optional helpers -->


### PR DESCRIPTION
## Summary
- upgrade MapStruct to 1.6.2 in shared BOM
- pin MapStruct dependency version in starter module

## Testing
- `mvn -U clean install -pl shared-starters/starter-mapstruct -am` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9fd8bac4832f815ebd7f176ef9a5