### PR TITLE
Align superadmin temporary token TTL with configuration

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
@@ -282,7 +282,7 @@ public class SuperadminServiceImpl implements SuperadminService {
                 SuperadminAuthResponse.builder()
                     .accessToken(firstLoginToken)
                     .tokenType("Bearer")
-                    .expiresInSeconds(900) // 15 minutes
+                    .expiresInSeconds(superadminTokenTtl.getSeconds())
                     .role("EJADA_OFFICER")
                     .permissions(List.of("CHANGE_PASSWORD"))
                     .requiresPasswordChange(true)
@@ -299,7 +299,7 @@ public class SuperadminServiceImpl implements SuperadminService {
                 SuperadminAuthResponse.builder()
                     .accessToken(expiredPasswordToken)
                     .tokenType("Bearer")
-                    .expiresInSeconds(900)
+                    .expiresInSeconds(superadminTokenTtl.getSeconds())
                     .role("EJADA_OFFICER")
                     .permissions(List.of("CHANGE_PASSWORD"))
                     .passwordExpired(true)
@@ -568,7 +568,7 @@ public class SuperadminServiceImpl implements SuperadminService {
             null,
             List.of("EJADA_OFFICER"),
             claims,
-            Duration.ofMinutes(15));
+            superadminTokenTtl);
     }
 
     private String generateExpiredPasswordToken(Superadmin superadmin) {
@@ -586,7 +586,7 @@ public class SuperadminServiceImpl implements SuperadminService {
             null,
             List.of("EJADA_OFFICER"),
             claims,
-            Duration.ofMinutes(15));
+            superadminTokenTtl);
     }
     
     private String generateSuperadminToken(Superadmin superadmin) {

--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -198,6 +198,7 @@ shared:
     jwt:
       secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
       token-period: 15m
+      superadmin-ttl: PT24H
     hs256:
       secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
     resource-server:
@@ -211,6 +212,10 @@ shared:
     roles-claim: roles
     tenant-claim: tenant
     enable-role-check: true
+    superadmin:
+      password-expiry-days: 90
+      min-active-admins: 1
+      max-failed-attempts: 5
 
 logging:
   level:

--- a/sec-service/src/main/resources/application-qa.yaml
+++ b/sec-service/src/main/resources/application-qa.yaml
@@ -196,6 +196,7 @@ shared:
     jwt:
       secret: ${JWT_SECRET}
       token-period: 15m
+      superadmin-ttl: PT24H
     hs256:
       secret: ${JWT_SECRET}
     resource-server:
@@ -208,6 +209,10 @@ shared:
     roles-claim: roles
     tenant-claim: tenant
     enable-role-check: true
+    superadmin:
+      password-expiry-days: 90
+      min-active-admins: 1
+      max-failed-attempts: 5
 
 logging:
   level:

--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -38,6 +38,11 @@ shared:
     enable-role-check: true
     jwt:
       token-period: 15m
+      superadmin-ttl: PT24H
+    superadmin:
+      password-expiry-days: 90
+      min-active-admins: 1
+      max-failed-attempts: 5
 
 sec:
   superadmin:


### PR DESCRIPTION
## Summary
- use the configured superadmin token TTL for first-login and password-expired responses
- generate temporary superadmin tokens with the same configurable TTL instead of a fixed 15 minutes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8f2b45d38832f9999a269e009d172