### PR TITLE
fix: enable crypto starter for tenant-service

### DIFF
--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -68,9 +68,9 @@
       <groupId>com.ejada</groupId>
       <artifactId>starter-security</artifactId>
     </dependency>
-    <dependency> 
+    <dependency>
       <groupId>com.ejada</groupId>
-      <artifactId>shared-lib-crypto</artifactId>
+      <artifactId>starter-crypto</artifactId>
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>


### PR DESCRIPTION
## Summary
- add starter-crypto dependency to provide CryptoService bean

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl tenant-service -am test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf37bc730832fbb5c25403d56e0c0