### PR TITLE
Fix validation dependency and AuthService registration

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/service/impl/AuthServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/AuthServiceImpl.java
@@ -37,7 +37,7 @@ public class AuthServiceImpl implements AuthService {
             .password(req.getPassword())
             .roles(req.getRoles())
             .build()
-    );
+    ).getData();
     var tokens = issueTokens(created.getTenantId(), created.getUsername(), created.getId());
     return BaseResponse.success("User registered", tokens);
   }

--- a/shared-lib/shared-common/pom.xml
+++ b/shared-lib/shared-common/pom.xml
@@ -70,6 +70,12 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Validation API for jakarta.validation annotations like @NotNull -->
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>


### PR DESCRIPTION
## Summary
- add Jakarta Validation API to shared-common module
- extract created user data before issuing tokens in AuthService register

## Testing
- `mvn -q -f shared-lib/pom.xml -pl shared-common -am test` *(fails: Network is unreachable)*
- `mvn -q -f sec-service/pom.xml test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4e5da858832fbbba9fd0d58b76f0