### PR TITLE
Gracefully handle password history lookup failures

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/exception/PasswordHistoryUnavailableException.java
+++ b/sec-service/src/main/java/com/ejada/sec/exception/PasswordHistoryUnavailableException.java
@@ -1,0 +1,16 @@
+package com.ejada.sec.exception;
+
+/**
+ * Indicates that the platform could not verify a superadmin's password reuse history.
+ *
+ * <p>This typically happens when the password history table has not been
+ * provisioned yet or the underlying data source is unavailable. The
+ * exception allows higher layers to surface a clear error message instead of
+ * returning a generic 500 error.
+ */
+public class PasswordHistoryUnavailableException extends RuntimeException {
+
+    public PasswordHistoryUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
+++ b/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.ejada.sec.handler;
 
 import com.ejada.common.dto.ErrorResponse;
+import com.ejada.sec.exception.PasswordHistoryUnavailableException;
 import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,5 +18,17 @@ public class AuthExceptionHandler {
     public ResponseEntity<ErrorResponse> handleAuthExceptions(RuntimeException ex) {
         ErrorResponse body = ErrorResponse.of("ERR_AUTH", ex.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequest(IllegalArgumentException ex) {
+        ErrorResponse body = ErrorResponse.of("ERR_AUTH", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(PasswordHistoryUnavailableException.class)
+    public ResponseEntity<ErrorResponse> handlePasswordHistoryUnavailable(PasswordHistoryUnavailableException ex) {
+        ErrorResponse body = ErrorResponse.of("ERR_AUTH_HISTORY", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
     }
 }


### PR DESCRIPTION
## Summary
- throw a dedicated PasswordHistoryUnavailableException when the password history repository cannot be queried
- translate the new exception into a 503 error with a structured ERR_AUTH_HISTORY payload so first-login callers see a helpful message

## Testing
- not run (shared starter dependencies are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8f8da1560832f9a688ff0ec30a13f