### PR TITLE
Add SLA metrics actuator endpoint

### DIFF
--- a/shared-lib/shared-starters/starter-actuator/pom.xml
+++ b/shared-lib/shared-starters/starter-actuator/pom.xml
@@ -65,6 +65,12 @@
       <artifactId>spring-boot-autoconfigure-processor</artifactId>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorAutoConfiguration.java
@@ -1,14 +1,18 @@
 
 package com.ejada.actuator.starter.config;
 
+import com.ejada.actuator.starter.endpoints.SlaMetricsEndpoint;
 import com.ejada.actuator.starter.endpoints.WhoAmIEndpoint;
 import com.ejada.actuator.starter.info.SharedInfoContributor;
 import com.ejada.actuator.starter.metrics.CommonTagsCustomizer;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.actuate.web.exchanges.InMemoryHttpExchangeRepository;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -48,5 +52,15 @@ public class SharedActuatorAutoConfiguration {
   @ConditionalOnMissingBean
   public WhoAmIEndpoint whoAmIEndpoint() {
     return new WhoAmIEndpoint();
+  }
+
+  @Bean
+  @ConditionalOnClass({MeterRegistry.class, Endpoint.class})
+  @ConditionalOnBean(MeterRegistry.class)
+  @ConditionalOnAvailableEndpoint(endpoint = SlaMetricsEndpoint.class)
+  @ConditionalOnProperty(prefix = "shared.actuator.sla-metrics", name = "enabled", havingValue = "true", matchIfMissing = true)
+  @ConditionalOnMissingBean
+  public SlaMetricsEndpoint slaMetricsEndpoint(MeterRegistry registry, SharedActuatorProperties props) {
+    return new SlaMetricsEndpoint(registry, props);
   }
 }

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorProperties.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorProperties.java
@@ -9,10 +9,12 @@ public class SharedActuatorProperties {
   private final HttpExchanges httpExchanges = new HttpExchanges();
   private final MetricsTags metrics = new MetricsTags();
   private final Security security = new Security();
+  private final SlaMetrics slaMetrics = new SlaMetrics();
 
   public HttpExchanges getHttpExchanges() { return httpExchanges; }
   public MetricsTags getMetrics() { return metrics; }
   public Security getSecurity() { return security; }
+  public SlaMetrics getSlaMetrics() { return slaMetrics; }
 
   public static class HttpExchanges {
     private boolean enabled = true;
@@ -49,5 +51,21 @@ public class SharedActuatorProperties {
     public void setEnabled(boolean enabled) { this.enabled = enabled; }
     public boolean isPermitPrometheus() { return permitPrometheus; }
     public void setPermitPrometheus(boolean permitPrometheus) { this.permitPrometheus = permitPrometheus; }
+  }
+
+  public static class SlaMetrics {
+    private boolean enabled = true;
+    private String meterName = "http.server.requests";
+    private double sloTarget = 99.9D;
+    private double slaTarget = 99.0D;
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public String getMeterName() { return meterName; }
+    public void setMeterName(String meterName) { this.meterName = meterName; }
+    public double getSloTarget() { return sloTarget; }
+    public void setSloTarget(double sloTarget) { this.sloTarget = sloTarget; }
+    public double getSlaTarget() { return slaTarget; }
+    public void setSlaTarget(double slaTarget) { this.slaTarget = slaTarget; }
   }
 }

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/endpoints/SlaMetricsEndpoint.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/endpoints/SlaMetricsEndpoint.java
@@ -1,0 +1,84 @@
+package com.ejada.actuator.starter.endpoints;
+
+import com.ejada.actuator.starter.config.SharedActuatorProperties;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+
+@Endpoint(id = "sla-metrics")
+public class SlaMetricsEndpoint {
+
+  private final MeterRegistry meterRegistry;
+  private final SharedActuatorProperties properties;
+
+  public SlaMetricsEndpoint(MeterRegistry meterRegistry, SharedActuatorProperties properties) {
+    this.meterRegistry = meterRegistry;
+    this.properties = properties;
+  }
+
+  @ReadOperation
+  public Map<String, Object> slaMetrics() {
+    SharedActuatorProperties.SlaMetrics slaProps = properties.getSlaMetrics();
+    List<Timer> timers = meterRegistry.find(slaProps.getMeterName()).timers();
+
+    long totalRequests = 0L;
+    long successfulRequests = 0L;
+    for (Timer timer : timers) {
+      long count = timer.count();
+      totalRequests += count;
+      if (isSuccessful(timer)) {
+        successfulRequests += count;
+      }
+    }
+
+    long failedRequests = Math.max(0L, totalRequests - successfulRequests);
+    double sli = totalRequests == 0L ? 100.0D : ((double) successfulRequests / (double) totalRequests) * 100.0D;
+    double sloTarget = slaProps.getSloTarget();
+    double slaTarget = slaProps.getSlaTarget();
+    double downtime = 100.0D - sli;
+    double errorBudget = Math.max(0.0D, 100.0D - sloTarget);
+    double errorBudgetConsumed = Math.min(errorBudget, downtime);
+    double errorBudgetRemaining = Math.max(0.0D, errorBudget - downtime);
+
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("meter", slaProps.getMeterName());
+    response.put("totalRequests", totalRequests);
+    response.put("successfulRequests", successfulRequests);
+    response.put("failedRequests", failedRequests);
+    response.put("sli", round(sli));
+    response.put("sloTarget", round(sloTarget));
+    response.put("slaTarget", round(slaTarget));
+    response.put("sloMet", sli >= sloTarget);
+    response.put("slaMet", sli >= slaTarget);
+    response.put("errorBudget", round(errorBudget));
+    response.put("errorBudgetConsumed", round(errorBudgetConsumed));
+    response.put("errorBudgetRemaining", round(errorBudgetRemaining));
+    return response;
+  }
+
+  private boolean isSuccessful(Timer timer) {
+    String outcome = timer.getId().getTag("outcome");
+    if (outcome != null) {
+      if (outcome.equalsIgnoreCase("SERVER_ERROR") || outcome.equalsIgnoreCase("CLIENT_ERROR")) {
+        return false;
+      }
+      return true;
+    }
+    String status = timer.getId().getTag("status");
+    if (status == null || status.isBlank()) {
+      return true;
+    }
+    char leading = status.charAt(0);
+    return leading == '1' || leading == '2' || leading == '3';
+  }
+
+  private double round(double value) {
+    return BigDecimal.valueOf(value).setScale(3, RoundingMode.HALF_UP).doubleValue();
+  }
+}

--- a/shared-lib/shared-starters/starter-actuator/src/main/resources/com/shared/actuator/starter/actuator-defaults.properties
+++ b/shared-lib/shared-starters/starter-actuator/src/main/resources/com/shared/actuator/starter/actuator-defaults.properties
@@ -10,3 +10,7 @@ shared.actuator.metrics.common-tags.region-enabled=true
 shared.actuator.metrics.common-tags.zone-enabled=true
 shared.actuator.security.enabled=false
 shared.actuator.security.permit-prometheus=true
+shared.actuator.sla-metrics.enabled=true
+shared.actuator.sla-metrics.meter-name=http.server.requests
+shared.actuator.sla-metrics.slo-target=99.9
+shared.actuator.sla-metrics.sla-target=99.0

--- a/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/endpoints/SlaMetricsEndpointTest.java
+++ b/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/endpoints/SlaMetricsEndpointTest.java
@@ -1,0 +1,72 @@
+package com.ejada.actuator.starter.endpoints;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.actuator.starter.config.SharedActuatorProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class SlaMetricsEndpointTest {
+
+  @Test
+  void calculatesRatiosAndBudgetFromHttpServerRequests() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    Timer success = Timer.builder("http.server.requests")
+        .tag("outcome", "SUCCESS")
+        .tag("status", "200")
+        .register(registry);
+    Timer failure = Timer.builder("http.server.requests")
+        .tag("outcome", "SERVER_ERROR")
+        .tag("status", "500")
+        .register(registry);
+
+    for (int i = 0; i < 95; i++) {
+      success.record(Duration.ofMillis(10));
+    }
+    for (int i = 0; i < 5; i++) {
+      failure.record(Duration.ofMillis(10));
+    }
+
+    SharedActuatorProperties props = new SharedActuatorProperties();
+    props.getSlaMetrics().setSloTarget(94.0D);
+    props.getSlaMetrics().setSlaTarget(90.0D);
+
+    SlaMetricsEndpoint endpoint = new SlaMetricsEndpoint(registry, props);
+
+    var result = endpoint.slaMetrics();
+
+    assertThat(result).containsEntry("meter", "http.server.requests");
+    assertThat(result).containsEntry("totalRequests", 100L);
+    assertThat(result).containsEntry("successfulRequests", 95L);
+    assertThat(result).containsEntry("failedRequests", 5L);
+    assertThat(result).containsEntry("sli", 95.0D);
+    assertThat(result).containsEntry("sloTarget", 94.0D);
+    assertThat(result).containsEntry("slaTarget", 90.0D);
+    assertThat(result).containsEntry("sloMet", true);
+    assertThat(result).containsEntry("slaMet", true);
+    assertThat(result).containsEntry("errorBudget", 6.0D);
+    assertThat(result).containsEntry("errorBudgetConsumed", 5.0D);
+    assertThat(result).containsEntry("errorBudgetRemaining", 1.0D);
+  }
+
+  @Test
+  void treatsEmptyRegistryAsFullyCompliant() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    SharedActuatorProperties props = new SharedActuatorProperties();
+
+    SlaMetricsEndpoint endpoint = new SlaMetricsEndpoint(registry, props);
+
+    var result = endpoint.slaMetrics();
+
+    assertThat(result).containsEntry("totalRequests", 0L);
+    assertThat(result).containsEntry("successfulRequests", 0L);
+    assertThat(result).containsEntry("failedRequests", 0L);
+    assertThat(result).containsEntry("sli", 100.0D);
+    assertThat(result).containsEntry("sloMet", true);
+    assertThat(result).containsEntry("slaMet", true);
+    assertThat(result).containsEntry("errorBudgetConsumed", 0.0D);
+    assertThat(result).containsEntry("errorBudgetRemaining", 0.1D);
+  }
+}


### PR DESCRIPTION
## Summary
- add an `/actuator/sla-metrics` endpoint that derives SLI/SLO/SLA figures from `http.server.requests`
- surface configuration properties and defaults for the SLA metrics endpoint and register it via auto-configuration
- cover the new endpoint with unit tests and add the missing test dependency to the starter

## Testing
- `mvn -pl shared-starters/starter-actuator -am test` *(fails: cannot reach Maven Central to resolve BOMs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5283d67ec832f9d7e024682d38a8e