### PR TITLE
Leverage shared tenant context in sec-service

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/controller/EffectivePrivilegesController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/EffectivePrivilegesController.java
@@ -1,24 +1,29 @@
 package com.ejada.sec.controller;
 
+import com.ejada.common.context.ContextManager;
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.domain.EffectivePrivilegeProjection;
 import com.ejada.sec.repository.EffectivePrivilegeViewRepository;
+import com.ejada.starter_core.tenant.RequireTenant;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.UUID;
-
 @RestController
 @RequestMapping("/api/effective-privileges")
 @RequiredArgsConstructor
+@RequireTenant
 public class EffectivePrivilegesController {
 
   private final EffectivePrivilegeViewRepository viewRepo;
 
   @GetMapping("/{userId}")
-  public ResponseEntity<List<EffectivePrivilegeProjection>> list(@PathVariable Long userId,
-                                                                 @RequestParam("tenantId") UUID tenantId) {
-    return ResponseEntity.ok(viewRepo.findEffectiveByUserAndTenant(userId, tenantId));
+  public ResponseEntity<BaseResponse<List<EffectivePrivilegeProjection>>> list(@PathVariable Long userId) {
+    UUID tenantId = UUID.fromString(ContextManager.Tenant.get());
+    return ResponseEntity.ok(
+        BaseResponse.success("Effective privileges listed",
+            viewRepo.findEffectiveByUserAndTenant(userId, tenantId)));
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/PrivilegeController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/PrivilegeController.java
@@ -1,46 +1,46 @@
 package com.ejada.sec.controller;
 
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.PrivilegeService;
+import com.ejada.starter_core.tenant.RequireTenant;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.UUID;
-
 @RestController
 @RequestMapping("/api/privileges")
 @RequiredArgsConstructor
+@RequireTenant
 public class PrivilegeController {
 
   private final PrivilegeService privilegeService;
 
   @GetMapping
-  public ResponseEntity<List<PrivilegeDto>> list(@RequestParam("tenantId") UUID tenantId) {
-    return ResponseEntity.ok(privilegeService.listByTenant(tenantId));
+  public ResponseEntity<BaseResponse<List<PrivilegeDto>>> list() {
+    return ResponseEntity.ok(privilegeService.listByTenant());
   }
 
   @GetMapping("/{id}")
-  public ResponseEntity<PrivilegeDto> get(@PathVariable("id") Long id) {
+  public ResponseEntity<BaseResponse<PrivilegeDto>> get(@PathVariable("id") Long id) {
     return ResponseEntity.ok(privilegeService.get(id));
   }
 
   @PostMapping
-  public ResponseEntity<PrivilegeDto> create(@Valid @RequestBody CreatePrivilegeRequest req) {
+  public ResponseEntity<BaseResponse<PrivilegeDto>> create(@Valid @RequestBody CreatePrivilegeRequest req) {
     return ResponseEntity.ok(privilegeService.create(req));
   }
 
   @PatchMapping("/{id}")
-  public ResponseEntity<PrivilegeDto> update(@PathVariable("id") Long id,
+  public ResponseEntity<BaseResponse<PrivilegeDto>> update(@PathVariable("id") Long id,
                                              @Valid @RequestBody UpdatePrivilegeRequest req) {
     return ResponseEntity.ok(privilegeService.update(id, req));
   }
 
   @DeleteMapping("/{id}")
-  public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
-    privilegeService.delete(id);
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<BaseResponse<Void>> delete(@PathVariable("id") Long id) {
+    return ResponseEntity.ok(privilegeService.delete(id));
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/RoleController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/RoleController.java
@@ -1,46 +1,46 @@
 package com.ejada.sec.controller;
 
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.RoleService;
+import com.ejada.starter_core.tenant.RequireTenant;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.UUID;
-
 @RestController
 @RequestMapping("/api/roles")
 @RequiredArgsConstructor
+@RequireTenant
 public class RoleController {
 
   private final RoleService roleService;
 
   @GetMapping
-  public ResponseEntity<List<RoleDto>> list(@RequestParam("tenantId") UUID tenantId) {
-    return ResponseEntity.ok(roleService.listByTenant(tenantId));
+  public ResponseEntity<BaseResponse<List<RoleDto>>> list() {
+    return ResponseEntity.ok(roleService.listByTenant());
   }
 
   @GetMapping("/{id}")
-  public ResponseEntity<RoleDto> get(@PathVariable("id") Long id) {
+  public ResponseEntity<BaseResponse<RoleDto>> get(@PathVariable("id") Long id) {
     return ResponseEntity.ok(roleService.get(id));
   }
 
   @PostMapping
-  public ResponseEntity<RoleDto> create(@Valid @RequestBody CreateRoleRequest req) {
+  public ResponseEntity<BaseResponse<RoleDto>> create(@Valid @RequestBody CreateRoleRequest req) {
     return ResponseEntity.ok(roleService.create(req));
   }
 
   @PatchMapping("/{id}")
-  public ResponseEntity<RoleDto> update(@PathVariable("id") Long id,
+  public ResponseEntity<BaseResponse<RoleDto>> update(@PathVariable("id") Long id,
                                         @Valid @RequestBody UpdateRoleRequest req) {
     return ResponseEntity.ok(roleService.update(id, req));
   }
 
   @DeleteMapping("/{id}")
-  public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
-    roleService.delete(id);
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<BaseResponse<Void>> delete(@PathVariable("id") Long id) {
+    return ResponseEntity.ok(roleService.delete(id));
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/UserController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/UserController.java
@@ -1,71 +1,66 @@
 package com.ejada.sec.controller;
 
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.UserService;
+import com.ejada.starter_core.tenant.RequireTenant;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.UUID;
-
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+@RequireTenant
 public class UserController {
 
   private final UserService userService;
 
-  // List by tenant: pass tenantId as query param (or switch to header if you prefer)
   @GetMapping
-  public ResponseEntity<List<UserDto>> list(@RequestParam("tenantId") UUID tenantId) {
-    return ResponseEntity.ok(userService.listByTenant(tenantId));
+  public ResponseEntity<BaseResponse<List<UserDto>>> list() {
+    return ResponseEntity.ok(userService.listByTenant());
   }
 
   @GetMapping("/{id}")
-  public ResponseEntity<UserDto> get(@PathVariable("id") Long id) {
+  public ResponseEntity<BaseResponse<UserDto>> get(@PathVariable("id") Long id) {
     return ResponseEntity.ok(userService.get(id));
   }
 
   @PostMapping
-  public ResponseEntity<UserDto> create(@Valid @RequestBody CreateUserRequest req) {
+  public ResponseEntity<BaseResponse<UserDto>> create(@Valid @RequestBody CreateUserRequest req) {
     return ResponseEntity.ok(userService.create(req));
   }
 
   @PatchMapping("/{id}")
-  public ResponseEntity<UserDto> update(@PathVariable("id") Long id,
+  public ResponseEntity<BaseResponse<UserDto>> update(@PathVariable("id") Long id,
                                         @Valid @RequestBody UpdateUserRequest req) {
     return ResponseEntity.ok(userService.update(id, req));
   }
 
   @DeleteMapping("/{id}")
-  public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
-    userService.delete(id);
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<BaseResponse<Void>> delete(@PathVariable("id") Long id) {
+    return ResponseEntity.ok(userService.delete(id));
   }
 
   @PostMapping("/{id}/enable")
-  public ResponseEntity<Void> enable(@PathVariable("id") Long id) {
-    userService.enable(id);
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<BaseResponse<Void>> enable(@PathVariable("id") Long id) {
+    return ResponseEntity.ok(userService.enable(id));
   }
 
   @PostMapping("/{id}/disable")
-  public ResponseEntity<Void> disable(@PathVariable("id") Long id) {
-    userService.disable(id);
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<BaseResponse<Void>> disable(@PathVariable("id") Long id) {
+    return ResponseEntity.ok(userService.disable(id));
   }
 
   @PostMapping("/{id}/lock")
-  public ResponseEntity<Void> lock(@PathVariable("id") Long id) {
-    userService.lock(id);
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<BaseResponse<Void>> lock(@PathVariable("id") Long id) {
+    return ResponseEntity.ok(userService.lock(id));
   }
 
   @PostMapping("/{id}/unlock")
-  public ResponseEntity<Void> unlock(@PathVariable("id") Long id) {
-    userService.unlock(id);
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<BaseResponse<Void>> unlock(@PathVariable("id") Long id) {
+    return ResponseEntity.ok(userService.unlock(id));
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/PrivilegeService.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/PrivilegeService.java
@@ -1,13 +1,13 @@
 package com.ejada.sec.service;
 
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
 import java.util.List;
-import java.util.UUID;
 
 public interface PrivilegeService {
-  PrivilegeDto create(CreatePrivilegeRequest req);
-  PrivilegeDto update(Long privilegeId, UpdatePrivilegeRequest req);
-  void         delete(Long privilegeId);
-  PrivilegeDto get(Long privilegeId);
-  List<PrivilegeDto> listByTenant(UUID tenantId);
+  BaseResponse<PrivilegeDto> create(CreatePrivilegeRequest req);
+  BaseResponse<PrivilegeDto> update(Long privilegeId, UpdatePrivilegeRequest req);
+  BaseResponse<Void>         delete(Long privilegeId);
+  BaseResponse<PrivilegeDto> get(Long privilegeId);
+  BaseResponse<List<PrivilegeDto>> listByTenant();
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/RoleService.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/RoleService.java
@@ -1,13 +1,13 @@
 package com.ejada.sec.service;
 
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
 import java.util.List;
-import java.util.UUID;
 
 public interface RoleService {
-  RoleDto create(CreateRoleRequest req);
-  RoleDto update(Long roleId, UpdateRoleRequest req);
-  void    delete(Long roleId);
-  RoleDto get(Long roleId);
-  List<RoleDto> listByTenant(UUID tenantId);
+  BaseResponse<RoleDto> create(CreateRoleRequest req);
+  BaseResponse<RoleDto> update(Long roleId, UpdateRoleRequest req);
+  BaseResponse<Void>    delete(Long roleId);
+  BaseResponse<RoleDto> get(Long roleId);
+  BaseResponse<List<RoleDto>> listByTenant();
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/UserService.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/UserService.java
@@ -1,19 +1,19 @@
 package com.ejada.sec.service;
 
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
 import java.util.List;
-import java.util.UUID;
 
 public interface UserService {
-  UserDto create(CreateUserRequest req);
-  UserDto update(Long userId, UpdateUserRequest req);
-  void   delete(Long userId);
-  UserDto get(Long userId);
-  List<UserDto> listByTenant(UUID tenantId);
+  BaseResponse<UserDto> create(CreateUserRequest req);
+  BaseResponse<UserDto> update(Long userId, UpdateUserRequest req);
+  BaseResponse<Void>   delete(Long userId);
+  BaseResponse<UserDto> get(Long userId);
+  BaseResponse<List<UserDto>> listByTenant();
 
   // role membership (full replace helpers are in GrantService below)
-  void enable(Long userId);
-  void disable(Long userId);
-  void lock(Long userId);
-  void unlock(Long userId);
+  BaseResponse<Void> enable(Long userId);
+  BaseResponse<Void> disable(Long userId);
+  BaseResponse<Void> lock(Long userId);
+  BaseResponse<Void> unlock(Long userId);
 }


### PR DESCRIPTION
## Summary
- Require tenant headers across security controllers
- Fetch tenant ID from shared ContextManager instead of query params
- Wrap security endpoints and services with `BaseResponse`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf49dd2a84832f8bc5e21cd49ce16e