### PR TITLE
refactor: reuse secure random in integration key service

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantIntegrationKeyServiceImpl.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantIntegrationKeyServiceImpl.java
@@ -25,6 +25,8 @@ import java.util.Base64;
 @Transactional
 public class TenantIntegrationKeyServiceImpl implements TenantIntegrationKeyService {
 
+    private static final SecureRandom RANDOM = new SecureRandom();
+
     private final TenantIntegrationKeyRepository repo;
     private final TenantRepository tenantRepo;
     private final TenantIntegrationKeyMapper mapper;
@@ -67,7 +69,7 @@ public class TenantIntegrationKeyServiceImpl implements TenantIntegrationKeyServ
         String plainSecret = req.plainSecret();
         if (plainSecret == null || plainSecret.isBlank()) {
             byte[] secretBytes = new byte[32];
-            new SecureRandom().nextBytes(secretBytes);
+            RANDOM.nextBytes(secretBytes);
             plainSecret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
         }
         try {


### PR DESCRIPTION
## Summary
- reuse a shared `SecureRandom` instance for tenant integration key secret generation

## Testing
- `mvn -q -pl tenant-service -am verify` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bf104d023c832fb70ba60c4dbe6af8