### PR TITLE
Use blocking RestTemplate and set BOM encoding

### DIFF
--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -11,6 +11,7 @@
   <description>Centralized dependency management for Ejada modules</description>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Platforms -->
     <spring.boot.version>3.5.5</spring.boot.version>
     <spring.cloud.version>2024.0.2</spring.cloud.version> <!-- 2024.0.3 is not on Central -->

--- a/shared-lib/shared-starters/starter-resilience/src/main/java/com/ejada/shared_starter_resilience/ResilienceAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-resilience/src/main/java/com/ejada/shared_starter_resilience/ResilienceAutoConfiguration.java
@@ -1,21 +1,20 @@
 package com.ejada.shared_starter_resilience;
 
-import java.time.Duration;
-
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 /**
  * Auto-configuration for basic HTTP resilience features.
  *
  * <p>This configuration provides a {@link RestTemplateBuilder} that sets
- * connect and read timeouts based on {@link SharedResilienceProps}. It avoids
- * any dependency on WebFlux or reactive clients.</p>
+ * connect and read timeouts based on {@link SharedResilienceProps}. It relies
+ * solely on the blocking {@link RestTemplate} API.</p>
  */
 @AutoConfiguration
 @ConditionalOnClass(RestTemplateBuilder.class)
@@ -34,8 +33,13 @@ public class ResilienceAutoConfiguration {
   @ConditionalOnMissingBean(RestTemplateBuilder.class)
   public RestTemplateBuilder resilientRestTemplateBuilder(SharedResilienceProps props) {
     return new RestTemplateBuilder()
-        .setConnectTimeout(Duration.ofMillis(props.getConnectTimeoutMs()))
-        .setReadTimeout(Duration.ofMillis(props.getHttpTimeoutMs()));
+        .requestFactory(
+            () -> {
+              SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+              factory.setConnectTimeout((int) props.getConnectTimeoutMs());
+              factory.setReadTimeout((int) props.getHttpTimeoutMs());
+              return factory;
+            });
   }
 
   /**


### PR DESCRIPTION
## Summary
- remove any mention of WebFlux and rely solely on blocking RestTemplate
- configure RestTemplate timeouts using a request factory to avoid deprecated APIs
- set UTF-8 as the source encoding in the shared BOM

## Testing
- `mvn -pl shared-bom,shared-starters/starter-resilience -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68beb5770004832fb32b40191a7822eb