### PR TITLE
fix: correct tenant status enum usage in queries

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantIntegrationKeyRepository.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantIntegrationKeyRepository.java
@@ -31,7 +31,7 @@ public interface TenantIntegrationKeyRepository extends JpaRepository<TenantInte
             where k.tenant.id = :tenantId
               and k.keyId     = :keyId
               and k.isDeleted = false
-              and k.status    = com.ejada.catalog.model.TenantIntegrationKey.Status.ACTIVE
+              and k.status    = com.ejada.tenant.model.TenantIntegrationKey$Status.ACTIVE
               and k.validFrom <= CURRENT_TIMESTAMP
               and k.expiresAt >  CURRENT_TIMESTAMP
            """)
@@ -44,7 +44,7 @@ public interface TenantIntegrationKeyRepository extends JpaRepository<TenantInte
              from TenantIntegrationKey k
             where k.isDeleted = false
               and k.expiresAt <= CURRENT_TIMESTAMP
-              and k.status <> com.ejada.catalog.model.TenantIntegrationKey.Status.EXPIRED
+              and k.status <> com.ejada.tenant.model.TenantIntegrationKey$Status.EXPIRED
            """)
     List<TenantIntegrationKey> findAllExpiredAndNotMarked();
 
@@ -53,7 +53,7 @@ public interface TenantIntegrationKeyRepository extends JpaRepository<TenantInte
     @Query("""
            update TenantIntegrationKey k
               set k.isDeleted = true,
-                  k.status    = com.ejada.catalog.model.TenantIntegrationKey.Status.REVOKED
+                  k.status    = com.ejada.tenant.model.TenantIntegrationKey$Status.REVOKED
             where k.tikId     = :id
               and k.isDeleted = false
            """)


### PR DESCRIPTION
## Summary
- fix fully-qualified enum references in `TenantIntegrationKeyRepository`

## Testing
- `mvn -q -pl tenant-service test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf01766c0832f890f2d2224aec3ae