### PR TITLE
Add auditing and logging to security service

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/SecServiceApplication.java
+++ b/sec-service/src/main/java/com/ejada/sec/SecServiceApplication.java
@@ -2,6 +2,7 @@ package com.ejada.sec;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 /**
  * Entry point for the security service.  This class bootstraps the Spring Boot
@@ -10,6 +11,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * parent repository and exposes authentication and user management APIs.
  */
 @SpringBootApplication
+@EnableJpaAuditing
 public final class SecServiceApplication {
 
     private SecServiceApplication() {

--- a/sec-service/src/main/java/com/ejada/sec/domain/AuditableEntity.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/AuditableEntity.java
@@ -1,17 +1,27 @@
 package com.ejada.sec.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
 
 @MappedSuperclass
-@Getter @Setter
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
 public abstract class AuditableEntity {
-    @Column(name = "created_at", updatable = false, insertable = false)
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
     private Instant createdAt;
 
-    @Column(name = "updated_at", insertable = false)
+    @LastModifiedDate
+    @Column(name = "updated_at")
     private Instant updatedAt;
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/AuthServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/AuthServiceImpl.java
@@ -10,6 +10,7 @@ import com.ejada.sec.service.TokenIssuer;
 import com.ejada.sec.service.UserService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthServiceImpl implements AuthService {
 
   private final UserRepository userRepository;
@@ -29,6 +31,7 @@ public class AuthServiceImpl implements AuthService {
   @Transactional
   @Override
   public BaseResponse<AuthResponse> register(RegisterRequest req) {
+    log.info("Registering user '{}' for tenant {}", req.getUsername(), req.getTenantId());
     var created = userService.create(
         CreateUserRequest.builder()
             .tenantId(req.getTenantId())
@@ -39,6 +42,7 @@ public class AuthServiceImpl implements AuthService {
             .build()
     ).getData();
     var tokens = issueTokens(created.getTenantId(), created.getUsername(), created.getId());
+    log.info("User '{}' registered for tenant {}", created.getUsername(), created.getTenantId());
     return BaseResponse.success("User registered", tokens);
   }
 
@@ -46,18 +50,22 @@ public class AuthServiceImpl implements AuthService {
   @Override
   public BaseResponse<AuthResponse> login(AuthRequest req) {
     UUID tenantId = req.getTenantId();
+    log.info("User '{}' attempting login for tenant {}", req.getIdentifier(), tenantId);
     // identifier can be username or email
     User user = userRepository.findByTenantIdAndUsername(tenantId, req.getIdentifier())
         .or(() -> userRepository.findByTenantIdAndEmail(tenantId, req.getIdentifier()))
         .orElseThrow(() -> new NoSuchElementException("Invalid credentials"));
 
     if (!user.isEnabled() || user.isLocked()) {
+      log.warn("Login denied for user '{}' in tenant {}: disabled or locked", user.getUsername(), tenantId);
       throw new IllegalStateException("Account disabled or locked");
     }
     if (!passwordEncoder.matches(req.getPassword(), user.getPasswordHash())) {
+      log.warn("Invalid credentials for user '{}' in tenant {}", req.getIdentifier(), tenantId);
       throw new NoSuchElementException("Invalid credentials");
     }
     var tokens = issueTokens(user.getTenantId(), user.getUsername(), user.getId());
+    log.info("User '{}' logged in for tenant {}", user.getUsername(), tenantId);
     return BaseResponse.success("Login successful", tokens);
   }
 
@@ -65,6 +73,7 @@ public class AuthServiceImpl implements AuthService {
   @Override
   public BaseResponse<AuthResponse> refresh(RefreshTokenRequest req) {
     var user = refreshTokenService.validateAndGetUser(req.getRefreshToken());
+    log.info("Refreshing token for user '{}' in tenant {}", user.getUsername(), user.getTenantId());
     var tokens = issueTokens(user.getTenantId(), user.getUsername(), user.getId());
     return BaseResponse.success("Token refreshed", tokens);
   }
@@ -72,6 +81,7 @@ public class AuthServiceImpl implements AuthService {
   @Transactional
   @Override
   public BaseResponse<Void> logout(String refreshToken) {
+    log.info("Revoking refresh token during logout");
     refreshTokenService.revoke(refreshToken);
     return BaseResponse.success("Logged out", null);
   }


### PR DESCRIPTION
## Summary
- add structured logging to AuthService operations
- enable JPA auditing in security service

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c010909268832fa1025b258032037b