### PR TITLE
fix: ensure AddonMapper registered as Spring bean

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
@@ -5,7 +5,8 @@ import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
 import org.mapstruct.*;
 import org.springframework.lang.NonNull;
 
-@Mapper(config = SharedMapstructConfig.class)
+// Explicitly declare componentModel to ensure Spring Bean generation
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, config = SharedMapstructConfig.class)
 public interface AddonMapper {
 
     // ---------- Create ----------


### PR DESCRIPTION
## Summary
- explicitly declare Spring component model for AddonMapper to guarantee mapper implementation is registered as a bean

## Testing
- `mvn -q -f tenant-platform/pom.xml -pl catalog-service -am test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfce83aac832fba6e4a31c39e4064