### PR TITLE
feat: compute SLA indicator from live metrics

### DIFF
--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/endpoints/SlaMetricsEndpoint.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/endpoints/SlaMetricsEndpoint.java
@@ -1,11 +1,9 @@
 package com.ejada.actuator.starter.endpoints;
 
-import com.ejada.actuator.starter.config.SharedActuatorProperties;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
+import com.ejada.actuator.starter.metrics.SlaMetricsCalculator;
+import com.ejada.actuator.starter.metrics.SlaMetricsCalculator.Result;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
@@ -14,68 +12,30 @@ import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 @Endpoint(id = "sla-metrics")
 public class SlaMetricsEndpoint {
 
-  private final MeterRegistry meterRegistry;
-  private final SharedActuatorProperties properties;
+  private final SlaMetricsCalculator calculator;
 
-  public SlaMetricsEndpoint(MeterRegistry meterRegistry, SharedActuatorProperties properties) {
-    this.meterRegistry = meterRegistry;
-    this.properties = properties;
+  public SlaMetricsEndpoint(SlaMetricsCalculator calculator) {
+    this.calculator = calculator;
   }
 
   @ReadOperation
   public Map<String, Object> slaMetrics() {
-    SharedActuatorProperties.SlaMetrics slaProps = properties.getSlaMetrics();
-    Collection<Timer> timers = meterRegistry.find(slaProps.getMeterName()).timers();
-
-    long totalRequests = 0L;
-    long successfulRequests = 0L;
-    for (Timer timer : timers) {
-      long count = timer.count();
-      totalRequests += count;
-      if (isSuccessful(timer)) {
-        successfulRequests += count;
-      }
-    }
-
-    long failedRequests = Math.max(0L, totalRequests - successfulRequests);
-    double sli = totalRequests == 0L ? 100.0D : ((double) successfulRequests / (double) totalRequests) * 100.0D;
-    double sloTarget = slaProps.getSloTarget();
-    double slaTarget = slaProps.getSlaTarget();
-    double downtime = 100.0D - sli;
-    double errorBudget = Math.max(0.0D, 100.0D - sloTarget);
-    double errorBudgetConsumed = Math.min(errorBudget, downtime);
-    double errorBudgetRemaining = Math.max(0.0D, errorBudget - downtime);
+    Result result = calculator.calculate();
 
     Map<String, Object> response = new LinkedHashMap<>();
-    response.put("meter", slaProps.getMeterName());
-    response.put("totalRequests", totalRequests);
-    response.put("successfulRequests", successfulRequests);
-    response.put("failedRequests", failedRequests);
-    response.put("sli", round(sli));
-    response.put("sloTarget", round(sloTarget));
-    response.put("slaTarget", round(slaTarget));
-    response.put("sloMet", sli >= sloTarget);
-    response.put("slaMet", sli >= slaTarget);
-    response.put("errorBudget", round(errorBudget));
-    response.put("errorBudgetConsumed", round(errorBudgetConsumed));
-    response.put("errorBudgetRemaining", round(errorBudgetRemaining));
+    response.put("meter", result.getMeterName());
+    response.put("totalRequests", result.getTotalRequests());
+    response.put("successfulRequests", result.getSuccessfulRequests());
+    response.put("failedRequests", result.getFailedRequests());
+    response.put("sli", round(result.getSli()));
+    response.put("sloTarget", round(result.getSloTarget()));
+    response.put("slaTarget", round(result.getSlaTarget()));
+    response.put("sloMet", result.isSloMet());
+    response.put("slaMet", result.isSlaMet());
+    response.put("errorBudget", round(result.getErrorBudget()));
+    response.put("errorBudgetConsumed", round(result.getErrorBudgetConsumed()));
+    response.put("errorBudgetRemaining", round(result.getErrorBudgetRemaining()));
     return response;
-  }
-
-  private boolean isSuccessful(Timer timer) {
-    String outcome = timer.getId().getTag("outcome");
-    if (outcome != null) {
-      if (outcome.equalsIgnoreCase("SERVER_ERROR") || outcome.equalsIgnoreCase("CLIENT_ERROR")) {
-        return false;
-      }
-      return true;
-    }
-    String status = timer.getId().getTag("status");
-    if (status == null || status.isBlank()) {
-      return true;
-    }
-    char leading = status.charAt(0);
-    return leading == '1' || leading == '2' || leading == '3';
   }
 
   private double round(double value) {

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/health/SlaHealthIndicator.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/health/SlaHealthIndicator.java
@@ -1,32 +1,51 @@
 package com.ejada.actuator.starter.health;
 
-import com.ejada.actuator.starter.config.SharedActuatorProperties;
+import com.ejada.actuator.starter.metrics.SlaMetricsCalculator;
+import com.ejada.actuator.starter.metrics.SlaMetricsCalculator.Result;
 import java.time.Clock;
 import java.time.OffsetDateTime;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
 public class SlaHealthIndicator extends AbstractHealthIndicator {
 
-  private final SharedActuatorProperties properties;
+  private final SlaMetricsCalculator calculator;
   private final Clock clock;
 
-  public SlaHealthIndicator(SharedActuatorProperties properties) {
-    this(properties, Clock.systemUTC());
+  public SlaHealthIndicator(SlaMetricsCalculator calculator) {
+    this(calculator, Clock.systemUTC());
   }
 
-  SlaHealthIndicator(SharedActuatorProperties properties, Clock clock) {
-    this.properties = properties;
+  SlaHealthIndicator(SlaMetricsCalculator calculator, Clock clock) {
+    this.calculator = calculator;
     this.clock = clock;
   }
 
   @Override
   protected void doHealthCheck(Health.Builder builder) {
-    SharedActuatorProperties.SlaReport sla = properties.getSlaReport();
-    builder.status(Status.UP)
-        .withDetail("sla_compliant", sla.isSlaCompliant())
-        .withDetail("availability_percent", sla.getAvailabilityPercent())
+    Result result = calculator.calculate();
+    boolean slaMet = result.isSlaMet();
+
+    builder.status(slaMet ? Status.UP : Status.DOWN)
+        .withDetail("sla_compliant", slaMet)
+        .withDetail("availability_percent", round(result.getSli()))
+        .withDetail("sli", round(result.getSli()))
+        .withDetail("slo", round(result.getSloTarget()))
+        .withDetail("slo_met", result.isSloMet())
+        .withDetail("sla", round(result.getSlaTarget()))
+        .withDetail("total_requests", result.getTotalRequests())
+        .withDetail("successful_requests", result.getSuccessfulRequests())
+        .withDetail("failed_requests", result.getFailedRequests())
+        .withDetail("error_budget", round(result.getErrorBudget()))
+        .withDetail("error_budget_consumed", round(result.getErrorBudgetConsumed()))
+        .withDetail("error_budget_remaining", round(result.getErrorBudgetRemaining()))
         .withDetail("last_check", OffsetDateTime.now(clock));
+  }
+
+  private double round(double value) {
+    return BigDecimal.valueOf(value).setScale(3, RoundingMode.HALF_UP).doubleValue();
   }
 }

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/metrics/SlaMetricsCalculator.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/metrics/SlaMetricsCalculator.java
@@ -1,0 +1,159 @@
+package com.ejada.actuator.starter.metrics;
+
+import com.ejada.actuator.starter.config.SharedActuatorProperties;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.Collection;
+
+/**
+ * Utility component that inspects Micrometer timers to derive SLI/SLO/SLA metrics.
+ */
+public class SlaMetricsCalculator {
+
+  private final MeterRegistry meterRegistry;
+  private final SharedActuatorProperties properties;
+
+  public SlaMetricsCalculator(MeterRegistry meterRegistry, SharedActuatorProperties properties) {
+    this.meterRegistry = meterRegistry;
+    this.properties = properties;
+  }
+
+  public Result calculate() {
+    SharedActuatorProperties.SlaMetrics metricsProps = properties.getSlaMetrics();
+    String meterName = metricsProps.getMeterName();
+
+    Collection<Timer> timers = meterRegistry.find(meterName).timers();
+
+    long totalRequests = 0L;
+    long successfulRequests = 0L;
+    for (Timer timer : timers) {
+      long count = timer.count();
+      totalRequests += count;
+      if (isSuccessful(timer)) {
+        successfulRequests += count;
+      }
+    }
+
+    long failedRequests = Math.max(0L, totalRequests - successfulRequests);
+    double sli = totalRequests == 0L ? 100.0D : ((double) successfulRequests / (double) totalRequests) * 100.0D;
+    double sloTarget = metricsProps.getSloTarget();
+    double slaTarget = metricsProps.getSlaTarget();
+    double downtime = 100.0D - sli;
+    double errorBudget = Math.max(0.0D, 100.0D - sloTarget);
+    double errorBudgetConsumed = Math.min(errorBudget, downtime);
+    double errorBudgetRemaining = Math.max(0.0D, errorBudget - downtime);
+
+    return new Result(
+        meterName,
+        totalRequests,
+        successfulRequests,
+        failedRequests,
+        sli,
+        sloTarget,
+        slaTarget,
+        errorBudget,
+        errorBudgetConsumed,
+        errorBudgetRemaining);
+  }
+
+  private boolean isSuccessful(Timer timer) {
+    String outcome = timer.getId().getTag("outcome");
+    if (outcome != null) {
+      if (outcome.equalsIgnoreCase("SERVER_ERROR") || outcome.equalsIgnoreCase("CLIENT_ERROR")) {
+        return false;
+      }
+      return true;
+    }
+    String status = timer.getId().getTag("status");
+    if (status == null || status.isBlank()) {
+      return true;
+    }
+    char leading = status.charAt(0);
+    return leading == '1' || leading == '2' || leading == '3';
+  }
+
+  public static final class Result {
+    private final String meterName;
+    private final long totalRequests;
+    private final long successfulRequests;
+    private final long failedRequests;
+    private final double sli;
+    private final double sloTarget;
+    private final double slaTarget;
+    private final double errorBudget;
+    private final double errorBudgetConsumed;
+    private final double errorBudgetRemaining;
+
+    private Result(
+        String meterName,
+        long totalRequests,
+        long successfulRequests,
+        long failedRequests,
+        double sli,
+        double sloTarget,
+        double slaTarget,
+        double errorBudget,
+        double errorBudgetConsumed,
+        double errorBudgetRemaining) {
+      this.meterName = meterName;
+      this.totalRequests = totalRequests;
+      this.successfulRequests = successfulRequests;
+      this.failedRequests = failedRequests;
+      this.sli = sli;
+      this.sloTarget = sloTarget;
+      this.slaTarget = slaTarget;
+      this.errorBudget = errorBudget;
+      this.errorBudgetConsumed = errorBudgetConsumed;
+      this.errorBudgetRemaining = errorBudgetRemaining;
+    }
+
+    public String getMeterName() {
+      return meterName;
+    }
+
+    public long getTotalRequests() {
+      return totalRequests;
+    }
+
+    public long getSuccessfulRequests() {
+      return successfulRequests;
+    }
+
+    public long getFailedRequests() {
+      return failedRequests;
+    }
+
+    public double getSli() {
+      return sli;
+    }
+
+    public double getSloTarget() {
+      return sloTarget;
+    }
+
+    public double getSlaTarget() {
+      return slaTarget;
+    }
+
+    public double getErrorBudget() {
+      return errorBudget;
+    }
+
+    public double getErrorBudgetConsumed() {
+      return errorBudgetConsumed;
+    }
+
+    public double getErrorBudgetRemaining() {
+      return errorBudgetRemaining;
+    }
+
+    public boolean isSloMet() {
+      return sli >= sloTarget;
+    }
+
+    public boolean isSlaMet() {
+      return sli >= slaTarget;
+    }
+  }
+}
+

--- a/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/endpoints/SlaMetricsEndpointTest.java
+++ b/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/endpoints/SlaMetricsEndpointTest.java
@@ -3,6 +3,7 @@ package com.ejada.actuator.starter.endpoints;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ejada.actuator.starter.config.SharedActuatorProperties;
+import com.ejada.actuator.starter.metrics.SlaMetricsCalculator;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
@@ -33,7 +34,8 @@ class SlaMetricsEndpointTest {
     props.getSlaMetrics().setSloTarget(94.0D);
     props.getSlaMetrics().setSlaTarget(90.0D);
 
-    SlaMetricsEndpoint endpoint = new SlaMetricsEndpoint(registry, props);
+    SlaMetricsCalculator calculator = new SlaMetricsCalculator(registry, props);
+    SlaMetricsEndpoint endpoint = new SlaMetricsEndpoint(calculator);
 
     var result = endpoint.slaMetrics();
 
@@ -56,7 +58,8 @@ class SlaMetricsEndpointTest {
     SimpleMeterRegistry registry = new SimpleMeterRegistry();
     SharedActuatorProperties props = new SharedActuatorProperties();
 
-    SlaMetricsEndpoint endpoint = new SlaMetricsEndpoint(registry, props);
+    SlaMetricsCalculator calculator = new SlaMetricsCalculator(registry, props);
+    SlaMetricsEndpoint endpoint = new SlaMetricsEndpoint(calculator);
 
     var result = endpoint.slaMetrics();
 

--- a/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/health/SlaHealthIndicatorTest.java
+++ b/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/health/SlaHealthIndicatorTest.java
@@ -1,0 +1,63 @@
+package com.ejada.actuator.starter.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.actuator.starter.config.SharedActuatorProperties;
+import com.ejada.actuator.starter.metrics.SlaMetricsCalculator;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+class SlaHealthIndicatorTest {
+
+  @Test
+  void reportsDownWhenSlaIsNotMet() {
+    SharedActuatorProperties props = new SharedActuatorProperties();
+    props.getSlaMetrics().setSlaTarget(95.0D);
+
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    Timer success = Timer.builder("http.server.requests").tag("status", "200").register(registry);
+    Timer failure = Timer.builder("http.server.requests").tag("status", "500").register(registry);
+
+    success.record(Duration.ofMillis(5));
+    failure.record(Duration.ofMillis(5));
+    failure.record(Duration.ofMillis(5));
+
+    SlaMetricsCalculator calculator = new SlaMetricsCalculator(registry, props);
+    SlaHealthIndicator indicator = new SlaHealthIndicator(calculator);
+
+    Health health = indicator.getHealth(true);
+
+    assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+    assertThat(health.getDetails()).containsEntry("sla_compliant", false);
+  }
+
+  @Test
+  void reportsUpWhenSlaIsMet() {
+    SharedActuatorProperties props = new SharedActuatorProperties();
+    props.getSlaMetrics().setSlaTarget(80.0D);
+    props.getSlaMetrics().setSloTarget(60.0D);
+
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    Timer success = Timer.builder("http.server.requests").tag("status", "200").register(registry);
+    Timer failure = Timer.builder("http.server.requests").tag("status", "500").register(registry);
+
+    success.record(Duration.ofMillis(5));
+    success.record(Duration.ofMillis(5));
+    failure.record(Duration.ofMillis(5));
+
+    SlaMetricsCalculator calculator = new SlaMetricsCalculator(registry, props);
+    SlaHealthIndicator indicator = new SlaHealthIndicator(calculator);
+
+    Health health = indicator.getHealth(true);
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
+    assertThat(health.getDetails()).containsEntry("sla_compliant", true);
+    assertThat(health.getDetails()).containsEntry("sli", 66.667D);
+    assertThat(health.getDetails()).containsEntry("sla", 80.0D);
+  }
+}
+

--- a/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/web/SlaReportControllerTest.java
+++ b/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/web/SlaReportControllerTest.java
@@ -4,6 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ejada.actuator.starter.config.SharedActuatorProperties;
 import com.ejada.actuator.starter.health.SlaHealthIndicator;
+import com.ejada.actuator.starter.metrics.SlaMetricsCalculator;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -14,8 +18,18 @@ class SlaReportControllerTest {
   @Test
   void reportUsesDirectIndicatorWhenRegistryUnavailable() {
     SharedActuatorProperties properties = new SharedActuatorProperties();
-    properties.getSlaReport().setSlaCompliant(false);
-    SlaHealthIndicator indicator = new SlaHealthIndicator(properties);
+    properties.getSlaMetrics().setSlaTarget(90.0D);
+    properties.getSlaMetrics().setSloTarget(95.0D);
+
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    Timer.builder("http.server.requests").tag("status", "200").register(registry).record(Duration.ofMillis(5));
+    Timer failureTimer =
+        Timer.builder("http.server.requests").tag("status", "500").register(registry);
+    failureTimer.record(Duration.ofMillis(5));
+    failureTimer.record(Duration.ofMillis(5));
+
+    SlaMetricsCalculator calculator = new SlaMetricsCalculator(registry, properties);
+    SlaHealthIndicator indicator = new SlaHealthIndicator(calculator);
 
     SlaReportController controller =
         new SlaReportController(
@@ -29,7 +43,17 @@ class SlaReportControllerTest {
     assertThat(indicatorBody.get("status")).isEqualTo("UP");
     Map<String, Object> details = (Map<String, Object>) indicatorBody.get("details");
     assertThat(details.get("sla_compliant")).isEqualTo(false);
-    assertThat(details).containsKeys("availability_percent", "last_check");
+    assertThat(details)
+        .containsKeys(
+            "availability_percent",
+            "last_check",
+            "sli",
+            "slo",
+            "slo_met",
+            "sla",
+            "total_requests",
+            "failed_requests",
+            "error_budget_remaining");
   }
 
   private static final class EmptyObjectProvider<T> implements ObjectProvider<T> {


### PR DESCRIPTION
## Summary
- add a reusable `SlaMetricsCalculator` to derive SLI/SLO/SLA data from Micrometer timers
- update the SLA actuator endpoint and health indicator to expose live SLI/SLO/SLA readings and compliance flags
- wire the calculator into auto-configuration and extend tests to cover the new behaviour

## Testing
- `mvn test` *(fails: missing shared BOM artifacts while offline)*

------
https://chatgpt.com/codex/tasks/task_e_68d53aafd26c832f9943f7ba19f335b1