### PR TITLE
Handle first-login validation failures as client errors

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/dto/admin/FirstLoginRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/admin/FirstLoginRequest.java
@@ -8,7 +8,7 @@ import lombok.*;
 public class FirstLoginRequest {
     
     @NotBlank(message = "Current password is required")
-    @JsonAlias("current_password")
+    @JsonAlias({"current_password", "currentPassword"})
     private String currentPassword;
     
     @NotBlank(message = "New password is required")
@@ -17,26 +17,26 @@ public class FirstLoginRequest {
         regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
         message = "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"
     )
-    @JsonAlias("new_password")
+    @JsonAlias({"new_password", "newPassword"})
     private String newPassword;
 
     @NotBlank(message = "Password confirmation is required")
-    @JsonAlias("confirm_password")
+    @JsonAlias({"confirm_password", "confirmPassword"})
     private String confirmPassword;
 
     // Optional profile updates during first login
     @Size(max = 100, message = "First name cannot exceed 100 characters")
-    @JsonAlias("first_name")
+    @JsonAlias({"first_name", "firstName"})
     private String firstName;
 
     @Size(max = 100, message = "Last name cannot exceed 100 characters")
-    @JsonAlias("last_name")
+    @JsonAlias({"last_name", "lastName"})
     private String lastName;
 
     @Pattern(
         regexp = "^\\+?[0-9]{10,15}$",
         message = "Phone number must be valid"
     )
-    @JsonAlias("phone_number")
+    @JsonAlias({"phone_number", "phoneNumber"})
     private String phoneNumber;
 }

--- a/sec-service/src/test/java/com/ejada/sec/dto/admin/FirstLoginRequestTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/dto/admin/FirstLoginRequestTest.java
@@ -31,4 +31,27 @@ class FirstLoginRequestTest {
         assertThat(request.getLastName()).isEqualTo("Doe");
         assertThat(request.getPhoneNumber()).isEqualTo("+15551234567");
     }
+
+    @Test
+    void deserializesCamelCasePayload() throws Exception {
+        String json = """
+            {
+              "currentPassword": "Admin@123!",
+              "newPassword": "StrongerPass123!",
+              "confirmPassword": "StrongerPass123!",
+              "firstName": "Jane",
+              "lastName": "Doe",
+              "phoneNumber": "+15551234567"
+            }
+            """;
+
+        FirstLoginRequest request = objectMapper.readValue(json, FirstLoginRequest.class);
+
+        assertThat(request.getCurrentPassword()).isEqualTo("Admin@123!");
+        assertThat(request.getNewPassword()).isEqualTo("StrongerPass123!");
+        assertThat(request.getConfirmPassword()).isEqualTo("StrongerPass123!");
+        assertThat(request.getFirstName()).isEqualTo("Jane");
+        assertThat(request.getLastName()).isEqualTo("Doe");
+        assertThat(request.getPhoneNumber()).isEqualTo("+15551234567");
+    }
 }

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java
@@ -20,6 +20,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
  * Global exception handler producing {@link BaseResponse} payloads.
@@ -54,6 +55,20 @@ public class GlobalExceptionHandler {
         log.warn("Business logic violation: {}", ex.getMessage());
         return ResponseEntity.badRequest()
                 .body(BaseResponse.error("ERR_BUSINESS_LOGIC", ex.getMessage()));
+    }
+
+    @ExceptionHandler({IllegalArgumentException.class})
+    public ResponseEntity<BaseResponse<?>> handleIllegalArgument(IllegalArgumentException ex, WebRequest request) {
+        log.warn("Invalid argument: {}", ex.getMessage());
+        return ResponseEntity.badRequest()
+                .body(BaseResponse.error("ERR_INVALID_ARGUMENT", ex.getMessage()));
+    }
+
+    @ExceptionHandler({IllegalStateException.class})
+    public ResponseEntity<BaseResponse<?>> handleIllegalState(IllegalStateException ex, WebRequest request) {
+        log.warn("Illegal state: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(BaseResponse.error("ERR_ILLEGAL_STATE", ex.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -104,6 +119,13 @@ public class GlobalExceptionHandler {
         log.warn("Duplicate resource: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(BaseResponse.error(ex.getErrorCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<BaseResponse<?>> handleNoSuchElement(NoSuchElementException ex, WebRequest request) {
+        log.warn("Resource missing: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(BaseResponse.error("ERR_RESOURCE_NOT_FOUND", ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/GlobalExceptionHandlerTest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/web/GlobalExceptionHandlerTest.java
@@ -17,4 +17,25 @@ class GlobalExceptionHandlerTest {
         assertEquals("ERR_INTERNAL", resp.getBody().getCode());
     }
 
+    @Test
+    void handleIllegalArgumentReturnsBadRequest() {
+        ResponseEntity<BaseResponse<?>> resp = handler.handleIllegalArgument(new IllegalArgumentException("invalid"), null);
+        assertEquals(400, resp.getStatusCode().value());
+        assertEquals("ERR_INVALID_ARGUMENT", resp.getBody().getCode());
+    }
+
+    @Test
+    void handleIllegalStateReturnsConflict() {
+        ResponseEntity<BaseResponse<?>> resp = handler.handleIllegalState(new IllegalStateException("already done"), null);
+        assertEquals(409, resp.getStatusCode().value());
+        assertEquals("ERR_ILLEGAL_STATE", resp.getBody().getCode());
+    }
+
+    @Test
+    void handleNoSuchElementReturnsNotFound() {
+        ResponseEntity<BaseResponse<?>> resp = handler.handleNoSuchElement(new java.util.NoSuchElementException("missing"), null);
+        assertEquals(404, resp.getStatusCode().value());
+        assertEquals("ERR_RESOURCE_NOT_FOUND", resp.getBody().getCode());
+    }
+
 }


### PR DESCRIPTION
## Summary
- return structured `BaseResponse` payloads for `IllegalArgumentException`, `IllegalStateException`, and `NoSuchElementException`
- surface client-friendly HTTP statuses instead of bubbling runtime exceptions from first-login flows
- cover the new exception mapping paths with dedicated unit tests

## Testing
- `mvn test -Dtest=GlobalExceptionHandlerTest` *(fails: internal Ejada artifacts such as `shared-bom:1.0.0` are not available in Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d932873568832fa0d6510571d28fd6