### PR TITLE
fix: add context to subscription mappers

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionAdditionalServiceMapper.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionAdditionalServiceMapper.java
@@ -26,7 +26,7 @@ public interface SubscriptionAdditionalServiceMapper {
     @Mapping(target = "paymentTypeCd", source = "dto.paymentTypeCd")
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    SubscriptionAdditionalService toEntity(SubscriptionAdditionalServiceDto dto, Subscription subscription);
+    SubscriptionAdditionalService toEntity(SubscriptionAdditionalServiceDto dto, @Context Subscription subscription);
 
     List<SubscriptionAdditionalService> toEntities(List<SubscriptionAdditionalServiceDto> dtos, @Context Subscription subscription);
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionEnvironmentIdentifierMapper.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionEnvironmentIdentifierMapper.java
@@ -15,7 +15,7 @@ public interface SubscriptionEnvironmentIdentifierMapper {
     @Mapping(target = "identifierCd",    source = "dto.identifierCd")
     @Mapping(target = "identifierValue", source = "dto.identifierValue")
     @Mapping(target = "createdAt", ignore = true)
-    SubscriptionEnvironmentIdentifier toEntity(EnvironmentIdentifierDto dto, Subscription subscription);
+    SubscriptionEnvironmentIdentifier toEntity(EnvironmentIdentifierDto dto, @Context Subscription subscription);
 
     // entity -> dto (no 'subscription' on DTO)
     EnvironmentIdentifierDto toDto(SubscriptionEnvironmentIdentifier entity);

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionFeatureMapper.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionFeatureMapper.java
@@ -16,7 +16,7 @@ public interface SubscriptionFeatureMapper {
     @Mapping(target = "featureCount", source = "dto.featureCount")
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    SubscriptionFeature toEntity(SubscriptionFeatureDto dto, Subscription subscription);
+    SubscriptionFeature toEntity(SubscriptionFeatureDto dto, @Context Subscription subscription);
 
     List<SubscriptionFeature> toEntities(List<SubscriptionFeatureDto> dtos, @Context Subscription subscription);
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionProductPropertyMapper.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionProductPropertyMapper.java
@@ -15,7 +15,7 @@ public interface SubscriptionProductPropertyMapper {
     @Mapping(target = "propertyCd", source = "dto.propertyCd")
     @Mapping(target = "propertyValue", source = "dto.propertyValue")
     @Mapping(target = "createdAt", ignore = true)
-    SubscriptionProductProperty toEntity(ProductPropertyDto dto, Subscription subscription);
+    SubscriptionProductProperty toEntity(ProductPropertyDto dto, @Context Subscription subscription);
 
     List<SubscriptionProductProperty> toEntities(List<ProductPropertyDto> dtos, @Context Subscription subscription);
 }


### PR DESCRIPTION
## Summary
- mark Subscription entity parameters as `@Context` in list element mapping methods for MapStruct

## Testing
- `mvn -q -pl subscription-service -am test` *(failed: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd46b7abcc832f9e09f351a6dc25a3