### PR TITLE
Add Testcontainers Redis module to BOM

### DIFF
--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -133,6 +133,11 @@
      <version>${mockito.version}</version>
      <scope>test</scope>
      </dependency>
+     <dependency>
+       <groupId>org.testcontainers</groupId>
+       <artifactId>redis</artifactId>
+       <version>${testcontainers.version}</version>
+     </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>


### PR DESCRIPTION
## Summary
- add org.testcontainers:redis to shared BOM so its version is managed

## Testing
- `mvn -q -pl shared-test-support -am test` *(fails: Network is unreachable to Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68c047eda2d0832f90530ae7f4f5ee08