### PR TITLE
Add validation for first-login profile fields

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/dto/admin/FirstLoginRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/admin/FirstLoginRequest.java
@@ -21,7 +21,15 @@ public class FirstLoginRequest {
     private String confirmPassword;
     
     // Optional profile updates during first login
+    @Size(max = 100, message = "First name cannot exceed 100 characters")
     private String firstName;
+
+    @Size(max = 100, message = "Last name cannot exceed 100 characters")
     private String lastName;
+
+    @Pattern(
+        regexp = "^\\+?[0-9]{10,15}$",
+        message = "Phone number must be valid"
+    )
     private String phoneNumber;
 }


### PR DESCRIPTION
## Summary
- enforce maximum length for first and last name in the superadmin first-login request
- validate the optional phone number format so bad input is rejected before hitting the database

## Testing
- `mvn -pl . test` *(fails: requires internal com.ejada shared artifacts that are not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d900033644832fa09f28ad30498cb4