### PR TITLE
Handle invalid auth requests with proper status

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
+++ b/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
@@ -18,4 +18,10 @@ public class AuthExceptionHandler {
         ErrorResponse body = ErrorResponse.of("ERR_AUTH", ex.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequest(IllegalArgumentException ex) {
+        ErrorResponse body = ErrorResponse.of("ERR_AUTH", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
 }


### PR DESCRIPTION
## Summary
- add dedicated handling for IllegalArgumentException in the auth exception advice
- return a 400 Bad Request error payload for invalid authentication inputs instead of propagating a 500

## Testing
- not run (missing shared starter dependencies in local Maven repo)

------
https://chatgpt.com/codex/tasks/task_e_68d8f8da1560832f9a688ff0ec30a13f