### PR TITLE
Preload Byte Buddy agent for Mockito inline tests

### DIFF
--- a/sec-service/pom.xml
+++ b/sec-service/pom.xml
@@ -24,6 +24,8 @@
         <!-- Import shared BOM version so we use the same versions of shared libraries as other services -->
         <ejada.shared.version>1.0.0</ejada.shared.version>
         <plugin.spotbugs.version>4.8.6.5</plugin.spotbugs.version>
+        <mockito.inline.version>5.2.0</mockito.inline.version>
+        <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
 
     </properties>
 
@@ -196,6 +198,13 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
+        </configuration>
       </plugin>
      <plugin>
     <groupId>org.apache.maven.plugins</groupId>

--- a/setup-service/pom.xml
+++ b/setup-service/pom.xml
@@ -21,6 +21,8 @@
     <!-- shared BOM version -->
     <ejada.shared.version>1.0.0</ejada.shared.version>
     <plugin.spotbugs.version>4.8.6.5</plugin.spotbugs.version>
+    <mockito.inline.version>5.2.0</mockito.inline.version>
+    <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
 
   </properties>
 
@@ -190,11 +192,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
+        </configuration>
+      </plugin>
      <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-checkstyle-plugin</artifactId>
-    <version>3.5.0</version>
-    <configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.5.0</version>
+        <configuration>
         <configLocation>../shared-lib/shared-quality/checkstyle.xml</configLocation>
         <suppressionsLocation>${project.basedir}/../shared-lib/shared-quality/suppressions.xml</suppressionsLocation>
         <consoleOutput>true</consoleOutput>

--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -49,6 +49,8 @@
     <jacoco.coverage.minimum>0.00</jacoco.coverage.minimum>
                 <!-- if any module uses Boot plugin -->
     <spring.boot.version>3.5.5</spring.boot.version>
+    <mockito.inline.version>5.2.0</mockito.inline.version>
+    <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
   </properties>
 
   <!-- Centralize dependency versions -->
@@ -139,7 +141,7 @@
           <configuration>
             <useModulePath>false</useModulePath>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>${argLine}</argLine>
+            <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
           </configuration>
         </plugin>
 
@@ -156,7 +158,7 @@
                   <include>**/*IT.java</include>
                   <include>**/*ITCase.java</include>
                 </includes>
-                <argLine>${argLine}</argLine>
+                <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
               </configuration>
             </execution>
           </executions>

--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -43,7 +43,8 @@
   <lombok.version>1.18.32</lombok.version>
   <lombokMapstruct.version>0.2.0</lombokMapstruct.version>
   <logstashLogback.version>8.0</logstashLogback.version>
-  <mockito.version>5.2.0</mockito.version>
+  <mockito.inline.version>5.2.0</mockito.inline.version>
+  <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
   <otel.instrumentation.version>2.7.0-alpha</otel.instrumentation.version>
   <spotbugs-annotations.version>4.7.3</spotbugs-annotations.version>
   <ehcache.version>3.10.8</ehcache.version>
@@ -128,10 +129,22 @@
         <version>${flyway.version}</version>
       </dependency>
      <dependency>
-     <groupId>org.mockito</groupId>
-     <artifactId>mockito-inline</artifactId>
-     <version>${mockito.version}</version>
-     <scope>test</scope>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>${mockito.inline.version}</version>
+        <scope>test</scope>
+      </dependency>
+     <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.inline.version}</version>
+        <scope>test</scope>
+     </dependency>
+     <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>${bytebuddy.agent.version}</version>
+        <scope>test</scope>
      </dependency>
      	
      <dependency>

--- a/shared-lib/shared-test-support/pom.xml
+++ b/shared-lib/shared-test-support/pom.xml
@@ -47,6 +47,16 @@
       <artifactId>kafka</artifactId>
     </dependency>
 
+    <!-- Mockito inline mock maker requires dedicated agent -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy-agent</artifactId>
+    </dependency>
+
     <!-- JJWT: versions come from jjwt-bom imported in shared-bom -->
      <dependency>
     <groupId>io.jsonwebtoken</groupId>

--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -35,6 +35,8 @@
     <plugin.spotless.version>2.43.0</plugin.spotless.version>
     <plugin.checkstyle.version>3.5.0</plugin.checkstyle.version>
     <plugin.spotbugs.version>4.8.6.5</plugin.spotbugs.version>
+    <mockito.inline.version>5.2.0</mockito.inline.version>
+    <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
   </properties>
 
   <dependencyManagement>
@@ -168,6 +170,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- add Byte Buddy agent properties and Surefire configuration to services so Mockito's inline mock maker is preloaded at JVM startup
- extend the shared BOM and test-support module with explicit Mockito inline/core and byte-buddy-agent dependencies for consistent version management

## Testing
- mvn -f setup-service/pom.xml test

------
https://chatgpt.com/codex/tasks/task_e_68d8fe664584832f8ca9b2a5399fcef3