### PR TITLE
Fix security service unit tests

### DIFF
--- a/sec-service/src/test/java/com/ejada/sec/service/impl/AuthServiceImplTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/service/impl/AuthServiceImplTest.java
@@ -111,8 +111,11 @@ class AuthServiceImplTest {
     when(userRepository.findByTenantIdAndUsername(tenantId, "locked-user"))
         .thenReturn(Optional.of(lockedUser));
 
-    assertThatThrownBy(() -> service.login(request))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Account disabled or locked");
+    BaseResponse<AuthResponse> response = service.login(request);
+
+    assertThat(response.isSuccess()).isFalse();
+    assertThat(response.getCode()).isEqualTo("ERR-AUTH-LOCKED");
+    assertThat(response.getMessage()).contains("Account disabled or locked");
+    assertThat(response.getData()).isNull();
   }
 }

--- a/sec-service/src/test/java/com/ejada/sec/service/impl/PasswordResetServiceImplTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/service/impl/PasswordResetServiceImplTest.java
@@ -56,8 +56,9 @@ class PasswordResetServiceImplTest {
         .identifier("user")
         .build();
 
+    UUID generated = UUID.fromString("123e4567-e89b-12d3-a456-426614174001");
     try (var mockedUuid = mockStatic(UUID.class)) {
-      mockedUuid.when(UUID::randomUUID).thenReturn(UUID.fromString("123e4567-e89b-12d3-a456-426614174001"));
+      mockedUuid.when(UUID::randomUUID).thenReturn(generated);
 
       BaseResponse<Void> response = service.createToken(request);
 

--- a/sec-service/src/test/java/com/ejada/sec/service/impl/RefreshTokenServiceImplTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/service/impl/RefreshTokenServiceImplTest.java
@@ -49,8 +49,9 @@ class RefreshTokenServiceImplTest {
     when(refreshTokenRepository.findActiveTokensByTenant(eq(tenantId), any())).thenReturn(java.util.Collections.emptyList());
     when(refreshTokenRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
+    UUID generated = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
     try (var mockedUuid = mockStatic(UUID.class)) {
-      mockedUuid.when(UUID::randomUUID).thenReturn(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+      mockedUuid.when(UUID::randomUUID).thenReturn(generated);
       String issued = service.issue(5L, true, "prev-token");
       assertThat(issued).isEqualTo("123e4567-e89b-12d3-a456-426614174000");
     }


### PR DESCRIPTION
## Summary
- update the login rejection test to assert the BaseResponse contract instead of expecting an exception
- precompute deterministic UUIDs before activating static mocking in refresh and password reset service tests to avoid unfinished stubbing

## Testing
- mvn test *(fails: missing internal dependencies com.ejada:shared-lib et al.)*

------
https://chatgpt.com/codex/tasks/task_e_68d90f7d6210832fba79ca76cded118a