### PR TITLE
chore: begin WebFlux migration with reactive stack

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,12 @@
+# WebFlux Migration Notes
+
+This repository has begun migration from the blocking Spring MVC stack to the reactive Spring WebFlux stack.
+
+## Key updates
+- Replaced `spring-boot-starter-web` with `spring-boot-starter-webflux` and added `reactor-netty`.
+- Switched data access from JPA/JDBC to R2DBC with the PostgreSQL reactive driver.
+- Retained Flyway for schema migrations using the JDBC driver.
+- Added reactor-kafka for non-blocking Kafka integration and reactive testing utilities.
+- Configured R2DBC and Flyway settings in application configuration.
+
+These changes lay the groundwork for fully reactive controllers, services and messaging pipelines across the project.

--- a/setup-service/pom.xml
+++ b/setup-service/pom.xml
@@ -37,23 +37,22 @@
 
   <dependencies>
       <dependency>
-  <groupId>org.springframework.boot</groupId>
-  <artifactId>spring-boot-starter-jdbc</artifactId>
-</dependency>
-
-<dependency>
-  <groupId>org.postgresql</groupId>
-  <artifactId>postgresql</artifactId>
-  <scope>runtime</scope>
-</dependency>
-<dependency>
-      <groupId>org.flywaydb</groupId>
-      <artifactId>flyway-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.flywaydb</groupId>
-      <artifactId>flyway-database-postgresql</artifactId>
-    </dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>r2dbc-postgresql</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-core</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-database-postgresql</artifactId>
+      </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
@@ -62,6 +61,14 @@
     <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor.netty</groupId>
+      <artifactId>reactor-netty</artifactId>
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
@@ -73,7 +80,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <artifactId>spring-boot-starter-data-r2dbc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -82,6 +89,10 @@
     <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
@@ -105,6 +116,10 @@
       <artifactId>starter-kafka</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.projectreactor.kafka</groupId>
+      <artifactId>reactor-kafka</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-audit</artifactId>
     </dependency>
@@ -114,20 +129,12 @@
     </dependency>
     <dependency>
       <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-web</artifactId>
-</dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
@@ -136,6 +143,22 @@
     <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>shared-test-support</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/setup-service/src/main/resources/application.yaml
+++ b/setup-service/src/main/resources/application.yaml
@@ -3,14 +3,20 @@ spring:
     name: setup-service
   profiles:
     active: dev
+  r2dbc:
+    url: r2dbc:postgresql://postgres:5432/lms
+    username: postgres
+    password: postgres
   flyway:
-    baseline-on-migrate: true
-    baseline-version: 0
+    enabled: true
+    url: jdbc:postgresql://postgres:5432/lms
+    user: postgres
+    password: postgres
+  webflux:
+    base-path: /core
 server:
   port: 8080
   shutdown: graceful
-  servlet:
-    context-path: /core
   compression:
     enabled: true
     mime-types:

--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -99,11 +99,6 @@
 
       <!-- Specific pins -->
       <dependency>
-        <groupId>org.springdoc</groupId>
-        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-        <version>${springdoc.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.mapstruct</groupId>
         <artifactId>mapstruct</artifactId>
         <version>${mapstruct.version}</version>

--- a/shared-lib/shared-starters/starter-core/pom.xml
+++ b/shared-lib/shared-starters/starter-core/pom.xml
@@ -64,7 +64,12 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor.netty</groupId>
+      <artifactId>reactor-netty</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/shared-lib/shared-starters/starter-data/pom.xml
+++ b/shared-lib/shared-starters/starter-data/pom.xml
@@ -46,21 +46,19 @@
       <artifactId>spring-data-commons</artifactId>
     </dependency>
 
-		<!-- JPA left to the app -->
+                <!-- Reactive data access -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <optional>true</optional>
+      <artifactId>spring-boot-starter-data-r2dbc</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.persistence</groupId>
-      <artifactId>jakarta.persistence-api</artifactId>
-      <optional>true</optional>
+      <groupId>org.postgresql</groupId>
+      <artifactId>r2dbc-postgresql</artifactId>
     </dependency>
-      <dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-aop</artifactId>
-  </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
 
 		<!-- Time/Jackson helpers -->
     <dependency>


### PR DESCRIPTION
## Summary
- replace blocking MVC dependencies with WebFlux and Reactor Netty
- introduce R2DBC PostgreSQL driver and reactive Kafka support
- document migration steps and configure reactive database access

## Testing
- `mvn -f shared-lib/pom.xml install` *(failed: Network is unreachable)*
- `mvn test` *(failed: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68be01837058832fa00dc93b87cc750f