### PR TITLE
Fix SlaReportControllerTest map assertions

### DIFF
--- a/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/web/SlaReportControllerTest.java
+++ b/shared-lib/shared-starters/starter-actuator/src/test/java/com/ejada/actuator/starter/web/SlaReportControllerTest.java
@@ -38,10 +38,10 @@ class SlaReportControllerTest {
     Map<String, Object> report = controller.report();
 
     assertThat(report.get("status")).isEqualTo("UP");
-    Map<?, ?> components = Map.class.cast(report.get("components"));
-    Map<?, ?> indicatorBody = Map.class.cast(components.get("slaHealthIndicator"));
+    Map<String, ?> components = castToMap(report.get("components"));
+    Map<String, ?> indicatorBody = castToMap(components.get("slaHealthIndicator"));
     assertThat(indicatorBody.get("status")).isEqualTo("UP");
-    Map<?, ?> details = Map.class.cast(indicatorBody.get("details"));
+    Map<String, ?> details = castToMap(indicatorBody.get("details"));
     assertThat(details.get("sla_compliant")).isEqualTo(false);
     assertThat(details)
         .containsKeys(
@@ -54,6 +54,11 @@ class SlaReportControllerTest {
             "total_requests",
             "failed_requests",
             "error_budget_remaining");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, ?> castToMap(Object value) {
+    return (Map<String, ?>) value;
   }
 
   private static final class EmptyObjectProvider<T> implements ObjectProvider<T> {


### PR DESCRIPTION
## Summary
- add a helper to cast actuator report sections to typed maps in SlaReportControllerTest
- use the helper to retrieve nested maps so that AssertJ key assertions compile

## Testing
- mvn -pl shared-starters/starter-actuator test *(fails: Network is unreachable when downloading Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d53f077c50832fa057b2dfc4b06c52