### PR TITLE
Add SLA metrics configuration support

### DIFF
--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorAutoConfiguration.java
@@ -81,4 +81,12 @@ public class SharedActuatorAutoConfiguration {
         environment,
         properties);
   }
+
+  @Bean
+  @ConditionalOnClass({Endpoint.class, MeterRegistry.class})
+  @ConditionalOnProperty(prefix = "shared.actuator.sla-metrics", name = "enabled", havingValue = "true", matchIfMissing = true)
+  @ConditionalOnMissingBean
+  public SlaMetricsEndpoint slaMetricsEndpoint(MeterRegistry meterRegistry, SharedActuatorProperties properties) {
+    return new SlaMetricsEndpoint(meterRegistry, properties);
+  }
 }

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorProperties.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorProperties.java
@@ -10,12 +10,14 @@ public class SharedActuatorProperties {
   private final MetricsTags metrics = new MetricsTags();
   private final Security security = new Security();
   private final SlaReport slaReport = new SlaReport();
+  private final SlaMetrics slaMetrics = new SlaMetrics();
 
 
   public HttpExchanges getHttpExchanges() { return httpExchanges; }
   public MetricsTags getMetrics() { return metrics; }
   public Security getSecurity() { return security; }
   public SlaReport getSlaReport() { return slaReport; }
+  public SlaMetrics getSlaMetrics() { return slaMetrics; }
 
   public static class HttpExchanges {
     private boolean enabled = true;
@@ -69,5 +71,44 @@ public class SharedActuatorProperties {
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
 
+  }
+
+  public static class SlaMetrics {
+    private boolean enabled = true;
+    private String meterName = "http.server.requests";
+    private double sloTarget = 99.9D;
+    private double slaTarget = 99.0D;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public String getMeterName() {
+      return meterName;
+    }
+
+    public void setMeterName(String meterName) {
+      this.meterName = meterName;
+    }
+
+    public double getSloTarget() {
+      return sloTarget;
+    }
+
+    public void setSloTarget(double sloTarget) {
+      this.sloTarget = sloTarget;
+    }
+
+    public double getSlaTarget() {
+      return slaTarget;
+    }
+
+    public void setSlaTarget(double slaTarget) {
+      this.slaTarget = slaTarget;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add SLA metrics configuration properties including meter and targets
- register the SLA metrics actuator endpoint when enabled

## Testing
- `mvn -pl shared-starters/starter-actuator test` *(fails: repository downloads blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d52e0dfdac832fba5baf4f351473d6