### PR TITLE
feat: harden lookup and tenant services

### DIFF
--- a/setup-service/src/main/java/com/ejada/setup/controller/LookupController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/LookupController.java
@@ -1,7 +1,9 @@
 package com.ejada.setup.controller;
 
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.setup.model.Lookup;
+import com.ejada.setup.dto.LookupCreateRequest;
+import com.ejada.setup.dto.LookupResponse;
+import com.ejada.setup.dto.LookupUpdateRequest;
 import com.ejada.setup.security.SetupAuthorized;
 import com.ejada.setup.service.LookupService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -51,7 +53,8 @@ public class LookupController {
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "409", description = "Lookup already exists")
     })
-    public ResponseEntity<BaseResponse<Lookup>> add(@Valid @RequestBody final Lookup body) {
+    public ResponseEntity<BaseResponse<LookupResponse>> add(
+            @Valid @RequestBody final LookupCreateRequest body) {
         return ResponseEntity.ok(lookupService.add(body));
     }
 
@@ -64,10 +67,10 @@ public class LookupController {
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "404", description = "Lookup not found")
     })
-    public ResponseEntity<BaseResponse<Lookup>> update(
+    public ResponseEntity<BaseResponse<LookupResponse>> update(
             @Parameter(description = "ID of the lookup to update", required = true)
             @PathVariable @Min(1) final Integer lookupItemId,
-            @Valid @RequestBody final Lookup body) {
+            @Valid @RequestBody final LookupUpdateRequest body) {
         return ResponseEntity.ok(lookupService.update(lookupItemId, body));
     }
 
@@ -78,7 +81,7 @@ public class LookupController {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<BaseResponse<List<Lookup>>> getAllLookups() {
+    public ResponseEntity<BaseResponse<List<LookupResponse>>> getAllLookups() {
         return ResponseEntity.ok(lookupService.getAllLookups());
     }
 
@@ -89,7 +92,7 @@ public class LookupController {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<BaseResponse<List<Lookup>>> getByGroup(
+    public ResponseEntity<BaseResponse<List<LookupResponse>>> getByGroup(
             @Parameter(description = "Group code of lookups to retrieve", required = true)
             @PathVariable @NotBlank final String groupCode) {
         return ResponseEntity.ok(lookupService.getByGroup(groupCode));
@@ -105,7 +108,7 @@ public class LookupController {
         @ApiResponse(responseCode = "200", description = "Lookups retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<BaseResponse<List<Lookup>>> getAll() {
+    public ResponseEntity<BaseResponse<List<LookupResponse>>> getAll() {
         return ResponseEntity.ok(lookupService.getAll());
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/dto/LookupCreateRequest.java
+++ b/setup-service/src/main/java/com/ejada/setup/dto/LookupCreateRequest.java
@@ -1,0 +1,47 @@
+package com.ejada.setup.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(name = "LookupCreateRequest")
+public record LookupCreateRequest(
+        @NotNull
+        @Schema(description = "Unique lookup identifier", example = "1001")
+        Integer lookupItemId,
+
+        @NotBlank
+        @Size(max = 64)
+        @Schema(description = "Lookup code", example = "COUNTRY")
+        String lookupItemCd,
+
+        @Size(max = 128)
+        @Schema(description = "Lookup English name", example = "Country")
+        String lookupItemEnNm,
+
+        @Size(max = 128)
+        @Schema(description = "Lookup Arabic name")
+        String lookupItemArNm,
+
+        @NotBlank
+        @Size(max = 64)
+        @Schema(description = "Lookup group code", example = "COUNTRY")
+        String lookupGroupCode,
+
+        @Size(max = 64)
+        @Schema(description = "Parent lookup id when hierarchical")
+        String parentLookupId,
+
+        @Schema(description = "Whether lookup is active", example = "true")
+        Boolean isActive,
+
+        @Size(max = 512)
+        @Schema(description = "English description")
+        String itemEnDescription,
+
+        @Size(max = 512)
+        @Schema(description = "Arabic description")
+        String itemArDescription
+) {
+}

--- a/setup-service/src/main/java/com/ejada/setup/dto/LookupResponse.java
+++ b/setup-service/src/main/java/com/ejada/setup/dto/LookupResponse.java
@@ -1,0 +1,17 @@
+package com.ejada.setup.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "LookupResponse")
+public record LookupResponse(
+        Integer lookupItemId,
+        String lookupItemCd,
+        String lookupItemEnNm,
+        String lookupItemArNm,
+        String lookupGroupCode,
+        String parentLookupId,
+        Boolean isActive,
+        String itemEnDescription,
+        String itemArDescription
+) {
+}

--- a/setup-service/src/main/java/com/ejada/setup/dto/LookupUpdateRequest.java
+++ b/setup-service/src/main/java/com/ejada/setup/dto/LookupUpdateRequest.java
@@ -1,0 +1,39 @@
+package com.ejada.setup.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+@Schema(name = "LookupUpdateRequest")
+public record LookupUpdateRequest(
+        @Size(max = 64)
+        @Schema(description = "Lookup code", example = "COUNTRY")
+        String lookupItemCd,
+
+        @Size(max = 128)
+        @Schema(description = "Lookup English name", example = "Country")
+        String lookupItemEnNm,
+
+        @Size(max = 128)
+        @Schema(description = "Lookup Arabic name")
+        String lookupItemArNm,
+
+        @Size(max = 64)
+        @Schema(description = "Lookup group code", example = "COUNTRY")
+        String lookupGroupCode,
+
+        @Size(max = 64)
+        @Schema(description = "Parent lookup id when hierarchical")
+        String parentLookupId,
+
+        @Schema(description = "Whether lookup is active", example = "true")
+        Boolean isActive,
+
+        @Size(max = 512)
+        @Schema(description = "English description")
+        String itemEnDescription,
+
+        @Size(max = 512)
+        @Schema(description = "Arabic description")
+        String itemArDescription
+) {
+}

--- a/setup-service/src/main/java/com/ejada/setup/service/LookupService.java
+++ b/setup-service/src/main/java/com/ejada/setup/service/LookupService.java
@@ -1,21 +1,23 @@
 package com.ejada.setup.service;
 
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.setup.model.Lookup;
+import com.ejada.setup.dto.LookupCreateRequest;
+import com.ejada.setup.dto.LookupResponse;
+import com.ejada.setup.dto.LookupUpdateRequest;
 
 import java.util.List;
 
 public interface LookupService {
 
-    BaseResponse<List<Lookup>> getAll();                 // full list
+    BaseResponse<List<LookupResponse>> getAll();
 
-    BaseResponse<List<Lookup>> getByGroup(String groupCode);
+    BaseResponse<List<LookupResponse>> getByGroup(String groupCode);
 
-    BaseResponse<Lookup> add(Lookup request);
+    BaseResponse<LookupResponse> add(LookupCreateRequest request);
 
-    BaseResponse<Lookup> update(Integer lookupItemId, Lookup request);
+    BaseResponse<LookupResponse> update(Integer lookupItemId, LookupUpdateRequest request);
 
-    default BaseResponse<List<Lookup>> getAllLookups() {
+    default BaseResponse<List<LookupResponse>> getAllLookups() {
         return getAll();
     }
 

--- a/setup-service/src/test/java/com/ejada/setup/service/LookupServiceImplTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/service/LookupServiceImplTest.java
@@ -1,25 +1,33 @@
 package com.ejada.setup.service;
 
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.setup.model.Lookup;
+import com.ejada.setup.dto.LookupCreateRequest;
+import com.ejada.setup.dto.LookupResponse;
 import com.ejada.setup.repository.LookupRepository;
 import com.ejada.setup.service.impl.LookupServiceImpl;
+import com.ejada.setup.model.Lookup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.cache.CacheManager;
 
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 class LookupServiceImplTest {
 
     @Mock
     private LookupRepository lookupRepository;
+
+    @Mock
+    private CacheManager cacheManager;
 
     @InjectMocks
     private LookupServiceImpl service;
@@ -31,8 +39,20 @@ class LookupServiceImplTest {
 
     @Test
     void getAllLookups_ok() {
-        when(lookupRepository.findAll()).thenReturn(Collections.singletonList(new Lookup()));
-        BaseResponse<List<Lookup>> resp = service.getAllLookups();
+        Lookup entity = Lookup.builder().lookupItemId(1).lookupItemCd("CODE").lookupGroupCode("GROUP").build();
+        when(lookupRepository.findAll()).thenReturn(Collections.singletonList(entity));
+        BaseResponse<List<LookupResponse>> resp = service.getAllLookups();
         assertNotNull(resp);
+        assertEquals(1, resp.getData().size());
+    }
+
+    @Test
+    void addLookup_convertsRequest() {
+        LookupCreateRequest req = new LookupCreateRequest(1, "CODE", null, null, "GROUP", null, Boolean.TRUE, null, null);
+        Lookup saved = Lookup.builder().lookupItemId(1).lookupItemCd("CODE").lookupGroupCode("GROUP").build();
+        when(lookupRepository.save(any(Lookup.class))).thenReturn(saved);
+        BaseResponse<LookupResponse> resp = service.add(req);
+        assertNotNull(resp.getData());
+        assertEquals("CODE", resp.getData().lookupItemCd());
     }
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImpl.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImpl.java
@@ -225,43 +225,127 @@ public class SubscriptionInboundServiceImpl implements SubscriptionInboundServic
 
     private void replaceFeatures(final Subscription sub, final List<SubscriptionFeatureDto> dtos) {
         var existing = featureRepo.findBySubscriptionSubscriptionId(sub.getSubscriptionId());
-        if (!existing.isEmpty()) {
-            featureRepo.deleteAllInBatch(existing);
-        }
-        if (dtos != null && !dtos.isEmpty()) {
-            var mapped = new ArrayList<SubscriptionFeature>(dtos.size());
-            for (var d : dtos) {
-                mapped.add(featureMapper.toEntity(d, sub));
+        if (dtos == null || dtos.isEmpty()) {
+            if (!existing.isEmpty()) {
+                featureRepo.deleteAll(existing);
             }
-            featureRepo.saveAll(mapped);
+            return;
+        }
+
+        var existingByCode = new java.util.HashMap<String, SubscriptionFeature>(existing.size());
+        for (SubscriptionFeature feature : existing) {
+            existingByCode.put(feature.getFeatureCd(), feature);
+        }
+
+        var toCreate = new ArrayList<SubscriptionFeature>();
+        var toUpdate = new ArrayList<SubscriptionFeature>();
+
+        for (SubscriptionFeatureDto dto : dtos) {
+            SubscriptionFeature entity = existingByCode.remove(dto.featureCd());
+            if (entity == null) {
+                toCreate.add(featureMapper.toEntity(dto, sub));
+            } else {
+                entity.setFeatureCount(dto.featureCount());
+                entity.setUpdatedAt(OffsetDateTime.now());
+                toUpdate.add(entity);
+            }
+        }
+
+        if (!existingByCode.isEmpty()) {
+            featureRepo.deleteAll(existingByCode.values());
+        }
+        if (!toUpdate.isEmpty()) {
+            featureRepo.saveAll(toUpdate);
+        }
+        if (!toCreate.isEmpty()) {
+            featureRepo.saveAll(toCreate);
         }
     }
 
     private void replaceAdditionalServices(final Subscription sub, final List<SubscriptionAdditionalServiceDto> dtos) {
         var existing = additionalServiceRepo.findBySubscriptionSubscriptionId(sub.getSubscriptionId());
-        if (!existing.isEmpty()) {
-            additionalServiceRepo.deleteAllInBatch(existing);
-        }
-        if (dtos != null && !dtos.isEmpty()) {
-            var mapped = new ArrayList<SubscriptionAdditionalService>(dtos.size());
-            for (var d : dtos) {
-                mapped.add(additionalServiceMapper.toEntity(d, sub));
+        if (dtos == null || dtos.isEmpty()) {
+            if (!existing.isEmpty()) {
+                additionalServiceRepo.deleteAll(existing);
             }
-            additionalServiceRepo.saveAll(mapped);
+            return;
+        }
+
+        var existingById = new java.util.HashMap<Long, SubscriptionAdditionalService>(existing.size());
+        for (SubscriptionAdditionalService svc : existing) {
+            existingById.put(svc.getProductAdditionalServiceId(), svc);
+        }
+
+        var toCreate = new ArrayList<SubscriptionAdditionalService>();
+        var toUpdate = new ArrayList<SubscriptionAdditionalService>();
+
+        for (SubscriptionAdditionalServiceDto dto : dtos) {
+            SubscriptionAdditionalService entity = existingById.remove(dto.productAdditionalServiceId());
+            if (entity == null) {
+                toCreate.add(additionalServiceMapper.toEntity(dto, sub));
+            } else {
+                entity.setServiceCd(dto.serviceCd());
+                entity.setServiceNameEn(dto.serviceNameEn());
+                entity.setServiceNameAr(dto.serviceNameAr());
+                entity.setServiceDescEn(dto.serviceDescEn());
+                entity.setServiceDescAr(dto.serviceDescAr());
+                entity.setServicePrice(dto.servicePrice());
+                entity.setTotalAmount(dto.totalAmount());
+                entity.setCurrency(dto.currency());
+                entity.setIsCountable(Boolean.TRUE.equals(dto.isCountable()));
+                entity.setRequestedCount(dto.requestedCount());
+                entity.setPaymentTypeCd(dto.paymentTypeCd());
+                entity.setUpdatedAt(OffsetDateTime.now());
+                toUpdate.add(entity);
+            }
+        }
+
+        if (!existingById.isEmpty()) {
+            additionalServiceRepo.deleteAll(existingById.values());
+        }
+        if (!toUpdate.isEmpty()) {
+            additionalServiceRepo.saveAll(toUpdate);
+        }
+        if (!toCreate.isEmpty()) {
+            additionalServiceRepo.saveAll(toCreate);
         }
     }
 
     private void replaceProductProperties(final Subscription sub, final List<ProductPropertyDto> dtos) {
         var existing = propertyRepo.findBySubscriptionSubscriptionId(sub.getSubscriptionId());
-        if (!existing.isEmpty()) {
-            propertyRepo.deleteAllInBatch(existing);
-        }
-        if (dtos != null && !dtos.isEmpty()) {
-            var mapped = new ArrayList<SubscriptionProductProperty>(dtos.size());
-            for (var d : dtos) {
-                mapped.add(propertyMapper.toEntity(d, sub));
+        if (dtos == null || dtos.isEmpty()) {
+            if (!existing.isEmpty()) {
+                propertyRepo.deleteAll(existing);
             }
-            propertyRepo.saveAll(mapped);
+            return;
+        }
+
+        var existingByCode = new java.util.HashMap<String, SubscriptionProductProperty>(existing.size());
+        for (SubscriptionProductProperty prop : existing) {
+            existingByCode.put(prop.getPropertyCd(), prop);
+        }
+
+        var toCreate = new ArrayList<SubscriptionProductProperty>();
+        var toUpdate = new ArrayList<SubscriptionProductProperty>();
+
+        for (ProductPropertyDto dto : dtos) {
+            SubscriptionProductProperty entity = existingByCode.remove(dto.propertyCd());
+            if (entity == null) {
+                toCreate.add(propertyMapper.toEntity(dto, sub));
+            } else {
+                entity.setPropertyValue(dto.propertyValue());
+                toUpdate.add(entity);
+            }
+        }
+
+        if (!existingByCode.isEmpty()) {
+            propertyRepo.deleteAll(existingByCode.values());
+        }
+        if (!toUpdate.isEmpty()) {
+            propertyRepo.saveAll(toUpdate);
+        }
+        if (!toCreate.isEmpty()) {
+            propertyRepo.saveAll(toCreate);
         }
     }
 

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyCreateReq.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyCreateReq.java
@@ -4,6 +4,7 @@ import static com.ejada.tenant.model.TenantIntegrationKey.KEY_ID_LENGTH;
 import static com.ejada.tenant.model.TenantIntegrationKey.LABEL_LENGTH;
 import static com.ejada.tenant.model.TenantIntegrationKey.PLAIN_SECRET_LENGTH;
 import static com.ejada.tenant.model.TenantIntegrationKey.SCOPE_LENGTH;
+import static com.ejada.tenant.model.TenantIntegrationKey.AUDIT_NAME_LENGTH;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
@@ -52,7 +53,11 @@ public record TenantIntegrationKeyCreateReq(
         Integer dailyQuota,
 
         @Schema(description = "Arbitrary JSON metadata (stringified if not using json type mapping)")
-        String meta
+        String meta,
+
+        @Size(max = AUDIT_NAME_LENGTH)
+        @Schema(description = "Actor that created the key", example = "system")
+        String createdBy
 ) {
     public TenantIntegrationKeyCreateReq {
         scopes = scopes == null ? List.of() : List.copyOf(scopes);

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyRes.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyRes.java
@@ -22,6 +22,9 @@ public record TenantIntegrationKeyRes(
         Boolean isDeleted,
         OffsetDateTime createdAt,
         OffsetDateTime updatedAt,
+        String createdBy,
+        OffsetDateTime secretLastRotatedAt,
+        String secretLastRotatedBy,
         @Schema(description = "Plain secret returned only on creation")
         String plainSecret
 ) {
@@ -37,6 +40,6 @@ public record TenantIntegrationKeyRes(
     public TenantIntegrationKeyRes withPlainSecret(final String secret) {
         return new TenantIntegrationKeyRes(tikId, tenantId, keyId, label, scopes, status,
                 validFrom, expiresAt, lastUsedAt, useCount, dailyQuota, meta, isDeleted,
-                createdAt, updatedAt, secret);
+                createdAt, updatedAt, createdBy, secretLastRotatedAt, secretLastRotatedBy, secret);
     }
 }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyUpdateReq.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantIntegrationKeyUpdateReq.java
@@ -2,6 +2,8 @@ package com.ejada.tenant.dto;
 
 import static com.ejada.tenant.model.TenantIntegrationKey.LABEL_LENGTH;
 import static com.ejada.tenant.model.TenantIntegrationKey.SCOPE_LENGTH;
+import static com.ejada.tenant.model.TenantIntegrationKey.AUDIT_NAME_LENGTH;
+import static com.ejada.tenant.model.TenantIntegrationKey.PLAIN_SECRET_LENGTH;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
@@ -35,7 +37,15 @@ public record TenantIntegrationKeyUpdateReq(
         Integer dailyQuota,
 
         @Schema(description = "Arbitrary JSON metadata")
-        String meta
+        String meta,
+
+        @Size(max = PLAIN_SECRET_LENGTH)
+        @Schema(description = "Provide to rotate the secret; hashed and never persisted in plaintext")
+        String newPlainSecret,
+
+        @Size(max = AUDIT_NAME_LENGTH)
+        @Schema(description = "Actor rotating the secret", example = "tenant-admin")
+        String rotatedBy
 ) {
     public TenantIntegrationKeyUpdateReq {
         scopes = scopes == null ? List.of() : List.copyOf(scopes);

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/exception/TenantConflictException.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/exception/TenantConflictException.java
@@ -1,0 +1,15 @@
+package com.ejada.tenant.exception;
+
+public class TenantConflictException extends RuntimeException {
+
+    private final TenantErrorCode errorCode;
+
+    public TenantConflictException(final TenantErrorCode errorCode, final String details) {
+        super(details == null ? errorCode.getDefaultMessage() : details);
+        this.errorCode = errorCode;
+    }
+
+    public TenantErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/exception/TenantErrorCode.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/exception/TenantErrorCode.java
@@ -1,0 +1,22 @@
+package com.ejada.tenant.exception;
+
+public enum TenantErrorCode {
+    CODE_EXISTS("TENANT_CODE_EXISTS", "Tenant code already exists"),
+    NAME_EXISTS("TENANT_NAME_EXISTS", "Tenant name already exists");
+
+    private final String code;
+    private final String defaultMessage;
+
+    TenantErrorCode(final String code, final String defaultMessage) {
+        this.code = code;
+        this.defaultMessage = defaultMessage;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/exception/TenantExceptionHandler.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/exception/TenantExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.ejada.tenant.exception;
+
+import com.ejada.common.dto.BaseResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.ejada.tenant.controller")
+public class TenantExceptionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TenantExceptionHandler.class);
+
+    @ExceptionHandler(TenantConflictException.class)
+    public ResponseEntity<BaseResponse<Void>> handleTenantConflict(final TenantConflictException ex) {
+        TenantErrorCode code = ex.getErrorCode();
+        LOGGER.debug("Tenant conflict detected: {}", ex.getMessage());
+        BaseResponse<Void> body = BaseResponse.error(code.getCode(), code.getDefaultMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
@@ -42,6 +42,9 @@ public interface TenantIntegrationKeyMapper {
     @Mapping(target = "dailyQuota", source = "dailyQuota")
     @Mapping(target = "meta", source = "meta")
     @Mapping(target = "isDeleted", constant = "false")
+    @Mapping(target = "createdBy", source = "createdBy")
+    @Mapping(target = "secretLastRotatedAt", ignore = true)
+    @Mapping(target = "secretLastRotatedBy", ignore = true)
     // DB-managed timestamps
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
@@ -74,6 +77,9 @@ public interface TenantIntegrationKeyMapper {
     @Mapping(target = "isDeleted", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "createdBy", ignore = true)
+    @Mapping(target = "secretLastRotatedAt", ignore = true)
+    @Mapping(target = "secretLastRotatedBy", ignore = true)
     @Mapping(target = "scopes", source = "scopes", qualifiedByName = "toArray")
     @Mapping(target = "status", source = "status", qualifiedByName = "toEntityStatus")
     void update(@MappingTarget @NonNull TenantIntegrationKey entity, @NonNull TenantIntegrationKeyUpdateReq req);
@@ -84,6 +90,9 @@ public interface TenantIntegrationKeyMapper {
     @Mapping(target = "scopes", source = "scopes", qualifiedByName = "toList")
     @Mapping(target = "status", source = "status", qualifiedByName = "toDtoStatus")
     @Mapping(target = "isDeleted", source = "isDeleted")
+    @Mapping(target = "createdBy", source = "createdBy")
+    @Mapping(target = "secretLastRotatedAt", source = "secretLastRotatedAt")
+    @Mapping(target = "secretLastRotatedBy", source = "secretLastRotatedBy")
     @Mapping(target = "plainSecret", expression = "java(null)")
     @Mapping(target = "withPlainSecret", ignore = true)
     TenantIntegrationKeyRes toRes(@NonNull TenantIntegrationKey entity);

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantIntegrationKey.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantIntegrationKey.java
@@ -49,6 +49,7 @@ public class TenantIntegrationKey {
     public static final int STATUS_LENGTH = 16;
     public static final int PLAIN_SECRET_LENGTH = 256;
     public static final int SCOPE_LENGTH = 64;
+    public static final int AUDIT_NAME_LENGTH = 128;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -117,6 +118,15 @@ public class TenantIntegrationKey {
 
     @Column(name = "updated_at", insertable = false)
     private java.time.OffsetDateTime updatedAt;
+
+    @Column(name = "created_by", length = AUDIT_NAME_LENGTH)
+    private String createdBy;
+
+    @Column(name = "secret_last_rotated_at")
+    private java.time.OffsetDateTime secretLastRotatedAt;
+
+    @Column(name = "secret_last_rotated_by", length = AUDIT_NAME_LENGTH)
+    private String secretLastRotatedBy;
 
     public final Tenant getTenant() {
         return tenant == null ? null : Tenant.ref(tenant.getId());

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantServiceImpl.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantServiceImpl.java
@@ -4,6 +4,8 @@ import com.ejada.common.dto.BaseResponse;
 import com.ejada.tenant.dto.TenantCreateReq;
 import com.ejada.tenant.dto.TenantRes;
 import com.ejada.tenant.dto.TenantUpdateReq;
+import com.ejada.tenant.exception.TenantConflictException;
+import com.ejada.tenant.exception.TenantErrorCode;
 import com.ejada.tenant.mapper.TenantMapper;
 import com.ejada.tenant.model.Tenant;
 import com.ejada.tenant.repository.TenantRepository;
@@ -31,10 +33,10 @@ public class TenantServiceImpl implements TenantService {
     @Override
     public BaseResponse<TenantRes> create(final TenantCreateReq req) {
         if (repo.existsByCodeAndIsDeletedFalse(req.code())) {
-            throw new IllegalStateException("tenant code exists: " + req.code());
+            throw new TenantConflictException(TenantErrorCode.CODE_EXISTS, "tenant code exists: " + req.code());
         }
         if (repo.existsByNameIgnoreCaseAndIsDeletedFalse(req.name())) {
-            throw new IllegalStateException("tenant name exists: " + req.name());
+            throw new TenantConflictException(TenantErrorCode.NAME_EXISTS, "tenant name exists: " + req.name());
         }
         Tenant e = mapper.toEntity(req);
         e = repo.save(e);
@@ -48,11 +50,11 @@ public class TenantServiceImpl implements TenantService {
 
         if (req.code() != null && !req.code().equals(e.getCode())
                 && repo.existsByCodeAndIdNot(req.code(), id)) {
-            throw new IllegalStateException("tenant code exists: " + req.code());
+            throw new TenantConflictException(TenantErrorCode.CODE_EXISTS, "tenant code exists: " + req.code());
         }
         if (req.name() != null && !req.name().equalsIgnoreCase(e.getName())
                 && repo.existsByNameIgnoreCaseAndIdNot(req.name(), id)) {
-            throw new IllegalStateException("tenant name exists: " + req.name());
+            throw new TenantConflictException(TenantErrorCode.NAME_EXISTS, "tenant name exists: " + req.name());
         }
 
         mapper.update(e, req);

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/TenantIntegrationKeyServiceImplTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/TenantIntegrationKeyServiceImplTest.java
@@ -41,7 +41,7 @@ class TenantIntegrationKeyServiceImplTest {
 
         TenantIntegrationKeyCreateReq req = new TenantIntegrationKeyCreateReq(
                 1, "KEY", null, "label", List.of(), TikStatus.ACTIVE,
-                null, OffsetDateTime.now().plusDays(1), null, null
+                null, OffsetDateTime.now().plusDays(1), null, null, null
         );
 
         TenantIntegrationKeyServiceImpl service =
@@ -54,6 +54,8 @@ class TenantIntegrationKeyServiceImplTest {
         ArgumentCaptor<TenantIntegrationKey> captor = ArgumentCaptor.forClass(TenantIntegrationKey.class);
         verify(repo).save(captor.capture());
         assertEquals("hashed-secret", captor.getValue().getKeySecret());
+        assertEquals("system", captor.getValue().getCreatedBy());
+        assertNotNull(captor.getValue().getSecretLastRotatedAt());
     }
 }
 


### PR DESCRIPTION
## Summary
- switch lookup endpoints to validated DTOs, map cached entities into stable responses, and evict cache entries by group instead of full-table clears
- add explicit tenant conflict exceptions and secret validation/rotation metadata for tenant integration keys
- replace subscription notification delete-all cycles with differential updates for features, additional services, and product properties

## Testing
- `mvn test` *(fails: missing internal dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68d904d081b8832fb5462381ef89aa49