### PR TITLE
Prevent duplicate correlation ID fields in log output

### DIFF
--- a/setup-service/src/test/resources/logback-test.xml
+++ b/setup-service/src/test/resources/logback-test.xml
@@ -9,7 +9,9 @@
         <pattern>
           <pattern>{"message":"%message","X-Correlation-Id":"%X{X-Correlation-Id}"}</pattern>
         </pattern>
-        <mdc/>
+        <mdc>
+          <excludeMdcKeyName>X-Correlation-Id</excludeMdcKeyName>
+        </mdc>
       </providers>
     </encoder>
   </appender>

--- a/shared-lib/shared-starters/starter-observability/src/main/resources/logback-spring.xml
+++ b/shared-lib/shared-starters/starter-observability/src/main/resources/logback-spring.xml
@@ -9,7 +9,9 @@
         <pattern>
           <pattern>{"message":"%message","X-Correlation-Id":"%X{X-Correlation-Id}"}</pattern>
         </pattern>
-        <mdc/>
+        <mdc>
+          <excludeMdcKeyName>X-Correlation-Id</excludeMdcKeyName>
+        </mdc>
       </providers>
     </encoder>
   </appender>

--- a/tenant-platform/billing-service/src/test/resources/logback-test.xml
+++ b/tenant-platform/billing-service/src/test/resources/logback-test.xml
@@ -9,7 +9,9 @@
         <pattern>
           <pattern>{"message":"%message","X-Correlation-Id":"%X{X-Correlation-Id}"}</pattern>
         </pattern>
-        <mdc/>
+        <mdc>
+          <excludeMdcKeyName>X-Correlation-Id</excludeMdcKeyName>
+        </mdc>
       </providers>
     </encoder>
   </appender>

--- a/tenant-platform/catalog-service/src/test/resources/logback-test.xml
+++ b/tenant-platform/catalog-service/src/test/resources/logback-test.xml
@@ -9,7 +9,9 @@
         <pattern>
           <pattern>{"message":"%message","X-Correlation-Id":"%X{X-Correlation-Id}"}</pattern>
         </pattern>
-        <mdc/>
+        <mdc>
+          <excludeMdcKeyName>X-Correlation-Id</excludeMdcKeyName>
+        </mdc>
       </providers>
     </encoder>
   </appender>

--- a/tenant-platform/subscription-service/src/test/resources/logback-test.xml
+++ b/tenant-platform/subscription-service/src/test/resources/logback-test.xml
@@ -9,7 +9,9 @@
         <pattern>
           <pattern>{"message":"%message","X-Correlation-Id":"%X{X-Correlation-Id}"}</pattern>
         </pattern>
-        <mdc/>
+        <mdc>
+          <excludeMdcKeyName>X-Correlation-Id</excludeMdcKeyName>
+        </mdc>
       </providers>
     </encoder>
   </appender>

--- a/tenant-platform/tenant-service/src/test/resources/logback-test.xml
+++ b/tenant-platform/tenant-service/src/test/resources/logback-test.xml
@@ -9,7 +9,9 @@
         <pattern>
           <pattern>{"message":"%message","X-Correlation-Id":"%X{X-Correlation-Id}"}</pattern>
         </pattern>
-        <mdc/>
+        <mdc>
+          <excludeMdcKeyName>X-Correlation-Id</excludeMdcKeyName>
+        </mdc>
       </providers>
     </encoder>
   </appender>


### PR DESCRIPTION
## Summary
- exclude the correlation ID MDC entry from the shared logback JSON encoder to avoid duplicate keys in log records
- apply the same exclusion to service-specific test logback configurations for consistent log output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ec0d0f68832f9ab276ab767fee4f