### PR TITLE
Fix SpotBugs warnings in subscription service

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/ReceiveSubscriptionNotificationRq.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/ReceiveSubscriptionNotificationRq.java
@@ -4,9 +4,23 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import java.util.List;
 
+/**
+ * DTO representing a subscription notification request. The list of product
+ * properties is defensively copied to prevent external mutation.
+ */
 public record ReceiveSubscriptionNotificationRq(
-    @NotNull @Valid CustomerInfoDto customerInfo,
-    @NotNull @Valid AdminUserInfoDto adminUserInfo,
-    @NotNull @Valid SubscriptionInfoDto subscriptionInfo,
-    @Valid List<ProductPropertyDto> productProperties
-) {}
+        @NotNull @Valid CustomerInfoDto customerInfo,
+        @NotNull @Valid AdminUserInfoDto adminUserInfo,
+        @NotNull @Valid SubscriptionInfoDto subscriptionInfo,
+        @Valid List<ProductPropertyDto> productProperties) {
+
+    public ReceiveSubscriptionNotificationRq {
+        productProperties =
+                productProperties == null ? List.of() : List.copyOf(productProperties);
+    }
+
+    public List<ProductPropertyDto> productProperties() {
+        return productProperties;
+    }
+}
+

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/ReceiveSubscriptionNotificationRs.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/ReceiveSubscriptionNotificationRs.java
@@ -3,8 +3,23 @@ package com.ejada.subscription.dto;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
-/** What we return to the marketplace after processing notification. */
+/**
+ * Response returned to the marketplace after processing the notification. The
+ * list of environment identifiers is copied to maintain immutability.
+ */
 public record ReceiveSubscriptionNotificationRs(
-    @NotNull Boolean isNotificationReceived,
-    List<EnvironmentIdentifierDto> environmentIdentiferLst // optional if auto-provisioning produced identifiers
-) {}
+        @NotNull Boolean isNotificationReceived,
+        List<EnvironmentIdentifierDto> environmentIdentiferLst) {
+
+    public ReceiveSubscriptionNotificationRs {
+        environmentIdentiferLst =
+                environmentIdentiferLst == null
+                        ? List.of()
+                        : List.copyOf(environmentIdentiferLst);
+    }
+
+    public List<EnvironmentIdentifierDto> environmentIdentiferLst() {
+        return environmentIdentiferLst;
+    }
+}
+

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/SubscriptionInfoDto.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/SubscriptionInfoDto.java
@@ -6,43 +6,67 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+/**
+ * Subscription information received from the marketplace. Collection fields are
+ * defensively copied to avoid exposing internal mutable state.
+ */
 public record SubscriptionInfoDto(
-    @NotNull Long subscriptionId,
-    @NotNull Long customerId,
-    @NotNull Long productId,
-    @NotNull Long tierId,
+        @NotNull Long subscriptionId,
+        @NotNull Long customerId,
+        @NotNull Long productId,
+        @NotNull Long tierId,
 
-    String tierNameEn,
-    String tierNameAr,
+        String tierNameEn,
+        String tierNameAr,
 
-    @NotNull LocalDate startDt,
-    @NotNull LocalDate endDt,
+        @NotNull LocalDate startDt,
+        @NotNull LocalDate endDt,
 
-    BigDecimal subscriptionAmount,
-    BigDecimal totalBilledAmount,
-    BigDecimal totalPaidAmount,
+        BigDecimal subscriptionAmount,
+        BigDecimal totalBilledAmount,
+        BigDecimal totalPaidAmount,
 
-    @NotBlank String subscriptionSttsCd, // marketplace status code (string)
-    String createChannel,                // optional (PORTAL | GCP_MARKETPLACE)
+        @NotBlank String subscriptionSttsCd, // marketplace status code (string)
+        String createChannel, // optional (PORTAL | GCP_MARKETPLACE)
 
-    // Limits (we use Boolean here; entities handle Y/N conversion)
-    Boolean unlimitedUsersFlag,
-    Long usersLimit,
-    String usersLimitResetType,          // FULL_SUBSCRIPTION_PERIOD | PAYMENT_FREQUENCY_PERIOD
+        // Limits (we use Boolean here; entities handle Y/N conversion)
+        Boolean unlimitedUsersFlag,
+        Long usersLimit,
+        String usersLimitResetType, // FULL_SUBSCRIPTION_PERIOD | PAYMENT_FREQUENCY_PERIOD
 
-    Boolean unlimitedTransFlag,
-    Long transactionsLimit,
-    String transLimitResetType,
+        Boolean unlimitedTransFlag,
+        Long transactionsLimit,
+        String transLimitResetType,
 
-    BigDecimal balanceLimit,
-    String balanceLimitResetType,
+        BigDecimal balanceLimit,
+        String balanceLimitResetType,
 
-    String environmentSizeCd,           // L | XL
+        String environmentSizeCd, // L | XL
 
-    Boolean isAutoProvEnabled,
-    Long prevSubscriptionId,
-    String prevSubscriptionUpdateAction, // UPGRADE | DOWNGRADE | RENEWAL
+        Boolean isAutoProvEnabled,
+        Long prevSubscriptionId,
+        String prevSubscriptionUpdateAction, // UPGRADE | DOWNGRADE | RENEWAL
 
-    @Valid List<SubscriptionFeatureDto> subscriptionFeatureLst,
-    @Valid List<SubscriptionAdditionalServiceDto> subscriptionAdditionalServicesLst
-) {}
+        @Valid List<SubscriptionFeatureDto> subscriptionFeatureLst,
+        @Valid List<SubscriptionAdditionalServiceDto> subscriptionAdditionalServicesLst) {
+
+    public SubscriptionInfoDto {
+        subscriptionFeatureLst =
+                subscriptionFeatureLst == null
+                        ? List.of()
+                        : List.copyOf(subscriptionFeatureLst);
+        subscriptionAdditionalServicesLst =
+                subscriptionAdditionalServicesLst == null
+                        ? List.of()
+                        : List.copyOf(subscriptionAdditionalServicesLst);
+    }
+
+    public List<SubscriptionFeatureDto> subscriptionFeatureLst() {
+        return subscriptionFeatureLst;
+    }
+
+    public List<SubscriptionAdditionalServiceDto> subscriptionAdditionalServicesLst() {
+        return subscriptionAdditionalServicesLst;
+    }
+}
+

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/EntitlementCache.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/EntitlementCache.java
@@ -1,5 +1,6 @@
 package com.ejada.subscription.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
@@ -27,6 +28,7 @@ public class EntitlementCache {
     @EqualsAndHashCode.Include
     private Long entitlementCacheId;
 
+    @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "subscription_id", nullable = false)
     private Subscription subscription;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionAdditionalService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionAdditionalService.java
@@ -1,5 +1,6 @@
 package com.ejada.subscription.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
@@ -23,6 +24,7 @@ public class SubscriptionAdditionalService {
     @EqualsAndHashCode.Include
     private Long subscriptionAdditionalServiceId;
 
+    @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "subscription_id", nullable = false)
     private Subscription subscription;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionEnvironmentIdentifier.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionEnvironmentIdentifier.java
@@ -1,5 +1,6 @@
 package com.ejada.subscription.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
@@ -23,6 +24,7 @@ public class SubscriptionEnvironmentIdentifier {
     @EqualsAndHashCode.Include
     private Long subscriptionEnvId;
 
+    @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "subscription_id", nullable = false)
     private Subscription subscription;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionFeature.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionFeature.java
@@ -1,5 +1,6 @@
 package com.ejada.subscription.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
@@ -23,6 +24,7 @@ public class SubscriptionFeature {
     @EqualsAndHashCode.Include
     private Long subscriptionFeatureId;
 
+    @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "subscription_id", nullable = false)
     private Subscription subscription;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionProductProperty.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionProductProperty.java
@@ -1,5 +1,6 @@
 package com.ejada.subscription.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
@@ -23,6 +24,7 @@ public class SubscriptionProductProperty {
     @EqualsAndHashCode.Include
     private Long subscriptionProductPropertyId;
 
+    @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "subscription_id", nullable = false)
     private Subscription subscription;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImpl.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImpl.java
@@ -7,6 +7,7 @@ import com.ejada.subscription.model.*;
 import com.ejada.subscription.repository.*;
 import com.ejada.subscription.service.SubscriptionInboundService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.*;
@@ -51,6 +53,7 @@ public class SubscriptionInboundServiceImpl implements SubscriptionInboundServic
     private final SubscriptionUpdateEventMapper updateEventMapper;
 
     // JSON
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     private final ObjectMapper objectMapper;
 
     private static final String EP_NOTIFICATION = "RECEIVE_NOTIFICATION";
@@ -233,7 +236,9 @@ public class SubscriptionInboundServiceImpl implements SubscriptionInboundServic
 
     // Enum overload (your enum package)
     private void transitionStatus(Subscription sub, SubscriptionUpdateType type) {
-        transitionStatus(sub, type == null ? null : type.name());
+        if (type != null) {
+            transitionStatus(sub, type.name());
+        }
     }
 
     private String writeJson(Object o) {
@@ -249,7 +254,7 @@ public class SubscriptionInboundServiceImpl implements SubscriptionInboundServic
             StringBuilder sb = new StringBuilder(hash.length * 2);
             for (byte b : hash) sb.append(String.format("%02x", b));
             return sb.toString();
-        } catch (Exception e) {
+        } catch (NoSuchAlgorithmException e) {
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- defensively copy DTO collections to avoid exposing mutable state
- suppress false positive SpotBugs warnings on JPA relationships
- harden `SubscriptionInboundServiceImpl` against null update types and catch specific hashing exceptions

## Testing
- `mvn -q -pl subscription-service -am spotless:apply` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q -pl subscription-service -am -DskipTests verify` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf141b26cc832fadec3d5cf353fd38