### PR TITLE
Fix superadmin admin endpoint mappings

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/controller/SuperadminController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/SuperadminController.java
@@ -65,13 +65,13 @@ public class SuperadminController {
     }
     
 
-    @PostMapping("admin/first-login")
+    @PostMapping("/admin/first-login")
     @PreAuthorize("hasRole('EJADA_OFFICER')")
     public ResponseEntity<BaseResponse<Void>> completeFirstLogin(@Valid @RequestBody FirstLoginRequest request) {
       return ResponseEntity.ok(superadminService.completeFirstLogin(request));
     }
 
-    @PostMapping("admin/change-password")
+    @PostMapping("/admin/change-password")
     @PreAuthorize("hasRole('EJADA_OFFICER')")
     public ResponseEntity<BaseResponse<Void>> changeSuperadminPassword(@Valid @RequestBody ChangePasswordRequest request) {
       return ResponseEntity.ok(superadminService.changePassword(request));


### PR DESCRIPTION
## Summary
- ensure the superadmin first-login and change-password routes include the leading slash so they map under `/api/superadmin/admins`

## Testing
- `mvn -q test` *(fails: missing shared-lib artifacts referenced by the POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f2978344832f828f121b499d57e4