### PR TITLE
Fix boolean field mapping in catalog-service mappers

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonFeatureMapper.java
@@ -34,7 +34,7 @@ public interface AddonFeatureMapper {
     @Mapping(target = "overageUnitPrice", source = "overageUnitPrice")
     @Mapping(target = "overageCurrency", source = "overageCurrency", defaultValue = "SAR")
     @Mapping(target = "meta", source = "meta")
-    @Mapping(target = "deleted", constant = "false")
+    @Mapping(target = "isDeleted", constant = "false")
     AddonFeature toEntity(@NonNull AddonFeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
@@ -45,6 +45,6 @@ public interface AddonFeatureMapper {
 
     @Mapping(target = "addonId", source = "addon.addonId")
     @Mapping(target = "featureId", source = "feature.featureId")
-    @Mapping(target = "isDeleted", source = "deleted")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     AddonFeatureRes toRes(@NonNull AddonFeature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/AddonMapper.java
@@ -25,8 +25,8 @@ public interface AddonMapper {
     @Mapping(target = "addonArNm", source = "addonArNm")
     @Mapping(target = "description", source = "description")
     @Mapping(target = "category", source = "category")
-    @Mapping(target = "active", source = "isActive")
-    @Mapping(target = "deleted", constant = "false")
+    @Mapping(target = "isActive", source = "isActive")
+    @Mapping(target = "isDeleted", constant = "false")
     Addon toEntity(@NonNull AddonCreateReq req);
 
     @AfterMapping
@@ -42,13 +42,13 @@ public interface AddonMapper {
     // ---------- Update ----------
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "addonId", ignore = true)
-    @Mapping(target = "deleted", ignore = true)
+    @Mapping(target = "isDeleted", ignore = true)
     void update(@MappingTarget @NonNull Addon entity, @NonNull AddonUpdateReq req);
 
     // ---------- Response ----------
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    @Mapping(target = "isActive", source = "active")
-    @Mapping(target = "isDeleted", source = "deleted")
+    @Mapping(target = "isActive", source = "isActive")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     AddonRes toRes(@NonNull Addon entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/FeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/FeatureMapper.java
@@ -21,9 +21,9 @@ public interface FeatureMapper {
     @Mapping(target = "featureArNm", source = "featureArNm")
     @Mapping(target = "description", source = "description")
     @Mapping(target = "category", source = "category")
-    @Mapping(target = "metered", source = "isMetered", defaultValue = "false")
-    @Mapping(target = "active", source = "isActive", defaultValue = "true")
-    @Mapping(target = "deleted", constant = "false")
+    @Mapping(target = "isMetered", source = "isMetered", defaultValue = "false")
+    @Mapping(target = "isActive", source = "isActive", defaultValue = "true")
+    @Mapping(target = "isDeleted", constant = "false")
     Feature toEntity(@NonNull FeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
@@ -31,8 +31,8 @@ public interface FeatureMapper {
     @Mapping(target = "featureKey", ignore = true)
     void update(@MappingTarget @NonNull Feature entity, @NonNull FeatureUpdateReq req);
 
-    @Mapping(target = "isMetered", source = "metered")
-    @Mapping(target = "isActive", source = "active")
-    @Mapping(target = "isDeleted", source = "deleted")
+    @Mapping(target = "isMetered", source = "isMetered")
+    @Mapping(target = "isActive", source = "isActive")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     FeatureRes toRes(@NonNull Feature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierAddonMapper.java
@@ -26,7 +26,7 @@ public interface TierAddonMapper {
     @Mapping(target = "sortOrder", source = "sortOrder", defaultValue = "0")
     @Mapping(target = "basePrice", source = "basePrice")
     @Mapping(target = "currency", source = "currency")
-    @Mapping(target = "deleted", constant = "false")
+    @Mapping(target = "isDeleted", constant = "false")
     TierAddon toEntity(@NonNull TierAddonCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
@@ -37,6 +37,6 @@ public interface TierAddonMapper {
 
     @Mapping(target = "tierId", source = "tier.tierId")
     @Mapping(target = "addonId", source = "addon.addonId")
-    @Mapping(target = "isDeleted", source = "deleted")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     TierAddonRes toRes(@NonNull TierAddon entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierFeatureMapper.java
@@ -34,7 +34,7 @@ public interface TierFeatureMapper {
     @Mapping(target = "overageUnitPrice", source = "overageUnitPrice")
     @Mapping(target = "overageCurrency", source = "overageCurrency", defaultValue = "SAR")
     @Mapping(target = "meta", source = "meta")
-    @Mapping(target = "deleted", constant = "false")
+    @Mapping(target = "isDeleted", constant = "false")
     TierFeature toEntity(@NonNull TierFeatureCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
@@ -45,6 +45,6 @@ public interface TierFeatureMapper {
 
     @Mapping(target = "tierId", source = "tier.tierId")
     @Mapping(target = "featureId", source = "feature.featureId")
-    @Mapping(target = "isDeleted", source = "deleted")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     TierFeatureRes toRes(@NonNull TierFeature entity);
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierMapper.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/mapper/TierMapper.java
@@ -21,8 +21,8 @@ public interface TierMapper {
     @Mapping(target = "tierArNm", source = "tierArNm")
     @Mapping(target = "description", source = "description")
     @Mapping(target = "rankOrder", source = "rankOrder", defaultValue = "0")
-    @Mapping(target = "active", source = "isActive", defaultValue = "true")
-    @Mapping(target = "deleted", constant = "false")
+    @Mapping(target = "isActive", source = "isActive", defaultValue = "true")
+    @Mapping(target = "isDeleted", constant = "false")
     Tier toEntity(@NonNull TierCreateReq req);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
@@ -30,7 +30,7 @@ public interface TierMapper {
     @Mapping(target = "tierCd", ignore = true)
     void update(@MappingTarget @NonNull Tier entity, @NonNull TierUpdateReq req);
 
-    @Mapping(target = "isActive", source = "active")
-    @Mapping(target = "isDeleted", source = "deleted")
+    @Mapping(target = "isActive", source = "isActive")
+    @Mapping(target = "isDeleted", source = "isDeleted")
     TierRes toRes(@NonNull Tier entity);
 }


### PR DESCRIPTION
## Summary
- correct MapStruct mappings for `isActive`, `isDeleted`, and `isMetered` fields across catalog-service mappers
- ensure update methods ignore `isDeleted` and responses expose boolean flags correctly

## Testing
- `mvn -q -f tenant-platform/catalog-service/pom.xml test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1e82a2dc832fac2d60c16d8d0166