### PR TITLE
Adjust SLA compliance threshold for indicator

### DIFF
--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/metrics/SlaMetricsCalculator.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/metrics/SlaMetricsCalculator.java
@@ -152,7 +152,7 @@ public class SlaMetricsCalculator {
     }
 
     public boolean isSlaMet() {
-      return sli >= slaTarget;
+      return sli >= Math.min(slaTarget, sloTarget);
     }
   }
 }


### PR DESCRIPTION
## Summary
- ensure SLA compliance checks use the less strict of the configured SLA and SLO thresholds so misordered values still report correctly

## Testing
- mvn -pl shared-starters/starter-actuator test *(fails: repository download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d542655b78832f8197815e9216203e