### PR TITLE
Fix tenant integration key repository nested property methods

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantIntegrationKeyRepository.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantIntegrationKeyRepository.java
@@ -18,13 +18,13 @@ public interface TenantIntegrationKeyRepository extends JpaRepository<TenantInte
 
     Optional<TenantIntegrationKey> findByTikIdAndIsDeletedFalse(Long tikId);
 
-    Optional<TenantIntegrationKey> findByTenantIdAndKeyIdAndIsDeletedFalse(Integer tenantId, String keyId);
+    Optional<TenantIntegrationKey> findByTenant_IdAndKeyIdAndIsDeletedFalse(Integer tenantId, String keyId);
 
-    Page<TenantIntegrationKey> findByTenantIdAndIsDeletedFalse(Integer tenantId, Pageable pageable);
+    Page<TenantIntegrationKey> findByTenant_IdAndIsDeletedFalse(Integer tenantId, Pageable pageable);
 
-    List<TenantIntegrationKey> findByTenantIdAndStatusAndIsDeletedFalse(Integer tenantId, Status status);
+    List<TenantIntegrationKey> findByTenant_IdAndStatusAndIsDeletedFalse(Integer tenantId, Status status);
 
-    boolean existsByTenantIdAndKeyIdAndIsDeletedFalse(Integer tenantId, String keyId);
+    boolean existsByTenant_IdAndKeyIdAndIsDeletedFalse(Integer tenantId, String keyId);
 
     // --- Usable (active + within validity window + not deleted) ---
     @Query("""

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantIntegrationKeyServiceImpl.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantIntegrationKeyServiceImpl.java
@@ -52,7 +52,7 @@ public final class TenantIntegrationKeyServiceImpl implements TenantIntegrationK
                 .orElseThrow(() -> new EntityNotFoundException("Tenant " + req.tenantId()));
 
         // Uniqueness under soft delete
-        if (repo.existsByTenantIdAndKeyIdAndIsDeletedFalse(req.tenantId(), req.keyId())) {
+        if (repo.existsByTenant_IdAndKeyIdAndIsDeletedFalse(req.tenantId(), req.keyId())) {
             throw new IllegalStateException("integration key exists for tenant=" + req.tenantId() + " keyId=" + req.keyId());
         }
 
@@ -134,7 +134,7 @@ public final class TenantIntegrationKeyServiceImpl implements TenantIntegrationK
         tenantRepo.findByIdAndIsDeletedFalse(tenantId)
                 .orElseThrow(() -> new EntityNotFoundException("Tenant " + tenantId));
         Page<TenantIntegrationKeyRes> page =
-                repo.findByTenantIdAndIsDeletedFalse(tenantId, pageable).map(mapper::toRes);
+                repo.findByTenant_IdAndIsDeletedFalse(tenantId, pageable).map(mapper::toRes);
         return BaseResponse.success("Tenant integration keys listed", page);
     }
 


### PR DESCRIPTION
## Summary
- use Spring Data's nested property syntax for tenant lookup in tenant integration key repository
- update service to use the new repository methods

## Testing
- `mvn -q -pl tenant-service test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68bf127557c0832fa2d723f826c10cc9