### PR TITLE
Fix request matcher list type in security config

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
@@ -184,8 +184,8 @@ public class SecurityAutoConfiguration {
             .filter(StringUtils::hasText)
             .map(String::trim)
             .filter(s -> !s.isEmpty())
-            .map(AntPathRequestMatcher::new)
-            .toList();
+            .map(pattern -> (RequestMatcher) new AntPathRequestMatcher(pattern))
+            .collect(Collectors.toCollection(ArrayList::new));
         if (!ignoreMatchers.isEmpty()) {
           csrf.ignoringRequestMatchers(ignoreMatchers.toArray(new RequestMatcher[0]));
         }


### PR DESCRIPTION
## Summary
- ensure CSRF ignore patterns are collected as RequestMatcher instances

## Testing
- mvn -pl shared-starters/starter-security -am compile *(fails: dependency download blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68d53413c9e8832faaf48aa570d2f583