### PR TITLE
Fix shared-common missing Spring dependencies

### DIFF
--- a/shared-lib/shared-common/pom.xml
+++ b/shared-lib/shared-common/pom.xml
@@ -31,6 +31,27 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Web annotations and ResponseEntity support -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- JPA repository base interfaces -->
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-jpa</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Transactional annotation -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+      <optional>true</optional>
+    </dependency>
+
   
     <dependency>
     <groupId>net.logstash.logback</groupId>


### PR DESCRIPTION
## Summary
- add optional Spring Web, Data JPA, and Tx dependencies to shared-common module

## Testing
- `mvn -pl shared-common -am test` *(fails: Non-resolvable import POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd77bf1a58832fa2fb059da2b80400