### PR TITLE
feat(sec): introduce base request and unified auth responses

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/controller/AuthController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.ejada.sec.controller;
 
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.AuthService;
 import com.ejada.sec.service.PasswordResetService;
@@ -17,36 +18,33 @@ public class AuthController {
   private final PasswordResetService passwordResetService;
 
   @PostMapping("/register")
-  public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest req) {
+  public ResponseEntity<BaseResponse<AuthResponse>> register(@Valid @RequestBody RegisterRequest req) {
     return ResponseEntity.ok(authService.register(req));
   }
 
   @PostMapping("/login")
-  public ResponseEntity<AuthResponse> login(@Valid @RequestBody AuthRequest req) {
+  public ResponseEntity<BaseResponse<AuthResponse>> login(@Valid @RequestBody AuthRequest req) {
     return ResponseEntity.ok(authService.login(req));
   }
 
   @PostMapping("/refresh")
-  public ResponseEntity<AuthResponse> refresh(@Valid @RequestBody RefreshTokenRequest req) {
+  public ResponseEntity<BaseResponse<AuthResponse>> refresh(@Valid @RequestBody RefreshTokenRequest req) {
     return ResponseEntity.ok(authService.refresh(req));
   }
 
   @PostMapping("/logout")
-  public ResponseEntity<Void> logout(@RequestParam("refreshToken") String refreshToken) {
-    authService.logout(refreshToken);
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<BaseResponse<Void>> logout(@RequestParam("refreshToken") String refreshToken) {
+    return ResponseEntity.ok(authService.logout(refreshToken));
   }
 
   @PostMapping("/forgot-password")
-  public ResponseEntity<String> forgotPassword(@Valid @RequestBody ForgotPasswordRequest req) {
+  public ResponseEntity<BaseResponse<String>> forgotPassword(@Valid @RequestBody ForgotPasswordRequest req) {
     // Return token for demo; in production, send via email/SMS and return 204
-    String token = passwordResetService.createToken(req);
-    return ResponseEntity.ok(token);
+    return ResponseEntity.ok(passwordResetService.createToken(req));
   }
 
   @PostMapping("/reset-password")
-  public ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequest req) {
-    passwordResetService.reset(req);
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<BaseResponse<Void>> resetPassword(@Valid @RequestBody ResetPasswordRequest req) {
+    return ResponseEntity.ok(passwordResetService.reset(req));
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/AssignRolesToUserRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/AssignRolesToUserRequest.java
@@ -1,13 +1,18 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import java.util.List;
-import java.util.UUID;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class AssignRolesToUserRequest {
-  @NotNull private UUID tenantId;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class AssignRolesToUserRequest extends BaseRequest {
   @NotNull private Long userId;
   private List<@NotBlank String> roleCodes;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/AuthRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/AuthRequest.java
@@ -1,12 +1,17 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
-import java.util.UUID;
+import lombok.experimental.SuperBuilder;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class AuthRequest {
-  @NotNull private UUID tenantId;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class AuthRequest extends BaseRequest {
   @NotBlank private String identifier; // username or email
   @NotBlank private String password;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/CreatePrivilegeRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/CreatePrivilegeRequest.java
@@ -1,15 +1,20 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
-import java.util.UUID;
+import lombok.experimental.SuperBuilder;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class CreatePrivilegeRequest {
-  @NotNull private UUID tenantId;
-  @NotBlank @Size(max=100) private String code;
-  @NotBlank @Size(max=100) private String resource;
-  @NotBlank @Size(max=50)  private String action;
-  @NotBlank @Size(max=200) private String name;
-  @Size(max=500) private String description;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class CreatePrivilegeRequest extends BaseRequest {
+  @NotBlank @Size(max = 100) private String code;
+  @NotBlank @Size(max = 100) private String resource;
+  @NotBlank @Size(max = 50) private String action;
+  @NotBlank @Size(max = 200) private String name;
+  @Size(max = 500) private String description;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/CreateRoleRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/CreateRoleRequest.java
@@ -1,12 +1,17 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
-import java.util.UUID;
+import lombok.experimental.SuperBuilder;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class CreateRoleRequest {
-  @NotNull private UUID tenantId;
-  @NotBlank @Size(max=64) private String code;
-  @NotBlank @Size(max=128) private String name;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class CreateRoleRequest extends BaseRequest {
+  @NotBlank @Size(max = 64) private String code;
+  @NotBlank @Size(max = 128) private String name;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/CreateUserRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/CreateUserRequest.java
@@ -1,13 +1,18 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import java.util.List;
-import java.util.UUID;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class CreateUserRequest {
-  @NotNull private UUID tenantId;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class CreateUserRequest extends BaseRequest {
   @NotBlank @Size(max = 120) private String username;
   @Email @NotBlank @Size(max = 255) private String email;
   @NotBlank @Size(min = 8, max = 120) private String password;

--- a/sec-service/src/main/java/com/ejada/sec/dto/FederatedLinkRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/FederatedLinkRequest.java
@@ -1,12 +1,17 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
-import java.util.UUID;
+import lombok.experimental.SuperBuilder;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class FederatedLinkRequest {
-  @NotNull private UUID tenantId;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class FederatedLinkRequest extends BaseRequest {
   @NotNull private Long userId;
   @NotBlank private String provider;
   @NotBlank private String providerUserId;

--- a/sec-service/src/main/java/com/ejada/sec/dto/ForgotPasswordRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/ForgotPasswordRequest.java
@@ -1,11 +1,16 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
-import java.util.UUID;
+import lombok.experimental.SuperBuilder;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class ForgotPasswordRequest {
-  @NotNull private UUID tenantId;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class ForgotPasswordRequest extends BaseRequest {
   @NotBlank private String identifier;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/GrantPrivilegesToRoleRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/GrantPrivilegesToRoleRequest.java
@@ -1,13 +1,18 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import java.util.List;
-import java.util.UUID;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class GrantPrivilegesToRoleRequest {
-  @NotNull private UUID tenantId;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class GrantPrivilegesToRoleRequest extends BaseRequest {
   @NotBlank private String roleCode;
   private List<@NotBlank String> privilegeCodes;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/RefreshTokenRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/RefreshTokenRequest.java
@@ -1,11 +1,16 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
-import java.util.UUID;
+import lombok.experimental.SuperBuilder;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class RefreshTokenRequest {
-  @NotNull private UUID tenantId;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class RefreshTokenRequest extends BaseRequest {
   @NotBlank private String refreshToken;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/RegisterRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/RegisterRequest.java
@@ -1,15 +1,20 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import java.util.List;
-import java.util.UUID;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class RegisterRequest {
-  @NotNull private UUID tenantId;
-  @NotBlank @Size(max=120) private String username;
-  @Email @NotBlank @Size(max=255) private String email;
-  @NotBlank @Size(min=8, max=120) private String password;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class RegisterRequest extends BaseRequest {
+  @NotBlank @Size(max = 120) private String username;
+  @Email @NotBlank @Size(max = 255) private String email;
+  @NotBlank @Size(min = 8, max = 120) private String password;
   private List<@NotBlank String> roles;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/ResetPasswordRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/ResetPasswordRequest.java
@@ -1,12 +1,17 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
-import java.util.UUID;
+import lombok.experimental.SuperBuilder;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class ResetPasswordRequest {
-  @NotNull private UUID tenantId;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class ResetPasswordRequest extends BaseRequest {
   @NotBlank private String resetToken;
-  @NotBlank @Size(min=8, max=120) private String newPassword;
+  @NotBlank @Size(min = 8, max = 120) private String newPassword;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/RevokePrivilegesFromRoleRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/RevokePrivilegesFromRoleRequest.java
@@ -1,13 +1,18 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import java.util.List;
-import java.util.UUID;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class RevokePrivilegesFromRoleRequest {
-  @NotNull private UUID tenantId;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class RevokePrivilegesFromRoleRequest extends BaseRequest {
   @NotBlank private String roleCode;
   private List<@NotBlank String> privilegeCodes;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/RevokeRolesFromUserRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/RevokeRolesFromUserRequest.java
@@ -1,13 +1,18 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import java.util.List;
-import java.util.UUID;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class RevokeRolesFromUserRequest {
-  @NotNull private UUID tenantId;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class RevokeRolesFromUserRequest extends BaseRequest {
   @NotNull private Long userId;
   private List<@NotBlank String> roleCodes;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/SetUserPrivilegeOverrideRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/SetUserPrivilegeOverrideRequest.java
@@ -1,12 +1,17 @@
 package com.ejada.sec.dto;
 
+import com.ejada.common.dto.BaseRequest;
 import jakarta.validation.constraints.*;
 import lombok.*;
-import java.util.UUID;
+import lombok.experimental.SuperBuilder;
 
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
-public class SetUserPrivilegeOverrideRequest {
-  @NotNull private UUID tenantId;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class SetUserPrivilegeOverrideRequest extends BaseRequest {
   @NotNull private Long userId;
   @NotBlank private String privilegeCode;
   @NotNull private Boolean granted;

--- a/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
+++ b/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.ejada.sec.handler;
+
+import com.ejada.common.dto.BaseResponse;
+import java.util.NoSuchElementException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Handles authentication-related exceptions and converts them to {@link BaseResponse} payloads.
+ */
+@RestControllerAdvice
+public class AuthExceptionHandler {
+
+    @ExceptionHandler({NoSuchElementException.class, IllegalStateException.class})
+    public ResponseEntity<BaseResponse<?>> handleAuthExceptions(RuntimeException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(BaseResponse.error("ERR_AUTH", ex.getMessage()));
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/service/AuthService.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/AuthService.java
@@ -1,10 +1,11 @@
 package com.ejada.sec.service;
 
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
 
 public interface AuthService {
-  AuthResponse register(RegisterRequest req);
-  AuthResponse login(AuthRequest req);
-  AuthResponse refresh(RefreshTokenRequest req);
-  void logout(String refreshToken); // revoke
+  BaseResponse<AuthResponse> register(RegisterRequest req);
+  BaseResponse<AuthResponse> login(AuthRequest req);
+  BaseResponse<AuthResponse> refresh(RefreshTokenRequest req);
+  BaseResponse<Void> logout(String refreshToken); // revoke
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/PasswordResetService.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/PasswordResetService.java
@@ -1,9 +1,10 @@
 package com.ejada.sec.service;
 
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.ForgotPasswordRequest;
 import com.ejada.sec.dto.ResetPasswordRequest;
 
 public interface PasswordResetService {
-  String createToken(ForgotPasswordRequest req); // returns token to deliver via email/SMS
-  void reset(ResetPasswordRequest req);
+  BaseResponse<String> createToken(ForgotPasswordRequest req); // returns token to deliver via email/SMS
+  BaseResponse<Void> reset(ResetPasswordRequest req);
 }

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
@@ -1,0 +1,24 @@
+package com.ejada.common.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Standard request wrapper containing common request fields.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class BaseRequest {
+
+    /** Tenant identifier for multi-tenant requests. */
+    @NotNull
+    private UUID tenantId;
+}


### PR DESCRIPTION
## Summary
- add reusable `BaseRequest` DTO for tenant-scoped requests
- wrap auth endpoints with `BaseResponse` payloads
- add authentication exception handler for consistent error output

## Testing
- `mvn -q -pl shared-common -am test` *(failed: Network is unreachable)*
- `mvn -q test` in `sec-service` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4c51a854832f8c4edbea82d2f9b9