### PR TITLE
refactor: tidy LookupController imports and parameters

### DIFF
--- a/setup-service/src/main/java/com/ejada/setup/controller/LookupController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/LookupController.java
@@ -16,9 +16,15 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -26,12 +32,12 @@ import java.util.List;
 @RequestMapping("/setup/lookups")
 @Validated
 @Tag(name = "Lookup Management", description = "APIs for managing lookup values")
-public class LookupController {
+public final class LookupController {
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Injected service is managed by Spring")
     private final LookupService lookupService;
 
-    public LookupController(LookupService lookupService) {
+    public LookupController(final LookupService lookupService) {
         this.lookupService = lookupService;
     }
 
@@ -45,7 +51,8 @@ public class LookupController {
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "409", description = "Lookup already exists")
     })
-    public ResponseEntity<BaseResponse<Lookup>> add(@Valid @RequestBody Lookup body) {
+    public ResponseEntity<BaseResponse<Lookup>> add(
+            @Valid @RequestBody final Lookup body) {
         return ResponseEntity.ok(lookupService.add(body));
     }
 
@@ -60,8 +67,8 @@ public class LookupController {
     })
     public ResponseEntity<BaseResponse<Lookup>> update(
             @Parameter(description = "ID of the lookup to update", required = true)
-            @PathVariable @Min(1) Integer lookupItemId,
-            @Valid @RequestBody Lookup body) {
+            @PathVariable @Min(1) final Integer lookupItemId,
+            @Valid @RequestBody final Lookup body) {
         return ResponseEntity.ok(lookupService.update(lookupItemId, body));
     }
 
@@ -85,12 +92,15 @@ public class LookupController {
     })
     public ResponseEntity<BaseResponse<List<Lookup>>> getByGroup(
             @Parameter(description = "Group code of lookups to retrieve", required = true)
-            @PathVariable @NotBlank String groupCode) {
+            @PathVariable @NotBlank final String groupCode) {
         return ResponseEntity.ok(lookupService.getByGroup(groupCode));
     }
 
     @GetMapping("/all")
-    @PreAuthorize("@roleChecker.hasRole(authentication, T(com.ejada.starter_security.Role).EJADA_OFFICER, T(com.ejada.starter_security.Role).TENANT_ADMIN, T(com.ejada.starter_security.Role).TENANT_OFFICER)")
+    @PreAuthorize(
+            "@roleChecker.hasRole(authentication, T(com.ejada.starter_security.Role).EJADA_OFFICER," +
+            " T(com.ejada.starter_security.Role).TENANT_ADMIN," +
+            " T(com.ejada.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Get all lookups (alternative endpoint)", description = "Retrieves all lookup values")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),


### PR DESCRIPTION
## Summary
- replace wildcard Spring imports with explicit ones
- mark controller and method parameters as final
- wrap long `@PreAuthorize` string to meet line-length check

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer org.springframework.boot:spring-boot-starter-parent:pom:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68bece6e0668832f8776aa8cc2d7f680