### PR TITLE
Enable MapStruct processing in catalog-service

### DIFF
--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -148,6 +148,31 @@
           </java>
         </configuration>
       </plugin>
+
+      <!-- Enable MapStruct annotation processing -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
+              <version>${mapstruct.version}</version>
+            </path>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok-mapstruct-binding</artifactId>
+              <version>${lombokMapstruct.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
## Summary
- enable MapStruct annotation processing so mappers are registered as Spring beans

## Testing
- `mvn -q -DskipTests compile` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfb8c60d0832fb390c7328b319ba6