### PR TITLE
Hash superadmin bootstrap password via shared crypto

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/config/FlywayPlaceholderConfig.java
+++ b/sec-service/src/main/java/com/ejada/sec/config/FlywayPlaceholderConfig.java
@@ -1,0 +1,37 @@
+package com.ejada.sec.config;
+
+import com.ejada.crypto.password.PasswordHasher;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers Flyway placeholders that should be shared across migrations. The
+ * default superadmin password is hashed using the shared crypto
+ * {@link PasswordHasher} so the application never needs to embed a raw BCrypt
+ * string.
+ */
+@Configuration
+public class FlywayPlaceholderConfig {
+
+  private final String superadminPasswordHash;
+
+  public FlywayPlaceholderConfig(
+      @Value("${sec.superadmin.bootstrap.default-password:Admin@123!}")
+          String defaultSuperadminPassword) {
+    this.superadminPasswordHash = PasswordHasher.bcrypt(defaultSuperadminPassword);
+  }
+
+  @Bean
+  FlywayConfigurationCustomizer sharedPasswordPlaceholdersCustomizer() {
+    return this::applySharedPlaceholders;
+  }
+
+  private void applySharedPlaceholders(FluentConfiguration configuration) {
+    configuration.placeholders(Map.of("superadminPasswordHash", superadminPasswordHash));
+  }
+}
+

--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -38,3 +38,8 @@ shared:
     enable-role-check: true
     jwt:
       token-period: 15m
+
+sec:
+  superadmin:
+    bootstrap:
+      default-password: ${SEC_SUPERADMIN_DEFAULT_PASSWORD:Admin@123!}

--- a/sec-service/src/main/resources/db/migration/postgresql/V4__create_superadmin_table.sql
+++ b/sec-service/src/main/resources/db/migration/postgresql/V4__create_superadmin_table.sql
@@ -50,12 +50,12 @@ ALTER TABLE superadmins
 CREATE INDEX IF NOT EXISTS idx_superadmins_username ON superadmins(username);
 CREATE INDEX IF NOT EXISTS idx_superadmins_email ON superadmins(email);
 
--- Default superadmin account (password: Admin@123!)
+-- Default superadmin account (hash generated via shared-crypto PasswordHasher)
 INSERT INTO superadmins (username, email, password_hash, role, created_by)
 VALUES (
     'superadmin',
     'admin@ejada.com',
-    '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a',
+    '${superadminPasswordHash}',
     'EJADA_OFFICER',
     'system'
 )

--- a/shared-lib/shared-lib-crypto/pom.xml
+++ b/shared-lib/shared-lib-crypto/pom.xml
@@ -25,16 +25,22 @@
 
 		<!-- Spring Boot Autoconfigure (for @Configuration, @ConditionalOnClass,
 		etc.) -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-autoconfigure</artifactId>
+                </dependency>
 
-		<!-- Spring Boot Actuator (optional; used only if HealthIndicator beans
-		exist) -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-actuator</artifactId>
+                <!-- Spring Security crypto utilities for password hashing -->
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-crypto</artifactId>
+                </dependency>
+
+                <!-- Spring Boot Actuator (optional; used only if HealthIndicator beans
+                exist) -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-actuator</artifactId>
 			<optional>true</optional>
 		</dependency>
 		

--- a/shared-lib/shared-lib-crypto/src/main/java/com/ejada/crypto/password/PasswordHasher.java
+++ b/shared-lib/shared-lib-crypto/src/main/java/com/ejada/crypto/password/PasswordHasher.java
@@ -1,0 +1,44 @@
+package com.ejada.crypto.password;
+
+import java.util.Objects;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Utility class that centralises password hashing routines so services do not
+ * need to instantiate their own encoders.  By delegating to Spring Security's
+ * {@link BCryptPasswordEncoder} we ensure passwords are hashed following
+ * industry best practices with a random salt per value.
+ */
+public final class PasswordHasher {
+
+  private static final PasswordEncoder BCRYPT = new BCryptPasswordEncoder();
+
+  private PasswordHasher() {
+    // utility class
+  }
+
+  /**
+   * Hashes the provided password using BCrypt.
+   *
+   * @param rawPassword the plaintext password to hash
+   * @return BCrypt hash of the password
+   */
+  public static String bcrypt(String rawPassword) {
+    Objects.requireNonNull(rawPassword, "rawPassword must not be null");
+    return BCRYPT.encode(rawPassword);
+  }
+
+  /**
+   * Verifies a password against a previously generated BCrypt hash.
+   *
+   * @param rawPassword the candidate password to verify
+   * @param hashedPassword the stored BCrypt hash
+   * @return {@code true} if the raw password matches the hash, otherwise {@code false}
+   */
+  public static boolean matchesBcrypt(String rawPassword, String hashedPassword) {
+    Objects.requireNonNull(rawPassword, "rawPassword must not be null");
+    Objects.requireNonNull(hashedPassword, "hashedPassword must not be null");
+    return BCRYPT.matches(rawPassword, hashedPassword);
+  }
+}


### PR DESCRIPTION
## Summary
- replace the hard-coded superadmin hash with a shared `PasswordHasher` utility in `shared-lib-crypto`
- hash the bootstrap password at Flyway configuration time using the shared hasher and a configurable plaintext secret
- expose the default bootstrap password through service configuration so it can be overridden via environment variables

## Testing
- `mvn -f shared-lib/shared-lib-crypto/pom.xml test` *(fails: repository depends on internal BOM that is unreachable without network access, which also prevents resolving dependency versions)*
- `mvn -f sec-service/pom.xml test` *(fails: cannot resolve Spring Boot parent POM because Maven Central is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d539693204832f9fa9d62e08fce38f