### PR TITLE
Improve superadmin access error handling

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
+++ b/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
@@ -4,10 +4,11 @@ import com.ejada.common.dto.ErrorResponse;
 import com.ejada.common.exception.ValidationException;
 
 import com.ejada.sec.exception.PasswordHistoryUnavailableException;
-import java.util.NoSuchElementException;
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -19,6 +20,12 @@ public class AuthExceptionHandler {
 
     @ExceptionHandler({NoSuchElementException.class, IllegalStateException.class})
     public ResponseEntity<ErrorResponse> handleAuthExceptions(RuntimeException ex) {
+        ErrorResponse body = ErrorResponse.of("ERR_AUTH", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+
+    @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleMissingCredentials(AuthenticationCredentialsNotFoundException ex) {
         ErrorResponse body = ErrorResponse.of("ERR_AUTH", ex.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
     }

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
@@ -27,6 +27,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
@@ -454,23 +456,23 @@ public class SuperadminServiceImpl implements SuperadminService {
     private void validateSuperadminAccess() {
         var authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || authentication.getPrincipal() == null) {
-            throw new SecurityException("No authenticated user found");
+            throw new AuthenticationCredentialsNotFoundException("No authenticated user found");
         }
-        
+
         boolean isSuperadmin = authentication.getAuthorities().stream()
             .anyMatch(auth -> auth.getAuthority().equals("ROLE_EJADA_OFFICER"));
-        
+
         if (!isSuperadmin) {
-            throw new SecurityException("Access denied. Only superadmins can perform this action");
+            throw new AccessDeniedException("Access denied. Only superadmins can perform this action");
         }
     }
-    
+
     private Long getCurrentSuperadminId() {
         Long id = getCurrentSuperadminIdOrNull();
         if (id != null) {
             return id;
         }
-        throw new IllegalStateException("No authenticated superadmin found");
+        throw new AuthenticationCredentialsNotFoundException("No authenticated superadmin found");
     }
 
     private Long getCurrentSuperadminIdOrNull() {


### PR DESCRIPTION
## Summary
- throw `AuthenticationCredentialsNotFoundException` or `AccessDeniedException` when superadmin endpoints are invoked without proper credentials so Spring Security can translate them into 401/403 responses
- extend the local authentication exception handler to return a 401 response for missing credentials instead of bubbling up as a 500 error

## Testing
- `mvn -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68d905b40e68832fb5bd4b34dec297de