### PR TITLE
Handle CSRF ignore matchers without deprecated API

### DIFF
--- a/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/web/SlaReportControllerTest.java
+++ b/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/web/SlaReportControllerTest.java
@@ -24,10 +24,10 @@ class SlaReportControllerTest {
     Map<String, Object> report = controller.report();
 
     assertThat(report.get("status")).isEqualTo("UP");
-    Map<String, Object> components = (Map<String, Object>) report.get("components");
-    Map<String, Object> indicatorBody = (Map<String, Object>) components.get("slaHealthIndicator");
+    Map<?, ?> components = Map.class.cast(report.get("components"));
+    Map<?, ?> indicatorBody = Map.class.cast(components.get("slaHealthIndicator"));
     assertThat(indicatorBody.get("status")).isEqualTo("UP");
-    Map<String, Object> details = (Map<String, Object>) indicatorBody.get("details");
+    Map<?, ?> details = Map.class.cast(indicatorBody.get("details"));
     assertThat(details.get("sla_compliant")).isEqualTo(false);
     assertThat(details).containsKeys("availability_percent", "last_check");
   }


### PR DESCRIPTION
## Summary
- stop instantiating the deprecated `AntPathRequestMatcher` by relying on MVC request matchers with an Ant-style fallback
- inject the handler mapping introspector lazily so CSRF ignore rules can be built without deprecated APIs
- adjust the SLA report controller test to avoid unchecked map casts

## Testing
- `mvn -pl starter-security,starter-actuator test` *(fails: requires downloading com.ejada:shared-bom:1.0.0 and the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d53b057660832f9eae1f681f5e28af