### PR TITLE
refactor: resolve lint warnings in tenant service

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/TenantApplication.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/TenantApplication.java
@@ -9,8 +9,8 @@ import io.swagger.v3.oas.annotations.info.Info;
 @SpringBootApplication
 @EnableCaching
 @OpenAPIDefinition(info = @Info(title = "Ejada Tenant Service", version = "1.0"))
-public class TenantApplication {
-  private TenantApplication() {}
+public final class TenantApplication {
+  private TenantApplication() { }
 
   public static void main(final String[] args) {
     SpringApplication.run(TenantApplication.class, args);

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantCreateReq.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantCreateReq.java
@@ -1,5 +1,11 @@
 package com.ejada.tenant.dto;
 
+import static com.ejada.tenant.model.Tenant.CODE_LENGTH;
+import static com.ejada.tenant.model.Tenant.EMAIL_LENGTH;
+import static com.ejada.tenant.model.Tenant.LOGO_URL_LENGTH;
+import static com.ejada.tenant.model.Tenant.NAME_LENGTH;
+import static com.ejada.tenant.model.Tenant.PHONE_LENGTH;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -7,23 +13,23 @@ import jakarta.validation.constraints.Size;
 
 @Schema(name = "TenantCreateReq")
 public record TenantCreateReq(
-        @NotBlank @Size(max = 64)
+        @NotBlank @Size(max = CODE_LENGTH)
         @Schema(description = "Unique tenant code", example = "EJADA")
         String code,
 
-        @NotBlank @Size(max = 128)
+        @NotBlank @Size(max = NAME_LENGTH)
         @Schema(description = "Tenant display name", example = "Ejada Systems")
         String name,
 
-        @Email @Size(max = 255)
+        @Email @Size(max = EMAIL_LENGTH)
         @Schema(description = "Contact email", example = "ops@ejada.com")
         String contactEmail,
 
-        @Size(max = 32)
+        @Size(max = PHONE_LENGTH)
         @Schema(description = "Contact phone (normalized E.164 preferred)", example = "+966500000000")
         String contactPhone,
 
-        @Size(max = 255)
+        @Size(max = LOGO_URL_LENGTH)
         @Schema(description = "Tenant logo URL", example = "https://example.com/logo.png")
         String logoUrl,
 

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyCreateReq.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyCreateReq.java
@@ -1,4 +1,10 @@
 package com.ejada.tenant.dto;
+
+import static com.ejada.tenant.model.TenantIntegrationKey.KEY_ID_LENGTH;
+import static com.ejada.tenant.model.TenantIntegrationKey.LABEL_LENGTH;
+import static com.ejada.tenant.model.TenantIntegrationKey.PLAIN_SECRET_LENGTH;
+import static com.ejada.tenant.model.TenantIntegrationKey.SCOPE_LENGTH;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
@@ -14,20 +20,20 @@ public record TenantIntegrationKeyCreateReq(
         @Schema(description = "Owning tenant ID", example = "1")
         Integer tenantId,
 
-        @NotBlank @Size(max = 64)
+        @NotBlank @Size(max = KEY_ID_LENGTH)
         @Schema(description = "Public key identifier", example = "SYS_DEFAULT")
         String keyId,
 
-        @Size(max = 256)
+        @Size(max = PLAIN_SECRET_LENGTH)
         @Schema(description = "Optional plain secret to be hashed server-side; generated if blank", example = "S3cure-Plain-Secret")
         String plainSecret,
 
-        @Size(max = 128)
+        @Size(max = LABEL_LENGTH)
         @Schema(description = "Friendly label", example = "Backoffice API key")
         String label,
 
         @Schema(description = "List of scopes/permissions")
-        List<@NotBlank @Size(max = 64) String> scopes,
+        List<@NotBlank @Size(max = SCOPE_LENGTH) String> scopes,
 
         @NotNull
         @Schema(description = "Status", example = "ACTIVE")

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyUpdateReq.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyUpdateReq.java
@@ -1,4 +1,8 @@
 package com.ejada.tenant.dto;
+
+import static com.ejada.tenant.model.TenantIntegrationKey.LABEL_LENGTH;
+import static com.ejada.tenant.model.TenantIntegrationKey.SCOPE_LENGTH;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
@@ -9,12 +13,12 @@ import java.util.List;
 
 @Schema(name = "TenantIntegrationKeyUpdateReq")
 public record TenantIntegrationKeyUpdateReq(
-        @Size(max = 128)
+        @Size(max = LABEL_LENGTH)
         @Schema(description = "Friendly label", example = "Backoffice API key")
         String label,
 
         @Schema(description = "List of scopes/permissions")
-        List<@NotBlank @Size(max = 64) String> scopes,
+        List<@NotBlank @Size(max = SCOPE_LENGTH) String> scopes,
 
         @Schema(description = "Status", example = "SUSPENDED")
         TikStatus status,

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantUpdateReq.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantUpdateReq.java
@@ -1,28 +1,34 @@
 package com.ejada.tenant.dto;
 
+import static com.ejada.tenant.model.Tenant.CODE_LENGTH;
+import static com.ejada.tenant.model.Tenant.EMAIL_LENGTH;
+import static com.ejada.tenant.model.Tenant.LOGO_URL_LENGTH;
+import static com.ejada.tenant.model.Tenant.NAME_LENGTH;
+import static com.ejada.tenant.model.Tenant.PHONE_LENGTH;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 
 @Schema(name = "TenantUpdateReq")
 public record TenantUpdateReq(
-        @Size(max = 64)
+        @Size(max = CODE_LENGTH)
         @Schema(description = "Unique tenant code", example = "EJADA")
         String code,
 
-        @Size(max = 128)
+        @Size(max = NAME_LENGTH)
         @Schema(description = "Tenant display name", example = "Ejada Systems")
         String name,
 
-        @Email @Size(max = 255)
+        @Email @Size(max = EMAIL_LENGTH)
         @Schema(description = "Contact email", example = "ops@ejada.com")
         String contactEmail,
 
-        @Size(max = 32)
+        @Size(max = PHONE_LENGTH)
         @Schema(description = "Contact phone (normalized E.164 preferred)", example = "+966500000000")
         String contactPhone,
 
-        @Size(max = 255)
+        @Size(max = LOGO_URL_LENGTH)
         @Schema(description = "Tenant logo URL", example = "https://example.com/logo.png")
         String logoUrl,
 

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/Tenant.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/Tenant.java
@@ -7,7 +7,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -88,18 +87,4 @@ public class Tenant {
         return t;
     }
 
-    @Builder
-    @SuppressWarnings("checkstyle:ParameterNumber")
-    public Tenant(final Integer id, final String code, final String name,
-                  final String contactEmail, final String contactPhone, final String logoUrl,
-                  final Boolean active, final Boolean isDeleted) {
-        this.id = id;
-        this.code = code;
-        this.name = name;
-        this.contactEmail = contactEmail;
-        this.contactPhone = contactPhone;
-        this.logoUrl = logoUrl;
-        this.active = (active != null) ? active : Boolean.TRUE;
-        this.isDeleted = (isDeleted != null) ? isDeleted : Boolean.FALSE;
-    }
 }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantIntegrationKey.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantIntegrationKey.java
@@ -17,7 +17,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.Builder;
 import org.hibernate.annotations.DynamicUpdate;
 
 // Uncomment if using hibernate-types library:
@@ -48,6 +47,8 @@ public class TenantIntegrationKey {
     public static final int SECRET_LENGTH = 255;
     public static final int LABEL_LENGTH = 128;
     public static final int STATUS_LENGTH = 16;
+    public static final int PLAIN_SECRET_LENGTH = 256;
+    public static final int SCOPE_LENGTH = 64;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantIntegrationKeyRepository.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantIntegrationKeyRepository.java
@@ -18,13 +18,44 @@ public interface TenantIntegrationKeyRepository extends JpaRepository<TenantInte
 
     Optional<TenantIntegrationKey> findByTikIdAndIsDeletedFalse(Long tikId);
 
-    Optional<TenantIntegrationKey> findByTenant_IdAndKeyIdAndIsDeletedFalse(Integer tenantId, String keyId);
+    @Query("""
+           select k
+             from TenantIntegrationKey k
+            where k.tenant.id = :tenantId
+              and k.keyId     = :keyId
+              and k.isDeleted = false
+           """)
+    Optional<TenantIntegrationKey> findByTenantIdAndKeyIdAndIsDeletedFalse(@Param("tenantId") Integer tenantId,
+                                                                           @Param("keyId") String keyId);
 
-    Page<TenantIntegrationKey> findByTenant_IdAndIsDeletedFalse(Integer tenantId, Pageable pageable);
+    @Query("""
+           select k
+             from TenantIntegrationKey k
+            where k.tenant.id = :tenantId
+              and k.isDeleted = false
+           """)
+    Page<TenantIntegrationKey> findByTenantIdAndIsDeletedFalse(@Param("tenantId") Integer tenantId,
+                                                              Pageable pageable);
 
-    List<TenantIntegrationKey> findByTenant_IdAndStatusAndIsDeletedFalse(Integer tenantId, Status status);
+    @Query("""
+           select k
+             from TenantIntegrationKey k
+            where k.tenant.id = :tenantId
+              and k.status    = :status
+              and k.isDeleted = false
+           """)
+    List<TenantIntegrationKey> findByTenantIdAndStatusAndIsDeletedFalse(@Param("tenantId") Integer tenantId,
+                                                                       @Param("status") Status status);
 
-    boolean existsByTenant_IdAndKeyIdAndIsDeletedFalse(Integer tenantId, String keyId);
+    @Query("""
+           select count(k) > 0
+             from TenantIntegrationKey k
+            where k.tenant.id = :tenantId
+              and k.keyId     = :keyId
+              and k.isDeleted = false
+           """)
+    boolean existsByTenantIdAndKeyIdAndIsDeletedFalse(@Param("tenantId") Integer tenantId,
+                                                      @Param("keyId") String keyId);
 
     // --- Usable (active + within validity window + not deleted) ---
     @Query("""

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantIntegrationKeyServiceImpl.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantIntegrationKeyServiceImpl.java
@@ -28,7 +28,7 @@ import java.util.Base64;
 public final class TenantIntegrationKeyServiceImpl implements TenantIntegrationKeyService {
 
     private static final SecureRandom RANDOM = new SecureRandom();
-
+    private static final int SECRET_BYTES_LENGTH = 32;
     private final TenantIntegrationKeyRepository repo;
     private final TenantRepository tenantRepo;
     private final TenantIntegrationKeyMapper mapper;
@@ -52,7 +52,7 @@ public final class TenantIntegrationKeyServiceImpl implements TenantIntegrationK
                 .orElseThrow(() -> new EntityNotFoundException("Tenant " + req.tenantId()));
 
         // Uniqueness under soft delete
-        if (repo.existsByTenant_IdAndKeyIdAndIsDeletedFalse(req.tenantId(), req.keyId())) {
+        if (repo.existsByTenantIdAndKeyIdAndIsDeletedFalse(req.tenantId(), req.keyId())) {
             throw new IllegalStateException("integration key exists for tenant=" + req.tenantId() + " keyId=" + req.keyId());
         }
 
@@ -70,7 +70,7 @@ public final class TenantIntegrationKeyServiceImpl implements TenantIntegrationK
         // Secret handling
         String plainSecret = req.plainSecret();
         if (plainSecret == null || plainSecret.isBlank()) {
-            byte[] secretBytes = new byte[32];
+            byte[] secretBytes = new byte[SECRET_BYTES_LENGTH];
             RANDOM.nextBytes(secretBytes);
             plainSecret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
         }
@@ -134,9 +134,7 @@ public final class TenantIntegrationKeyServiceImpl implements TenantIntegrationK
         tenantRepo.findByIdAndIsDeletedFalse(tenantId)
                 .orElseThrow(() -> new EntityNotFoundException("Tenant " + tenantId));
         Page<TenantIntegrationKeyRes> page =
-                repo.findByTenant_IdAndIsDeletedFalse(tenantId, pageable).map(mapper::toRes);
+                repo.findByTenantIdAndIsDeletedFalse(tenantId, pageable).map(mapper::toRes);
         return BaseResponse.success("Tenant integration keys listed", page);
     }
-
-    private static final int SECRET_BYTES_LENGTH = 32;
 }

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/TenantIntegrationKeyServiceImplTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/TenantIntegrationKeyServiceImplTest.java
@@ -35,7 +35,7 @@ class TenantIntegrationKeyServiceImplTest {
         Tenant tenant = new Tenant();
         tenant.setId(1);
         when(tenantRepo.findByIdAndIsDeletedFalse(1)).thenReturn(Optional.of(tenant));
-        when(repo.existsByTenant_IdAndKeyIdAndIsDeletedFalse(1, "KEY")).thenReturn(false);
+        when(repo.existsByTenantIdAndKeyIdAndIsDeletedFalse(1, "KEY")).thenReturn(false);
         when(crypto.signToBase64(anyString())).thenReturn("hashed-secret");
         when(repo.save(any(TenantIntegrationKey.class))).thenAnswer(invocation -> invocation.getArgument(0));
 


### PR DESCRIPTION
## Summary
- replace magic numbers in tenant DTOs with shared constants
- rename integration key repository methods and add explicit JPQL queries
- streamline tenant models and services to satisfy checkstyle

## Testing
- `mvn -q verify` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf16067cd8832fb466eb483f25dd88