### PR TITLE
fix: correct checkstyle suppressions path

### DIFF
--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -102,8 +102,8 @@
             <artifactId>maven-checkstyle-plugin</artifactId>
             <version>${plugin.checkstyle.version}</version>
             <configuration>
-              <configLocation>${maven.multiModuleProjectDirectory}/../shared-lib/shared-quality/checkstyle.xml</configLocation>
-              <suppressionsLocation>${maven.multiModuleProjectDirectory}/../shared-lib/shared-quality/suppressions.xml</suppressionsLocation>
+              <configLocation>${project.basedir}/../shared-lib/shared-quality/checkstyle.xml</configLocation>
+              <suppressionsLocation>${project.basedir}/../shared-lib/shared-quality/suppressions.xml</suppressionsLocation>
               <consoleOutput>true</consoleOutput>
               <failOnViolation>false</failOnViolation>
             </configuration>


### PR DESCRIPTION
## Summary
- fix Checkstyle configuration to resolve suppressions file within repository

## Testing
- `mvn -q -e checkstyle:check` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent from Maven Central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68beda1a64bc832f85e1bdddb29d7c22