### PR TITLE
Fix Lombok builder failures and clean up warnings

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/domain/RolePrivilege.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/RolePrivilege.java
@@ -22,6 +22,7 @@ public class RolePrivilege {
     private Privilege privilege;
 
     @Column(name = "granted_at", nullable = false)
+    @Builder.Default
     private Instant grantedAt = Instant.now();
 
     @Column(name = "granted_by")

--- a/sec-service/src/main/java/com/ejada/sec/domain/RolePrivilegeId.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/RolePrivilegeId.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 @Embeddable
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @EqualsAndHashCode
 public class RolePrivilegeId implements Serializable {
+    private static final long serialVersionUID = 1L;
     private Long roleId;
     private Long privilegeId;
 }

--- a/sec-service/src/main/java/com/ejada/sec/domain/User.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/User.java
@@ -38,8 +38,13 @@ public class User extends AuditableEntity {
     @Column(name = "password_hash", nullable = false, length = 255)
     private String passwordHash;
 
-    @Column(nullable = false) private boolean enabled = true;
-    @Column(nullable = false) private boolean locked  = false;
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean enabled = true;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean locked  = false;
 
     @Column(name = "last_login_at") private Instant lastLoginAt;
 

--- a/sec-service/src/main/java/com/ejada/sec/domain/UserPrivilege.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/UserPrivilege.java
@@ -25,6 +25,7 @@ public class UserPrivilege {
     private boolean granted;
 
     @Column(name = "noted_at", nullable = false)
+    @Builder.Default
     private Instant notedAt = Instant.now();
 
     @Column(name = "noted_by")

--- a/sec-service/src/main/java/com/ejada/sec/domain/UserPrivilegeId.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/UserPrivilegeId.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 @Embeddable
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @EqualsAndHashCode
 public class UserPrivilegeId implements Serializable {
+    private static final long serialVersionUID = 1L;
     private Long userId;
     private Long privilegeId;
 }

--- a/sec-service/src/main/java/com/ejada/sec/domain/UserRoleId.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/UserRoleId.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 @Embeddable
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @EqualsAndHashCode
 public class UserRoleId implements Serializable {
+    private static final long serialVersionUID = 1L;
     private Long userId;
     private Long roleId;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/AssignRolesToUserRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/AssignRolesToUserRequest.java
@@ -9,5 +9,5 @@ import java.util.UUID;
 public class AssignRolesToUserRequest {
   @NotNull private UUID tenantId;
   @NotNull private Long userId;
-  @Singular private List<@NotBlank String> roleCodes;
+  private List<@NotBlank String> roleCodes;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/AuthResponse.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/AuthResponse.java
@@ -7,6 +7,6 @@ import lombok.*;
 public class AuthResponse {
   @NotBlank private String accessToken;
   @NotBlank private String refreshToken;
-  private String tokenType = "Bearer";
+  @Builder.Default private String tokenType = "Bearer";
   private long expiresInSeconds;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/CreateUserRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/CreateUserRequest.java
@@ -11,5 +11,5 @@ public class CreateUserRequest {
   @NotBlank @Size(max = 120) private String username;
   @Email @NotBlank @Size(max = 255) private String email;
   @NotBlank @Size(min = 8, max = 120) private String password;
-  @Singular private List<@NotBlank String> roles;
+  private List<@NotBlank String> roles;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/GrantPrivilegesToRoleRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/GrantPrivilegesToRoleRequest.java
@@ -9,5 +9,5 @@ import java.util.UUID;
 public class GrantPrivilegesToRoleRequest {
   @NotNull private UUID tenantId;
   @NotBlank private String roleCode;
-  @Singular private List<@NotBlank String> privilegeCodes;
+  private List<@NotBlank String> privilegeCodes;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/RegisterRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/RegisterRequest.java
@@ -11,5 +11,5 @@ public class RegisterRequest {
   @NotBlank @Size(max=120) private String username;
   @Email @NotBlank @Size(max=255) private String email;
   @NotBlank @Size(min=8, max=120) private String password;
-  @Singular private List<@NotBlank String> roles;
+  private List<@NotBlank String> roles;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/RevokePrivilegesFromRoleRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/RevokePrivilegesFromRoleRequest.java
@@ -9,5 +9,5 @@ import java.util.UUID;
 public class RevokePrivilegesFromRoleRequest {
   @NotNull private UUID tenantId;
   @NotBlank private String roleCode;
-  @Singular private List<@NotBlank String> privilegeCodes;
+  private List<@NotBlank String> privilegeCodes;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/RevokeRolesFromUserRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/RevokeRolesFromUserRequest.java
@@ -9,5 +9,5 @@ import java.util.UUID;
 public class RevokeRolesFromUserRequest {
   @NotNull private UUID tenantId;
   @NotNull private Long userId;
-  @Singular private List<@NotBlank String> roleCodes;
+  private List<@NotBlank String> roleCodes;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/UpdateUserRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/UpdateUserRequest.java
@@ -9,5 +9,5 @@ public class UpdateUserRequest {
   @Email @Size(max = 255) private String email;
   private Boolean enabled;
   private Boolean locked;
-  @Singular private List<@NotBlank String> roles;
+  private List<@NotBlank String> roles;
 }

--- a/setup-service/src/test/java/com/ejada/setup/service/CityServiceImplTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/service/CityServiceImplTest.java
@@ -9,10 +9,13 @@ import com.ejada.setup.repository.CountryRepository;
 import com.ejada.setup.service.impl.CityServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.util.Collections;
 
@@ -38,12 +41,12 @@ class CityServiceImplTest {
     void list_ok() {
         var cityPage = new org.springframework.data.domain.PageImpl<>(Collections.singletonList(new City()));
         when(cityRepository.findAll(
-                (org.springframework.data.jpa.domain.Specification<City>) any(org.springframework.data.jpa.domain.Specification.class),
-                any(org.springframework.data.domain.Pageable.class)))
+                ArgumentMatchers.<Specification<City>>any(),
+                any(Pageable.class)))
                 .thenReturn(cityPage);
         when(mapper.toDtoPage(cityPage)).thenReturn(org.springframework.data.domain.Page.<CityDto>empty());
 
-        BaseResponse<Page<CityDto>> resp = service.list(org.springframework.data.domain.Pageable.unpaged(), null, false);
+        BaseResponse<Page<CityDto>> resp = service.list(Pageable.unpaged(), null, false);
         assertNotNull(resp);
     }
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/EntitlementCache.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/EntitlementCache.java
@@ -35,7 +35,6 @@ import java.time.OffsetDateTime;
 @Setter
 @NoArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@SuppressWarnings("checkstyle:MagicNumber")
 public class EntitlementCache {
 
     @Id

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/IdempotentRequest.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/IdempotentRequest.java
@@ -20,7 +20,6 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@SuppressWarnings("checkstyle:MagicNumber")
 public class IdempotentRequest {
 
     @Id

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/InboundNotificationAudit.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/InboundNotificationAudit.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@SuppressWarnings("checkstyle:MagicNumber")
 public class InboundNotificationAudit {
 
     @Id

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/OutboxEvent.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/OutboxEvent.java
@@ -25,7 +25,6 @@ import java.time.OffsetDateTime;
 @Setter
 @NoArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@SuppressWarnings("checkstyle:MagicNumber")
 public class OutboxEvent {
 
     @Id

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/Subscription.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/Subscription.java
@@ -34,7 +34,6 @@ import java.time.OffsetDateTime;
 @Setter
 @NoArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@SuppressWarnings("checkstyle:MagicNumber")
 public class Subscription {
 
     @Id


### PR DESCRIPTION
## Summary
- remove Lombok `@Singular` usage from request DTOs to restore builder generation
- honor field defaults with `@Builder.Default` and serialVersionUIDs for id classes
- simplify CityServiceImpl test and drop unsupported `@SuppressWarnings`

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM for com.ejada:sec-service:1.0.0)*
- `mvn -q -e test` *(fails: Non-resolvable parent POM for com.ejada:setup-service:1.0.0)*
- `mvn -q -e test` *(fails: Non-resolvable parent POM for com.ejada:tenant-platform:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf46f1954c832f8883454de2fabff3