### PR TITLE
Add SLA metrics configuration properties

### DIFF
--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorProperties.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorProperties.java
@@ -79,4 +79,34 @@ public class SharedActuatorProperties {
     public void setAvailabilityPercent(double availabilityPercent) { this.availabilityPercent = availabilityPercent; }
 
   }
+
+  public static class SlaMetrics {
+    private String meterName = "http.server.requests";
+    private double sloTarget = 99.9D;
+    private double slaTarget = 99.0D;
+
+    public String getMeterName() {
+      return meterName;
+    }
+
+    public void setMeterName(String meterName) {
+      this.meterName = meterName;
+    }
+
+    public double getSloTarget() {
+      return sloTarget;
+    }
+
+    public void setSloTarget(double sloTarget) {
+      this.sloTarget = sloTarget;
+    }
+
+    public double getSlaTarget() {
+      return slaTarget;
+    }
+
+    public void setSlaTarget(double slaTarget) {
+      this.slaTarget = slaTarget;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add the missing `SlaMetrics` nested configuration class so the SLA metrics endpoint compiles

## Testing
- mvn -pl shared-starters/starter-actuator test *(fails: dependency downloads blocked by offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5302b2948832f9248beacdea96587