### PR TITLE
refactor: reduce checkstyle warnings

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/domain/FederatedIdentity.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/FederatedIdentity.java
@@ -1,7 +1,21 @@
 package com.ejada.sec.domain;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.UUID;
 
@@ -10,12 +24,15 @@ import java.util.UUID;
   name = "federated_identities",
   uniqueConstraints = @UniqueConstraint(
     name = "ux_fed_identity_provider_user",
-    columnNames = {"provider","provider_user_id"}
+    columnNames = {"provider", "provider_user_id"}
   ),
   indexes = @Index(name = "ix_fed_identity_tenant_user", columnList = "tenant_id,user_id")
 )
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class FederatedIdentity {
+
+    private static final int PROVIDER_LENGTH = 64;
+    private static final int PROVIDER_USER_ID_LENGTH = 255;
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -26,9 +43,9 @@ public class FederatedIdentity {
     @Column(name = "tenant_id", nullable = false)
     private UUID tenantId;
 
-    @Column(nullable = false, length = 64)
+    @Column(nullable = false, length = PROVIDER_LENGTH)
     private String provider; // google, okta...
 
-    @Column(name = "provider_user_id", nullable = false, length = 255)
+    @Column(name = "provider_user_id", nullable = false, length = PROVIDER_USER_ID_LENGTH)
     private String providerUserId;
 }

--- a/sec-service/src/main/java/com/ejada/sec/domain/PasswordResetToken.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/PasswordResetToken.java
@@ -1,7 +1,21 @@
 package com.ejada.sec.domain;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.Instant;
 
@@ -10,12 +24,14 @@ import java.time.Instant;
   name = "password_reset_tokens",
   uniqueConstraints = @UniqueConstraint(name = "ux_password_reset_token", columnNames = "token"),
   indexes = {
-    @Index(name="ix_password_reset_user", columnList="user_id"),
-    @Index(name="ix_password_reset_expiry", columnList="expires_at")
+    @Index(name = "ix_password_reset_user", columnList = "user_id"),
+    @Index(name = "ix_password_reset_expiry", columnList = "expires_at")
   }
 )
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class PasswordResetToken {
+
+    private static final int TOKEN_LENGTH = 255;
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -23,7 +39,7 @@ public class PasswordResetToken {
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false, length = 255)
+    @Column(nullable = false, length = TOKEN_LENGTH)
     private String token;
 
     @Column(name = "expires_at", nullable = false)


### PR DESCRIPTION
## Summary
- replace star imports with explicit ones in FederatedIdentity and PasswordResetToken
- introduce constants for annotation lengths and format annotations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe5099670832f9a61dfa38e1c11dd