### PR TITLE
chore: address checkstyle warnings

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/SubscriptionApplication.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/SubscriptionApplication.java
@@ -9,8 +9,8 @@ import io.swagger.v3.oas.annotations.info.Info;
 @SpringBootApplication
 @EnableCaching
 @OpenAPIDefinition(info = @Info(title = "Ejada Ehub subscription Service", version = "1.0"))
-public class SubscriptionApplication {
-  private SubscriptionApplication() {}
+public final class SubscriptionApplication {
+  private SubscriptionApplication() { }
 
   public static void main(final String[] args) {
     SpringApplication.run(SubscriptionApplication.class, args);

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionInboundController.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionInboundController.java
@@ -1,13 +1,20 @@
 package com.ejada.subscription.controller;
 
-import com.ejada.subscription.dto.*;
+import com.ejada.subscription.dto.ReceiveSubscriptionNotificationRq;
+import com.ejada.subscription.dto.ReceiveSubscriptionNotificationRs;
+import com.ejada.subscription.dto.ReceiveSubscriptionUpdateRq;
+import com.ejada.subscription.dto.ServiceResult;
 import com.ejada.subscription.service.SubscriptionInboundService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionAdditionalService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionAdditionalService.java
@@ -1,8 +1,21 @@
 package com.ejada.subscription.model;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.math.BigDecimal;
@@ -18,6 +31,14 @@ import java.time.OffsetDateTime;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class SubscriptionAdditionalService {
 
+    private static final int SERVICE_CD_LENGTH = 128;
+    private static final int SERVICE_NAME_LENGTH = 256;
+    private static final int PRICE_PRECISION = 18;
+    private static final int PRICE_SCALE = 4;
+    private static final int CURRENCY_LENGTH = 3;
+    private static final int FLAG_LENGTH = 1;
+    private static final int PAYMENT_TYPE_LENGTH = 32;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "subscription_additional_service_id", nullable = false, updatable = false)
@@ -32,13 +53,13 @@ public class SubscriptionAdditionalService {
     @Column(name = "product_additional_service_id", nullable = false)
     private Long productAdditionalServiceId;
 
-    @Column(name = "service_cd", length = 128, nullable = false)
+    @Column(name = "service_cd", length = SERVICE_CD_LENGTH, nullable = false)
     private String serviceCd;
 
-    @Column(name = "service_name_en", length = 256, nullable = false)
+    @Column(name = "service_name_en", length = SERVICE_NAME_LENGTH, nullable = false)
     private String serviceNameEn;
 
-    @Column(name = "service_name_ar", length = 256, nullable = false)
+    @Column(name = "service_name_ar", length = SERVICE_NAME_LENGTH, nullable = false)
     private String serviceNameAr;
 
     @Column(name = "service_desc_en", columnDefinition = "text")
@@ -47,23 +68,23 @@ public class SubscriptionAdditionalService {
     @Column(name = "service_desc_ar", columnDefinition = "text")
     private String serviceDescAr;
 
-    @Column(name = "service_price", precision = 18, scale = 4)
+    @Column(name = "service_price", precision = PRICE_PRECISION, scale = PRICE_SCALE)
     private BigDecimal servicePrice;
 
-    @Column(name = "total_amount", precision = 18, scale = 4)
+    @Column(name = "total_amount", precision = PRICE_PRECISION, scale = PRICE_SCALE)
     private BigDecimal totalAmount;
 
-    @Column(name = "currency", length = 3)
+    @Column(name = "currency", length = CURRENCY_LENGTH)
     private String currency;
 
     @Convert(converter = YesNoBooleanConverter.class)
-    @Column(name = "is_countable", length = 1)
+    @Column(name = "is_countable", length = FLAG_LENGTH)
     private Boolean isCountable = Boolean.FALSE;
 
     @Column(name = "requested_count")
     private Long requestedCount;
 
-    @Column(name = "payment_type_cd", length = 32)
+    @Column(name = "payment_type_cd", length = PAYMENT_TYPE_LENGTH)
     private String paymentTypeCd; // ONE_TIME_FEES | WITH_INSTALLMENT
 
     @Column(name = "created_at", nullable = false)
@@ -72,8 +93,10 @@ public class SubscriptionAdditionalService {
     @Column(name = "updated_at")
     private OffsetDateTime updatedAt;
 
-    public static SubscriptionAdditionalService ref(Long id) {
-        if (id == null) return null;
+    public static SubscriptionAdditionalService ref(final Long id) {
+        if (id == null) {
+            return null;
+        }
         SubscriptionAdditionalService x = new SubscriptionAdditionalService();
         x.setSubscriptionAdditionalServiceId(id);
         return x;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionEnvironmentIdentifier.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionEnvironmentIdentifier.java
@@ -1,8 +1,21 @@
 package com.ejada.subscription.model;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.OffsetDateTime;
@@ -18,6 +31,9 @@ import java.time.OffsetDateTime;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class SubscriptionEnvironmentIdentifier {
 
+    private static final int IDENTIFIER_CD_LENGTH = 64;
+    private static final int IDENTIFIER_VALUE_LENGTH = 512;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "subscription_env_id", nullable = false, updatable = false)
@@ -29,17 +45,19 @@ public class SubscriptionEnvironmentIdentifier {
     @JoinColumn(name = "subscription_id", nullable = false)
     private Subscription subscription;
 
-    @Column(name = "identifier_cd", length = 64, nullable = false)
+    @Column(name = "identifier_cd", length = IDENTIFIER_CD_LENGTH, nullable = false)
     private String identifierCd; // e.g., DB_ID
 
-    @Column(name = "identifier_value", length = 512, nullable = false)
+    @Column(name = "identifier_value", length = IDENTIFIER_VALUE_LENGTH, nullable = false)
     private String identifierValue;
 
     @Column(name = "created_at", nullable = false)
     private OffsetDateTime createdAt = OffsetDateTime.now();
 
-    public static SubscriptionEnvironmentIdentifier ref(Long id) {
-        if (id == null) return null;
+    public static SubscriptionEnvironmentIdentifier ref(final Long id) {
+        if (id == null) {
+            return null;
+        }
         SubscriptionEnvironmentIdentifier x = new SubscriptionEnvironmentIdentifier();
         x.setSubscriptionEnvId(id);
         return x;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionFeature.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionFeature.java
@@ -1,8 +1,21 @@
 package com.ejada.subscription.model;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.OffsetDateTime;
@@ -18,6 +31,8 @@ import java.time.OffsetDateTime;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class SubscriptionFeature {
 
+    private static final int FEATURE_CD_LENGTH = 128;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "subscription_feature_id", nullable = false, updatable = false)
@@ -29,7 +44,7 @@ public class SubscriptionFeature {
     @JoinColumn(name = "subscription_id", nullable = false)
     private Subscription subscription;
 
-    @Column(name = "feature_cd", length = 128, nullable = false)
+    @Column(name = "feature_cd", length = FEATURE_CD_LENGTH, nullable = false)
     private String featureCd;
 
     @Column(name = "feature_count")
@@ -41,8 +56,10 @@ public class SubscriptionFeature {
     @Column(name = "updated_at")
     private OffsetDateTime updatedAt;
 
-    public static SubscriptionFeature ref(Long id) {
-        if (id == null) return null;
+    public static SubscriptionFeature ref(final Long id) {
+        if (id == null) {
+            return null;
+        }
         SubscriptionFeature x = new SubscriptionFeature();
         x.setSubscriptionFeatureId(id);
         return x;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionProductProperty.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionProductProperty.java
@@ -1,8 +1,21 @@
 package com.ejada.subscription.model;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.OffsetDateTime;
@@ -18,6 +31,9 @@ import java.time.OffsetDateTime;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class SubscriptionProductProperty {
 
+    private static final int PROPERTY_CD_LENGTH = 128;
+    private static final int PROPERTY_VALUE_LENGTH = 2048;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "subscription_product_property_id", nullable = false, updatable = false)
@@ -29,17 +45,19 @@ public class SubscriptionProductProperty {
     @JoinColumn(name = "subscription_id", nullable = false)
     private Subscription subscription;
 
-    @Column(name = "property_cd", length = 128, nullable = false)
+    @Column(name = "property_cd", length = PROPERTY_CD_LENGTH, nullable = false)
     private String propertyCd;
 
-    @Column(name = "property_value", length = 2048, nullable = false)
+    @Column(name = "property_value", length = PROPERTY_VALUE_LENGTH, nullable = false)
     private String propertyValue;
 
     @Column(name = "created_at", nullable = false)
     private OffsetDateTime createdAt = OffsetDateTime.now();
 
-    public static SubscriptionProductProperty ref(Long id) {
-        if (id == null) return null;
+    public static SubscriptionProductProperty ref(final Long id) {
+        if (id == null) {
+            return null;
+        }
         SubscriptionProductProperty x = new SubscriptionProductProperty();
         x.setSubscriptionProductPropertyId(id);
         return x;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionUpdateEvent.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/SubscriptionUpdateEvent.java
@@ -1,7 +1,17 @@
 package com.ejada.subscription.model;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.OffsetDateTime;
@@ -18,6 +28,8 @@ import java.util.UUID;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class SubscriptionUpdateEvent {
 
+    private static final int UPDATE_TYPE_LENGTH = 16;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "subscription_update_event_id", nullable = false, updatable = false)
@@ -33,7 +45,7 @@ public class SubscriptionUpdateEvent {
     @Column(name = "ext_customer_id", nullable = false)
     private Long extCustomerId;
 
-    @Column(name = "update_type", length = 16, nullable = false)
+    @Column(name = "update_type", length = UPDATE_TYPE_LENGTH, nullable = false)
     private String updateType; // SUSPENDED | RESUMED | TERMINATED | EXPIRED
 
     @Column(name = "received_at", nullable = false)
@@ -45,8 +57,10 @@ public class SubscriptionUpdateEvent {
     @Column(name = "processed_at")
     private OffsetDateTime processedAt;
 
-    public static SubscriptionUpdateEvent ref(Long id) {
-        if (id == null) return null;
+    public static SubscriptionUpdateEvent ref(final Long id) {
+        if (id == null) {
+            return null;
+        }
         SubscriptionUpdateEvent x = new SubscriptionUpdateEvent();
         x.setSubscriptionUpdateEventId(id);
         return x;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/YesNoBooleanConverter.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/YesNoBooleanConverter.java
@@ -3,17 +3,19 @@ package com.ejada.subscription.model;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
-@Converter(autoApply = false) 
-public class YesNoBooleanConverter implements AttributeConverter<Boolean, String> {
+@Converter(autoApply = false)
+public final class YesNoBooleanConverter implements AttributeConverter<Boolean, String> {
 
     @Override
-    public String convertToDatabaseColumn(Boolean value) {
-        if (value == null) return "N";
+    public String convertToDatabaseColumn(final Boolean value) {
+        if (value == null) {
+            return "N";
+        }
         return value ? "Y" : "N";
     }
 
     @Override
-    public Boolean convertToEntityAttribute(String dbValue) {
+    public Boolean convertToEntityAttribute(final String dbValue) {
         return "Y".equalsIgnoreCase(dbValue);
     }
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/EntitlementCacheRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/EntitlementCacheRepository.java
@@ -1,7 +1,10 @@
 package com.ejada.subscription.repository;
 
 import com.ejada.subscription.model.EntitlementCache;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,9 +13,9 @@ import java.util.Optional;
 @Repository
 public interface EntitlementCacheRepository extends JpaRepository<EntitlementCache, Long>, JpaSpecificationExecutor<EntitlementCache> {
 
-    List<EntitlementCache> findBySubscription_SubscriptionId(Long subscriptionId);
+    List<EntitlementCache> findBySubscriptionSubscriptionId(Long subscriptionId);
 
-    Optional<EntitlementCache> findBySubscription_SubscriptionIdAndFeatureKey(Long subscriptionId, String featureKey);
+    Optional<EntitlementCache> findBySubscriptionSubscriptionIdAndFeatureKey(Long subscriptionId, String featureKey);
 
     @Modifying
     @Query("delete from EntitlementCache e where e.subscription.subscriptionId = :subscriptionId")

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/IdempotentRequestRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/IdempotentRequestRepository.java
@@ -1,7 +1,8 @@
 package com.ejada.subscription.repository;
 
 import com.ejada.subscription.model.IdempotentRequest;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/InboundNotificationAuditRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/InboundNotificationAuditRepository.java
@@ -1,20 +1,29 @@
 package com.ejada.subscription.repository;
 
 import com.ejada.subscription.model.InboundNotificationAudit;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface InboundNotificationAuditRepository extends JpaRepository<InboundNotificationAudit, Long>, JpaSpecificationExecutor<InboundNotificationAudit> {
+public interface InboundNotificationAuditRepository
+        extends JpaRepository<InboundNotificationAudit, Long>,
+        JpaSpecificationExecutor<InboundNotificationAudit> {
 
     Optional<InboundNotificationAudit> findByRqUidAndEndpoint(UUID rqUid, String endpoint);
 
     boolean existsByRqUidAndEndpoint(UUID rqUid, String endpoint);
 
     @Modifying
-    @Query("update InboundNotificationAudit a set a.processed = true, a.processedAt = current timestamp, a.statusCode = :code, a.statusDesc = :desc, a.statusDtls = :details where a.inboundNotificationAuditId = :id")
+    @Query(
+            "update InboundNotificationAudit a set a.processed = true, a.processedAt = current timestamp,"
+                    + " a.statusCode = :code, a.statusDesc = :desc, a.statusDtls = :details"
+                    + " where a.inboundNotificationAuditId = :id"
+    )
     int markProcessed(Long id, String code, String desc, String details);
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/OutboxEventRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/OutboxEventRepository.java
@@ -1,7 +1,8 @@
 package com.ejada.subscription.repository;
 
 import com.ejada.subscription.model.OutboxEvent;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionAdditionalServiceRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionAdditionalServiceRepository.java
@@ -1,16 +1,22 @@
 package com.ejada.subscription.repository;
 
 import com.ejada.subscription.model.SubscriptionAdditionalService;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface SubscriptionAdditionalServiceRepository extends JpaRepository<SubscriptionAdditionalService, Long>, JpaSpecificationExecutor<SubscriptionAdditionalService> {
+public interface SubscriptionAdditionalServiceRepository
+        extends JpaRepository<SubscriptionAdditionalService, Long>,
+        JpaSpecificationExecutor<SubscriptionAdditionalService> {
 
-    List<SubscriptionAdditionalService> findBySubscription_SubscriptionId(Long subscriptionId);
+    List<SubscriptionAdditionalService> findBySubscriptionSubscriptionId(Long subscriptionId);
 
-    Optional<SubscriptionAdditionalService> findBySubscription_SubscriptionIdAndProductAdditionalServiceId(Long subscriptionId, Long productAdditionalServiceId);
+    Optional<SubscriptionAdditionalService> findBySubscriptionSubscriptionIdAndProductAdditionalServiceId(
+            Long subscriptionId,
+            Long productAdditionalServiceId
+    );
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionEnvironmentIdentifierRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionEnvironmentIdentifierRepository.java
@@ -1,18 +1,24 @@
 package com.ejada.subscription.repository;
 
 import com.ejada.subscription.model.SubscriptionEnvironmentIdentifier;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface SubscriptionEnvironmentIdentifierRepository extends JpaRepository<SubscriptionEnvironmentIdentifier, Long>, JpaSpecificationExecutor<SubscriptionEnvironmentIdentifier> {
+public interface SubscriptionEnvironmentIdentifierRepository
+        extends JpaRepository<SubscriptionEnvironmentIdentifier, Long>,
+        JpaSpecificationExecutor<SubscriptionEnvironmentIdentifier> {
 
-    List<SubscriptionEnvironmentIdentifier> findBySubscription_SubscriptionId(Long subscriptionId);
+    List<SubscriptionEnvironmentIdentifier> findBySubscriptionSubscriptionId(Long subscriptionId);
 
-    Optional<SubscriptionEnvironmentIdentifier> findBySubscription_SubscriptionIdAndIdentifierCd(Long subscriptionId, String identifierCd);
+    Optional<SubscriptionEnvironmentIdentifier> findBySubscriptionSubscriptionIdAndIdentifierCd(
+            Long subscriptionId,
+            String identifierCd
+    );
 
-    boolean existsBySubscription_SubscriptionIdAndIdentifierCd(Long subscriptionId, String identifierCd);
+    boolean existsBySubscriptionSubscriptionIdAndIdentifierCd(Long subscriptionId, String identifierCd);
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionFeatureRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionFeatureRepository.java
@@ -1,18 +1,21 @@
 package com.ejada.subscription.repository;
 
 import com.ejada.subscription.model.SubscriptionFeature;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface SubscriptionFeatureRepository extends JpaRepository<SubscriptionFeature, Long>, JpaSpecificationExecutor<SubscriptionFeature> {
+public interface SubscriptionFeatureRepository
+        extends JpaRepository<SubscriptionFeature, Long>,
+        JpaSpecificationExecutor<SubscriptionFeature> {
 
-    List<SubscriptionFeature> findBySubscription_SubscriptionId(Long subscriptionId);
+    List<SubscriptionFeature> findBySubscriptionSubscriptionId(Long subscriptionId);
 
-    Optional<SubscriptionFeature> findBySubscription_SubscriptionIdAndFeatureCd(Long subscriptionId, String featureCd);
+    Optional<SubscriptionFeature> findBySubscriptionSubscriptionIdAndFeatureCd(Long subscriptionId, String featureCd);
 
-    boolean existsBySubscription_SubscriptionIdAndFeatureCd(Long subscriptionId, String featureCd);
+    boolean existsBySubscriptionSubscriptionIdAndFeatureCd(Long subscriptionId, String featureCd);
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionProductPropertyRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionProductPropertyRepository.java
@@ -1,18 +1,21 @@
 package com.ejada.subscription.repository;
 
 import com.ejada.subscription.model.SubscriptionProductProperty;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface SubscriptionProductPropertyRepository extends JpaRepository<SubscriptionProductProperty, Long>, JpaSpecificationExecutor<SubscriptionProductProperty> {
+public interface SubscriptionProductPropertyRepository
+        extends JpaRepository<SubscriptionProductProperty, Long>,
+        JpaSpecificationExecutor<SubscriptionProductProperty> {
 
-    List<SubscriptionProductProperty> findBySubscription_SubscriptionId(Long subscriptionId);
+    List<SubscriptionProductProperty> findBySubscriptionSubscriptionId(Long subscriptionId);
 
-    Optional<SubscriptionProductProperty> findBySubscription_SubscriptionIdAndPropertyCd(Long subscriptionId, String propertyCd);
+    Optional<SubscriptionProductProperty> findBySubscriptionSubscriptionIdAndPropertyCd(Long subscriptionId, String propertyCd);
 
-    boolean existsBySubscription_SubscriptionIdAndPropertyCd(Long subscriptionId, String propertyCd);
+    boolean existsBySubscriptionSubscriptionIdAndPropertyCd(Long subscriptionId, String propertyCd);
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionRepository.java
@@ -1,7 +1,9 @@
 package com.ejada.subscription.repository;
 
 import com.ejada.subscription.model.Subscription;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionUpdateEventRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionUpdateEventRepository.java
@@ -1,7 +1,8 @@
 package com.ejada.subscription.repository;
 
 import com.ejada.subscription.model.SubscriptionUpdateEvent;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,7 +10,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface SubscriptionUpdateEventRepository extends JpaRepository<SubscriptionUpdateEvent, Long>, JpaSpecificationExecutor<SubscriptionUpdateEvent> {
+public interface SubscriptionUpdateEventRepository
+        extends JpaRepository<SubscriptionUpdateEvent, Long>,
+        JpaSpecificationExecutor<SubscriptionUpdateEvent> {
 
     Optional<SubscriptionUpdateEvent> findByRqUid(UUID rqUid);
 

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/SubscriptionInboundService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/SubscriptionInboundService.java
@@ -1,6 +1,9 @@
 package com.ejada.subscription.service;
 
-import com.ejada.subscription.dto.*;
+import com.ejada.subscription.dto.ReceiveSubscriptionNotificationRq;
+import com.ejada.subscription.dto.ReceiveSubscriptionNotificationRs;
+import com.ejada.subscription.dto.ReceiveSubscriptionUpdateRq;
+import com.ejada.subscription.dto.ServiceResult;
 
 import java.util.UUID;
 


### PR DESCRIPTION
## Summary
- replace magic numbers in subscription entity models with named constants
- enforce brace usage and final parameters across inbound service logic
- rename repository methods to remove underscores and avoid star imports

## Testing
- `mvn -q -pl subscription-service checkstyle:check` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1a1377d0832f980628c769cc7b95