### PR TITLE
Switch starters to WebFlux

### DIFF
--- a/setup-service/pom.xml
+++ b/setup-service/pom.xml
@@ -114,20 +114,16 @@
     </dependency>
     <dependency>
       <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
     </dependency>
-    <dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-web</artifactId>
-</dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>

--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -99,11 +99,6 @@
 
       <!-- Specific pins -->
       <dependency>
-        <groupId>org.springdoc</groupId>
-        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-        <version>${springdoc.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.mapstruct</groupId>
         <artifactId>mapstruct</artifactId>
         <version>${mapstruct.version}</version>

--- a/shared-lib/shared-starters/starter-openapi/pom.xml
+++ b/shared-lib/shared-starters/starter-openapi/pom.xml
@@ -29,16 +29,10 @@
       <artifactId>springdoc-openapi-starter-common</artifactId>
     </dependency>
 
-    <!-- UI stacks (opt-in; app chooses MVC or WebFlux) -->
-    <dependency>
-      <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <optional>true</optional>
-    </dependency>
+    <!-- WebFlux UI -->
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
-      <optional>true</optional>
     </dependency>
 
     <!-- Actuator integration (opt-in) -->

--- a/shared-lib/shared-starters/starter-security/pom.xml
+++ b/shared-lib/shared-starters/starter-security/pom.xml
@@ -51,16 +51,10 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- Optional web stacks if you ship filters or MVC advice -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-      <optional>true</optional>
-    </dependency>
+    <!-- Reactive web stack -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
-      <optional>true</optional>
     </dependency>
 
     <!-- Validation API -->


### PR DESCRIPTION
## Summary
- remove Spring MVC starter from security module and ensure WebFlux is mandatory
- swap springdoc webmvc UI for webflux variant
- remove webmvc artifacts from setup service and BOM

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.ejada:setup-service:1.0.0)*
- `mvn -q test` *(fails: Non-resolvable import POM: com.ejada:shared-bom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68be9928932c832fa2e47f281e5b3920