### PR TITLE
fix: insert new audit outbox record

### DIFF
--- a/shared-lib/shared-starters/starter-audit/src/main/resources/db/migration/common/V2__add_correlation_id_to_outbox.sql
+++ b/shared-lib/shared-starters/starter-audit/src/main/resources/db/migration/common/V2__add_correlation_id_to_outbox.sql
@@ -1,0 +1,1 @@
+ALTER TABLE audit_outbox ADD COLUMN IF NOT EXISTS correlation_id text;


### PR DESCRIPTION
## Summary
- remove ON CONFLICT clause and generate a new UUID for each audit outbox insert so every event persists as a new record
- store the request correlation ID in `audit_outbox` for traceability

## Testing
- `mvn -q -pl shared-starters/starter-audit -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c14fae4000832facd2f1ac46741e94