### PR TITLE
Fix duplicate constructors in billing models

### DIFF
--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/model/InvoiceAttachment.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/model/InvoiceAttachment.java
@@ -12,7 +12,6 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,7 +26,7 @@ import java.time.OffsetDateTime;
        indexes = @Index(name = "idx_invoice_attachment_invoice_created",
                         columnList = "invoice_id,created_at DESC"))
 @DynamicUpdate
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+@Getter @Setter @NoArgsConstructor
 public final class InvoiceAttachment {
 
   private static final int FILE_NM_LENGTH = 255;

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/model/InvoiceItem.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/model/InvoiceItem.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,7 +23,7 @@ import java.math.BigDecimal;
 @Table(name = "invoice_item",
        indexes = @Index(name = "idx_invoice_item_invoice", columnList = "invoice_id,line_no"))
 @DynamicUpdate
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+@Getter @Setter @NoArgsConstructor
 public final class InvoiceItem {
 
   private static final int ITEM_CD_LENGTH = 64;


### PR DESCRIPTION
## Summary
- Remove redundant Lombok annotations from InvoiceItem to avoid duplicate constructors
- Remove redundant Lombok annotations from InvoiceAttachment to avoid duplicate constructors

## Testing
- ⚠️ `mvn -f tenant-platform/pom.xml -pl billing-service -am compile` *(failed: Non-resolvable parent POM due to network access)*
- ⚠️ `mvn -o -f tenant-platform/pom.xml -pl billing-service -am compile` *(failed: required dependencies not cached)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1d4244c0832f927ee6da843c3322