### PR TITLE
Resolve Checkstyle warnings in setup-service

### DIFF
--- a/setup-service/src/main/java/com/ejada/setup/SetupApplication.java
+++ b/setup-service/src/main/java/com/ejada/setup/SetupApplication.java
@@ -9,8 +9,8 @@ import io.swagger.v3.oas.annotations.info.Info;
 @SpringBootApplication
 @EnableCaching
 @OpenAPIDefinition(info = @Info(title = "Ejada Setup Service", version = "1.0"))
-public class SetupApplication {
-  private SetupApplication() {}
+public final class SetupApplication {
+  private SetupApplication() { }
 
   public static void main(final String[] args) {
     SpringApplication.run(SetupApplication.class, args);

--- a/setup-service/src/main/java/com/ejada/setup/controller/LookupController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/LookupController.java
@@ -97,9 +97,9 @@ public final class LookupController {
 
     @GetMapping("/all")
     @PreAuthorize(
-            "@roleChecker.hasRole(authentication, T(com.ejada.starter_security.Role).EJADA_OFFICER, " +
-            "T(com.ejada.starter_security.Role).TENANT_ADMIN, " +
-            "T(com.ejada.starter_security.Role).TENANT_OFFICER)")
+            "@roleChecker.hasRole(authentication, T(com.ejada.starter_security.Role).EJADA_OFFICER, "
+                    + "T(com.ejada.starter_security.Role).TENANT_ADMIN, "
+                    + "T(com.ejada.starter_security.Role).TENANT_OFFICER)")
     @Operation(summary = "Get all lookups (alternative endpoint)", description = "Retrieves all lookup values")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),

--- a/setup-service/src/main/java/com/ejada/setup/controller/ResourceController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/ResourceController.java
@@ -31,12 +31,11 @@ import com.ejada.setup.constants.ValidationConstants;
 
 import java.util.List;
 
-@SuppressWarnings("checkstyle:DesignForExtension")
 @RestController
 @RequestMapping("/setup/resources")
 @Validated
 @Tag(name = "Resource Management", description = "APIs for managing resources")
-public class ResourceController {
+public final class ResourceController {
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Injected service is managed by Spring")
     private final ResourceService resourceService;

--- a/setup-service/src/main/java/com/ejada/setup/enums/ECMEnums.java
+++ b/setup-service/src/main/java/com/ejada/setup/enums/ECMEnums.java
@@ -1,8 +1,8 @@
 package com.ejada.setup.enums;
 
-public class ECMEnums {
+public final class ECMEnums {
 
-    public static enum DocumentAttributeValueType {
+    public enum DocumentAttributeValueType {
         NUMBER("NUMBER"),
         TEXT("TEXT"),
         CHOICE("CHOICE"),
@@ -10,7 +10,7 @@ public class ECMEnums {
 
         private final String description;
 
-        DocumentAttributeValueType(String description) {
+        DocumentAttributeValueType(final String description) {
             this.description = description;
         }
 
@@ -19,7 +19,7 @@ public class ECMEnums {
         }
     }
 
-    public static enum ErrorMessage {
+    public enum ErrorMessage {
 
         // 200s Status messages.
         OK("INFO_ECM_200_00000", "Success Operation"),
@@ -45,9 +45,10 @@ public class ECMEnums {
         INTERNAL_SERVER_ERROR("ERROR_ECM_500_00001", "Error While processing an API call to {0}:{1}"),
         GENERAL_ERROR("ERROR_ECM_500_00002", "General Error");
 
-        private String errorCode, description;
+        private final String errorCode;
+        private final String description;
 
-        ErrorMessage(String errorCode, String description) {
+        ErrorMessage(final String errorCode, final String description) {
             this.errorCode = errorCode;
             this.description = description;
         }

--- a/setup-service/src/main/java/com/ejada/setup/mapper/CityMapper.java
+++ b/setup-service/src/main/java/com/ejada/setup/mapper/CityMapper.java
@@ -39,7 +39,9 @@ public interface CityMapper {
 
   // Uses the list mapper above
   default Page<CityDto> toDtoPage(Page<City> page) {
-    if (page == null) return Page.empty();
+    if (page == null) {
+      return Page.empty();
+    }
     List<CityDto> content = toDtoList(page.getContent());
     return new PageImpl<>(content, page.getPageable(), page.getTotalElements());
   }

--- a/setup-service/src/main/java/com/ejada/setup/mapper/ResourceMapper.java
+++ b/setup-service/src/main/java/com/ejada/setup/mapper/ResourceMapper.java
@@ -22,7 +22,9 @@ public interface ResourceMapper {
     List<ResourceDto> toDtoList(@NonNull List<Resource> entities);
 
     default Page<ResourceDto> toDtoPage(Page<Resource> page) {
-        if (page == null) return Page.empty();
+        if (page == null) {
+            return Page.empty();
+        }
         return new PageImpl<>(toDtoList(page.getContent()), page.getPageable(), page.getTotalElements());
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/model/City.java
+++ b/setup-service/src/main/java/com/ejada/setup/model/City.java
@@ -1,6 +1,16 @@
 package com.ejada.setup.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import org.hibernate.annotations.DynamicUpdate;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -32,13 +42,16 @@ public class City {
     @EqualsAndHashCode.Include
     private Integer cityId;
 
-    @Column(name = "city_cd", length = 50, nullable = false)
+    private static final int CODE_LENGTH = 50;
+    private static final int NAME_LENGTH = 200;
+
+    @Column(name = "city_cd", length = CODE_LENGTH, nullable = false)
     private String cityCd;
 
-    @Column(name = "city_en_nm", length = 200, nullable = false)
+    @Column(name = "city_en_nm", length = NAME_LENGTH, nullable = false)
     private String cityEnNm;
 
-    @Column(name = "city_ar_nm", length = 200, nullable = false)
+    @Column(name = "city_ar_nm", length = NAME_LENGTH, nullable = false)
     private String cityArNm;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -50,7 +63,9 @@ public class City {
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = Boolean.TRUE;
 
-    public boolean isActive() { return Boolean.TRUE.equals(isActive); }
+    public final boolean isActive() {
+        return Boolean.TRUE.equals(isActive);
+    }
 
     @Builder
     public City(final Integer cityId, final String cityCd, final String cityEnNm,

--- a/setup-service/src/main/java/com/ejada/setup/model/Country.java
+++ b/setup-service/src/main/java/com/ejada/setup/model/Country.java
@@ -3,7 +3,17 @@ package com.ejada.setup.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.hibernate.annotations.CreationTimestamp;
@@ -46,6 +56,11 @@ public class Country implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
+    private static final int CODE_LENGTH = 3;
+    private static final int NAME_LENGTH = 256;
+    private static final int DIALING_LENGTH = 10;
+    private static final int DESC_LENGTH = 1000;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "country_id", unique = true, nullable = false)
@@ -54,42 +69,42 @@ public class Country implements Serializable {
     private Integer countryId;
 
     @NotBlank
-    @Size(max = 3) // ISO alpha-2 or alpha-3; relax if you need longer
-    @Column(name = "country_cd", length = 3, nullable = false)
+    @Size(max = CODE_LENGTH) // ISO alpha-2 or alpha-3; relax if you need longer
+    @Column(name = "country_cd", length = CODE_LENGTH, nullable = false)
     private String countryCd;
 
     @NotBlank
-    @Size(max = 256)
-    @Column(name = "country_en_nm", length = 256, nullable = false)
+    @Size(max = NAME_LENGTH)
+    @Column(name = "country_en_nm", length = NAME_LENGTH, nullable = false)
     private String countryEnNm;
 
     @NotBlank
-    @Size(max = 256)
-    @Column(name = "country_ar_nm", length = 256, nullable = false)
+    @Size(max = NAME_LENGTH)
+    @Column(name = "country_ar_nm", length = NAME_LENGTH, nullable = false)
     private String countryArNm;
 
-    @Size(max = 10)
-    @Column(name = "dialing_code", length = 10)
+    @Size(max = DIALING_LENGTH)
+    @Column(name = "dialing_code", length = DIALING_LENGTH)
     private String dialingCode;
 
-    @Size(max = 256)
-    @Column(name = "nationality_en", length = 256)
+    @Size(max = NAME_LENGTH)
+    @Column(name = "nationality_en", length = NAME_LENGTH)
     private String nationalityEn;
 
-    @Size(max = 256)
-    @Column(name = "nationality_ar", length = 256)
+    @Size(max = NAME_LENGTH)
+    @Column(name = "nationality_ar", length = NAME_LENGTH)
     private String nationalityAr;
 
     @Builder.Default
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = Boolean.TRUE;
 
-    @Size(max = 1000)
-    @Column(name = "en_description", length = 1000)
+    @Size(max = DESC_LENGTH)
+    @Column(name = "en_description", length = DESC_LENGTH)
     private String enDescription;
 
-    @Size(max = 1000)
-    @Column(name = "ar_description", length = 1000)
+    @Size(max = DESC_LENGTH)
+    @Column(name = "ar_description", length = DESC_LENGTH)
     private String arDescription;
 
     @Version
@@ -110,13 +125,27 @@ public class Country implements Serializable {
     @PrePersist @PreUpdate
     @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "Called by JPA lifecycle")
     private void normalize() {
-        if (countryCd != null) countryCd = countryCd.trim();
-        if (countryEnNm != null) countryEnNm = countryEnNm.trim();
-        if (countryArNm != null) countryArNm = countryArNm.trim();
-        if (dialingCode != null) dialingCode = dialingCode.trim();
-        if (nationalityEn != null) nationalityEn = nationalityEn.trim();
-        if (nationalityAr != null) nationalityAr = nationalityAr.trim();
-        if (isActive == null) isActive = Boolean.TRUE;
+        if (countryCd != null) {
+            countryCd = countryCd.trim();
+        }
+        if (countryEnNm != null) {
+            countryEnNm = countryEnNm.trim();
+        }
+        if (countryArNm != null) {
+            countryArNm = countryArNm.trim();
+        }
+        if (dialingCode != null) {
+            dialingCode = dialingCode.trim();
+        }
+        if (nationalityEn != null) {
+            nationalityEn = nationalityEn.trim();
+        }
+        if (nationalityAr != null) {
+            nationalityAr = nationalityAr.trim();
+        }
+        if (isActive == null) {
+            isActive = Boolean.TRUE;
+        }
     }
 
     public static Country ref(final Long id) {

--- a/setup-service/src/main/java/com/ejada/setup/model/Lookup.java
+++ b/setup-service/src/main/java/com/ejada/setup/model/Lookup.java
@@ -1,7 +1,10 @@
 package com.ejada.setup.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -49,5 +52,7 @@ public class Lookup {
     @Column(name = "item_ar_description")
     private String itemArDescription;
 
-    public Boolean isActive() { return isActive != null ? isActive : Boolean.FALSE; }
+    public final Boolean isActive() {
+        return isActive != null ? isActive : Boolean.FALSE;
+    }
 }

--- a/setup-service/src/main/java/com/ejada/setup/model/Resource.java
+++ b/setup-service/src/main/java/com/ejada/setup/model/Resource.java
@@ -1,7 +1,17 @@
 package com.ejada.setup.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.hibernate.annotations.CreationTimestamp;
@@ -45,6 +55,12 @@ public class Resource implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
+    private static final int CODE_LENGTH = 128;
+    private static final int NAME_LENGTH = 256;
+    private static final int PATH_LENGTH = 512;
+    private static final int METHOD_LENGTH = 16;
+    private static final int DESC_LENGTH = 1000;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "resource_id",  unique = true, nullable = false)
@@ -52,26 +68,26 @@ public class Resource implements Serializable {
     private Integer resourceId;
 
     @NotBlank
-    @Size(max = 128)
-    @Column(name = "resource_cd", length = 128, nullable = false)
+    @Size(max = CODE_LENGTH)
+    @Column(name = "resource_cd", length = CODE_LENGTH, nullable = false)
     private String resourceCd;
 
     @NotBlank
-    @Size(max = 256)
-    @Column(name = "resource_en_nm", length = 256, nullable = false)
+    @Size(max = NAME_LENGTH)
+    @Column(name = "resource_en_nm", length = NAME_LENGTH, nullable = false)
     private String resourceEnNm;
 
     @NotBlank
-    @Size(max = 256)
-    @Column(name = "resource_ar_nm", length = 256, nullable = false)
+    @Size(max = NAME_LENGTH)
+    @Column(name = "resource_ar_nm", length = NAME_LENGTH, nullable = false)
     private String resourceArNm;
 
-    @Size(max = 512)
-    @Column(name = "path", length = 512)
+    @Size(max = PATH_LENGTH)
+    @Column(name = "path", length = PATH_LENGTH)
     private String path;
 
-    @Size(max = 16)
-    @Column(name = "http_method", length = 16)
+    @Size(max = METHOD_LENGTH)
+    @Column(name = "http_method", length = METHOD_LENGTH)
     private String httpMethod;
 
     @Column(name = "parent_resource_id")
@@ -81,12 +97,12 @@ public class Resource implements Serializable {
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = Boolean.TRUE;
 
-    @Size(max = 1000)
-    @Column(name = "en_description", length = 1000)
+    @Size(max = DESC_LENGTH)
+    @Column(name = "en_description", length = DESC_LENGTH)
     private String enDescription;
 
-    @Size(max = 1000)
-    @Column(name = "ar_description", length = 1000)
+    @Size(max = DESC_LENGTH)
+    @Column(name = "ar_description", length = DESC_LENGTH)
     private String arDescription;
 
     @Version
@@ -107,12 +123,24 @@ public class Resource implements Serializable {
     @PrePersist @PreUpdate
     @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "Called by JPA lifecycle")
     private void normalize() {
-        if (resourceCd != null) resourceCd = resourceCd.trim();
-        if (resourceEnNm != null) resourceEnNm = resourceEnNm.trim();
-        if (resourceArNm != null) resourceArNm = resourceArNm.trim();
-        if (path != null) path = path.trim();
-        if (httpMethod != null) httpMethod = httpMethod.trim().toUpperCase(Locale.ROOT);
-        if (isActive == null) isActive = Boolean.TRUE;
+        if (resourceCd != null) {
+            resourceCd = resourceCd.trim();
+        }
+        if (resourceEnNm != null) {
+            resourceEnNm = resourceEnNm.trim();
+        }
+        if (resourceArNm != null) {
+            resourceArNm = resourceArNm.trim();
+        }
+        if (path != null) {
+            path = path.trim();
+        }
+        if (httpMethod != null) {
+            httpMethod = httpMethod.trim().toUpperCase(Locale.ROOT);
+        }
+        if (isActive == null) {
+            isActive = Boolean.TRUE;
+        }
     }
 
 }

--- a/setup-service/src/main/java/com/ejada/setup/model/SystemParameter.java
+++ b/setup-service/src/main/java/com/ejada/setup/model/SystemParameter.java
@@ -1,7 +1,12 @@
 package com.ejada.setup.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -26,25 +31,35 @@ public class SystemParameter {
     @EqualsAndHashCode.Include
     private Integer paramId;
 
-    @Column(name = "param_key", nullable = false, unique = true, length = 150)
+    private static final int KEY_LENGTH = 150;
+    private static final int VALUE_LENGTH = 1000;
+
+    @Column(name = "param_key", nullable = false, unique = true, length = KEY_LENGTH)
     private String paramKey;
 
-    @Column(name = "param_value", nullable = false, length = 1000)
+    @Column(name = "param_value", nullable = false, length = VALUE_LENGTH)
     private String paramValue;
 
-    @Column(name = "description", length = 1000)
+    @Column(name = "description", length = VALUE_LENGTH)
     private String description;
 
     // DB column might be 'group_code' — map it to Java property 'paramGroup' that your service uses
-    @Column(name = "group_code", length = 150)
+    @Column(name = "group_code", length = KEY_LENGTH)
     private String paramGroup;
 
     @Builder.Default
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = Boolean.TRUE;
 
-    public Boolean isActive() { return isActive != null ? isActive : Boolean.FALSE; }
+    public final Boolean isActive() {
+        return isActive != null ? isActive : Boolean.FALSE;
+    }
 
-   public String getGroupCode() { return paramGroup; }
-   public void setGroupCode(String groupCode) { this.paramGroup = groupCode; }
+    public final String getGroupCode() {
+        return paramGroup;
+    }
+
+    public final void setGroupCode(final String groupCode) {
+        this.paramGroup = groupCode;
+    }
 }

--- a/setup-service/src/main/java/com/ejada/setup/repository/CityRepository.java
+++ b/setup-service/src/main/java/com/ejada/setup/repository/CityRepository.java
@@ -5,17 +5,18 @@ import com.ejada.setup.model.City;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface CityRepository     extends JpaRepository<City, Integer>, JpaSpecificationExecutor<City> {
+public interface CityRepository extends JpaRepository<City, Integer>, JpaSpecificationExecutor<City> {
 
-    List<City> findByCountry_CountryIdAndIsActiveTrue(Integer countryId);
+    List<City> findByCountryCountryIdAndIsActiveTrue(Integer countryId);
     Page<City> findByIsActiveTrue(Pageable pageable);
-    List<City> findByCountry_CountryIdAndIsActiveTrueOrderByCityEnNmAsc(Integer countryId);
+    List<City> findByCountryCountryIdAndIsActiveTrueOrderByCityEnNmAsc(Integer countryId);
 
     // used by list(..., all=true, q != blank)
     List<City> findByCityEnNmContainingIgnoreCaseOrCityArNmContainingIgnoreCase(

--- a/setup-service/src/main/java/com/ejada/setup/repository/CountryRepository.java
+++ b/setup-service/src/main/java/com/ejada/setup/repository/CountryRepository.java
@@ -4,7 +4,8 @@ import com.ejada.setup.model.Country;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/setup-service/src/main/java/com/ejada/setup/repository/ResourceRepository.java
+++ b/setup-service/src/main/java/com/ejada/setup/repository/ResourceRepository.java
@@ -3,7 +3,8 @@ package com.ejada.setup.repository;
 import com.ejada.setup.model.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/setup-service/src/main/java/com/ejada/setup/repository/SystemParameterRepository.java
+++ b/setup-service/src/main/java/com/ejada/setup/repository/SystemParameterRepository.java
@@ -3,7 +3,8 @@ package com.ejada.setup.repository;
 import com.ejada.setup.model.SystemParameter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;

--- a/setup-service/src/main/java/com/ejada/setup/security/SetupAuthorized.java
+++ b/setup-service/src/main/java/com/ejada/setup/security/SetupAuthorized.java
@@ -11,6 +11,9 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@PreAuthorize("@roleChecker.hasRole(authentication, T(com.ejada.starter_security.Role).EJADA_OFFICER, T(com.ejada.starter_security.Role).TENANT_ADMIN, T(com.ejada.starter_security.Role).TENANT_OFFICER)")
+@PreAuthorize(
+        "@roleChecker.hasRole(authentication, T(com.ejada.starter_security.Role).EJADA_OFFICER, "
+                + "T(com.ejada.starter_security.Role).TENANT_ADMIN, "
+                + "T(com.ejada.starter_security.Role).TENANT_OFFICER)")
 public @interface SetupAuthorized {
 }

--- a/setup-service/src/main/java/com/ejada/setup/service/CountryService.java
+++ b/setup-service/src/main/java/com/ejada/setup/service/CountryService.java
@@ -3,7 +3,6 @@ package com.ejada.setup.service;
 import com.ejada.common.dto.BaseResponse;
 import com.ejada.setup.model.Country;
 import com.ejada.setup.dto.CountryDto;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;

--- a/setup-service/src/main/java/com/ejada/setup/service/impl/CountryServiceImpl.java
+++ b/setup-service/src/main/java/com/ejada/setup/service/impl/CountryServiceImpl.java
@@ -23,11 +23,11 @@ import java.util.List;
 
 @Service
 @Transactional
-public class CountryServiceImpl implements CountryService {
+public final class CountryServiceImpl implements CountryService {
 
     private final CountryRepository countryRepository;
 
-    public CountryServiceImpl(CountryRepository countryRepository) {
+    public CountryServiceImpl(final CountryRepository countryRepository) {
         this.countryRepository = countryRepository;
     }
 
@@ -37,7 +37,7 @@ public class CountryServiceImpl implements CountryService {
             @CacheEvict(cacheNames = "countries", key = "#result.data.countryId", condition = "#result.isSuccess()"),
             @CacheEvict(cacheNames = "countries:active", key = "'active'")
     })
-    public BaseResponse<Country> add(CountryDto request) {
+    public BaseResponse<Country> add(final CountryDto request) {
         if (countryRepository.existsByCountryCdIgnoreCase(request.getCountryCd())) {
             return BaseResponse.error("ERR_COUNTRY_DUP_CD", "Country code already exists");
         }
@@ -62,15 +62,15 @@ public class CountryServiceImpl implements CountryService {
             @CacheEvict(cacheNames = "countries", key = "#countryId"),
             @CacheEvict(cacheNames = "countries:active", key = "'active'")
     })
-    public BaseResponse<Country> update(Integer countryId, CountryDto request) {
+    public BaseResponse<Country> update(final Integer countryId, final CountryDto request) {
         Country existing = countryRepository.findById(countryId)
                 .orElse(null);
         if (existing == null) {
             return BaseResponse.error("ERR_COUNTRY_NOT_FOUND", "Country not found");
         }
-        if (request.getCountryCd() != null &&
-            !request.getCountryCd().equalsIgnoreCase(existing.getCountryCd()) &&
-            countryRepository.existsByCountryCdIgnoreCase(request.getCountryCd())) {
+        if (request.getCountryCd() != null
+                && !request.getCountryCd().equalsIgnoreCase(existing.getCountryCd())
+                && countryRepository.existsByCountryCdIgnoreCase(request.getCountryCd())) {
             return BaseResponse.error("ERR_COUNTRY_DUP_CD", "Country code already exists");
         }
         existing.setCountryCd(request.getCountryCd());
@@ -91,7 +91,7 @@ public class CountryServiceImpl implements CountryService {
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "Country", dataClass = DataClass.HEALTH, message = "Get country")
     @Cacheable(cacheNames = "countries", key = "#countryId")
-    public BaseResponse<Country> get(Integer countryId) {
+    public BaseResponse<Country> get(final Integer countryId) {
         return countryRepository.findById(countryId)
                 .map(c -> BaseResponse.success("Country", c))
                 .orElseGet(() -> BaseResponse.error("ERR_COUNTRY_NOT_FOUND", "Country not found"));
@@ -100,7 +100,7 @@ public class CountryServiceImpl implements CountryService {
     @Override
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "Country", dataClass = DataClass.HEALTH, message = "List countries")
-    public BaseResponse<?> list(Pageable pageable, String q, boolean unpaged) {
+    public BaseResponse<?> list(final Pageable pageable, final String q, final boolean unpaged) {
         Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
                 "countryEnNm", "countryArNm", "countryCd");
         Pageable pg = (pageable == null || !pageable.isPaged()

--- a/setup-service/src/main/java/com/ejada/setup/service/impl/LookupServiceImpl.java
+++ b/setup-service/src/main/java/com/ejada/setup/service/impl/LookupServiceImpl.java
@@ -1,7 +1,6 @@
 package com.ejada.setup.service.impl;
 
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.enums.StatusEnums.ApiStatus;
 import com.ejada.setup.model.Lookup;
 import com.ejada.setup.repository.LookupRepository;
 import com.ejada.setup.service.LookupService;
@@ -19,13 +18,13 @@ import java.util.List;
 
 @Service
 @Transactional
-public class LookupServiceImpl implements LookupService {
+public final class LookupServiceImpl implements LookupService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LookupServiceImpl.class);
 
     private final LookupRepository lookupRepository;
 
-    public LookupServiceImpl(LookupRepository lookupRepository) {
+    public LookupServiceImpl(final LookupRepository lookupRepository) {
         this.lookupRepository = lookupRepository;
     }
 
@@ -51,13 +50,13 @@ public class LookupServiceImpl implements LookupService {
     }
 
     @Cacheable(cacheNames = "lookups:byGroup", key = "#groupCode")
-    public List<Lookup> getByGroupRaw(String groupCode) {
+    public List<Lookup> getByGroupRaw(final String groupCode) {
         return lookupRepository.findByLookupGroupCodeAndIsActiveTrueOrderByLookupItemEnNmAsc(groupCode);
     }
 
     @Override
     @Audited(action = AuditAction.READ, entity = "Lookup", dataClass = DataClass.HEALTH, message = "Fetch lookups by group")
-    public BaseResponse<List<Lookup>> getByGroup(String groupCode) {
+    public BaseResponse<List<Lookup>> getByGroup(final String groupCode) {
         try {
             if (groupCode == null || groupCode.isBlank()) {
                 return BaseResponse.error("ERR_LOOKUP_GROUP_REQUIRED", "Group code is required");
@@ -72,7 +71,7 @@ public class LookupServiceImpl implements LookupService {
     @Override
     @Audited(action = AuditAction.CREATE, entity = "Lookup", dataClass = DataClass.HEALTH, message = "Create lookup")
     @CacheEvict(cacheNames = {"lookups:all", "lookups:byGroup"}, allEntries = true)
-    public BaseResponse<Lookup> add(Lookup request) {
+    public BaseResponse<Lookup> add(final Lookup request) {
         try {
             if (request.getLookupItemId() == null) {
                 return BaseResponse.error("ERR_LOOKUP_ID_REQUIRED", "Lookup item id is required");
@@ -94,21 +93,37 @@ public class LookupServiceImpl implements LookupService {
     @Override
     @Audited(action = AuditAction.UPDATE, entity = "Lookup", dataClass = DataClass.HEALTH, message = "Update lookup")
     @CacheEvict(cacheNames = {"lookups:all", "lookups:byGroup"}, allEntries = true)
-    public BaseResponse<Lookup> update(Integer lookupItemId, Lookup request) {
+    public BaseResponse<Lookup> update(final Integer lookupItemId, final Lookup request) {
         try {
             Lookup existing = lookupRepository.findById(lookupItemId).orElse(null);
             if (existing == null) {
                 return BaseResponse.error("ERR_LOOKUP_NOT_FOUND", "Lookup not found");
             }
 
-            if (request.getLookupItemCd() != null) existing.setLookupItemCd(request.getLookupItemCd());
-            if (request.getLookupItemEnNm() != null) existing.setLookupItemEnNm(request.getLookupItemEnNm());
-            if (request.getLookupItemArNm() != null) existing.setLookupItemArNm(request.getLookupItemArNm());
-            if (request.getLookupGroupCode() != null) existing.setLookupGroupCode(request.getLookupGroupCode());
-            if (request.getParentLookupId() != null) existing.setParentLookupId(request.getParentLookupId());
-            if (request.getIsActive() != null) existing.setIsActive(request.getIsActive());
-            if (request.getItemEnDescription() != null) existing.setItemEnDescription(request.getItemEnDescription());
-            if (request.getItemArDescription() != null) existing.setItemArDescription(request.getItemArDescription());
+            if (request.getLookupItemCd() != null) {
+                existing.setLookupItemCd(request.getLookupItemCd());
+            }
+            if (request.getLookupItemEnNm() != null) {
+                existing.setLookupItemEnNm(request.getLookupItemEnNm());
+            }
+            if (request.getLookupItemArNm() != null) {
+                existing.setLookupItemArNm(request.getLookupItemArNm());
+            }
+            if (request.getLookupGroupCode() != null) {
+                existing.setLookupGroupCode(request.getLookupGroupCode());
+            }
+            if (request.getParentLookupId() != null) {
+                existing.setParentLookupId(request.getParentLookupId());
+            }
+            if (request.getIsActive() != null) {
+                existing.setIsActive(request.getIsActive());
+            }
+            if (request.getItemEnDescription() != null) {
+                existing.setItemEnDescription(request.getItemEnDescription());
+            }
+            if (request.getItemArDescription() != null) {
+                existing.setItemArDescription(request.getItemArDescription());
+            }
 
             Lookup saved = lookupRepository.save(existing);
             return BaseResponse.success("Lookup updated", saved);

--- a/setup-service/src/main/java/com/ejada/setup/service/impl/SystemParameterServiceImpl.java
+++ b/setup-service/src/main/java/com/ejada/setup/service/impl/SystemParameterServiceImpl.java
@@ -21,24 +21,23 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional
-public class SystemParameterServiceImpl implements SystemParameterService {
+public final class SystemParameterServiceImpl implements SystemParameterService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SystemParameterServiceImpl.class);
 
     private final SystemParameterRepository systemParameterRepository;
 
-    public SystemParameterServiceImpl(SystemParameterRepository systemParameterRepository) {
+    public SystemParameterServiceImpl(final SystemParameterRepository systemParameterRepository) {
         this.systemParameterRepository = systemParameterRepository;
     }
 
     @Override
     @Audited(action = AuditAction.CREATE, entity = "SystemParameter", dataClass = DataClass.HEALTH, message = "Create system parameter")
     @CacheEvict(cacheNames = {"sysparams:byKeys"}, allEntries = true)
-    public BaseResponse<SystemParameter> add(SystemParameter request) {
+    public BaseResponse<SystemParameter> add(final SystemParameter request) {
         try {
             if (request.getParamKey() == null || request.getParamKey().isBlank()) {
                 return BaseResponse.error("ERR_PARAM_KEY_REQUIRED", "Parameter key is required");
@@ -57,24 +56,33 @@ public class SystemParameterServiceImpl implements SystemParameterService {
     @Override
     @Audited(action = AuditAction.UPDATE, entity = "SystemParameter", dataClass = DataClass.HEALTH, message = "Update system parameter")
     @CacheEvict(cacheNames = {"sysparams:byKeys"}, allEntries = true)
-    public BaseResponse<SystemParameter> update(Integer paramId, SystemParameter request) {
+    public BaseResponse<SystemParameter> update(final Integer paramId, final SystemParameter request) {
         try {
             SystemParameter existing = systemParameterRepository.findById(paramId).orElse(null);
             if (existing == null) {
                 return BaseResponse.error("ERR_PARAM_NOT_FOUND", "System parameter not found");
             }
 
-            if (request.getParamKey() != null &&
-                !request.getParamKey().equalsIgnoreCase(existing.getParamKey()) &&
-                systemParameterRepository.existsByParamKeyIgnoreCase(request.getParamKey())) {
+            if (request.getParamKey() != null
+                    && !request.getParamKey().equalsIgnoreCase(existing.getParamKey())
+                    && systemParameterRepository.existsByParamKeyIgnoreCase(request.getParamKey())) {
                 return BaseResponse.error("ERR_PARAM_DUP_KEY", "Parameter key already exists");
             }
-
-            if (request.getParamKey() != null)   existing.setParamKey(request.getParamKey());
-            if (request.getParamValue() != null) existing.setParamValue(request.getParamValue());
-            if (request.getParamGroup() != null) existing.setParamGroup(request.getParamGroup());
-            if (request.getIsActive() != null)   existing.setIsActive(request.getIsActive());
-            if (request.getDescription() != null) existing.setDescription(request.getDescription());
+            if (request.getParamKey() != null) {
+                existing.setParamKey(request.getParamKey());
+            }
+            if (request.getParamValue() != null) {
+                existing.setParamValue(request.getParamValue());
+            }
+            if (request.getParamGroup() != null) {
+                existing.setParamGroup(request.getParamGroup());
+            }
+            if (request.getIsActive() != null) {
+                existing.setIsActive(request.getIsActive());
+            }
+            if (request.getDescription() != null) {
+                existing.setDescription(request.getDescription());
+            }
 
             SystemParameter saved = systemParameterRepository.save(existing);
             return BaseResponse.success("System parameter updated", saved);
@@ -87,7 +95,7 @@ public class SystemParameterServiceImpl implements SystemParameterService {
     @Override
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "SystemParameter", dataClass = DataClass.HEALTH, message = "Get system parameter")
-    public BaseResponse<SystemParameter> get(Integer paramId) {
+    public BaseResponse<SystemParameter> get(final Integer paramId) {
         try {
             return systemParameterRepository.findById(paramId)
                     .map(p -> BaseResponse.success("System parameter", p))
@@ -101,7 +109,7 @@ public class SystemParameterServiceImpl implements SystemParameterService {
     @Override
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "SystemParameter", dataClass = DataClass.HEALTH, message = "List system parameters")
-    public BaseResponse<Page<SystemParameter>> list(Pageable pageable, String group, Boolean onlyActive) {
+    public BaseResponse<Page<SystemParameter>> list(final Pageable pageable, final String group, final Boolean onlyActive) {
         try {
             Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
                     "paramKey", "paramGroup", "paramValue");
@@ -126,14 +134,14 @@ public class SystemParameterServiceImpl implements SystemParameterService {
 
     @Cacheable(cacheNames = "sysparams:byKeys", key = "#keys")
     @Transactional(Transactional.TxType.SUPPORTS)
-    public List<SystemParameter> getByKeysRaw(Collection<String> keys) {
+    public List<SystemParameter> getByKeysRaw(final Collection<String> keys) {
         return systemParameterRepository.findByParamKeyIn(keys);
     }
 
     @Override
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "SystemParameter", dataClass = DataClass.HEALTH, message = "Get system parameters by keys")
-    public BaseResponse<List<SystemParameter>> getByKeys(List<String> keys) {
+    public BaseResponse<List<SystemParameter>> getByKeys(final List<String> keys) {
         try {
             if (keys == null || keys.isEmpty()) {
                 return BaseResponse.error("ERR_PARAM_KEYS_REQUIRED", "Keys list is required");
@@ -146,7 +154,7 @@ public class SystemParameterServiceImpl implements SystemParameterService {
     }
     
     @Override
-    public BaseResponse<SystemParameter> getByKey(String paramKey) {
+    public BaseResponse<SystemParameter> getByKey(final String paramKey) {
         return systemParameterRepository.findByParamKey(paramKey)
                 .map(p -> BaseResponse.success("System parameter", p))
                 .orElseGet(() -> BaseResponse.error("ERR_PARAM_NOT_FOUND", "System parameter not found"));


### PR DESCRIPTION
## Summary
- eliminate wildcard imports and magic numbers in models and repositories
- mark controllers and service implementations as final with brace-safe logic
- wrap lengthy security expressions to satisfy style rules

## Testing
- `mvn -f setup-service/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bed47ec2f4832f83e9e242825624bd