### PR TITLE
Fix superadmin entities schema

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/domain/Superadmin.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/Superadmin.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(
   name = "superadmins",
-  schema = "public",
+  schema = "security",
   uniqueConstraints = {
     @UniqueConstraint(name = "ux_superadmins_username", columnNames = {"username"}),
     @UniqueConstraint(name = "ux_superadmins_email", columnNames = {"email"})

--- a/sec-service/src/main/java/com/ejada/sec/domain/SuperadminAuditLog.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/SuperadminAuditLog.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "superadmin_audit_logs", schema = "public")
+@Table(name = "superadmin_audit_logs", schema = "security")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/sec-service/src/main/java/com/ejada/sec/domain/SuperadminPasswordHistory.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/SuperadminPasswordHistory.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "superadmin_password_history", schema = "public")
+@Table(name = "superadmin_password_history", schema = "security")
 @Getter
 @Setter
 @NoArgsConstructor


### PR DESCRIPTION
## Summary
- point the superadmin-related entities to the security schema so Hibernate matches the Flyway-managed tables

## Testing
- mvn test *(fails: unable to download org.springframework.boot:spring-boot-starter-parent:3.5.5 because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d5328eb8dc832fab0ba85f6f3edc0c