### PR TITLE
Add reusable SLA report endpoint

### DIFF
--- a/shared-lib/shared-starters/starter-actuator/README.md
+++ b/shared-lib/shared-starters/starter-actuator/README.md
@@ -7,6 +7,7 @@ Spring Boot Actuator starter with:
 - Http exchanges repository (optional)
 - Actuator-only security chain (optional)
 - Custom endpoint: /actuator/whoami
+- SLA report at `/sla/report` with build/runtime metadata
 
 ## Usage
 Add the dependency:
@@ -17,3 +18,21 @@ Add the dependency:
   <artifactId>starter-actuator</artifactId>
 </dependency>
 ```
+
+### SLA report endpoint
+
+The starter registers a lightweight REST controller at `/sla/report`. It provides
+service name, build metadata, uptime, host details, and the current health/info
+snapshots. You can enrich the response with optional contact data:
+
+```yaml
+shared:
+  actuator:
+    sla-report:
+      owner: Platform SRE
+      contact: sre@example.com
+      description: Security service availability contact
+```
+
+Set `shared.actuator.sla-report.enabled=false` if you need to disable the
+endpoint for a particular service.

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorAutoConfiguration.java
@@ -4,18 +4,25 @@ package com.ejada.actuator.starter.config;
 import com.ejada.actuator.starter.endpoints.WhoAmIEndpoint;
 import com.ejada.actuator.starter.info.SharedInfoContributor;
 import com.ejada.actuator.starter.metrics.CommonTagsCustomizer;
+import com.ejada.actuator.starter.web.SlaReportController;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration;
 import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.actuate.info.InfoEndpoint;
 import org.springframework.boot.actuate.web.exchanges.InMemoryHttpExchangeRepository;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
 
 @AutoConfiguration(after = InfoContributorAutoConfiguration.class)
 @EnableConfigurationProperties(SharedActuatorProperties.class)
@@ -48,5 +55,25 @@ public class SharedActuatorAutoConfiguration {
   @ConditionalOnMissingBean
   public WhoAmIEndpoint whoAmIEndpoint() {
     return new WhoAmIEndpoint();
+  }
+
+  @Bean
+  @ConditionalOnClass(RestController.class)
+  @ConditionalOnProperty(prefix = "shared.actuator.sla-report", name = "enabled", havingValue = "true", matchIfMissing = true)
+  @ConditionalOnMissingBean
+  public SlaReportController slaReportController(
+      ObjectProvider<BuildProperties> buildProperties,
+      ObjectProvider<GitProperties> gitProperties,
+      ObjectProvider<HealthEndpoint> healthEndpoint,
+      ObjectProvider<InfoEndpoint> infoEndpoint,
+      Environment environment,
+      SharedActuatorProperties properties) {
+    return new SlaReportController(
+        buildProperties,
+        gitProperties,
+        healthEndpoint,
+        infoEndpoint,
+        environment,
+        properties);
   }
 }

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorProperties.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorProperties.java
@@ -9,10 +9,12 @@ public class SharedActuatorProperties {
   private final HttpExchanges httpExchanges = new HttpExchanges();
   private final MetricsTags metrics = new MetricsTags();
   private final Security security = new Security();
+  private final SlaReport slaReport = new SlaReport();
 
   public HttpExchanges getHttpExchanges() { return httpExchanges; }
   public MetricsTags getMetrics() { return metrics; }
   public Security getSecurity() { return security; }
+  public SlaReport getSlaReport() { return slaReport; }
 
   public static class HttpExchanges {
     private boolean enabled = true;
@@ -49,5 +51,21 @@ public class SharedActuatorProperties {
     public void setEnabled(boolean enabled) { this.enabled = enabled; }
     public boolean isPermitPrometheus() { return permitPrometheus; }
     public void setPermitPrometheus(boolean permitPrometheus) { this.permitPrometheus = permitPrometheus; }
+  }
+
+  public static class SlaReport {
+    private boolean enabled = true;
+    private String owner;
+    private String contact;
+    private String description;
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public String getOwner() { return owner; }
+    public void setOwner(String owner) { this.owner = owner; }
+    public String getContact() { return contact; }
+    public void setContact(String contact) { this.contact = contact; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
   }
 }

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/web/SlaReport.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/web/SlaReport.java
@@ -1,0 +1,38 @@
+package com.ejada.actuator.starter.web;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DTO returned by the /sla/report endpoint.
+ */
+public record SlaReport(
+    String service,
+    List<String> profiles,
+    String status,
+    OffsetDateTime generatedAt,
+    Duration uptime,
+    OffsetDateTime startedAt,
+    Build build,
+    Runtime runtime,
+    Metadata metadata,
+    Map<String, Object> info,
+    Map<String, Object> health
+) {
+
+  public record Build(String version, java.time.Instant time, String commit, String branch) {}
+
+  public record Runtime(
+      long pid,
+      String host,
+      String address,
+      String region,
+      String zone,
+      String pod,
+      String node
+  ) {}
+
+  public record Metadata(String owner, String contact, String description) {}
+}

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/web/SlaReportController.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/web/SlaReportController.java
@@ -1,0 +1,193 @@
+package com.ejada.actuator.starter.web;
+
+import com.ejada.actuator.starter.config.SharedActuatorProperties;
+import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.health.CompositeHealth;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthComponent;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.actuate.info.InfoEndpoint;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/sla")
+public class SlaReportController {
+
+  private final ObjectProvider<BuildProperties> buildProperties;
+  private final ObjectProvider<GitProperties> gitProperties;
+  private final ObjectProvider<HealthEndpoint> healthEndpoint;
+  private final ObjectProvider<InfoEndpoint> infoEndpoint;
+  private final Environment environment;
+  private final SharedActuatorProperties properties;
+  private final Clock clock;
+
+  public SlaReportController(
+      ObjectProvider<BuildProperties> buildProperties,
+      ObjectProvider<GitProperties> gitProperties,
+      ObjectProvider<HealthEndpoint> healthEndpoint,
+      ObjectProvider<InfoEndpoint> infoEndpoint,
+      Environment environment,
+      SharedActuatorProperties properties) {
+    this(buildProperties, gitProperties, healthEndpoint, infoEndpoint, environment, properties,
+        Clock.systemUTC());
+  }
+
+  SlaReportController(
+      ObjectProvider<BuildProperties> buildProperties,
+      ObjectProvider<GitProperties> gitProperties,
+      ObjectProvider<HealthEndpoint> healthEndpoint,
+      ObjectProvider<InfoEndpoint> infoEndpoint,
+      Environment environment,
+      SharedActuatorProperties properties,
+      Clock clock) {
+    this.buildProperties = buildProperties;
+    this.gitProperties = gitProperties;
+    this.healthEndpoint = healthEndpoint;
+    this.infoEndpoint = infoEndpoint;
+    this.environment = environment;
+    this.properties = properties;
+    this.clock = clock;
+  }
+
+  @GetMapping("/report")
+  public SlaReport report() {
+    var runtimeBean = ManagementFactory.getRuntimeMXBean();
+    Duration uptime = Duration.ofMillis(runtimeBean.getUptime());
+    OffsetDateTime generatedAt = OffsetDateTime.now(clock);
+    OffsetDateTime startedAt = generatedAt.minus(uptime);
+
+    String serviceName = environment.getProperty("spring.application.name", "application");
+    List<String> profiles = resolveProfiles();
+
+    BuildProperties build = buildProperties.getIfAvailable();
+    GitProperties git = gitProperties.getIfAvailable();
+
+    SlaReport.Build buildInfo = (build != null || git != null)
+        ? new SlaReport.Build(
+            build != null ? build.getVersion() : null,
+            build != null ? build.getTime() : null,
+            git != null ? git.getShortCommitId() : null,
+            git != null ? git.getBranch() : null)
+        : null;
+
+    String[] host = resolveHost();
+    SlaReport.Runtime runtime = new SlaReport.Runtime(
+        runtimeBean.getPid(),
+        host[0],
+        host[1],
+        envOrNull("REGION"),
+        envOrNull("ZONE"),
+        envOrNull("POD_NAME"),
+        envOrNull("NODE_NAME"));
+
+    HealthComponent healthComponent = null;
+    Status status = Status.UNKNOWN;
+    Map<String, Object> healthDetails = null;
+    HealthEndpoint healthEndpoint = this.healthEndpoint.getIfAvailable();
+    if (healthEndpoint != null) {
+      healthComponent = healthEndpoint.health();
+    }
+    if (healthComponent != null) {
+      status = healthComponent.getStatus();
+      healthDetails = nullIfEmpty(asHealthMap(healthComponent));
+    }
+
+    Map<String, Object> infoDetails = null;
+    InfoEndpoint infoEndpoint = this.infoEndpoint.getIfAvailable();
+    if (infoEndpoint != null) {
+      infoDetails = nullIfEmpty(new LinkedHashMap<>(infoEndpoint.info()));
+    }
+
+    SharedActuatorProperties.SlaReport sla = properties.getSlaReport();
+    String owner = blankToNull(sla.getOwner());
+    String contact = blankToNull(sla.getContact());
+    String description = blankToNull(sla.getDescription());
+    SlaReport.Metadata metadata =
+        (owner != null || contact != null || description != null)
+            ? new SlaReport.Metadata(owner, contact, description)
+            : null;
+
+    return new SlaReport(
+        serviceName,
+        profiles,
+        status != null ? status.getCode() : Status.UNKNOWN.getCode(),
+        generatedAt,
+        uptime,
+        startedAt,
+        buildInfo,
+        runtime,
+        metadata,
+        infoDetails,
+        healthDetails);
+  }
+
+  private List<String> resolveProfiles() {
+    List<String> active = Arrays.stream(environment.getActiveProfiles())
+        .filter(StringUtils::hasText)
+        .toList();
+    if (!active.isEmpty()) {
+      return active;
+    }
+    return Arrays.stream(environment.getDefaultProfiles())
+        .filter(StringUtils::hasText)
+        .toList();
+  }
+
+  private Map<String, Object> asHealthMap(HealthComponent component) {
+    Map<String, Object> result = new LinkedHashMap<>();
+    Status componentStatus = component.getStatus();
+    if (componentStatus != null) {
+      result.put("status", componentStatus.getCode());
+    }
+    if (component instanceof Health health && !health.getDetails().isEmpty()) {
+      result.put("details", new LinkedHashMap<>(health.getDetails()));
+    }
+    if (component instanceof CompositeHealth composite && !composite.getComponents().isEmpty()) {
+      Map<String, Object> components = new LinkedHashMap<>();
+      composite.getComponents()
+          .forEach((name, child) -> components.put(name, asHealthMap(child)));
+      result.put("components", components);
+    }
+    return result;
+  }
+
+  private String[] resolveHost() {
+    try {
+      InetAddress host = InetAddress.getLocalHost();
+      return new String[] {host.getHostName(), host.getHostAddress()};
+    } catch (Exception ex) {
+      return new String[] {"unknown", "unknown"};
+    }
+  }
+
+  private Map<String, Object> nullIfEmpty(Map<String, Object> source) {
+    if (source == null || source.isEmpty()) {
+      return null;
+    }
+    return source;
+  }
+
+  private String envOrNull(String key) {
+    return blankToNull(System.getenv(key));
+  }
+
+  private String blankToNull(String value) {
+    return (value == null || value.isBlank()) ? null : value;
+  }
+}

--- a/shared-lib/shared-starters/starter-actuator/src/main/resources/com/shared/actuator/starter/actuator-defaults.properties
+++ b/shared-lib/shared-starters/starter-actuator/src/main/resources/com/shared/actuator/starter/actuator-defaults.properties
@@ -10,3 +10,4 @@ shared.actuator.metrics.common-tags.region-enabled=true
 shared.actuator.metrics.common-tags.zone-enabled=true
 shared.actuator.security.enabled=false
 shared.actuator.security.permit-prometheus=true
+shared.actuator.sla-report.enabled=true


### PR DESCRIPTION
## Summary
- add a shared `/sla/report` controller that surfaces build, health and runtime metadata for every service using the actuator starter
- expose configuration switches for the SLA report and document how to customise owner/contact information

## Testing
- `mvn -pl shared-starters/starter-actuator -am test` *(fails: missing remote dependencies because outbound network is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d529a51c7c832fac2a9b80213bc523