### PR TITLE
refactor: remove magic numbers in DTOs

### DIFF
--- a/setup-service/src/main/java/com/ejada/setup/constants/ValidationConstants.java
+++ b/setup-service/src/main/java/com/ejada/setup/constants/ValidationConstants.java
@@ -6,5 +6,7 @@ public final class ValidationConstants {
     public static final int CODE_LEN = 128;
     public static final int NAME_LEN = 256;
     public static final int PAGE_SIZE_DEFAULT = 20;
+    public static final int PATH_LEN = 512;
+    public static final int HTTP_METHOD_LEN = 16;
     public static final int TEXT_LEN_1000 = 1000;
 }

--- a/setup-service/src/main/java/com/ejada/setup/dto/CityDto.java
+++ b/setup-service/src/main/java/com/ejada/setup/dto/CityDto.java
@@ -1,22 +1,27 @@
 package com.ejada.setup.dto;
 
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Size;
 
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
 public class CityDto {
+  private static final int CODE_LEN = 50;
+  private static final int NAME_LEN = 200;
   @Null // server-generated
   private Integer id;
 
-  @NotBlank @Size(max = 50)
+  @NotBlank @Size(max = CODE_LEN)
   private String cityCd;
 
-  @NotBlank @Size(max = 200)
+  @NotBlank @Size(max = NAME_LEN)
   private String cityEnNm;
 
-  @NotBlank @Size(max = 200)
+  @NotBlank @Size(max = NAME_LEN)
   private String cityArNm;
 
   @NotNull

--- a/setup-service/src/main/java/com/ejada/setup/dto/CountryDto.java
+++ b/setup-service/src/main/java/com/ejada/setup/dto/CountryDto.java
@@ -1,39 +1,46 @@
 package com.ejada.setup.dto;
 
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Size;
 
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
 public class CountryDto {
+  private static final int CODE_LEN = 3;
+  private static final int NAME_LEN = 256;
+  private static final int DIALING_LEN = 10;
+  private static final int DESCRIPTION_LEN = 1000;
   @Null
   private Integer countryId;
 
-  @NotBlank @Size(max = 3)
+  @NotBlank @Size(max = CODE_LEN)
   private String countryCd;
 
-  @NotBlank @Size(max = 256)
+  @NotBlank @Size(max = NAME_LEN)
   private String countryEnNm;
 
-  @NotBlank @Size(max = 256)
+  @NotBlank @Size(max = NAME_LEN)
   private String countryArNm;
 
-  @Size(max = 10)
+  @Size(max = DIALING_LEN)
   private String dialingCode;
 
-  @Size(max = 256)
+  @Size(max = NAME_LEN)
   private String nationalityEn;
 
-  @Size(max = 256)
+  @Size(max = NAME_LEN)
   private String nationalityAr;
 
   @NotNull
   private Boolean isActive;
 
-  @Size(max = 1000)
+  @Size(max = DESCRIPTION_LEN)
   private String enDescription;
 
-  @Size(max = 1000)
+  @Size(max = DESCRIPTION_LEN)
   private String arDescription;
 }

--- a/setup-service/src/main/java/com/ejada/setup/dto/ResourceDto.java
+++ b/setup-service/src/main/java/com/ejada/setup/dto/ResourceDto.java
@@ -26,10 +26,10 @@ public class ResourceDto {
     @Size(max = ValidationConstants.NAME_LEN)
     private String resourceArNm;
 
-    @Size(max = 512)
+    @Size(max = ValidationConstants.PATH_LEN)
     private String path;
 
-    @Size(max = 16)
+    @Size(max = ValidationConstants.HTTP_METHOD_LEN)
     private String httpMethod;
 
     private Integer parentResourceId;


### PR DESCRIPTION
## Summary
- replace wildcard imports and magic numbers in CityDto and CountryDto
- centralize path and HTTP method length constants
- reuse validation constants in ResourceDto

## Testing
- `mvn -q -f setup-service/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bed27560f0832f91b3419187b3e758