### PR TITLE
Add required infrastructure services and fix Dockerfiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,101 @@ volumes:
   kafkadata:
 
 services:
+  postgres:
+    image: postgres:16
+    <<: [*restart_policy, *resources_light]
+    environment:
+      POSTGRES_DB: lms
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      TZ: Asia/Riyadh
+    ports: ["5432:5432"]
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "pg_isready -U postgres -d lms"]
+    networks:
+      backend:
+        aliases: [postgres]
 
+  redis:
+    image: redis:7
+    <<: [*restart_policy, *resources_light]
+    command: ["redis-server", "--appendonly", "yes"]
+    ports: ["6379:6379"]
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "redis-cli -h localhost ping | grep -q PONG"]
+    networks:
+      backend:
+        aliases: [redis]
 
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    <<: [*restart_policy, *resources_light]
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 3000
+      ZOOKEEPER_SYNC_LIMIT: 2
+    ports: ["2181:2181"]
+    volumes:
+      - zkdata:/var/lib/zookeeper/data
+      - zklog:/var/lib/zookeeper/log
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "echo srvr | nc -w 2 localhost 2181 | grep -q 'Mode:'"]
+    networks:
+      backend:
+        aliases: [zookeeper]
 
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    <<: [*restart_policy, *resources_light]
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    environment:
+      TZ: Asia/Riyadh
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_BROKER_ID: 1
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_LOG_RETENTION_HOURS: 168
+      KAFKA_LOG_SEGMENT_BYTES: 1073741824
+      KAFKA_MESSAGE_MAX_BYTES: 20971520
+      KAFKA_REPLICA_FETCH_MAX_BYTES: 20971520
+      KAFKA_HEAP_OPTS: "-Xms512m -Xmx1024m"
+    ports: ["9092:9092", "29092:29092"]
+    volumes:
+      - kafkadata:/var/lib/kafka/data
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "kafka-topics --bootstrap-server localhost:29092 --list >/dev/null 2>&1"]
+    networks:
+      backend:
+        aliases: [kafka]
+
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    <<: [*restart_policy, *resources_light]
+    volumes:
+      - "./shared-lib/shared-starters/starter-observability/src/main/resources:/etc/otelcol:ro"
+    command: ["--config=/etc/otelcol/otel-collector-config.yaml"]
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD", "/otelcol", "--version"]
+    networks:
+      backend:
+        aliases: [otel-collector]
 
   tenant-service:
     build: ./tenant-platform/tenant-service

--- a/setup-service/Dockerfile
+++ b/setup-service/Dockerfile
@@ -8,7 +8,7 @@ RUN addgroup -g 1001 -S appgroup && \
 WORKDIR /app
 
 # Copy the application JAR
-COPY target/ejada-setup-*.jar app.jar
+COPY target/*.jar app.jar
 
 # Change ownership to non-root user
 RUN chown -R appuser:appgroup /app

--- a/tenant-platform/billing-service/Dockerfile
+++ b/tenant-platform/billing-service/Dockerfile
@@ -8,7 +8,7 @@ RUN addgroup -g 1001 -S appgroup && \
 WORKDIR /app
 
 # Copy the application JAR
-COPY target/ejada-billing-*.jar app.jar
+COPY target/*.jar app.jar
 
 # Change ownership to non-root user
 RUN chown -R appuser:appgroup /app

--- a/tenant-platform/catalog-service/Dockerfile
+++ b/tenant-platform/catalog-service/Dockerfile
@@ -8,7 +8,7 @@ RUN addgroup -g 1001 -S appgroup && \
 WORKDIR /app
 
 # Copy the application JAR
-COPY target/ejada-catalog-*.jar app.jar
+COPY target/*.jar app.jar
 
 # Change ownership to non-root user
 RUN chown -R appuser:appgroup /app

--- a/tenant-platform/subscription-service/Dockerfile
+++ b/tenant-platform/subscription-service/Dockerfile
@@ -8,7 +8,7 @@ RUN addgroup -g 1001 -S appgroup && \
 WORKDIR /app
 
 # Copy the application JAR
-COPY target/ejada-subscription-*.jar app.jar
+COPY target/*.jar app.jar
 
 # Change ownership to non-root user
 RUN chown -R appuser:appgroup /app

--- a/tenant-platform/tenant-service/Dockerfile
+++ b/tenant-platform/tenant-service/Dockerfile
@@ -8,7 +8,7 @@ RUN addgroup -g 1001 -S appgroup && \
 WORKDIR /app
 
 # Copy the application JAR
-COPY target/ejada-tenant-*.jar app.jar
+COPY target/*.jar app.jar
 
 # Change ownership to non-root user
 RUN chown -R appuser:appgroup /app


### PR DESCRIPTION
## Summary
- add postgres, redis, zookeeper, kafka, and otel-collector services to docker-compose
- use generic jar pattern in service Dockerfiles so images build correctly

## Testing
- `docker compose config` *(fails: command not found)*
- `python - <<'PY'
import yaml
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bde3b3a7d8832f9233c4808aeaa31c