### PR TITLE
fix: correct addon feature constraints

### DIFF
--- a/tenant-platform/catalog-service/src/main/resources/db/migration/common/V4__catalog_addons.sql
+++ b/tenant-platform/catalog-service/src/main/resources/db/migration/common/V4__catalog_addons.sql
@@ -50,13 +50,12 @@ create table IF NOT EXISTS addon_feature (
   updated_at           timestamptz,
   updated_by           varchar(128),
 
-  constraint uk_addon_feature unique (addon_id, feature_id),
-  constraint fk_af_addon   foreign key (addon_id)   references addon(addon_id)   on delete cascade,
-  constraint fk_af_feature foreign key (feature_id) references feature(id) on delete cascade,
-
-  constraint ck_af_enforcement check (enforcement in ('ALLOW','BLOCK','ALLOW_WITH_OVERAGE')),
-  constraint ck_af_window      check (limit_window is null or limit_window in ('DAILY','MONTHLY','QUARTERLY','YEARLY','LIFETIME')),
-  constraint ck_af_soft_hard   check (soft_limit is null or hard_limit is null or hard_limit >= soft_limit),
+  constraint uk_addon_feature    unique (addon_id, feature_id),
+  constraint fk_af_addon         foreign key (addon_id)   references addon(addon_id) on delete cascade,
+  constraint fk_af_feature       foreign key (feature_id) references feature(id)  on delete cascade,
+  constraint ck_af_enforcement   check (enforcement in ('ALLOW','BLOCK','ALLOW_WITH_OVERAGE')),
+  constraint ck_af_window        check (limit_window is null or limit_window in ('DAILY','MONTHLY','QUARTERLY','YEARLY','LIFETIME')),
+  constraint ck_af_soft_hard     check (soft_limit is null or hard_limit is null or hard_limit >= soft_limit),
   constraint ck_af_block_has_hard check (enforcement <> 'BLOCK' or hard_limit is not null),
   constraint ck_af_overage_price check ((overage_enabled = false) or (overage_unit_price is not null))
 );


### PR DESCRIPTION
## Summary
- fix addon_feature table migration syntax

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl catalog-service -am test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf8fe18e0832f90c8b879425628d2