### PR TITLE
Handle missing tenant context in role listing

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/service/impl/RoleServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/RoleServiceImpl.java
@@ -17,7 +17,7 @@ import com.ejada.redis.starter.config.KeyPrefixStrategy;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
-import com.ejada.common.context.ContextManager;
+import com.ejada.common.context.TenantContext;
 
 @Service
 @RequiredArgsConstructor
@@ -98,7 +98,8 @@ public class RoleServiceImpl implements RoleService {
 
   @Override
     public BaseResponse<List<RoleDto>> listByTenant() {
-      UUID tenantId = UUID.fromString(ContextManager.Tenant.get());
+      UUID tenantId =
+          TenantContext.get().orElseThrow(() -> new IllegalStateException("Tenant context is not set"));
       log.debug("Listing roles for tenant {}", tenantId);
       String key = roleListKey(tenantId);
       @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- guard against missing tenant context when listing roles

## Testing
- `mvn -q -f shared-lib/pom.xml install` *(fails: Non-resolvable import POM, Network is unreachable)*
- `mvn -q -f sec-service/pom.xml test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c149169074832fabc0e019636a1ad4