### PR TITLE
Enhance security service YAML configuration

### DIFF
--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -33,10 +33,10 @@ spring:
     default-schema: security
 
   kafka:
-    bootstrap-servers: kafka:9092
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
     client-id: ejada-security-dev
     consumer:
-      group-id: ejada-backend-dev
+      group-id: ${KAFKA_CONSUMER_GROUP:ejada-backend-dev}
       auto-offset-reset: earliest
       enable-auto-commit: false
       properties:
@@ -125,10 +125,20 @@ shared:
         enabled: true
         max-age: 31536000
         include-subdomains: true
+        preload: true
       frame-options: SAMEORIGIN
       content-type-options: nosniff
       referrer-policy: no-referrer
+      permissions-policy: "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
+      csp: "default-src 'self'; frame-ancestors 'self'; img-src 'self' data: blob:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:8085; form-action 'self'"
+      coop: same-origin
+      coep: require-corp
+      x-download-options: noopen
       xss-protection: "0"
+      exclude-paths:
+        - /sec/swagger-ui/**
+        - /sec/v3/api-docs/**
+        - /sec/actuator/**
     propagation:
       enabled: true
       include:
@@ -174,18 +184,18 @@ shared:
     description: "security service endpoints for tenant/platform configuration."
     version: "1.0.0"
     servers:
-      - http://localhost:8085/sec
+      - ${OPENAPI_SERVER_URL:http://localhost:8085/sec}
     group:
       name: security
       packages-to-scan:
         - com.ejada.security
     jwt-security: false
   redis:
-    host: redis
-    port: 6379
-    timeout: 2s
-    key-prefix: security
-    default-ttl: 600s
+    host: ${REDIS_HOST:redis}
+    port: ${REDIS_PORT:6379}
+    timeout: ${REDIS_TIMEOUT:2s}
+    key-prefix: ${REDIS_KEY_PREFIX:security}
+    default-ttl: ${REDIS_DEFAULT_TTL:600s}
     reactive: false
   crypto:
     algorithm: AES_GCM
@@ -205,9 +215,14 @@ shared:
       enabled: true
       permit-all:
         - "/api/auth/**"
+        - "/v3/api-docs/**"
+        - "/swagger-ui/**"
+        - "/actuator/health/**"
       disable-csrf: false
       csrf-ignore:
         - "/api/auth/**"
+        - "/v3/api-docs/**"
+        - "/swagger-ui/**"
     stateless: true
     roles-claim: roles
     tenant-claim: tenant

--- a/sec-service/src/main/resources/application-qa.yaml
+++ b/sec-service/src/main/resources/application-qa.yaml
@@ -27,10 +27,10 @@ spring:
     enabled: false
     baseline-on-migrate: true
   kafka:
-    bootstrap-servers: kafka:9092
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
     client-id: ejada-security-qa
     consumer:
-      group-id: ejada-backend-qa
+      group-id: ${KAFKA_CONSUMER_GROUP:ejada-backend-qa}
       auto-offset-reset: earliest
       enable-auto-commit: false
       properties:
@@ -55,7 +55,7 @@ management:
     web:
       base-path: /actuator
       exposure:
-        include: health,info,metrics,prometheus,beans,conditions,configprops,loggers,threaddump
+        include: health,info,metrics,prometheus,beans,conditions,configprops,loggers,threaddump,slametrics
   endpoint:
     health:
       show-details: always
@@ -121,10 +121,20 @@ shared:
         enabled: true
         max-age: 31536000
         include-subdomains: true
+        preload: true
       frame-options: SAMEORIGIN
       content-type-options: nosniff
       referrer-policy: no-referrer
+      permissions-policy: "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
+      csp: "default-src 'self'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'self'"
+      coop: same-origin
+      coep: require-corp
+      x-download-options: noopen
       xss-protection: "1; mode=block"
+      exclude-paths:
+        - /sec/swagger-ui/**
+        - /sec/v3/api-docs/**
+        - /sec/actuator/**
     propagation:
       enabled: true
       include:
@@ -171,7 +181,7 @@ shared:
     description: "security service endpoints for tenant/platform configuration."
     version: "1.0.0"
     servers:
-      - http://localhost:8080/core
+      - ${OPENAPI_SERVER_URL:http://localhost:8080/sec}
     group:
       name: security
       packages-to-scan:
@@ -179,11 +189,11 @@ shared:
 
     jwt-security: true
   redis:
-    host: redis
-    port: 6379
-    timeout: 2s
-    key-prefix: ejada
-    default-ttl: 600s
+    host: ${REDIS_HOST:redis}
+    port: ${REDIS_PORT:6379}
+    timeout: ${REDIS_TIMEOUT:2s}
+    key-prefix: ${REDIS_KEY_PREFIX:ejada}
+    default-ttl: ${REDIS_DEFAULT_TTL:600s}
     reactive: false
   crypto:
     algorithm: AES_GCM
@@ -201,10 +211,16 @@ shared:
       secret: ${JWT_SECRET}
     resource-server:
       enabled: true
-      permit-all: ["/*"]
+      permit-all:
+        - "/api/auth/**"
+        - "/v3/api-docs/**"
+        - "/swagger-ui/**"
+        - "/actuator/health/**"
       disable-csrf: false
       csrf-ignore:
         - "/api/auth/**"
+        - "/v3/api-docs/**"
+        - "/swagger-ui/**"
       stateless: true
     roles-claim: roles
     tenant-claim: tenant

--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -34,6 +34,17 @@ shared:
       enabled: true
       sla-compliant: true
       availability-percent: 99.95
+  headers:
+    security:
+      permissions-policy: "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
+      csp: "default-src 'self'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'self'"
+      coop: same-origin
+      coep: require-corp
+      x-download-options: noopen
+      exclude-paths:
+        - /actuator/**
+        - /v3/api-docs/**
+        - /swagger-ui/**
   security:
     enable-role-check: true
     jwt:


### PR DESCRIPTION
## Summary
- add stricter security header defaults in the security service base configuration
- extend the dev and QA profiles with configurable Kafka/Redis endpoints and refined CSP/permissions settings
- align actuator exposure and resource server allowlists for documentation and health endpoints

## Testing
- No automated tests were run (configuration-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d953b62b1c832fa34ffb88cd89341d