### PR TITLE
feat: add password encoder bean

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/config/PasswordEncoderConfig.java
+++ b/sec-service/src/main/java/com/ejada/sec/config/PasswordEncoderConfig.java
@@ -1,0 +1,23 @@
+package com.ejada.sec.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Application-wide password encoder configuration.
+ */
+@Configuration
+public class PasswordEncoderConfig {
+
+  /**
+   * Provides a {@link PasswordEncoder} bean using BCrypt hashing.
+   *
+   * @return password encoder instance
+   */
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}


### PR DESCRIPTION
## Summary
- add PasswordEncoder bean using BCrypt for application-wide password hashing

## Testing
- `cd sec-service && mvn -q test` *(fails: Network is unreachable for parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c0afd26c8c832f84aefd0a25425950