### PR TITLE
Fix naming collision in tenant integration key update logic

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantIntegrationKeyServiceImpl.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantIntegrationKeyServiceImpl.java
@@ -112,8 +112,8 @@ public class TenantIntegrationKeyServiceImpl implements TenantIntegrationKeyServ
 
         // Validate window if either side is changing
         OffsetDateTime vf = req.validFrom() != null ? req.validFrom() : e.getValidFrom();
-        OffsetDateTime ex = req.expiresAt() != null ? req.expiresAt() : e.getExpiresAt();
-        if (vf != null && ex != null && !ex.isAfter(vf)) {
+        OffsetDateTime effectiveExpiresAt = req.expiresAt() != null ? req.expiresAt() : e.getExpiresAt();
+        if (vf != null && effectiveExpiresAt != null && !effectiveExpiresAt.isAfter(vf)) {
             throw new IllegalArgumentException("expiresAt must be after validFrom");
         }
 


### PR DESCRIPTION
## Summary
- rename the expires-at window variable in `TenantIntegrationKeyServiceImpl` to avoid clashing with exception variables during compilation

## Testing
- mvn -pl tenant-service -am compile *(fails: missing internal dependencies in tenant-platform/pom.xml)*

------
https://chatgpt.com/codex/tasks/task_e_68d91a2a7ad8832fbd558bfd43f9be51