### PR TITLE
Fix EffectivePrivilegeViewRepository bean creation

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/repository/EffectivePrivilegeViewRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/EffectivePrivilegeViewRepository.java
@@ -1,14 +1,18 @@
 package com.ejada.sec.repository;
 
+import com.ejada.sec.domain.EffectivePrivilegeProjection;
+import com.ejada.sec.domain.Privilege;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
-
-import com.ejada.sec.domain.EffectivePrivilegeProjection;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface EffectivePrivilegeViewRepository extends Repository<Object, Long> {
+// Spring Data requires a domain type to create a repository bean.  Although the
+// queries in this repository operate on the `effective_privileges` view and
+// return `EffectivePrivilegeProjection`, we associate the repository with the
+// `Privilege` entity so that Spring can create a proxy implementation.
+public interface EffectivePrivilegeViewRepository extends Repository<Privilege, Long> {
 
     @Query(value = """
         select user_id     as userId,


### PR DESCRIPTION
## Summary
- associate EffectivePrivilegeViewRepository with the Privilege entity so Spring can instantiate the repository

## Testing
- `mvn -f sec-service/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b30d4330832f9cbd9149393e4850