### PR TITLE
Ensure CSRF token cookie is delivered across CORS

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
@@ -268,7 +268,8 @@ public class SecurityAutoConfiguration {
         HeaderNames.CORRELATION_ID,
         HeaderNames.X_TENANT_ID,
         HeaderNames.CSRF_TOKEN));
-    configuration.setAllowCredentials(false);
+    boolean csrfEnabled = !props.getResourceServer().isDisableCsrf();
+    configuration.setAllowCredentials(csrfEnabled);
     configuration.setMaxAge(3600L);
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/SecurityAutoConfigurationCorsTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/SecurityAutoConfigurationCorsTest.java
@@ -1,0 +1,35 @@
+package com.ejada.starter_security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.cors.CorsConfiguration;
+
+class SecurityAutoConfigurationCorsTest {
+
+    private final SecurityAutoConfiguration configuration = new SecurityAutoConfiguration();
+
+    @Test
+    void allowsCredentialsWhenCsrfEnabled() {
+        SharedSecurityProps props = new SharedSecurityProps();
+        props.getResourceServer().setDisableCsrf(false);
+
+        CorsConfiguration cors = configuration.corsConfigurationSource(props)
+            .getCorsConfiguration(new MockHttpServletRequest());
+
+        assertTrue(Boolean.TRUE.equals(cors.getAllowCredentials()));
+    }
+
+    @Test
+    void disallowsCredentialsWhenCsrfDisabled() {
+        SharedSecurityProps props = new SharedSecurityProps();
+        props.getResourceServer().setDisableCsrf(true);
+
+        CorsConfiguration cors = configuration.corsConfigurationSource(props)
+            .getCorsConfiguration(new MockHttpServletRequest());
+
+        assertFalse(Boolean.TRUE.equals(cors.getAllowCredentials()));
+    }
+}


### PR DESCRIPTION
## Summary
- allow CORS credentials whenever the CSRF protection is enabled so the XSRF cookie can be persisted
- add regression tests covering the allowCredentials toggle for CSRF-enabled and CSRF-disabled setups

## Testing
- mvn -pl shared-starters/starter-security test *(fails: dependency com.ejada:shared-common:jar:1.0.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e7730ab8832f8ef5f9cd95d59b81