### PR TITLE
feat: extend DuplicateResourceException with error code

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/exception/DuplicateResourceException.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/exception/DuplicateResourceException.java
@@ -1,17 +1,31 @@
 package com.ejada.common.exception;
 
+import com.ejada.common.constants.ErrorCodes;
+
 /**
  * Thrown when attempting to create a resource that already exists.
  */
-public class DuplicateResourceException extends RuntimeException {
+public class DuplicateResourceException extends SharedException {
+
+    private static final long serialVersionUID = 1L;
 
     /**
-     * Create a new DuplicateResourceException with the given message.
+     * Create a new DuplicateResourceException with the default error code.
      *
      * @param message detail message describing the duplicate
      */
     public DuplicateResourceException(String message) {
-        super(message);
+        super(ErrorCodes.DATA_DUPLICATE, message);
+    }
+
+    /**
+     * Create a new DuplicateResourceException with additional details.
+     *
+     * @param message detail message describing the duplicate
+     * @param details more specific information about the violation
+     */
+    public DuplicateResourceException(String message, String details) {
+        super(ErrorCodes.DATA_DUPLICATE, message, details);
     }
 }
 


### PR DESCRIPTION
## Summary
- allow DuplicateResourceException to expose a consistent error code
- provide optional details for duplicate resource violations

## Testing
- `mvn -pl shared-starters/starter-core -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd81b8be60832f96966c1034b5850c