### PR TITLE
Cache roles and privileges in Redis

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/service/impl/PrivilegeServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/PrivilegeServiceImpl.java
@@ -8,7 +8,9 @@ import com.ejada.sec.repository.PrivilegeRepository;
 import com.ejada.sec.service.PrivilegeService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import com.ejada.redis.starter.config.KeyPrefixStrategy;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -21,21 +23,35 @@ public class PrivilegeServiceImpl implements PrivilegeService {
 
   private final PrivilegeRepository repository;
   private final PrivilegeMapper mapper;
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final KeyPrefixStrategy keyPrefixStrategy;
+
+  private static final String PRIV_KEY_PREFIX = "priv:";
+  private static final String PRIV_LIST_KEY_PREFIX = "privs:tenant:";
 
   @Transactional
   @Override
   public BaseResponse<PrivilegeDto> create(CreatePrivilegeRequest req) {
     Privilege p = repository.save(mapper.toEntity(req));
-    return BaseResponse.success("Privilege created", mapper.toDto(p));
+    PrivilegeDto dto = mapper.toDto(p);
+    redisTemplate.opsForValue().set(privKey(p.getId()), dto);
+    redisTemplate.delete(privListKey(p.getTenantId()));
+    return BaseResponse.success("Privilege created", dto);
   }
 
   @Transactional
   @Override
   public BaseResponse<PrivilegeDto> update(Long id, UpdatePrivilegeRequest req) {
-    Privilege p = repository.findById(id)
-        .orElseThrow(() -> new NoSuchElementException("Privilege not found: " + id));
+    Privilege p =
+        repository
+            .findById(id)
+            .orElseThrow(() -> new NoSuchElementException("Privilege not found: " + id));
     mapper.updateEntity(p, req);
-    return BaseResponse.success("Privilege updated", mapper.toDto(repository.save(p)));
+    p = repository.save(p);
+    PrivilegeDto dto = mapper.toDto(p);
+    redisTemplate.opsForValue().set(privKey(p.getId()), dto);
+    redisTemplate.delete(privListKey(p.getTenantId()));
+    return BaseResponse.success("Privilege updated", dto);
   }
 
   @Transactional
@@ -43,22 +59,50 @@ public class PrivilegeServiceImpl implements PrivilegeService {
   public BaseResponse<Void> delete(Long id) {
     if (repository.existsById(id)) {
       repository.deleteById(id);
+      redisTemplate.delete(privKey(id));
     }
+    // invalidate all privilege lists since tenant is unknown
+    String prefix = keyPrefixStrategy.resolvePrefix() + PRIV_LIST_KEY_PREFIX;
+    redisTemplate.keys(prefix + "*").forEach(redisTemplate::delete);
     return BaseResponse.success("Privilege deleted", null);
   }
 
   @Override
   public BaseResponse<PrivilegeDto> get(Long id) {
+    String key = privKey(id);
+    PrivilegeDto cached = (PrivilegeDto) redisTemplate.opsForValue().get(key);
+    if (cached != null) {
+      return BaseResponse.success("Privilege fetched", cached);
+    }
     return repository.findById(id)
         .map(mapper::toDto)
-        .map(dto -> BaseResponse.success("Privilege fetched", dto))
+        .map(
+            dto -> {
+              redisTemplate.opsForValue().set(key, dto);
+              return BaseResponse.success("Privilege fetched", dto);
+            })
         .orElseThrow(() -> new NoSuchElementException("Privilege not found: " + id));
   }
 
   @Override
   public BaseResponse<List<PrivilegeDto>> listByTenant() {
     UUID tenantId = UUID.fromString(ContextManager.Tenant.get());
-    return BaseResponse.success("Privileges listed",
-        mapper.toDto(repository.findAllByTenantId(tenantId)));
+    String key = privListKey(tenantId);
+    @SuppressWarnings("unchecked")
+    List<PrivilegeDto> cached = (List<PrivilegeDto>) redisTemplate.opsForValue().get(key);
+    if (cached != null) {
+      return BaseResponse.success("Privileges listed", cached);
+    }
+    List<PrivilegeDto> list = mapper.toDto(repository.findAllByTenantId(tenantId));
+    redisTemplate.opsForValue().set(key, list);
+    return BaseResponse.success("Privileges listed", list);
+  }
+
+  private String privKey(Long id) {
+    return keyPrefixStrategy.resolvePrefix() + PRIV_KEY_PREFIX + id;
+  }
+
+  private String privListKey(UUID tenantId) {
+    return keyPrefixStrategy.resolvePrefix() + PRIV_LIST_KEY_PREFIX + tenantId;
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/RoleServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/RoleServiceImpl.java
@@ -9,7 +9,9 @@ import com.ejada.sec.repository.RoleRepository;
 import com.ejada.sec.service.RoleService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import com.ejada.redis.starter.config.KeyPrefixStrategy;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -23,13 +25,21 @@ public class RoleServiceImpl implements RoleService {
   private final RoleRepository roleRepository;
   private final RoleMapper roleMapper;
   private final ReferenceResolver resolver;
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final KeyPrefixStrategy keyPrefixStrategy;
+
+  private static final String ROLE_KEY_PREFIX = "role:";
+  private static final String ROLE_LIST_KEY_PREFIX = "roles:tenant:";
 
   @Transactional
   @Override
   public BaseResponse<RoleDto> create(CreateRoleRequest req) {
     Role role = roleMapper.toEntity(req);
     role = roleRepository.save(role);
-    return BaseResponse.success("Role created", roleMapper.toDto(role, resolver));
+    RoleDto dto = roleMapper.toDto(role, resolver);
+    redisTemplate.opsForValue().set(roleKey(role.getId()), dto);
+    redisTemplate.delete(roleListKey(role.getTenantId()));
+    return BaseResponse.success("Role created", dto);
   }
 
   @Transactional
@@ -39,7 +49,10 @@ public class RoleServiceImpl implements RoleService {
         .orElseThrow(() -> new NoSuchElementException("Role not found: " + roleId));
     roleMapper.updateEntity(role, req);
     role = roleRepository.save(role);
-    return BaseResponse.success("Role updated", roleMapper.toDto(role, resolver));
+    RoleDto dto = roleMapper.toDto(role, resolver);
+    redisTemplate.opsForValue().set(roleKey(role.getId()), dto);
+    redisTemplate.delete(roleListKey(role.getTenantId()));
+    return BaseResponse.success("Role updated", dto);
   }
 
   @Transactional
@@ -47,22 +60,52 @@ public class RoleServiceImpl implements RoleService {
   public BaseResponse<Void> delete(Long roleId) {
     if (roleRepository.existsById(roleId)) {
       roleRepository.deleteById(roleId);
+      redisTemplate.delete(roleKey(roleId));
     }
+    // invalidate tenant role list cache - tenant cannot be determined from id, so clear all
+    // role lists
+    String prefix = keyPrefixStrategy.resolvePrefix() + ROLE_LIST_KEY_PREFIX;
+    redisTemplate.keys(prefix + "*").forEach(redisTemplate::delete);
     return BaseResponse.success("Role deleted", null);
   }
 
   @Override
   public BaseResponse<RoleDto> get(Long roleId) {
+    String key = roleKey(roleId);
+    RoleDto cached = (RoleDto) redisTemplate.opsForValue().get(key);
+    if (cached != null) {
+      return BaseResponse.success("Role fetched", cached);
+    }
     return roleRepository.findById(roleId)
         .map(r -> roleMapper.toDto(r, resolver))
-        .map(dto -> BaseResponse.success("Role fetched", dto))
+        .map(
+            dto -> {
+              redisTemplate.opsForValue().set(key, dto);
+              return BaseResponse.success("Role fetched", dto);
+            })
         .orElseThrow(() -> new NoSuchElementException("Role not found: " + roleId));
   }
 
   @Override
   public BaseResponse<List<RoleDto>> listByTenant() {
     UUID tenantId = UUID.fromString(ContextManager.Tenant.get());
-    return BaseResponse.success("Roles listed",
-        roleMapper.toDto(roleRepository.findAllByTenantId(tenantId), resolver));
+    String key = roleListKey(tenantId);
+    @SuppressWarnings("unchecked")
+    List<RoleDto> cached = (List<RoleDto>) redisTemplate.opsForValue().get(key);
+    if (cached != null) {
+      return BaseResponse.success("Roles listed", cached);
+    }
+    List<RoleDto> list =
+        roleMapper.toDto(roleRepository.findAllByTenantId(tenantId), resolver);
+    redisTemplate.opsForValue().set(key, list);
+    return BaseResponse.success("Roles listed", list);
+  }
+
+  private String roleKey(Long id) {
+    return keyPrefixStrategy.resolvePrefix() + ROLE_KEY_PREFIX + id;
+  }
+
+  private String roleListKey(UUID tenantId) {
+    return keyPrefixStrategy.resolvePrefix() + ROLE_LIST_KEY_PREFIX + tenantId;
   }
 }


### PR DESCRIPTION
## Summary
- cache role data in Redis for faster lookups and invalidation on changes
- cache privilege data similarly with tenant-scoped lists
- prefix Redis keys with shared KeyPrefixStrategy

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*
- `cd sec-service && mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf506684b4832f81c88dfd11dfdabe