### PR TITLE
chore: add spotbugs exclude file

### DIFF
--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -225,6 +225,7 @@
           <configuration>
             <effort>Max</effort>
             <threshold>Low</threshold>
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
           </configuration>
         </plugin>
 

--- a/shared-lib/shared-quality/pom.xml
+++ b/shared-lib/shared-quality/pom.xml
@@ -35,6 +35,7 @@
           <configuration>
             <effort>Max</effort>
             <threshold>Low</threshold>
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
           </configuration>
         </plugin>
       </plugins>

--- a/shared-lib/spotbugs/spotbugs-exclude.xml
+++ b/shared-lib/spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!-- Exclude MapStruct generated mapper implementations -->
+  <Match>
+    <Or>
+      <Class name="~.*\\.mapper\\..*MapperImpl"/>
+    </Or>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Summary
- add SpotBugs exclusion filter to shared library
- configure SpotBugs plugin to use centralized exclusion file

## Testing
- `mvn -f shared-lib/pom.xml -pl shared-common spotbugs:check` *(fails: Non-resolvable import POM: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68becd7b9454832fb600c736a89175c5