### PR TITLE
Fix handling of invalid superadmin password history hashes

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
@@ -711,7 +711,9 @@ public class SuperadminServiceImpl implements SuperadminService {
                     log.error("Invalid password hash detected for superadmin {} in history entry {}",
                         superadminId, entry.getId());
                     throw new PasswordHistoryUnavailableException(
-                        "Unable to verify password history at the moment. Please try again later or contact support.");
+                        "Unable to verify password history at the moment. Please try again later or contact support.",
+                        new IllegalStateException(
+                            "Invalid password hash format for history entry " + entry.getId()));
                 }
 
                 try {


### PR DESCRIPTION
## Summary
- ensure PasswordHistoryUnavailableException is constructed with both message and cause when rejecting malformed password history hashes

## Testing
- mvn -DskipTests compile *(fails: missing private dependencies from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d94c43ecb8832fad307101104c0b02