### PR TITLE
chore: remove webflux

### DIFF
--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -191,11 +191,6 @@
       <artifactId>springdoc-openapi-starter-common</artifactId>
       <version>${springdoc.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
-      <version>${springdoc.version}</version>
-    </dependency>
      <dependency><groupId>javax.money</groupId><artifactId>money-api</artifactId><version>${money.api.version}</version></dependency>
     <dependency><groupId>org.javamoney.moneta</groupId><artifactId>moneta-core</artifactId><version>${moneta.version}</version></dependency>
  <dependency>

--- a/shared-lib/shared-starters/starter-audit/pom.xml
+++ b/shared-lib/shared-starters/starter-audit/pom.xml
@@ -57,11 +57,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
       <optional>true</optional>
     </dependency>

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/http/AuditWebFluxFilter.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/http/AuditWebFluxFilter.java
@@ -1,5 +1,0 @@
-package com.ejada.audit.starter.http;
-
-// Placeholder for WebFlux filter implementation
-public class AuditWebFluxFilter {
-}

--- a/shared-lib/shared-starters/starter-headers/pom.xml
+++ b/shared-lib/shared-starters/starter-headers/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>starter-headers</artifactId>
   <packaging>jar</packaging>
   <name>Shared Starter - Headers</name>
-  <description>Correlation/request/tenant propagation, security response headers, outbound propagation (MVC/WebFlux/Feign)</description>
+  <description>Correlation/request/tenant propagation, security response headers, outbound propagation (MVC/Feign)</description>
 
   <dependencies>
     <!-- Autoconfiguration infra -->
@@ -30,12 +30,6 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- Reactive (opt-in) -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
-      <optional>true</optional>
-    </dependency>
 
     <!-- Feign for outbound header propagation (opt-in; version managed in shared-bom) -->
     <dependency>

--- a/shared-lib/shared-starters/starter-openapi/README.md
+++ b/shared-lib/shared-starters/starter-openapi/README.md
@@ -6,19 +6,10 @@ A lightweight Spring Boot starter that wires Springdoc OpenAPI with:
 - Dynamic grouped APIs from `application.properties`
 
 ## Add UI in your app
-Choose one (do **not** add both):
 ```xml
 <dependency>
   <groupId>org.springdoc</groupId>
   <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-  <version>2.6.0</version>
-</dependency>
-```
-or
-```xml
-<dependency>
-  <groupId>org.springdoc</groupId>
-  <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
   <version>2.6.0</version>
 </dependency>
 ```

--- a/shared-lib/shared-starters/starter-openapi/pom.xml
+++ b/shared-lib/shared-starters/starter-openapi/pom.xml
@@ -23,21 +23,16 @@
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
 
-    <!-- Springdoc common (doesn't force MVC vs WebFlux) -->
+    <!-- Springdoc common (doesn't force MVC) -->
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-common</artifactId>
     </dependency>
 
-    <!-- UI stacks (opt-in; app chooses MVC or WebFlux) -->
+    <!-- UI stack (opt-in for MVC) -->
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
       <optional>true</optional>
     </dependency>
 

--- a/shared-lib/shared-starters/starter-ratelimit/pom.xml
+++ b/shared-lib/shared-starters/starter-ratelimit/pom.xml
@@ -36,15 +36,10 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- Web stacks only if the app uses servlet/reactive filters -->
+    <!-- Web stack only if the app uses servlet filters -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
       <optional>true</optional>
     </dependency>
 

--- a/shared-lib/shared-starters/starter-resilience/pom.xml
+++ b/shared-lib/shared-starters/starter-resilience/pom.xml
@@ -41,12 +41,6 @@
       <artifactId>resilience4j-spring-boot3</artifactId>
     </dependency>
 
-    <!-- Optional reactive stack: only if the app uses WebFlux/WebClient -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
-      <optional>true</optional>
-    </dependency>
     <!-- Optional Reactor Netty if you customize HttpClient/ChannelOption -->
     <dependency>
       <groupId>io.projectreactor.netty</groupId>

--- a/shared-lib/shared-starters/starter-security/pom.xml
+++ b/shared-lib/shared-starters/starter-security/pom.xml
@@ -51,15 +51,10 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- Optional web stacks if you ship filters or MVC advice -->
+    <!-- Optional web stack if you ship filters or MVC advice -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
       <optional>true</optional>
     </dependency>
 


### PR DESCRIPTION
## Summary
- strip WebFlux UI dependency from shared BOM
- drop spring-boot-starter-webflux from starter modules
- clean openapi README and remove unused audit WebFlux filter

## Testing
- `mvn -q test` *(fails: Could not transfer artifacts; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68beaa4d41f4832f92388bcb7ac14517