### PR TITLE
Remove WebFlux from Resilience starter

### DIFF
--- a/shared-lib/shared-starters/starter-resilience/pom.xml
+++ b/shared-lib/shared-starters/starter-resilience/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>starter-resilience</artifactId>
   <name>Shared Starter - Resilience</name>
   <packaging>jar</packaging>
-  <description>Resilience4j auto-configuration with optional WebClient integration and Micrometer metrics</description>
+  <description>Resilience4j auto-configuration with configurable RestTemplate timeouts and Micrometer metrics</description>
 
   <dependencies>
     <!-- Autoconfiguration infra (if you expose @AutoConfiguration) -->
@@ -41,10 +41,10 @@
       <artifactId>resilience4j-spring-boot3</artifactId>
     </dependency>
 
-    <!-- Optional Reactor Netty if you customize HttpClient/ChannelOption -->
+    <!-- Spring Web for RestTemplate support (optional to avoid forcing web stack) -->
     <dependency>
-      <groupId>io.projectreactor.netty</groupId>
-      <artifactId>reactor-netty-http</artifactId>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
       <optional>true</optional>
     </dependency>
 


### PR DESCRIPTION
## Summary
- Replace WebClient-based configuration with RestTemplate builder to avoid WebFlux
- Drop reactor-netty dependency and add optional spring-web for RestTemplate support
- Update resilience starter description

## Testing
- `mvn -q -f shared-lib/pom.xml -pl :starter-resilience -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68beb3803a64832fb15c22f63c2e4bd4