### PR TITLE
Simplify SLA report endpoint to expose health indicator

### DIFF
--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -29,6 +29,11 @@ server:
 shared:
   observability:
     application-name: security-service
+  actuator:
+    sla-report:
+      enabled: true
+      sla-compliant: true
+      availability-percent: 99.95
   security:
     enable-role-check: true
     jwt:

--- a/shared-lib/shared-starters/starter-actuator/README.md
+++ b/shared-lib/shared-starters/starter-actuator/README.md
@@ -7,6 +7,7 @@ Spring Boot Actuator starter with:
 - Http exchanges repository (optional)
 - Actuator-only security chain (optional)
 - Custom endpoint: /actuator/whoami
+- SLA report at `/sla/report` backed by a dedicated health indicator
 
 ## Usage
 Add the dependency:
@@ -17,3 +18,38 @@ Add the dependency:
   <artifactId>starter-actuator</artifactId>
 </dependency>
 ```
+
+### SLA report endpoint
+
+The starter registers a lightweight REST controller at `/sla/report`. The
+payload mirrors the format of the actuator health endpoint and focuses on the
+`slaHealthIndicator` component:
+
+```json
+{
+  "status": "UP",
+  "components": {
+    "slaHealthIndicator": {
+      "status": "UP",
+      "details": {
+        "sla_compliant": true,
+        "availability_percent": 99.95,
+        "last_check": "2025-09-24T14:00:00Z"
+      }
+    }
+  }
+}
+```
+
+You can customise the indicator details per service:
+
+```yaml
+shared:
+  actuator:
+    sla-report:
+      availability-percent: 99.95
+      sla-compliant: true
+```
+
+Set `shared.actuator.sla-report.enabled=false` if you need to disable either
+the indicator or the `/sla/report` endpoint for a particular service.

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorAutoConfiguration.java
@@ -2,10 +2,14 @@
 package com.ejada.actuator.starter.config;
 
 import com.ejada.actuator.starter.endpoints.WhoAmIEndpoint;
+import com.ejada.actuator.starter.health.SlaHealthIndicator;
 import com.ejada.actuator.starter.info.SharedInfoContributor;
 import com.ejada.actuator.starter.metrics.CommonTagsCustomizer;
+import com.ejada.actuator.starter.web.SlaReportController;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration;
+import org.springframework.boot.actuate.health.HealthContributorRegistry;
+import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.actuate.web.exchanges.InMemoryHttpExchangeRepository;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -13,9 +17,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.RestController;
 
 @AutoConfiguration(after = InfoContributorAutoConfiguration.class)
 @EnableConfigurationProperties(SharedActuatorProperties.class)
@@ -48,5 +54,26 @@ public class SharedActuatorAutoConfiguration {
   @ConditionalOnMissingBean
   public WhoAmIEndpoint whoAmIEndpoint() {
     return new WhoAmIEndpoint();
+  }
+
+  @Bean
+  @ConditionalOnClass(RestController.class)
+  @ConditionalOnProperty(prefix = "shared.actuator.sla-report", name = "enabled", havingValue = "true", matchIfMissing = true)
+  @ConditionalOnMissingBean
+  public SlaReportController slaReportController(
+      ObjectProvider<HealthEndpoint> healthEndpoint,
+      ObjectProvider<HealthContributorRegistry> registry) {
+    return new SlaReportController(healthEndpoint, registry);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "shared.actuator.sla-report",
+      name = "enabled",
+      havingValue = "true",
+      matchIfMissing = true)
+  @ConditionalOnMissingBean(name = "slaHealthIndicator")
+  public SlaHealthIndicator slaHealthIndicator(SharedActuatorProperties properties) {
+    return new SlaHealthIndicator(properties);
   }
 }

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorProperties.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorProperties.java
@@ -9,10 +9,12 @@ public class SharedActuatorProperties {
   private final HttpExchanges httpExchanges = new HttpExchanges();
   private final MetricsTags metrics = new MetricsTags();
   private final Security security = new Security();
+  private final SlaReport slaReport = new SlaReport();
 
   public HttpExchanges getHttpExchanges() { return httpExchanges; }
   public MetricsTags getMetrics() { return metrics; }
   public Security getSecurity() { return security; }
+  public SlaReport getSlaReport() { return slaReport; }
 
   public static class HttpExchanges {
     private boolean enabled = true;
@@ -49,5 +51,27 @@ public class SharedActuatorProperties {
     public void setEnabled(boolean enabled) { this.enabled = enabled; }
     public boolean isPermitPrometheus() { return permitPrometheus; }
     public void setPermitPrometheus(boolean permitPrometheus) { this.permitPrometheus = permitPrometheus; }
+  }
+
+  public static class SlaReport {
+    private boolean enabled = true;
+    private String owner;
+    private String contact;
+    private String description;
+    private boolean slaCompliant = true;
+    private double availabilityPercent = 99.95d;
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public String getOwner() { return owner; }
+    public void setOwner(String owner) { this.owner = owner; }
+    public String getContact() { return contact; }
+    public void setContact(String contact) { this.contact = contact; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public boolean isSlaCompliant() { return slaCompliant; }
+    public void setSlaCompliant(boolean slaCompliant) { this.slaCompliant = slaCompliant; }
+    public double getAvailabilityPercent() { return availabilityPercent; }
+    public void setAvailabilityPercent(double availabilityPercent) { this.availabilityPercent = availabilityPercent; }
   }
 }

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/health/SlaHealthIndicator.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/health/SlaHealthIndicator.java
@@ -1,0 +1,32 @@
+package com.ejada.actuator.starter.health;
+
+import com.ejada.actuator.starter.config.SharedActuatorProperties;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+public class SlaHealthIndicator extends AbstractHealthIndicator {
+
+  private final SharedActuatorProperties properties;
+  private final Clock clock;
+
+  public SlaHealthIndicator(SharedActuatorProperties properties) {
+    this(properties, Clock.systemUTC());
+  }
+
+  SlaHealthIndicator(SharedActuatorProperties properties, Clock clock) {
+    this.properties = properties;
+    this.clock = clock;
+  }
+
+  @Override
+  protected void doHealthCheck(Health.Builder builder) {
+    SharedActuatorProperties.SlaReport sla = properties.getSlaReport();
+    builder.status(Status.UP)
+        .withDetail("sla_compliant", sla.isSlaCompliant())
+        .withDetail("availability_percent", sla.getAvailabilityPercent())
+        .withDetail("last_check", OffsetDateTime.now(clock));
+  }
+}

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/web/SlaReportController.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/web/SlaReportController.java
@@ -1,0 +1,103 @@
+package com.ejada.actuator.starter.web;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.health.CompositeHealth;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.CompositeHealthContributor;
+import org.springframework.boot.actuate.health.HealthComponent;
+import org.springframework.boot.actuate.health.HealthContributor;
+import org.springframework.boot.actuate.health.HealthContributorRegistry;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/sla")
+public class SlaReportController {
+
+  private static final String INDICATOR_NAME = "slaHealthIndicator";
+
+  private final ObjectProvider<HealthEndpoint> healthEndpoint;
+  private final ObjectProvider<HealthContributorRegistry> registry;
+
+  public SlaReportController(
+      ObjectProvider<HealthEndpoint> healthEndpoint,
+      ObjectProvider<HealthContributorRegistry> registry) {
+    this.healthEndpoint = healthEndpoint;
+    this.registry = registry;
+  }
+
+  @GetMapping("/report")
+  public Map<String, Object> report() {
+    HealthComponent component = resolveIndicator();
+    Map<String, Object> body = new LinkedHashMap<>();
+    Status status = component != null ? component.getStatus() : Status.UNKNOWN;
+    body.put("status", status != null ? status.getCode() : Status.UNKNOWN.getCode());
+
+    Map<String, Object> components = new LinkedHashMap<>();
+    components.put(INDICATOR_NAME, component != null ? toMap(component) : fallbackComponent());
+    body.put("components", components);
+
+    return body;
+  }
+
+  private HealthComponent resolveIndicator() {
+    HealthContributorRegistry registry = this.registry.getIfAvailable();
+    if (registry != null) {
+      HealthContributor contributor = registry.getContributor(INDICATOR_NAME);
+      if (contributor instanceof HealthIndicator indicator) {
+        return indicator.getHealth(true);
+      }
+      if (contributor instanceof CompositeHealthContributor compositeContributor) {
+        for (var named : compositeContributor) {
+          if (INDICATOR_NAME.equals(named.getName()) && named.getContributor() instanceof HealthIndicator indicator) {
+            return indicator.getHealth(true);
+          }
+        }
+      }
+    }
+
+    HealthEndpoint endpoint = healthEndpoint.getIfAvailable();
+    if (endpoint != null) {
+      HealthComponent root = endpoint.health();
+      if (root instanceof CompositeHealth composite) {
+        return composite.getComponents().get(INDICATOR_NAME);
+      }
+      return root;
+    }
+    return null;
+  }
+
+  private Map<String, Object> toMap(HealthComponent component) {
+    Map<String, Object> result = new LinkedHashMap<>();
+    Status status = component.getStatus();
+    result.put("status", status != null ? status.getCode() : Status.UNKNOWN.getCode());
+
+    if (component instanceof Health health) {
+      if (!health.getDetails().isEmpty()) {
+        result.put("details", new LinkedHashMap<>(health.getDetails()));
+      }
+    }
+
+    if (component instanceof CompositeHealth composite && !composite.getComponents().isEmpty()) {
+      Map<String, Object> children = new LinkedHashMap<>();
+      for (Map.Entry<String, HealthComponent> entry : composite.getComponents().entrySet()) {
+        children.put(entry.getKey(), toMap(entry.getValue()));
+      }
+      result.put("components", children);
+    }
+
+    return result;
+  }
+
+  private Map<String, Object> fallbackComponent() {
+    Map<String, Object> fallback = new LinkedHashMap<>();
+    fallback.put("status", Status.UNKNOWN.getCode());
+    return fallback;
+  }
+}

--- a/shared-lib/shared-starters/starter-actuator/src/main/resources/com/shared/actuator/starter/actuator-defaults.properties
+++ b/shared-lib/shared-starters/starter-actuator/src/main/resources/com/shared/actuator/starter/actuator-defaults.properties
@@ -10,3 +10,4 @@ shared.actuator.metrics.common-tags.region-enabled=true
 shared.actuator.metrics.common-tags.zone-enabled=true
 shared.actuator.security.enabled=false
 shared.actuator.security.permit-prometheus=true
+shared.actuator.sla-report.enabled=true


### PR DESCRIPTION
## Summary
- replace the SLA report controller with a lightweight wrapper around the slaHealthIndicator health component so `/sla/report` mirrors the actuator health payload
- introduce a dedicated `SlaHealthIndicator` with configurable compliance and availability details
- document the new behaviour and update the SEC service sample configuration to set the SLA properties

## Testing
- `mvn -pl starter-actuator -am test` *(fails: unable to resolve the shared BOM because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d529a51c7c832fac2a9b80213bc523