### PR TITLE
Fix SLA report indicator resolution

### DIFF
--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/config/SharedActuatorAutoConfiguration.java
@@ -70,8 +70,9 @@ public class SharedActuatorAutoConfiguration {
   @ConditionalOnMissingBean
   public SlaReportController slaReportController(
       ObjectProvider<HealthEndpoint> healthEndpoint,
-      ObjectProvider<HealthContributorRegistry> registry) {
-    return new SlaReportController(healthEndpoint, registry);
+      ObjectProvider<HealthContributorRegistry> registry,
+      ObjectProvider<SlaHealthIndicator> indicator) {
+    return new SlaReportController(healthEndpoint, registry, indicator);
   }
 
   @Bean

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/web/SlaReportController.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/web/SlaReportController.java
@@ -3,6 +3,7 @@ package com.ejada.actuator.starter.web;
 import java.util.LinkedHashMap;
 
 import java.util.Map;
+import com.ejada.actuator.starter.health.SlaHealthIndicator;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.health.CompositeHealth;
 import org.springframework.boot.actuate.health.Health;
@@ -26,12 +27,15 @@ public class SlaReportController {
 
   private final ObjectProvider<HealthEndpoint> healthEndpoint;
   private final ObjectProvider<HealthContributorRegistry> registry;
+  private final ObjectProvider<SlaHealthIndicator> indicator;
 
   public SlaReportController(
       ObjectProvider<HealthEndpoint> healthEndpoint,
-      ObjectProvider<HealthContributorRegistry> registry) {
+      ObjectProvider<HealthContributorRegistry> registry,
+      ObjectProvider<SlaHealthIndicator> indicator) {
     this.healthEndpoint = healthEndpoint;
     this.registry = registry;
+    this.indicator = indicator;
   }
 
   @GetMapping("/report")
@@ -62,6 +66,11 @@ public class SlaReportController {
           }
         }
       }
+    }
+
+    SlaHealthIndicator direct = indicator.getIfAvailable();
+    if (direct != null) {
+      return direct.getHealth(true);
     }
 
     HealthEndpoint endpoint = healthEndpoint.getIfAvailable();

--- a/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/web/SlaReportControllerTest.java
+++ b/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/web/SlaReportControllerTest.java
@@ -1,0 +1,106 @@
+package com.ejada.actuator.starter.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.actuator.starter.config.SharedActuatorProperties;
+import com.ejada.actuator.starter.health.SlaHealthIndicator;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+class SlaReportControllerTest {
+
+  @Test
+  void reportUsesDirectIndicatorWhenRegistryUnavailable() {
+    SharedActuatorProperties properties = new SharedActuatorProperties();
+    properties.getSlaReport().setSlaCompliant(false);
+    SlaHealthIndicator indicator = new SlaHealthIndicator(properties);
+
+    SlaReportController controller =
+        new SlaReportController(
+            new EmptyObjectProvider<>(), new EmptyObjectProvider<>(), new StaticObjectProvider<>(indicator));
+
+    Map<String, Object> report = controller.report();
+
+    assertThat(report.get("status")).isEqualTo("UP");
+    Map<String, Object> components = (Map<String, Object>) report.get("components");
+    Map<String, Object> indicatorBody = (Map<String, Object>) components.get("slaHealthIndicator");
+    assertThat(indicatorBody.get("status")).isEqualTo("UP");
+    Map<String, Object> details = (Map<String, Object>) indicatorBody.get("details");
+    assertThat(details.get("sla_compliant")).isEqualTo(false);
+    assertThat(details).containsKeys("availability_percent", "last_check");
+  }
+
+  private static final class EmptyObjectProvider<T> implements ObjectProvider<T> {
+
+    @Override
+    public T getObject(Object... args) {
+      throw new IllegalStateException("No instance available");
+    }
+
+    @Override
+    public T getIfAvailable() {
+      return null;
+    }
+
+    @Override
+    public T getIfUnique() {
+      return null;
+    }
+
+    @Override
+    public Stream<T> stream() {
+      return Stream.empty();
+    }
+
+    @Override
+    public Stream<T> orderedStream() {
+      return Stream.empty();
+    }
+
+    @Override
+    public T getObject() {
+      throw new IllegalStateException("No instance available");
+    }
+  }
+
+  private static final class StaticObjectProvider<T> implements ObjectProvider<T> {
+
+    private final T instance;
+
+    private StaticObjectProvider(T instance) {
+      this.instance = instance;
+    }
+
+    @Override
+    public T getObject(Object... args) {
+      return instance;
+    }
+
+    @Override
+    public T getIfAvailable() {
+      return instance;
+    }
+
+    @Override
+    public T getIfUnique() {
+      return instance;
+    }
+
+    @Override
+    public Stream<T> stream() {
+      return Stream.of(instance);
+    }
+
+    @Override
+    public Stream<T> orderedStream() {
+      return Stream.of(instance);
+    }
+
+    @Override
+    public T getObject() {
+      return instance;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- ensure the SLA report controller can fall back to the registered slaHealthIndicator bean when the health registry and endpoint are unavailable
- wire the indicator provider into the shared actuator auto-configuration
- add a focused unit test covering the direct indicator resolution path

## Testing
- `mvn -pl shared-starters/starter-actuator test` *(fails: unable to reach Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d532b29c90832fa891cc8abccb09b2