### PR TITLE
Fix setup service path in workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Build tenant platform
         run: mvn -B -DskipTests=true verify -f tenant-platform/pom.xml
       - name: Build setup service
-        run: mvn -B -DskipTests=true verify -f lms-setup/pom.xml
+        run: mvn -B -DskipTests=true verify -f setup-service/pom.xml


### PR DESCRIPTION
## Summary
- fix the GitHub Actions workflow to use the correct setup-service Maven module path

## Testing
- mvn -B -DskipTests=true install -f shared-lib/pom.xml *(fails: network access to Maven Central is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d52a245024832fa3c11d5b01bea3db