### PR TITLE
fix: correct jar names in service Dockerfiles

### DIFF
--- a/tenant-platform/billing-service/Dockerfile
+++ b/tenant-platform/billing-service/Dockerfile
@@ -8,7 +8,7 @@ RUN addgroup -g 1001 -S appgroup && \
 WORKDIR /app
 
 # Copy the application JAR
-COPY target/ejada-catalog-*.jar app.jar
+COPY target/ejada-billing-*.jar app.jar
 
 # Change ownership to non-root user
 RUN chown -R appuser:appgroup /app

--- a/tenant-platform/subscription-service/Dockerfile
+++ b/tenant-platform/subscription-service/Dockerfile
@@ -8,7 +8,7 @@ RUN addgroup -g 1001 -S appgroup && \
 WORKDIR /app
 
 # Copy the application JAR
-COPY target/ejada-catalog-*.jar app.jar
+COPY target/ejada-subscription-*.jar app.jar
 
 # Change ownership to non-root user
 RUN chown -R appuser:appgroup /app

--- a/tenant-platform/tenant-service/Dockerfile
+++ b/tenant-platform/tenant-service/Dockerfile
@@ -8,7 +8,7 @@ RUN addgroup -g 1001 -S appgroup && \
 WORKDIR /app
 
 # Copy the application JAR
-COPY target/ejada-catalog-*.jar app.jar
+COPY target/ejada-tenant-*.jar app.jar
 
 # Change ownership to non-root user
 RUN chown -R appuser:appgroup /app


### PR DESCRIPTION
## Summary
- fix Dockerfiles to copy the correct service JARs for tenant, subscription, and billing services

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd6306478832f8745b91684c55608