### PR TITLE
Add SpotBugs annotation dependency to tenant-platform

### DIFF
--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -55,6 +55,11 @@
       <artifactId>lombok</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Summary
- add `spotbugs-annotations` dependency to tenant-platform parent POM so child modules resolve `SuppressFBWarnings`

## Testing
- `mvn -q -f shared-lib/pom.xml install -DskipTests` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68c04f142af4832f9b6f784888ade712