### PR TITLE
Fix CSRF ignore configuration for auth endpoints

### DIFF
--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -203,10 +203,10 @@ shared:
     resource-server:
       enabled: true
       permit-all:
-        - "/sec/api/auth/**"
+        - "/api/auth/**"
       disable-csrf: false
       csrf-ignore:
-        - "/sec/api/auth/**"
+        - "/api/auth/**"
     stateless: true
     roles-claim: roles
     tenant-claim: tenant

--- a/sec-service/src/main/resources/application-qa.yaml
+++ b/sec-service/src/main/resources/application-qa.yaml
@@ -203,7 +203,7 @@ shared:
       permit-all: ["/*"]
       disable-csrf: false
       csrf-ignore:
-        - "/sec/api/auth/**"
+        - "/api/auth/**"
       stateless: true
     roles-claim: roles
     tenant-claim: tenant


### PR DESCRIPTION
## Summary
- correct the CSRF ignore pattern so it matches the application context path
- ensure authentication endpoints remain accessible without CSRF tokens in dev and qa profiles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d8211aa0832f8748e11e732ece3b