### PR TITLE
Support snake_case payloads for superadmin password endpoints

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/dto/admin/ChangePasswordRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/admin/ChangePasswordRequest.java
@@ -1,5 +1,6 @@
 package com.ejada.sec.dto.admin;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.*;
 import lombok.*;
 
@@ -11,6 +12,7 @@ import lombok.*;
 public class ChangePasswordRequest {
 
     @NotBlank(message = "Current password is required")
+    @JsonAlias("current_password")
     private String currentPassword;
 
     @NotBlank(message = "New password is required")
@@ -19,8 +21,10 @@ public class ChangePasswordRequest {
         regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
         message = "New password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"
     )
+    @JsonAlias("new_password")
     private String newPassword;
 
     @NotBlank(message = "Confirm password is required")
+    @JsonAlias("confirm_password")
     private String confirmPassword;
 }

--- a/sec-service/src/main/java/com/ejada/sec/dto/admin/FirstLoginRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/admin/FirstLoginRequest.java
@@ -1,5 +1,6 @@
 package com.ejada.sec.dto.admin;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.*;
 import lombok.*;
 
@@ -7,6 +8,7 @@ import lombok.*;
 public class FirstLoginRequest {
     
     @NotBlank(message = "Current password is required")
+    @JsonAlias("current_password")
     private String currentPassword;
     
     @NotBlank(message = "New password is required")
@@ -15,21 +17,26 @@ public class FirstLoginRequest {
         regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
         message = "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"
     )
+    @JsonAlias("new_password")
     private String newPassword;
-    
+
     @NotBlank(message = "Password confirmation is required")
+    @JsonAlias("confirm_password")
     private String confirmPassword;
-    
+
     // Optional profile updates during first login
     @Size(max = 100, message = "First name cannot exceed 100 characters")
+    @JsonAlias("first_name")
     private String firstName;
 
     @Size(max = 100, message = "Last name cannot exceed 100 characters")
+    @JsonAlias("last_name")
     private String lastName;
 
     @Pattern(
         regexp = "^\\+?[0-9]{10,15}$",
         message = "Phone number must be valid"
     )
+    @JsonAlias("phone_number")
     private String phoneNumber;
 }

--- a/sec-service/src/test/java/com/ejada/sec/dto/admin/ChangePasswordRequestTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/dto/admin/ChangePasswordRequestTest.java
@@ -1,0 +1,28 @@
+package com.ejada.sec.dto.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class ChangePasswordRequestTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void deserializesSnakeCasePayload() throws Exception {
+        String json = """
+            {
+              "current_password": "Admin@123!",
+              "new_password": "DifferentPass123!",
+              "confirm_password": "DifferentPass123!"
+            }
+            """;
+
+        ChangePasswordRequest request = objectMapper.readValue(json, ChangePasswordRequest.class);
+
+        assertThat(request.getCurrentPassword()).isEqualTo("Admin@123!");
+        assertThat(request.getNewPassword()).isEqualTo("DifferentPass123!");
+        assertThat(request.getConfirmPassword()).isEqualTo("DifferentPass123!");
+    }
+}

--- a/sec-service/src/test/java/com/ejada/sec/dto/admin/FirstLoginRequestTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/dto/admin/FirstLoginRequestTest.java
@@ -1,0 +1,34 @@
+package com.ejada.sec.dto.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class FirstLoginRequestTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void deserializesSnakeCasePayload() throws Exception {
+        String json = """
+            {
+              "current_password": "Admin@123!",
+              "new_password": "StrongerPass123!",
+              "confirm_password": "StrongerPass123!",
+              "first_name": "Jane",
+              "last_name": "Doe",
+              "phone_number": "+15551234567"
+            }
+            """;
+
+        FirstLoginRequest request = objectMapper.readValue(json, FirstLoginRequest.class);
+
+        assertThat(request.getCurrentPassword()).isEqualTo("Admin@123!");
+        assertThat(request.getNewPassword()).isEqualTo("StrongerPass123!");
+        assertThat(request.getConfirmPassword()).isEqualTo("StrongerPass123!");
+        assertThat(request.getFirstName()).isEqualTo("Jane");
+        assertThat(request.getLastName()).isEqualTo("Doe");
+        assertThat(request.getPhoneNumber()).isEqualTo("+15551234567");
+    }
+}


### PR DESCRIPTION
## Summary
- allow first-login and password-change DTOs to accept snake_case field names alongside camelCase
- add unit tests proving that both payloads deserialize correctly from snake_case JSON

## Testing
- mvn test *(fails: missing versions for internal starter dependencies in sec-service/pom.xml)*

------
https://chatgpt.com/codex/tasks/task_e_68d925bf14e8832f988c666b722021b5