### PR TITLE
Add primary ObjectMapper and auto-config entry

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/config/JacksonConfig.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/config/JacksonConfig.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.PageImpl;
 
 @Configuration
@@ -18,6 +19,7 @@ public class JacksonConfig {
      * This mapper is automatically picked up by Spring Boot.
      */
     @Bean
+    @Primary
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
 

--- a/shared-lib/shared-starters/starter-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/shared-lib/shared-starters/starter-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 com.ejada.starter_core.config.CoreExtrasAutoConfiguration
+com.ejada.starter_core.config.JacksonConfig
 com.ejada.starter_core.config.PerformanceConfig
 com.ejada.starter_core.exception.CoreExceptionAutoConfiguration


### PR DESCRIPTION
## Summary
- provide a global ObjectMapper bean and mark it as primary
- register JacksonConfig in auto-configuration imports so it is loaded automatically

## Testing
- `mvn -q -f shared-lib/pom.xml -pl shared-starters/starter-core -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf5504f28832f953cd3cf7fbb2578