### PR TITLE
feat: handle duplicate resources and improve addon management

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/exception/DuplicateResourceException.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/exception/DuplicateResourceException.java
@@ -1,0 +1,31 @@
+package com.ejada.common.exception;
+
+import com.ejada.common.constants.ErrorCodes;
+
+/**
+ * Exception thrown when attempting to create a resource that already exists.
+ */
+public class DuplicateResourceException extends SharedException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Create a DuplicateResourceException with resource type and identifier.
+     *
+     * @param resourceType the type of the resource
+     * @param resourceId the identifier of the conflicting resource
+     */
+    public DuplicateResourceException(String resourceType, String resourceId) {
+        super(ErrorCodes.DATA_DUPLICATE,
+              String.format("%s with id '%s' already exists", resourceType, resourceId));
+    }
+
+    /**
+     * Create a DuplicateResourceException with a custom message.
+     *
+     * @param message custom message describing the conflict
+     */
+    public DuplicateResourceException(String message) {
+        super(ErrorCodes.DATA_DUPLICATE, message);
+    }
+}

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.ejada.common.exception.BusinessException;
 import com.ejada.common.exception.BusinessRuleException;
 import com.ejada.common.exception.NotFoundException;
 import com.ejada.common.exception.ResourceNotFoundException;
+import com.ejada.common.exception.DuplicateResourceException;
 import com.ejada.common.exception.ValidationException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -104,6 +105,13 @@ public class GlobalExceptionHandler {
         log.error("Data integrity violation: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(BaseResponse.error("ERR_DATA_CONFLICT", "Data conflict occurred"));
+    }
+
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<BaseResponse<?>> handleDuplicateResource(DuplicateResourceException ex, WebRequest request) {
+        log.warn("Duplicate resource: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(BaseResponse.error(ex.getErrorCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/AddonController.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/AddonController.java
@@ -18,6 +18,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.*;
+import java.net.URI;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,14 +36,16 @@ public class AddonController {
     @CatalogAuthorized
     @Operation(summary = "Create a new addon", description = "Creates a new addon with the provided details")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "addon created successfully",
+            @ApiResponse(responseCode = "201", description = "addon created successfully",
                 content = @Content(schema = @Schema(implementation = BaseResponse.class))),
             @ApiResponse(responseCode = "400", description = "Invalid input data"),
             @ApiResponse(responseCode = "403", description = "Access denied"),
             @ApiResponse(responseCode = "409", description = "addon already exists")
         })
     public ResponseEntity<BaseResponse<AddonRes>> create(@Valid @RequestBody AddonCreateReq req) {
-        return ResponseEntity.ok(service.create(req));
+        BaseResponse<AddonRes> res = service.create(req);
+        URI location = URI.create("/api/v1/catalog/addons/" + res.data().addonId());
+        return ResponseEntity.created(location).body(res);
     }
 
     @PutMapping("/{id}")


### PR DESCRIPTION
## Summary
- add DuplicateResourceException and global handler for HTTP 409 responses
- guard addon CRUD with explicit saves, cache eviction, and duplicate handling
- return 201 Created with Location header for addon creation

## Testing
- `mvn -q -f shared-lib/pom.xml install` *(fails: Network is unreachable)*
- `mvn -q -f tenant-platform/pom.xml -pl catalog-service -am test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68bd719048c4832fbf95e919c644a981