### PR TITLE
feat: add flyway setup schema

### DIFF
--- a/setup-service/src/main/resources/application-dev.yaml
+++ b/setup-service/src/main/resources/application-dev.yaml
@@ -12,22 +12,24 @@ spring:
       connection-timeout: 300000 # 300s
       max-lifetime: 1800000      # 30m
 
-  jpa:
-    open-in-view: false
-    show-sql: true
-    hibernate:
-      ddl-auto: update
-    properties:
+    jpa:
+      open-in-view: false
+      show-sql: true
       hibernate:
-        default_schema: setup
-        hbm2ddl.create_namespaces: true
-        format_sql: true
+        ddl-auto: none
+      properties:
+        hibernate:
+          default_schema: setup
+          hbm2ddl.create_namespaces: true
+          format_sql: true
         jdbc.time_zone: UTC
 
-  flyway:
-    enabled: true
-    baseline-on-migrate: true
-    locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    flyway:
+      enabled: true
+      baseline-on-migrate: true
+      locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+      schemas: public,setup
+      default-schema: setup
 
   kafka:
     bootstrap-servers: kafka:9092

--- a/setup-service/src/main/resources/application.yaml
+++ b/setup-service/src/main/resources/application.yaml
@@ -6,6 +6,8 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
+    schemas: public,setup
+    default-schema: setup
 server:
   port: 8080
   shutdown: graceful

--- a/setup-service/src/main/resources/db/migration/common/V1__init_setup_schema.sql
+++ b/setup-service/src/main/resources/db/migration/common/V1__init_setup_schema.sql
@@ -1,0 +1,77 @@
+create schema if not exists setup;
+
+create table if not exists setup.country (
+  country_id serial primary key,
+  country_cd varchar(3) not null,
+  country_en_nm varchar(256) not null,
+  country_ar_nm varchar(256) not null,
+  dialing_code varchar(10),
+  nationality_en varchar(256),
+  nationality_ar varchar(256),
+  is_active boolean not null default true,
+  en_description varchar(1000),
+  ar_description varchar(1000),
+  version bigint not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz,
+  constraint uq_country_cd unique (country_cd)
+);
+create index if not exists idx_country_cd on setup.country(country_cd);
+create index if not exists idx_country_en_nm on setup.country(country_en_nm);
+
+create table if not exists setup.city (
+  city_id serial primary key,
+  city_cd varchar(50) not null,
+  city_en_nm varchar(200) not null,
+  city_ar_nm varchar(200) not null,
+  country_id integer not null references setup.country(country_id),
+  is_active boolean not null default true,
+  constraint uk_city_cd unique(city_cd)
+);
+create index if not exists idx_city_country_active on setup.city(country_id,is_active);
+create index if not exists idx_city_en_nm on setup.city(city_en_nm);
+create index if not exists idx_city_ar_nm on setup.city(city_ar_nm);
+
+create table if not exists setup.lookup (
+  lookup_item_id integer primary key,
+  lookup_item_cd varchar(255),
+  lookup_item_en_nm varchar(255),
+  lookup_item_ar_nm varchar(255),
+  lookup_group_code varchar(255),
+  parent_lookup_id varchar(255),
+  is_active boolean,
+  item_en_description varchar(1000),
+  item_ar_description varchar(1000)
+);
+
+create table if not exists setup.system_parameter (
+  param_id serial primary key,
+  param_key varchar(150) not null unique,
+  param_value varchar(1000) not null,
+  description varchar(1000),
+  group_code varchar(150),
+  is_active boolean not null default true
+);
+
+create table if not exists setup.resources (
+  resource_id serial primary key,
+  resource_cd varchar(128) not null,
+  resource_en_nm varchar(256) not null,
+  resource_ar_nm varchar(256) not null,
+  path varchar(512),
+  http_method varchar(16),
+  parent_resource_id integer,
+  is_active boolean not null default true,
+  en_description varchar(1000),
+  ar_description varchar(1000),
+  version bigint not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz,
+  constraint uq_resource_cd unique(resource_cd)
+);
+create index if not exists idx_resource_cd on setup.resources(resource_cd);
+create index if not exists idx_resource_parent on setup.resources(parent_resource_id);
+
+insert into setup.system_parameter (param_key, param_value, description, group_code, is_active)
+values ('MAX_USERS','1000','Maximum allowed users','SYSTEM', true)
+on conflict (param_key) do nothing;


### PR DESCRIPTION
## Summary
- configure Flyway to manage setup schema
- add initial migration creating setup tables and seed data

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be09f5b8d0832fb7cd1ba046feea71