### PR TITLE
Handle data access failures in auth handler

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
+++ b/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
@@ -9,6 +9,7 @@ import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -49,6 +50,14 @@ public class AuthExceptionHandler {
     @ExceptionHandler(PasswordHistoryUnavailableException.class)
     public ResponseEntity<ErrorResponse> handlePasswordHistoryUnavailable(PasswordHistoryUnavailableException ex) {
         ErrorResponse body = ErrorResponse.of("ERR_AUTH_HISTORY", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<ErrorResponse> handleDataAccess(DataAccessException ex) {
+        ErrorResponse body = ErrorResponse.of(
+            "ERR_AUTH_DATA_ACCESS",
+            "Authentication data is temporarily unavailable. Please try again later.");
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
     }
 

--- a/sec-service/src/test/java/com/ejada/sec/handler/AuthExceptionHandlerTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/handler/AuthExceptionHandlerTest.java
@@ -1,0 +1,24 @@
+package com.ejada.sec.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.common.dto.ErrorResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class AuthExceptionHandlerTest {
+
+  private final AuthExceptionHandler handler = new AuthExceptionHandler();
+
+  @Test
+  void handleDataAccessReturnsServiceUnavailable() {
+    ResponseEntity<ErrorResponse> response =
+        handler.handleDataAccess(new DataAccessResourceFailureException("db down"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getCode()).isEqualTo("ERR_AUTH_DATA_ACCESS");
+  }
+}


### PR DESCRIPTION
## Summary
- convert authentication-related DataAccessException failures into JSON 503 responses
- add unit coverage for the new handler behaviour

## Testing
- mvn -f sec-service/pom.xml test

------
https://chatgpt.com/codex/tasks/task_e_68d93c3a15f4832f9cc544745a831ea8