### PR TITLE
fix mapstruct warnings in catalog mappers

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
@@ -34,7 +34,7 @@ public interface AddonFeatureMapper {
     @Mapping(target = "overageUnitPrice", source = "overageUnitPrice")
     @Mapping(target = "overageCurrency", source = "overageCurrency", defaultValue = "SAR")
     @Mapping(target = "meta", source = "meta")
-    @Mapping(target = "isDeleted", constant = "false")
+    @Mapping(target = "deleted", constant = "false")
     AddonFeature toEntity(@NonNull AddonFeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
@@ -45,6 +45,6 @@ public interface AddonFeatureMapper {
 
     @Mapping(target = "addonId", source = "addon.addonId")
     @Mapping(target = "featureId", source = "feature.featureId")
-    @Mapping(target = "isDeleted", source = "isDeleted")
+    @Mapping(target = "isDeleted", source = "deleted")
     AddonFeatureRes toRes(@NonNull AddonFeature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
@@ -25,8 +25,8 @@ public interface AddonMapper {
     @Mapping(target = "addonArNm", source = "addonArNm")
     @Mapping(target = "description", source = "description")
     @Mapping(target = "category", source = "category")
-    @Mapping(target = "isActive", source = "isActive")
-    @Mapping(target = "isDeleted", constant = "false")
+    @Mapping(target = "active", source = "isActive")
+    @Mapping(target = "deleted", constant = "false")
     Addon toEntity(@NonNull AddonCreateReq req);
 
     @AfterMapping
@@ -42,13 +42,13 @@ public interface AddonMapper {
     // ---------- Update ----------
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "addonId", ignore = true)
-    @Mapping(target = "isDeleted", ignore = true)
+    @Mapping(target = "deleted", ignore = true)
     void update(@MappingTarget @NonNull Addon entity, @NonNull AddonUpdateReq req);
 
     // ---------- Response ----------
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    @Mapping(target = "isActive", source = "isActive")
-    @Mapping(target = "isDeleted", source = "isDeleted")
+    @Mapping(target = "isActive", source = "active")
+    @Mapping(target = "isDeleted", source = "deleted")
     AddonRes toRes(@NonNull Addon entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/FeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/FeatureMapper.java
@@ -1,9 +1,15 @@
 package com.ejada.catalog.mapper;
 
-import com.ejada.catalog.dto.*;
-import com.ejada.catalog.model.*;
+import com.ejada.catalog.dto.FeatureCreateReq;
+import com.ejada.catalog.dto.FeatureRes;
+import com.ejada.catalog.dto.FeatureUpdateReq;
+import com.ejada.catalog.model.Feature;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
-import org.mapstruct.*;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.springframework.lang.NonNull;
 
 @Mapper(config = SharedMapstructConfig.class)
@@ -15,9 +21,9 @@ public interface FeatureMapper {
     @Mapping(target = "featureArNm", source = "featureArNm")
     @Mapping(target = "description", source = "description")
     @Mapping(target = "category", source = "category")
-    @Mapping(target = "isMetered", source = "isMetered", defaultValue = "false")
-    @Mapping(target = "isActive", source = "isActive", defaultValue = "true")
-    @Mapping(target = "isDeleted", constant = "false")
+    @Mapping(target = "metered", source = "isMetered", defaultValue = "false")
+    @Mapping(target = "active", source = "isActive", defaultValue = "true")
+    @Mapping(target = "deleted", constant = "false")
     Feature toEntity(@NonNull FeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
@@ -25,8 +31,8 @@ public interface FeatureMapper {
     @Mapping(target = "featureKey", ignore = true)
     void update(@MappingTarget @NonNull Feature entity, @NonNull FeatureUpdateReq req);
 
-    @Mapping(target = "isMetered", source = "isMetered")
-    @Mapping(target = "isActive", source = "isActive")
-    @Mapping(target = "isDeleted", source = "isDeleted")
+    @Mapping(target = "isMetered", source = "metered")
+    @Mapping(target = "isActive", source = "active")
+    @Mapping(target = "isDeleted", source = "deleted")
     FeatureRes toRes(@NonNull Feature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
@@ -1,9 +1,17 @@
 package com.ejada.catalog.mapper;
 
-import com.ejada.catalog.dto.*;
-import com.ejada.catalog.model.*;
+import com.ejada.catalog.dto.TierAddonCreateReq;
+import com.ejada.catalog.dto.TierAddonRes;
+import com.ejada.catalog.dto.TierAddonUpdateReq;
+import com.ejada.catalog.model.Addon;
+import com.ejada.catalog.model.Tier;
+import com.ejada.catalog.model.TierAddon;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
-import org.mapstruct.*;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.springframework.lang.NonNull;
 
 @Mapper(config = SharedMapstructConfig.class,
@@ -18,7 +26,7 @@ public interface TierAddonMapper {
     @Mapping(target = "sortOrder", source = "sortOrder", defaultValue = "0")
     @Mapping(target = "basePrice", source = "basePrice")
     @Mapping(target = "currency", source = "currency")
-    @Mapping(target = "isDeleted", constant = "false")
+    @Mapping(target = "deleted", constant = "false")
     TierAddon toEntity(@NonNull TierAddonCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
@@ -29,6 +37,6 @@ public interface TierAddonMapper {
 
     @Mapping(target = "tierId", source = "tier.tierId")
     @Mapping(target = "addonId", source = "addon.addonId")
-    @Mapping(target = "isDeleted", source = "isDeleted")
+    @Mapping(target = "isDeleted", source = "deleted")
     TierAddonRes toRes(@NonNull TierAddon entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
@@ -1,9 +1,18 @@
 package com.ejada.catalog.mapper;
 
-import com.ejada.catalog.dto.*;
-import com.ejada.catalog.model.*;
+import com.ejada.catalog.dto.TierFeatureCreateReq;
+import com.ejada.catalog.dto.TierFeatureRes;
+import com.ejada.catalog.dto.TierFeatureUpdateReq;
+import com.ejada.catalog.model.Enforcement;
+import com.ejada.catalog.model.Feature;
+import com.ejada.catalog.model.Tier;
+import com.ejada.catalog.model.TierFeature;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
-import org.mapstruct.*;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.springframework.lang.NonNull;
 
 @Mapper(config = SharedMapstructConfig.class,
@@ -25,7 +34,7 @@ public interface TierFeatureMapper {
     @Mapping(target = "overageUnitPrice", source = "overageUnitPrice")
     @Mapping(target = "overageCurrency", source = "overageCurrency", defaultValue = "SAR")
     @Mapping(target = "meta", source = "meta")
-    @Mapping(target = "isDeleted", constant = "false")
+    @Mapping(target = "deleted", constant = "false")
     TierFeature toEntity(@NonNull TierFeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
@@ -36,6 +45,6 @@ public interface TierFeatureMapper {
 
     @Mapping(target = "tierId", source = "tier.tierId")
     @Mapping(target = "featureId", source = "feature.featureId")
-    @Mapping(target = "isDeleted", source = "isDeleted")
+    @Mapping(target = "isDeleted", source = "deleted")
     TierFeatureRes toRes(@NonNull TierFeature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierMapper.java
@@ -1,9 +1,15 @@
 package com.ejada.catalog.mapper;
 
-import com.ejada.catalog.dto.*;
-import com.ejada.catalog.model.*;
+import com.ejada.catalog.dto.TierCreateReq;
+import com.ejada.catalog.dto.TierRes;
+import com.ejada.catalog.dto.TierUpdateReq;
+import com.ejada.catalog.model.Tier;
 import com.ejada.mapstruct.starter.config.SharedMapstructConfig;
-import org.mapstruct.*;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.springframework.lang.NonNull;
 
 @Mapper(config = SharedMapstructConfig.class)
@@ -15,8 +21,8 @@ public interface TierMapper {
     @Mapping(target = "tierArNm", source = "tierArNm")
     @Mapping(target = "description", source = "description")
     @Mapping(target = "rankOrder", source = "rankOrder", defaultValue = "0")
-    @Mapping(target = "isActive", source = "isActive", defaultValue = "true")
-    @Mapping(target = "isDeleted", constant = "false")
+    @Mapping(target = "active", source = "isActive", defaultValue = "true")
+    @Mapping(target = "deleted", constant = "false")
     Tier toEntity(@NonNull TierCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
@@ -24,7 +30,7 @@ public interface TierMapper {
     @Mapping(target = "tierCd", ignore = true)
     void update(@MappingTarget @NonNull Tier entity, @NonNull TierUpdateReq req);
 
-    @Mapping(target = "isActive", source = "isActive")
-    @Mapping(target = "isDeleted", source = "isDeleted")
+    @Mapping(target = "isActive", source = "active")
+    @Mapping(target = "isDeleted", source = "deleted")
     TierRes toRes(@NonNull Tier entity);
 }


### PR DESCRIPTION
## Summary
- ensure catalog service mappers explicitly map boolean fields
- replace wildcard imports with explicit classes to satisfy checkstyle

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1c7a6078832fbb723bfb3b44383e