### PR TITLE
Allow camelCase aliases for first login request

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/dto/admin/FirstLoginRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/admin/FirstLoginRequest.java
@@ -8,7 +8,7 @@ import lombok.*;
 public class FirstLoginRequest {
     
     @NotBlank(message = "Current password is required")
-    @JsonAlias("current_password")
+    @JsonAlias({"current_password", "currentPassword"})
     private String currentPassword;
     
     @NotBlank(message = "New password is required")
@@ -17,26 +17,26 @@ public class FirstLoginRequest {
         regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
         message = "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"
     )
-    @JsonAlias("new_password")
+    @JsonAlias({"new_password", "newPassword"})
     private String newPassword;
 
     @NotBlank(message = "Password confirmation is required")
-    @JsonAlias("confirm_password")
+    @JsonAlias({"confirm_password", "confirmPassword"})
     private String confirmPassword;
 
     // Optional profile updates during first login
     @Size(max = 100, message = "First name cannot exceed 100 characters")
-    @JsonAlias("first_name")
+    @JsonAlias({"first_name", "firstName"})
     private String firstName;
 
     @Size(max = 100, message = "Last name cannot exceed 100 characters")
-    @JsonAlias("last_name")
+    @JsonAlias({"last_name", "lastName"})
     private String lastName;
 
     @Pattern(
         regexp = "^\\+?[0-9]{10,15}$",
         message = "Phone number must be valid"
     )
-    @JsonAlias("phone_number")
+    @JsonAlias({"phone_number", "phoneNumber"})
     private String phoneNumber;
 }

--- a/sec-service/src/test/java/com/ejada/sec/dto/admin/FirstLoginRequestTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/dto/admin/FirstLoginRequestTest.java
@@ -31,4 +31,27 @@ class FirstLoginRequestTest {
         assertThat(request.getLastName()).isEqualTo("Doe");
         assertThat(request.getPhoneNumber()).isEqualTo("+15551234567");
     }
+
+    @Test
+    void deserializesCamelCasePayload() throws Exception {
+        String json = """
+            {
+              "currentPassword": "Admin@123!",
+              "newPassword": "StrongerPass123!",
+              "confirmPassword": "StrongerPass123!",
+              "firstName": "Jane",
+              "lastName": "Doe",
+              "phoneNumber": "+15551234567"
+            }
+            """;
+
+        FirstLoginRequest request = objectMapper.readValue(json, FirstLoginRequest.class);
+
+        assertThat(request.getCurrentPassword()).isEqualTo("Admin@123!");
+        assertThat(request.getNewPassword()).isEqualTo("StrongerPass123!");
+        assertThat(request.getConfirmPassword()).isEqualTo("StrongerPass123!");
+        assertThat(request.getFirstName()).isEqualTo("Jane");
+        assertThat(request.getLastName()).isEqualTo("Doe");
+        assertThat(request.getPhoneNumber()).isEqualTo("+15551234567");
+    }
 }


### PR DESCRIPTION
## Summary
- add camelCase aliases to the first login request DTO so clients can submit either payload style
- cover camelCase deserialization with a unit test alongside the existing snake_case test

## Testing
- `mvn test -Dtest=FirstLoginRequestTest` *(fails: requires private Ejada dependencies that are not published to Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d932873568832fa0d6510571d28fd6