### PR TITLE
chore: reduce hibernate named query debug noise

### DIFF
--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -206,7 +206,7 @@ shared:
 
 logging:
   level:
-    root: DEBUG
+    root: INFO
     com.ejada: DEBUG
     com.ejada.audit.starter: DEBUG
     com.ejada.audit.starter.core.dispatch: DEBUG
@@ -214,7 +214,8 @@ logging:
     org.hibernate.tool.schema: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: DEBUG
+    org.hibernate.resource.transaction: INFO
     org.springframework.cache: DEBUG
     org.springframework.cache.interceptor.CacheAspectSupport: DEBUG
 
-debug: true
+debug: false

--- a/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
@@ -206,10 +206,11 @@ shared:
 
 logging:
   level:
-    root: INFO                
+    root: INFO
     com.ejada: INFO
-    org.hibernate.SQL: INFO   
+    org.hibernate.SQL: INFO
     org.hibernate.orm.jdbc.bind: INFO
+    org.hibernate.resource.transaction: INFO
     org.springframework.cache: ERROR
     org.springframework.cache.interceptor.CacheAspectSupport: ERROR
 

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -31,3 +31,7 @@ shared:
     enable-role-check: true
     jwt:
       token-period: 15m
+
+logging:
+  level:
+    org.hibernate.resource.transaction: INFO


### PR DESCRIPTION
## Summary
- keep Hibernate from emitting stack trace when named queries are missing by raising `org.hibernate.resource.transaction` log level to INFO
- reduce tenant-service dev log verbosity and disable global debug mode

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdedf65738832fb55048e7d5f6dff4