### PR TITLE
Secure sec-service controllers with shared security

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/controller/EffectivePrivilegesController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/EffectivePrivilegesController.java
@@ -5,6 +5,7 @@ import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.domain.EffectivePrivilegeProjection;
 import com.ejada.sec.repository.EffectivePrivilegeViewRepository;
 import com.ejada.starter_core.tenant.RequireTenant;
+import com.ejada.sec.security.SecAuthorized;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/effective-privileges")
 @RequiredArgsConstructor
 @RequireTenant
+@SecAuthorized
 public class EffectivePrivilegesController {
 
   private final EffectivePrivilegeViewRepository viewRepo;

--- a/sec-service/src/main/java/com/ejada/sec/controller/PrivilegeController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/PrivilegeController.java
@@ -4,6 +4,7 @@ import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.PrivilegeService;
 import com.ejada.starter_core.tenant.RequireTenant;
+import com.ejada.sec.security.SecAuthorized;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/privileges")
 @RequiredArgsConstructor
 @RequireTenant
+@SecAuthorized
 public class PrivilegeController {
 
   private final PrivilegeService privilegeService;

--- a/sec-service/src/main/java/com/ejada/sec/controller/RoleController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/RoleController.java
@@ -4,6 +4,7 @@ import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.RoleService;
 import com.ejada.starter_core.tenant.RequireTenant;
+import com.ejada.sec.security.SecAuthorized;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/roles")
 @RequiredArgsConstructor
 @RequireTenant
+@SecAuthorized
 public class RoleController {
 
   private final RoleService roleService;

--- a/sec-service/src/main/java/com/ejada/sec/controller/UserController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/UserController.java
@@ -4,6 +4,7 @@ import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.UserService;
 import com.ejada.starter_core.tenant.RequireTenant;
+import com.ejada.sec.security.SecAuthorized;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 @RequireTenant
+@SecAuthorized
 public class UserController {
 
   private final UserService userService;


### PR DESCRIPTION
## Summary
- add `SecAuthorized` annotation to privilege, role, user, and effective privileges controllers
- enforce role-based access using shared security starter

## Testing
- `mvn -f sec-service/pom.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bfeefc56ec832f8c53d77891a023f6