### PR TITLE
Add audit and security enforcement to grant operations

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/controller/GrantController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/GrantController.java
@@ -1,7 +1,9 @@
 package com.ejada.sec.controller;
 
 import com.ejada.sec.dto.*;
+import com.ejada.sec.security.SecAuthorized;
 import com.ejada.sec.service.GrantService;
+import com.ejada.starter_core.tenant.RequireTenant;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +12,8 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/grants")
 @RequiredArgsConstructor
+@RequireTenant
+@SecAuthorized
 public class GrantController {
 
   private final GrantService grantService;

--- a/sec-service/src/main/java/com/ejada/sec/security/SecAuthorized.java
+++ b/sec-service/src/main/java/com/ejada/sec/security/SecAuthorized.java
@@ -1,0 +1,11 @@
+package com.ejada.sec.security;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@PreAuthorize("@roleChecker.hasRole(authentication, T(com.ejada.starter_security.Role).EJADA_OFFICER, T(com.ejada.starter_security.Role).TENANT_ADMIN, T(com.ejada.starter_security.Role).TENANT_OFFICER)")
+public @interface SecAuthorized {
+}

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/GrantServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/GrantServiceImpl.java
@@ -1,5 +1,8 @@
 package com.ejada.sec.service.impl;
 
+import com.ejada.audit.starter.api.AuditAction;
+import com.ejada.audit.starter.api.DataClass;
+import com.ejada.audit.starter.api.annotations.Audited;
 import com.ejada.sec.domain.*;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.mapper.ReferenceResolver;
@@ -25,6 +28,8 @@ public class GrantServiceImpl implements GrantService {
 
   @Transactional
   @Override
+  @Audited(action = AuditAction.UPDATE, entity = "UserRole", dataClass = DataClass.CREDENTIALS,
+      message = "Assign roles to user")
   public void assignRolesToUser(AssignRolesToUserRequest req) {
     User user = userRepository.findById(req.getUserId())
         .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));
@@ -39,6 +44,8 @@ public class GrantServiceImpl implements GrantService {
 
   @Transactional
   @Override
+  @Audited(action = AuditAction.UPDATE, entity = "UserRole", dataClass = DataClass.CREDENTIALS,
+      message = "Revoke roles from user")
   public void revokeRolesFromUser(RevokeRolesFromUserRequest req) {
     User user = userRepository.findById(req.getUserId())
         .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));
@@ -48,6 +55,8 @@ public class GrantServiceImpl implements GrantService {
 
   @Transactional
   @Override
+  @Audited(action = AuditAction.UPDATE, entity = "RolePrivilege", dataClass = DataClass.CREDENTIALS,
+      message = "Grant privileges to role")
   public void grantPrivilegesToRole(GrantPrivilegesToRoleRequest req) {
     Role role = roleRepository.findByTenantIdAndCode(req.getTenantId(), req.getRoleCode())
         .orElseThrow(() -> new NoSuchElementException("Role not found: " + req.getRoleCode()));
@@ -62,6 +71,8 @@ public class GrantServiceImpl implements GrantService {
 
   @Transactional
   @Override
+  @Audited(action = AuditAction.UPDATE, entity = "RolePrivilege", dataClass = DataClass.CREDENTIALS,
+      message = "Revoke privileges from role")
   public void revokePrivilegesFromRole(RevokePrivilegesFromRoleRequest req) {
     Role role = roleRepository.findByTenantIdAndCode(req.getTenantId(), req.getRoleCode())
         .orElseThrow(() -> new NoSuchElementException("Role not found: " + req.getRoleCode()));
@@ -71,6 +82,8 @@ public class GrantServiceImpl implements GrantService {
 
   @Transactional
   @Override
+  @Audited(action = AuditAction.UPDATE, entity = "UserPrivilege", dataClass = DataClass.CREDENTIALS,
+      message = "Set user privilege override")
   public void setUserPrivilegeOverride(SetUserPrivilegeOverrideRequest req) {
     User user = userRepository.findById(req.getUserId())
         .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));


### PR DESCRIPTION
## Summary
- enforce tenant and role requirements on grant endpoints
- add SecAuthorized annotation for shared security roles
- audit role and privilege grants via `@Audited`

## Testing
- `mvn -q -f shared-lib/pom.xml install` *(fails: Non-resolvable import POM)*
- `mvn -q -f sec-service/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4ec041e4832fbcc3560151271356