### PR TITLE
Reduce password minimum length to eight characters

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/dto/admin/ChangePasswordRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/admin/ChangePasswordRequest.java
@@ -14,7 +14,7 @@ public class ChangePasswordRequest {
     private String currentPassword;
 
     @NotBlank(message = "New password is required")
-    @Size(min = 12, message = "New password must be at least 12 characters")
+    @Size(min = 8, message = "New password must be at least 8 characters")
     @Pattern(
         regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
         message = "New password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"

--- a/sec-service/src/main/java/com/ejada/sec/dto/admin/CreateSuperadminRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/admin/CreateSuperadminRequest.java
@@ -16,7 +16,7 @@ public class CreateSuperadminRequest {
     private String email;
     
     @NotBlank(message = "Password is required")
-    @Size(min = 12, message = "Password must be at least 12 characters")
+    @Size(min = 8, message = "Password must be at least 8 characters")
     @Pattern(
         regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
         message = "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"

--- a/sec-service/src/main/java/com/ejada/sec/dto/admin/FirstLoginRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/admin/FirstLoginRequest.java
@@ -10,7 +10,7 @@ public class FirstLoginRequest {
     private String currentPassword;
     
     @NotBlank(message = "New password is required")
-    @Size(min = 12, message = "Password must be at least 12 characters")
+    @Size(min = 8, message = "Password must be at least 8 characters")
     @Pattern(
         regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
         message = "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
@@ -499,8 +499,8 @@ public class SuperadminServiceImpl implements SuperadminService {
     private void validatePasswordComplexity(String password) {
         List<String> errors = new ArrayList<>();
         
-        if (password == null || password.length() < 12) {
-            errors.add("Password must be at least 12 characters long");
+        if (password == null || password.length() < 8) {
+            errors.add("Password must be at least 8 characters long");
         }
         
         if (!Pattern.compile("[A-Z]").matcher(password).find()) {


### PR DESCRIPTION
## Summary
- lower the minimum password length to eight characters for first-login, superadmin creation, and password change requests
- align server-side password complexity validation with the new minimum length requirement

## Testing
- mvn test *(fails: Unable to resolve Spring Boot parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d546a5aa3c832f92989e8f54fe0bcb