### PR TITLE
Rename SLA metrics actuator endpoint to valid id

### DIFF
--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -60,7 +60,7 @@ management:
     web:
       base-path: /actuator
       exposure:
-        include: health,info,metrics,prometheus,beans,conditions,configprops,loggers,threaddump,sla-metrics
+        include: health,info,metrics,prometheus,beans,conditions,configprops,loggers,threaddump,slametrics
   endpoint:
     health:
       show-details: always

--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/endpoints/SlaMetricsEndpoint.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/endpoints/SlaMetricsEndpoint.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 
-@Endpoint(id = "sla-metrics")
+@Endpoint(id = "slametrics")
 public class SlaMetricsEndpoint {
 
   private final SlaMetricsCalculator calculator;


### PR DESCRIPTION
## Summary
- rename the SLA metrics actuator endpoint id to use only valid characters
- update the Sec service actuator exposure list to use the new endpoint id

## Testing
- mvn -pl shared-starters/starter-actuator test

------
https://chatgpt.com/codex/tasks/task_e_68d8ffa7cfe8832f9d4a79ab9ddc19d1