### PR TITLE
Fix exception handler test method signatures

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/GlobalExceptionHandlerTest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/GlobalExceptionHandlerTest.java
@@ -12,7 +12,7 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void handleGenericReturnsInternalServerError() {
-        ResponseEntity<BaseResponse<?>> resp = handler.handleGeneric(new RuntimeException("boom"), null);
+        ResponseEntity<BaseResponse<?>> resp = handler.handleGeneric(new RuntimeException("boom"));
         assertEquals(500, resp.getStatusCode().value());
         assertEquals("ERR_INTERNAL", resp.getBody().getCode());
     }

--- a/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/SecurityExceptionHandlerTest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/SecurityExceptionHandlerTest.java
@@ -14,14 +14,14 @@ class SecurityExceptionHandlerTest {
 
     @Test
     void handleAccessDeniedReturnsForbidden() {
-        ResponseEntity<BaseResponse<?>> resp = handler.handleAccessDenied(new AccessDeniedException("denied"), null);
+        ResponseEntity<BaseResponse<?>> resp = handler.handleAccessDenied(new AccessDeniedException("denied"));
         assertEquals(403, resp.getStatusCode().value());
         assertEquals("ERR_ACCESS_DENIED", resp.getBody().getCode());
     }
 
     @Test
     void handleAuthorizationDeniedReturnsForbidden() {
-        ResponseEntity<BaseResponse<?>> resp = handler.handleAccessDenied(new AuthorizationDeniedException("denied"), null);
+        ResponseEntity<BaseResponse<?>> resp = handler.handleAccessDenied(new AuthorizationDeniedException("denied"));
         assertEquals(403, resp.getStatusCode().value());
         assertEquals("ERR_ACCESS_DENIED", resp.getBody().getCode());
     }


### PR DESCRIPTION
## Summary
- adjust GlobalExceptionHandlerTest to match new handleGeneric signature
- adjust SecurityExceptionHandlerTest to match updated handleAccessDenied signature

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact com.ejada:shared-bom:pom:1.0.0 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bea08df098832fa930e9e009aac293