### PR TITLE
Configure CSRF exception for auth endpoints in dev

### DIFF
--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -205,6 +205,8 @@ shared:
       permit-all:
         - "/sec/api/auth/**"
       disable-csrf: false
+      csrf-ignore:
+        - "/sec/api/auth/**"
     stateless: true
     roles-claim: roles
     tenant-claim: tenant


### PR DESCRIPTION
## Summary
- add the security service dev profile configuration to ignore CSRF validation for `/sec/api/auth/**` endpoints so login can succeed without a token

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d54878126c832fa0d31a4af50dad06