### PR TITLE
Fix superadmin flow and audit persistence

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/controller/AuthController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.ejada.sec.controller;
 
 import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.dto.*;
+import com.ejada.sec.dto.admin.ChangePasswordRequest;
+import com.ejada.sec.dto.admin.FirstLoginRequest;
 import com.ejada.sec.dto.admin.SuperadminAuthResponse;
 import com.ejada.sec.dto.admin.SuperadminLoginRequest;
 import com.ejada.sec.service.AuthService;
@@ -11,6 +13,7 @@ import com.ejada.sec.service.SuperadminService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -57,5 +60,17 @@ public class AuthController {
   @PostMapping("admin/login")
   public ResponseEntity<BaseResponse<SuperadminAuthResponse>> Adminlogin(@Valid @RequestBody SuperadminLoginRequest request) {
     return ResponseEntity.ok(superadminService.login(request));
+  }
+
+  @PostMapping("admin/first-login")
+  @PreAuthorize("hasRole('EJADA_OFFICER')")
+  public ResponseEntity<BaseResponse<Void>> completeFirstLogin(@Valid @RequestBody FirstLoginRequest request) {
+    return ResponseEntity.ok(superadminService.completeFirstLogin(request));
+  }
+
+  @PostMapping("admin/change-password")
+  @PreAuthorize("hasRole('EJADA_OFFICER')")
+  public ResponseEntity<BaseResponse<Void>> changeSuperadminPassword(@Valid @RequestBody ChangePasswordRequest request) {
+    return ResponseEntity.ok(superadminService.changePassword(request));
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/SuperadminController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/SuperadminController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/superadmin/admins")
 @RequiredArgsConstructor
 @Tag(name = "Superadmin Management", description = "APIs for managing superadmin accounts")
-@PreAuthorize("hasRole('ROLE_EJADA_OFFICER')")
+@PreAuthorize("hasRole('EJADA_OFFICER')")
 public class SuperadminController {
     
     private final SuperadminService superadminService;

--- a/sec-service/src/main/java/com/ejada/sec/domain/SuperadminAuditLog.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/SuperadminAuditLog.java
@@ -1,0 +1,48 @@
+package com.ejada.sec.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "superadmin_audit_logs", schema = "public")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SuperadminAuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "superadmin_id")
+    private Long superadminId;
+
+    @Column(nullable = false, length = 100)
+    private String action;
+
+    @Column(columnDefinition = "TEXT")
+    private String details;
+
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    @Column(name = "user_agent", length = 500)
+    private String userAgent;
+
+    @Column(nullable = false)
+    private LocalDateTime timestamp;
+
+    @PrePersist
+    void onCreate() {
+        if (timestamp == null) {
+            timestamp = LocalDateTime.now();
+        }
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/domain/SuperadminPasswordHistory.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/SuperadminPasswordHistory.java
@@ -1,0 +1,39 @@
+package com.ejada.sec.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "superadmin_password_history", schema = "public")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SuperadminPasswordHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "superadmin_id", nullable = false)
+    private Long superadminId;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/repository/SuperadminAuditLogRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/SuperadminAuditLogRepository.java
@@ -1,15 +1,12 @@
 package com.ejada.sec.repository;
 
+import com.ejada.sec.domain.SuperadminAuditLog;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
-public interface SuperadminAuditLogRepository {}
+public interface SuperadminAuditLogRepository extends JpaRepository<SuperadminAuditLog, Long> {
 
-//extends JpaRepository<SuperadminAuditLog, Long> {
-//
-//    List<SuperadminAuditLog> findBySuperadminIdOrderByTimestampDesc(Long superadminId);
-//
-//}
+    List<SuperadminAuditLog> findBySuperadminIdOrderByTimestampDesc(Long superadminId);
+}

--- a/sec-service/src/main/java/com/ejada/sec/repository/SuperadminPasswordHistoryRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/SuperadminPasswordHistoryRepository.java
@@ -1,16 +1,12 @@
 package com.ejada.sec.repository;
 
+import com.ejada.sec.domain.SuperadminPasswordHistory;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-
-import java.util.List;
-
 @Repository
-public interface SuperadminPasswordHistoryRepository{}
+public interface SuperadminPasswordHistoryRepository extends JpaRepository<SuperadminPasswordHistory, Long> {
 
-//extends JpaRepository<SuperadminPasswordHistory, Long> {
-//
-//    List<SuperadminPasswordHistory> findTop5BySuperadminIdOrderByCreatedAtDesc(Long superadminId);
-//
-//}
+    List<SuperadminPasswordHistory> findTop5BySuperadminIdOrderByCreatedAtDesc(Long superadminId);
+}

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminAuditService.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminAuditService.java
@@ -1,29 +1,57 @@
 package com.ejada.sec.service.impl;
 
-
-import org.springframework.stereotype.Service;
+import com.ejada.sec.domain.SuperadminAuditLog;
+import com.ejada.sec.repository.SuperadminAuditLogRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class SuperadminAuditService {
-    
+
+    private final SuperadminAuditLogRepository auditLogRepository;
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void logSuperadminAction(String action, Long superadminId, String details) {
-        // This should save to an audit table
-        log.info("SUPERADMIN_AUDIT: Action={}, SuperadminId={}, Details={}", 
-            action, superadminId, details);
-        
-        // In production, save to database:
-        // SuperadminAuditLog log = SuperadminAuditLog.builder()
-        //     .action(action)
-        //     .superadminId(superadminId)
-        //     .details(details)
-        //     .timestamp(LocalDateTime.now())
-        //     .ipAddress(getClientIp())
-        //     .build();
-        // auditRepository.save(log);
+        SuperadminAuditLog entry = SuperadminAuditLog.builder()
+            .action(action)
+            .superadminId(superadminId)
+            .details(details)
+            .ipAddress(resolveClientIp())
+            .userAgent(resolveUserAgent())
+            .build();
+
+        auditLogRepository.save(entry);
+        log.debug("Persisted superadmin audit entry: action={}, superadminId={}", action, superadminId);
+    }
+
+    private String resolveClientIp() {
+        return currentRequest()
+            .map(req -> Optional.ofNullable(req.getHeader("X-Forwarded-For"))
+                .map(value -> value.split(",")[0].trim())
+                .filter(ip -> !ip.isBlank())
+                .orElse(req.getRemoteAddr()))
+            .orElse(null);
+    }
+
+    private String resolveUserAgent() {
+        return currentRequest()
+            .map(req -> req.getHeader("User-Agent"))
+            .orElse(null);
+    }
+
+    private Optional<HttpServletRequest> currentRequest() {
+        return Optional.ofNullable(RequestContextHolder.getRequestAttributes())
+            .filter(ServletRequestAttributes.class::isInstance)
+            .map(ServletRequestAttributes.class::cast)
+            .map(ServletRequestAttributes::getRequest);
     }
 }

--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -93,6 +93,7 @@ shared:
       echo-response-header: true
       skip-patterns:
         - "/sec/api/auth/*"
+        - "/sec/api/superadmin/**"
     cors:
       enabled: true
       allowed-origins: http://localhost:3000

--- a/sec-service/src/main/resources/application-qa.yaml
+++ b/sec-service/src/main/resources/application-qa.yaml
@@ -86,6 +86,9 @@ shared:
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
+      skip-patterns:
+        - "/sec/api/auth/*"
+        - "/sec/api/superadmin/**"
     cors:
       enabled: true
       allowed-origins: http://localhost:3000


### PR DESCRIPTION
## Summary
- expose dedicated superadmin first-login and password change endpoints while fixing the controller role guard
- persist audit and password history records for superadmin activity and enforce password reuse protection
- normalize superadmin JWT claims and skip tenant filtering on platform-level endpoints

## Testing
- mvn test *(fails: cannot download spring-boot parent POM because Maven Central is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d521ac26ac832fbf47ee3441e2f90c