### PR TITLE
Configure Flyway to use public schema

### DIFF
--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
+    schemas: public
 server:
   port: 8080
   shutdown: graceful

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
+    schemas: public
 server:
   port: 8080
   shutdown: graceful

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
+    schemas: public
 server:
   port: 8080
   shutdown: graceful

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -6,8 +6,7 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
-    schemas: public,tenant
-    default-schema: tenant
+    schemas: public
 server:
   port: 8080
   shutdown: graceful


### PR DESCRIPTION
## Summary
- ensure catalog-service, tenant-service, subscription-service and billing-service run Flyway migrations in the public schema

## Testing
- `mvn -q -f tenant-platform/pom.xml test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be144c6be0832fb3e0f5be20331913