### PR TITLE
Remove nonexistent Testcontainers Redis dependency

### DIFF
--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -133,11 +133,6 @@
      <version>${mockito.version}</version>
      <scope>test</scope>
      </dependency>
-     <dependency>
-       <groupId>org.testcontainers</groupId>
-       <artifactId>redis</artifactId>
-       <version>${testcontainers.version}</version>
-     </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>

--- a/shared-lib/shared-test-support/pom.xml
+++ b/shared-lib/shared-test-support/pom.xml
@@ -34,18 +34,14 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>redis</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
-    </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>postgresql</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>kafka</artifactId>
+      </dependency>
 
     <!-- JJWT: versions come from jjwt-bom imported in shared-bom -->
      <dependency>


### PR DESCRIPTION
## Summary
- remove unused org.testcontainers:redis dependency from shared test support module
- drop redis artifact from shared BOM since it is not published on Maven Central

## Testing
- `mvn -q -pl shared-test-support -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c04a4fb194832fb39f144f016ac30a