### PR TITLE
Adjust sec-service tests for updated token APIs

### DIFF
--- a/sec-service/src/test/java/com/ejada/sec/service/impl/AuthServiceImplTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/service/impl/AuthServiceImplTest.java
@@ -58,7 +58,7 @@ class AuthServiceImplTest {
         .build();
 
     when(userService.create(any())).thenReturn(BaseResponse.success("created", dto));
-    when(refreshTokenService.issue(42L)).thenReturn("refresh-token");
+    when(refreshTokenService.issue(42L, false, null)).thenReturn("refresh-token");
     when(tokenIssuer.issueAccessToken(tenantId, 42L, "jane")).thenReturn("access-token");
     when(tokenIssuer.getAccessTokenTtlSeconds()).thenReturn(3600L);
 

--- a/sec-service/src/test/java/com/ejada/sec/service/impl/PasswordResetServiceImplTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/service/impl/PasswordResetServiceImplTest.java
@@ -3,6 +3,8 @@ package com.ejada.sec.service.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +15,7 @@ import com.ejada.sec.dto.ForgotPasswordRequest;
 import com.ejada.sec.dto.ResetPasswordRequest;
 import com.ejada.sec.repository.PasswordResetTokenRepository;
 import com.ejada.sec.repository.UserRepository;
+import com.ejada.sec.service.PasswordResetNotifier;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -29,12 +32,13 @@ class PasswordResetServiceImplTest {
 
   @Mock private UserRepository userRepository;
   @Mock private PasswordResetTokenRepository tokenRepository;
+  @Mock private PasswordResetNotifier passwordResetNotifier;
 
   private PasswordResetServiceImpl service;
 
   @BeforeEach
   void setUp() {
-    service = new PasswordResetServiceImpl(userRepository, tokenRepository);
+    service = new PasswordResetServiceImpl(userRepository, tokenRepository, passwordResetNotifier);
     ReflectionTestUtils.setField(service, "resetTtl", 300L);
   }
 
@@ -44,6 +48,7 @@ class PasswordResetServiceImplTest {
     User user = User.builder().id(7L).tenantId(tenantId).username("user").email("user@example.com").build();
     when(userRepository.findByTenantIdAndUsername(tenantId, "user"))
         .thenReturn(Optional.of(user));
+    when(tokenRepository.invalidateActiveTokens(eq(7L), any(Instant.class))).thenReturn(0);
     when(tokenRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
     ForgotPasswordRequest request = ForgotPasswordRequest.builder()
@@ -51,16 +56,24 @@ class PasswordResetServiceImplTest {
         .identifier("user")
         .build();
 
-    BaseResponse<String> response = service.createToken(request);
+    try (var mockedUuid = mockStatic(UUID.class)) {
+      mockedUuid.when(UUID::randomUUID).thenReturn(UUID.fromString("123e4567-e89b-12d3-a456-426614174001"));
 
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.getData()).isNotBlank();
+      BaseResponse<Void> response = service.createToken(request);
+
+      assertThat(response.isSuccess()).isTrue();
+      assertThat(response.getData()).isNull();
+    }
+
+    verify(tokenRepository).invalidateActiveTokens(eq(7L), any(Instant.class));
     verify(tokenRepository).deleteByUserId(7L);
     ArgumentCaptor<PasswordResetToken> captor = ArgumentCaptor.forClass(PasswordResetToken.class);
     verify(tokenRepository).save(captor.capture());
     PasswordResetToken saved = captor.getValue();
     assertThat(saved.getUser()).isEqualTo(user);
+    assertThat(saved.getToken()).isEqualTo("123e4567-e89b-12d3-a456-426614174001");
     assertThat(saved.getExpiresAt()).isAfter(Instant.now());
+    verify(passwordResetNotifier).notify(user, "123e4567-e89b-12d3-a456-426614174001");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- align `AuthServiceImplTest` with the new `RefreshTokenService.issue` signature
- update `PasswordResetServiceImplTest` for the notifier dependency and void response payload
- refresh `RefreshTokenServiceImplTest` to cover revocation behaviour and rotated token metadata

## Testing
- `mvn -q test` *(fails: missing internal com.ejada dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d90dfc88c8832f8aab5189b1585a88