### PR TITLE
chore: remove redundant jdbc starter

### DIFF
--- a/sec-service/pom.xml
+++ b/sec-service/pom.xml
@@ -41,11 +41,6 @@
   </dependencyManagement>
 
   <dependencies>
-      <dependency>
-  <groupId>org.springframework.boot</groupId>
-  <artifactId>spring-boot-starter-jdbc</artifactId>
-</dependency>
-
 <dependency>
   <groupId>org.postgresql</groupId>
   <artifactId>postgresql</artifactId>

--- a/setup-service/pom.xml
+++ b/setup-service/pom.xml
@@ -38,11 +38,6 @@
   </dependencyManagement>
 
   <dependencies>
-      <dependency>
-  <groupId>org.springframework.boot</groupId>
-  <artifactId>spring-boot-starter-jdbc</artifactId>
-</dependency>
-
 <dependency>
   <groupId>org.postgresql</groupId>
   <artifactId>postgresql</artifactId>


### PR DESCRIPTION
## Summary
- remove unneeded `spring-boot-starter-jdbc` from sec-service
- remove unneeded `spring-boot-starter-jdbc` from setup-service

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c00f2c7c0c832f9c5126aaf6dd4a54