### PR TITLE
Handle validation exceptions consistently

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
+++ b/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.ejada.sec.handler;
 
 import com.ejada.common.dto.ErrorResponse;
+import com.ejada.common.exception.ValidationException;
 import java.util.NoSuchElementException;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -22,6 +24,17 @@ public class AuthExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleBadRequest(IllegalArgumentException ex) {
         ErrorResponse body = ErrorResponse.of("ERR_AUTH", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(ValidationException ex) {
+        List<String> details =
+            (ex.getDetails() == null || ex.getDetails().isBlank())
+                ? List.of()
+                : List.of(ex.getDetails());
+
+        ErrorResponse body = ErrorResponse.of(ex.getErrorCode(), ex.getMessage(), details);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
     }
 }


### PR DESCRIPTION
## Summary
- extend the security service exception handler to translate ValidationException instances into ErrorResponse payloads
- include the validation details in the response to surface tenant/UUID parsing issues without triggering 500 errors

## Testing
- mvn -q -pl . test *(fails: missing internal shared dependencies in the local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8fc0e1174832f998378de2490a578