### PR TITLE
Harden auth token lifecycle and cleanup

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/controller/AuthController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/AuthController.java
@@ -47,8 +47,7 @@ public class AuthController {
   }
 
   @PostMapping("/forgot-password")
-  public ResponseEntity<BaseResponse<String>> forgotPassword(@Valid @RequestBody ForgotPasswordRequest req) {
-    // Return token for demo; in production, send via email/SMS and return 204
+  public ResponseEntity<BaseResponse<Void>> forgotPassword(@Valid @RequestBody ForgotPasswordRequest req) {
     return ResponseEntity.ok(passwordResetService.createToken(req));
   }
 

--- a/sec-service/src/main/java/com/ejada/sec/repository/PasswordResetTokenRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/PasswordResetTokenRepository.java
@@ -2,6 +2,9 @@ package com.ejada.sec.repository;
 
 import com.ejada.sec.domain.PasswordResetToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -9,4 +12,11 @@ import java.util.Optional;
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
 
     Optional<PasswordResetToken> findByTokenAndUsedAtIsNullAndExpiresAtAfter(String token, Instant now);
+
+    @Modifying
+    @Query("update PasswordResetToken t set t.usedAt = :now, t.expiresAt = :now where t.user.id = :userId and t.usedAt is null and t.expiresAt > :now")
+    int invalidateActiveTokens(@Param("userId") Long userId, @Param("now") Instant now);
+
+    @Modifying
+    int deleteByUserId(Long userId);
 }

--- a/sec-service/src/main/java/com/ejada/sec/repository/RefreshTokenRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/RefreshTokenRepository.java
@@ -3,16 +3,25 @@ package com.ejada.sec.repository;
 import com.ejada.sec.domain.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByToken(String token);
 
     List<RefreshToken> findAllByUserId(Long userId);
+
+    @Query("select t from RefreshToken t where t.user.id = :userId and t.revokedAt is null and t.expiresAt > :cutoff order by t.issuedAt asc")
+    List<RefreshToken> findActiveTokensByUserId(@Param("userId") Long userId, @Param("cutoff") Instant cutoff);
+
+    @Query("select t from RefreshToken t where t.user.tenantId = :tenantId and t.revokedAt is null and t.expiresAt > :cutoff order by t.issuedAt asc")
+    List<RefreshToken> findActiveTokensByTenant(@Param("tenantId") UUID tenantId, @Param("cutoff") Instant cutoff);
 
     @Modifying
     int deleteByUserId(Long userId);

--- a/sec-service/src/main/java/com/ejada/sec/service/PasswordResetNotifier.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/PasswordResetNotifier.java
@@ -1,0 +1,11 @@
+package com.ejada.sec.service;
+
+import com.ejada.sec.domain.User;
+
+/**
+ * Abstraction for delivering password reset tokens to end users via
+ * email, SMS or any other out-of-band channel.
+ */
+public interface PasswordResetNotifier {
+  void notify(User user, String token);
+}

--- a/sec-service/src/main/java/com/ejada/sec/service/PasswordResetService.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/PasswordResetService.java
@@ -5,6 +5,6 @@ import com.ejada.sec.dto.ForgotPasswordRequest;
 import com.ejada.sec.dto.ResetPasswordRequest;
 
 public interface PasswordResetService {
-  BaseResponse<String> createToken(ForgotPasswordRequest req); // returns token to deliver via email/SMS
+  BaseResponse<Void> createToken(ForgotPasswordRequest req);
   BaseResponse<Void> reset(ResetPasswordRequest req);
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/RefreshTokenService.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/RefreshTokenService.java
@@ -3,8 +3,9 @@ package com.ejada.sec.service;
 import com.ejada.sec.domain.User;
 
 public interface RefreshTokenService {
-  String issue(Long userId);
+  String issue(Long userId, boolean revokeExistingSessions, String rotatedFrom);
   User validateAndGetUser(String refreshToken);
   void revoke(String refreshToken);
+  void revokeAllForUser(Long userId);
   int  revokeExpired();
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/AuthServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/AuthServiceImpl.java
@@ -14,13 +14,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.NoSuchElementException;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class AuthServiceImpl implements AuthService {
+
+  private static final String CODE_USER_CREATE_FAILED = "ERR-USER-CREATE";
+  private static final String CODE_AUTH_INVALID = "ERR-AUTH-INVALID";
+  private static final String CODE_AUTH_LOCKED = "ERR-AUTH-LOCKED";
 
   private final UserRepository userRepository;
   private final UserService userService;
@@ -31,7 +34,7 @@ public class AuthServiceImpl implements AuthService {
   @Override
   public BaseResponse<AuthResponse> register(RegisterRequest req) {
     log.info("Registering user '{}' for tenant {}", req.getUsername(), req.getTenantId());
-    var created = userService.create(
+    var creationResponse = userService.create(
         CreateUserRequest.builder()
             .tenantId(req.getTenantId())
             .username(req.getUsername())
@@ -39,8 +42,21 @@ public class AuthServiceImpl implements AuthService {
             .password(req.getPassword())
             .roles(req.getRoles())
             .build()
-    ).getData();
-    var tokens = issueTokens(created.getTenantId(), created.getUsername(), created.getId());
+    );
+
+    if (creationResponse == null || !creationResponse.isSuccess() || creationResponse.getData() == null) {
+      String code = creationResponse != null && creationResponse.getCode() != null
+          ? creationResponse.getCode()
+          : CODE_USER_CREATE_FAILED;
+      String message = creationResponse != null && creationResponse.getMessage() != null
+          ? creationResponse.getMessage()
+          : "Failed to create user";
+      log.warn("User registration failed for tenant {}: {}", req.getTenantId(), message);
+      return BaseResponse.error(code, message);
+    }
+
+    var created = creationResponse.getData();
+    var tokens = issueTokens(created.getTenantId(), created.getUsername(), created.getId(), true, null);
     log.info("User '{}' registered for tenant {}", created.getUsername(), created.getTenantId());
     return BaseResponse.success("User registered", tokens);
   }
@@ -51,19 +67,25 @@ public class AuthServiceImpl implements AuthService {
     UUID tenantId = req.getTenantId();
     log.info("User '{}' attempting login for tenant {}", req.getIdentifier(), tenantId);
     // identifier can be username or email
-    User user = userRepository.findByTenantIdAndUsername(tenantId, req.getIdentifier())
-        .or(() -> userRepository.findByTenantIdAndEmail(tenantId, req.getIdentifier()))
-        .orElseThrow(() -> new NoSuchElementException("Invalid credentials"));
+    var userOpt = userRepository.findByTenantIdAndUsername(tenantId, req.getIdentifier())
+        .or(() -> userRepository.findByTenantIdAndEmail(tenantId, req.getIdentifier()));
+
+    if (userOpt.isEmpty()) {
+      log.warn("Invalid credentials for identifier '{}' in tenant {}", req.getIdentifier(), tenantId);
+      return BaseResponse.error(CODE_AUTH_INVALID, "Invalid credentials");
+    }
+
+    User user = userOpt.get();
 
     if (!user.isEnabled() || user.isLocked()) {
       log.warn("Login denied for user '{}' in tenant {}: disabled or locked", user.getUsername(), tenantId);
-      throw new IllegalStateException("Account disabled or locked");
+      return BaseResponse.error(CODE_AUTH_LOCKED, "Account disabled or locked");
     }
     if (!PasswordHasher.matchesBcrypt(req.getPassword(), user.getPasswordHash())) {
       log.warn("Invalid credentials for user '{}' in tenant {}", req.getIdentifier(), tenantId);
-      throw new NoSuchElementException("Invalid credentials");
+      return BaseResponse.error(CODE_AUTH_INVALID, "Invalid credentials");
     }
-    var tokens = issueTokens(user.getTenantId(), user.getUsername(), user.getId());
+    var tokens = issueTokens(user.getTenantId(), user.getUsername(), user.getId(), true, null);
     log.info("User '{}' logged in for tenant {}", user.getUsername(), tenantId);
     return BaseResponse.success("Login successful", tokens);
   }
@@ -73,7 +95,8 @@ public class AuthServiceImpl implements AuthService {
   public BaseResponse<AuthResponse> refresh(RefreshTokenRequest req) {
     var user = refreshTokenService.validateAndGetUser(req.getRefreshToken());
     log.info("Refreshing token for user '{}' in tenant {}", user.getUsername(), user.getTenantId());
-    var tokens = issueTokens(user.getTenantId(), user.getUsername(), user.getId());
+    refreshTokenService.revoke(req.getRefreshToken());
+    var tokens = issueTokens(user.getTenantId(), user.getUsername(), user.getId(), false, req.getRefreshToken());
     return BaseResponse.success("Token refreshed", tokens);
   }
 
@@ -85,9 +108,9 @@ public class AuthServiceImpl implements AuthService {
     return BaseResponse.success("Logged out", null);
   }
 
-  private AuthResponse issueTokens(UUID tenantId, String username, Long userId) {
+  private AuthResponse issueTokens(UUID tenantId, String username, Long userId, boolean revokeExistingSessions, String rotatedFrom) {
     String access = tokenIssuer.issueAccessToken(tenantId, userId, username);
-    String refresh = refreshTokenService.issue(userId);
+    String refresh = refreshTokenService.issue(userId, revokeExistingSessions, rotatedFrom);
     return AuthResponse.builder()
         .accessToken(access)
         .refreshToken(refresh)

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/LoggingPasswordResetNotifier.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/LoggingPasswordResetNotifier.java
@@ -1,0 +1,21 @@
+package com.ejada.sec.service.impl;
+
+import com.ejada.sec.domain.User;
+import com.ejada.sec.service.PasswordResetNotifier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default notifier that simply logs token dispatching. Real deployments
+ * should replace this bean with one that integrates with email/SMS
+ * providers.
+ */
+@Component
+@Slf4j
+public class LoggingPasswordResetNotifier implements PasswordResetNotifier {
+
+  @Override
+  public void notify(User user, String token) {
+    log.info("Password reset token issued for user '{}' in tenant {}", user.getUsername(), user.getTenantId());
+  }
+}

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/PasswordResetServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/PasswordResetServiceImpl.java
@@ -8,9 +8,11 @@ import com.ejada.sec.dto.ForgotPasswordRequest;
 import com.ejada.sec.dto.ResetPasswordRequest;
 import com.ejada.sec.repository.PasswordResetTokenRepository;
 import com.ejada.sec.repository.UserRepository;
+import com.ejada.sec.service.PasswordResetNotifier;
 import com.ejada.sec.service.PasswordResetService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -20,31 +22,40 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PasswordResetServiceImpl implements PasswordResetService {
 
   private final UserRepository userRepository;
   private final PasswordResetTokenRepository tokenRepository;
+  private final PasswordResetNotifier passwordResetNotifier;
 
   @Value("${security.reset.ttl-seconds:900}") // 15 minutes
   private long resetTtl;
 
   @Transactional
   @Override
-  public BaseResponse<String> createToken(ForgotPasswordRequest req) {
+  public BaseResponse<Void> createToken(ForgotPasswordRequest req) {
     // locate user by username OR email within tenant
     UUID tenantId = req.getTenantId();
     User user = userRepository.findByTenantIdAndUsername(tenantId, req.getIdentifier())
         .or(() -> userRepository.findByTenantIdAndEmail(tenantId, req.getIdentifier()))
         .orElseThrow(() -> new NoSuchElementException("Account not found"));
 
+    Instant now = Instant.now();
+    int revoked = tokenRepository.invalidateActiveTokens(user.getId(), now);
+    if (revoked > 0) {
+      log.debug("Expired {} previous password reset tokens for user '{}'", revoked, user.getUsername());
+    }
+
     String token = UUID.randomUUID().toString();
     var prt = PasswordResetToken.builder()
         .user(user)
         .token(token)
-        .expiresAt(Instant.now().plusSeconds(resetTtl))
+        .expiresAt(now.plusSeconds(resetTtl))
         .build();
     tokenRepository.save(prt);
-    return BaseResponse.success("Reset token generated", token); // deliver via mail/SMS service externally
+    passwordResetNotifier.notify(user, token);
+    return BaseResponse.success("Reset token generated", null);
   }
 
   @Transactional

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/RefreshTokenServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/RefreshTokenServiceImpl.java
@@ -7,15 +7,19 @@ import com.ejada.sec.repository.UserRepository;
 import com.ejada.sec.service.RefreshTokenService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RefreshTokenServiceImpl implements RefreshTokenService {
 
   private final RefreshTokenRepository repo;
@@ -24,18 +28,40 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
   @Value("${security.refresh.ttl-seconds:2592000}") // 30 days
   private long ttlSeconds;
 
+  @Value("${security.refresh.max-active-per-user:5}")
+  private int maxActivePerUser;
+
+  @Value("${security.refresh.max-active-per-tenant:1000}")
+  private int maxActivePerTenant;
+
   @Transactional
   @Override
-  public String issue(Long userId) {
-    String token = UUID.randomUUID().toString();
+  public String issue(Long userId, boolean revokeExistingSessions, String rotatedFrom) {
     var now = Instant.now();
+    var user = userRepository.findById(userId)
+        .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+
+    if (revokeExistingSessions) {
+      var revoked = revokeTokens(repo.findActiveTokensByUserId(userId, now), now);
+      if (revoked > 0) {
+        log.debug("Revoked {} active refresh tokens for user {} prior to issuing a new session", revoked, userId);
+      }
+    }
+
+    enforceTenantLimit(user.getTenantId(), now);
+
+    String token = UUID.randomUUID().toString();
     var rt = RefreshToken.builder()
-        .user(userRepository.findById(userId).orElseThrow())
+        .user(user)
         .token(token)
         .issuedAt(now)
         .expiresAt(now.plusSeconds(ttlSeconds))
+        .rotatedFrom(rotatedFrom)
         .build();
     repo.save(rt);
+
+    enforceUserLimit(userId, now);
+
     return token;
   }
 
@@ -59,7 +85,57 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
 
   @Transactional
   @Override
+  public void revokeAllForUser(Long userId) {
+    var now = Instant.now();
+    var revoked = revokeTokens(repo.findActiveTokensByUserId(userId, now), now);
+    if (revoked > 0) {
+      log.debug("Revoked {} active refresh tokens for user {}", revoked, userId);
+    }
+  }
+
+  @Transactional
+  @Override
   public int revokeExpired() {
     return repo.deleteByExpiresAtBefore(Instant.now());
+  }
+
+  private void enforceUserLimit(Long userId, Instant now) {
+    List<RefreshToken> active = repo.findActiveTokensByUserId(userId, now);
+    if (maxActivePerUser <= 0) {
+      return;
+    }
+
+    if (active.size() <= maxActivePerUser) {
+      return;
+    }
+
+    active.sort(Comparator.comparing(RefreshToken::getIssuedAt).reversed());
+    revokeTokens(active.subList(maxActivePerUser, active.size()), now);
+  }
+
+  private void enforceTenantLimit(UUID tenantId, Instant now) {
+    if (maxActivePerTenant <= 0) {
+      return;
+    }
+    List<RefreshToken> active = repo.findActiveTokensByTenant(tenantId, now);
+    int capacity = Math.max(maxActivePerTenant - 1, 0);
+    int toCull = active.size() - capacity;
+    if (toCull <= 0) {
+      return;
+    }
+    active.sort(Comparator.comparing(RefreshToken::getIssuedAt));
+    revokeTokens(active.subList(0, toCull), now);
+  }
+
+  private int revokeTokens(List<RefreshToken> tokens, Instant when) {
+    int count = 0;
+    for (RefreshToken token : tokens) {
+      if (token.getRevokedAt() == null && token.getExpiresAt().isAfter(when)) {
+        token.setRevokedAt(when);
+        repo.save(token);
+        count++;
+      }
+    }
+    return count;
   }
 }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/security/TenantAuthorized.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/security/TenantAuthorized.java
@@ -11,6 +11,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@PreAuthorize("@roleChecker.hasRole(authentication, T(com.ejada.starter_security.Role).EJADA_OFFICER")
+@PreAuthorize("@roleChecker.hasRole(authentication, T(com.ejada.starter_security.Role).EJADA_OFFICER)")
 public @interface TenantAuthorized {
 }


### PR DESCRIPTION
## Summary
- fix the TenantAuthorized pre-authorization annotation syntax so tenant checks execute
- harden registration/login by propagating controlled BaseResponse errors and rotating refresh tokens
- enforce refresh-token limits, revoke dependent credentials on user disable/delete, and deliver password reset tokens via a notifier while expiring old tokens

## Testing
- mvn test *(fails: missing internal com.ejada starter dependency versions in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d904c54748832fa8cceebbef08e96d