### PR TITLE
Align services with shared parent and update lookup tests

### DIFF
--- a/sec-service/pom.xml
+++ b/sec-service/pom.xml
@@ -6,10 +6,10 @@
 
     <!-- Parent pom for Spring Boot applications -->
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.5</version>
-        <relativePath/>
+        <groupId>com.ejada</groupId>
+        <artifactId>shared-lib</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../shared-lib/pom.xml</relativePath>
     </parent>
 
     <!-- Project coordinates -->
@@ -21,26 +21,7 @@
     <!-- Java language level -->
     <properties>
         <java.version>21</java.version>
-        <!-- Import shared BOM version so we use the same versions of shared libraries as other services -->
-        <ejada.shared.version>1.0.0</ejada.shared.version>
-        <plugin.spotbugs.version>4.8.6.5</plugin.spotbugs.version>
-        <mockito.inline.version>5.2.0</mockito.inline.version>
-        <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
-
     </properties>
-
-  <!-- Import shared  to pin internal starter & shared-lib versions -->
-   <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.ejada</groupId>
-        <artifactId>shared-lib</artifactId>
-        <version>${ejada.shared.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
 <dependency>
@@ -148,178 +129,46 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.5.0</version>
-          <executions>
-            <execution>
-              <id>enforce</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <dependencyConvergence/>
-                  <requireJavaVersion>
-                    <version>[21,)</version>
-                  </requireJavaVersion>
-                </rules>
-                <fail>true</fail>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.12</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.43.0</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <java>
-            <googleJavaFormat/>
-            <removeUnusedImports/>
-            <importOrder/>
-          </java>
+          <release>${java.version}</release>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok-mapstruct-binding</artifactId>
+              <version>${lombokMapstruct.version}</version>
+            </path>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
+              <version>${mapstruct.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amapstruct.defaultComponentModel=spring</arg>
+            <arg>-Amapstruct.unmappedTargetPolicy=IGNORE</arg>
+          </compilerArgs>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
         <executions>
           <execution>
             <goals>
-              <goal>apply</goal>
+              <goal>repackage</goal>
             </goals>
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
-        </configuration>
-      </plugin>
-     <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-checkstyle-plugin</artifactId>
-    <version>3.5.0</version>
-    <configuration>
-        <configLocation>../shared-lib/shared-quality/checkstyle.xml</configLocation>
-        <suppressionsLocation>${project.basedir}/../shared-lib/shared-quality/suppressions.xml</suppressionsLocation>
-        <consoleOutput>true</consoleOutput>
-        <failOnViolation>false</failOnViolation>
-    </configuration>
-    <executions>
-        <execution>
-            <phase>verify</phase>
-            <goals>
-                <goal>check</goal>
-            </goals>
-        </execution>
-    </executions>
-</plugin>
-  <plugin>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>${plugin.spotbugs.version}</version>
-            <configuration>
-              <effort>Max</effort>
-              <threshold>Low</threshold>
-              <xmlOutput>true</xmlOutput>
-              <htmlOutput>true</htmlOutput>
-              <outputDirectory>${project.build.directory}/spotbugs</outputDirectory>
-              <excludeFilterFile>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/spotbugs-exclude.xml</excludeFilterFile>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>com.h3xstream.findsecbugs</groupId>
-                <artifactId>findsecbugs-plugin</artifactId>
-                <version>1.12.0</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-compiler-plugin</artifactId>
-      <configuration>
-        <release>${java.version}</release>
-      </configuration>
-      <executions>
-        <execution>
-          <id>compile</id>
-          <goals><goal>compile</goal></goals>
-          <configuration>
-            <annotationProcessorPaths>
-              <path>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>${lombok.version}</version>
-              </path>
-              <path>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok-mapstruct-binding</artifactId>
-                <version>${lombok.mapstruct.binding.version}</version>
-              </path>
-              <path>
-                <groupId>org.mapstruct</groupId>
-                <artifactId>mapstruct-processor</artifactId>
-                <version>${mapstruct.version}</version>
-              </path>
-            </annotationProcessorPaths>
-            <compilerArgs>
-              <arg>-Amapstruct.defaultComponentModel=spring</arg>
-              <arg>-Amapstruct.unmappedTargetPolicy=IGNORE</arg>
-            </compilerArgs>
-          </configuration>
-        </execution>
-
-        <execution>
-          <id>test-compile</id>
-          <goals><goal>testCompile</goal></goals>
-          <configuration>
-            <annotationProcessorPaths>
-              <path>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>${lombok.version}</version>
-              </path>
-              <path>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok-mapstruct-binding</artifactId>
-                <version>${lombok.mapstruct.binding.version}</version>
-              </path>
-              <path>
-                <groupId>org.mapstruct</groupId>
-                <artifactId>mapstruct-processor</artifactId>
-                <version>${mapstruct.version}</version>
-              </path>
-            </annotationProcessorPaths>
-            <compilerArgs>
-              <arg>-Amapstruct.defaultComponentModel=spring</arg>
-              <arg>-Amapstruct.unmappedTargetPolicy=IGNORE</arg>
-            </compilerArgs>
-          </configuration>
-        </execution>
-      </executions>
-    </plugin>
-    <plugin>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-maven-plugin</artifactId>
-      <executions>
-        <execution>
-          <goals>
-            <goal>repackage</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-  </plugins> 
-</build>
+    </plugins>
+  </build>
 </project>

--- a/setup-service/pom.xml
+++ b/setup-service/pom.xml
@@ -3,11 +3,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent> 
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.5</version>
-    <relativePath/>
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>shared-lib</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../shared-lib/pom.xml</relativePath>
   </parent>
 
   <groupId>com.ejada</groupId>
@@ -17,27 +17,7 @@
 
   <properties>
     <java.version>21</java.version>
-
-    <!-- shared BOM version -->
-    <ejada.shared.version>1.0.0</ejada.shared.version>
-    <plugin.spotbugs.version>4.8.6.5</plugin.spotbugs.version>
-    <mockito.inline.version>5.2.0</mockito.inline.version>
-    <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
-
   </properties>
-
-  <!-- Import shared  to pin internal starter & shared-lib versions -->
-   <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.ejada</groupId>
-        <artifactId>shared-lib</artifactId>
-        <version>${ejada.shared.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
 <dependency>
@@ -146,178 +126,46 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.5.0</version>
-          <executions>
-            <execution>
-              <id>enforce</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <dependencyConvergence/>
-                  <requireJavaVersion>
-                    <version>[21,)</version>
-                  </requireJavaVersion>
-                </rules>
-                <fail>true</fail>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.12</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.43.0</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <java>
-            <googleJavaFormat/>
-            <removeUnusedImports/>
-            <importOrder/>
-          </java>
+          <release>${java.version}</release>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok-mapstruct-binding</artifactId>
+              <version>${lombokMapstruct.version}</version>
+            </path>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
+              <version>${mapstruct.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amapstruct.defaultComponentModel=spring</arg>
+            <arg>-Amapstruct.unmappedTargetPolicy=IGNORE</arg>
+          </compilerArgs>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
         <executions>
           <execution>
             <goals>
-              <goal>apply</goal>
+              <goal>repackage</goal>
             </goals>
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
-        </configuration>
-      </plugin>
-     <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.5.0</version>
-        <configuration>
-        <configLocation>../shared-lib/shared-quality/checkstyle.xml</configLocation>
-        <suppressionsLocation>${project.basedir}/../shared-lib/shared-quality/suppressions.xml</suppressionsLocation>
-        <consoleOutput>true</consoleOutput>
-        <failOnViolation>false</failOnViolation>
-    </configuration>
-    <executions>
-        <execution>
-            <phase>verify</phase>
-            <goals>
-                <goal>check</goal>
-            </goals>
-        </execution>
-    </executions>
-</plugin>
-  <plugin>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>${plugin.spotbugs.version}</version>
-            <configuration>
-              <effort>Max</effort>
-              <threshold>Low</threshold>
-              <xmlOutput>true</xmlOutput>
-              <htmlOutput>true</htmlOutput>
-              <outputDirectory>${project.build.directory}/spotbugs</outputDirectory>
-              <excludeFilterFile>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/spotbugs-exclude.xml</excludeFilterFile>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>com.h3xstream.findsecbugs</groupId>
-                <artifactId>findsecbugs-plugin</artifactId>
-                <version>1.12.0</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-compiler-plugin</artifactId>
-      <configuration>
-        <release>${java.version}</release>
-      </configuration>
-      <executions>
-        <execution>
-          <id>compile</id>
-          <goals><goal>compile</goal></goals>
-          <configuration>
-            <annotationProcessorPaths>
-              <path>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>${lombok.version}</version>
-              </path>
-              <path>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok-mapstruct-binding</artifactId>
-                <version>${lombok.mapstruct.binding.version}</version>
-              </path>
-              <path>
-                <groupId>org.mapstruct</groupId>
-                <artifactId>mapstruct-processor</artifactId>
-                <version>${mapstruct.version}</version>
-              </path>
-            </annotationProcessorPaths>
-            <compilerArgs>
-              <arg>-Amapstruct.defaultComponentModel=spring</arg>
-              <arg>-Amapstruct.unmappedTargetPolicy=IGNORE</arg>
-            </compilerArgs>
-          </configuration>
-        </execution>
-
-        <execution>
-          <id>test-compile</id>
-          <goals><goal>testCompile</goal></goals>
-          <configuration>
-            <annotationProcessorPaths>
-              <path>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>${lombok.version}</version>
-              </path>
-              <path>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok-mapstruct-binding</artifactId>
-                <version>${lombok.mapstruct.binding.version}</version>
-              </path>
-              <path>
-                <groupId>org.mapstruct</groupId>
-                <artifactId>mapstruct-processor</artifactId>
-                <version>${mapstruct.version}</version>
-              </path>
-            </annotationProcessorPaths>
-            <compilerArgs>
-              <arg>-Amapstruct.defaultComponentModel=spring</arg>
-              <arg>-Amapstruct.unmappedTargetPolicy=IGNORE</arg>
-            </compilerArgs>
-          </configuration>
-        </execution>
-      </executions>
-    </plugin>
-    <plugin>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-maven-plugin</artifactId>
-      <executions>
-        <execution>
-          <goals>
-            <goal>repackage</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-  </plugins>
-</build>
+    </plugins>
+  </build>
 </project>

--- a/setup-service/src/test/java/com/ejada/setup/controller/LookupControllerTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/controller/LookupControllerTest.java
@@ -1,7 +1,7 @@
 package com.ejada.setup.controller;
 
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.setup.model.Lookup;
+import com.ejada.setup.dto.LookupResponse;
 import com.ejada.setup.service.LookupService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +36,7 @@ class LookupControllerTest {
 
   @Test
   void getAllLookups_ok() throws Exception {
-    BaseResponse<List<Lookup>> resp = BaseResponse.success("ok", List.of());
+    BaseResponse<List<LookupResponse>> resp = BaseResponse.success("ok", List.of());
     when(lookupService.getAllLookups()).thenReturn(resp);
 
     mockMvc.perform(get("/setup/lookups").accept(MediaType.APPLICATION_JSON))

--- a/setup-service/src/test/java/com/ejada/setup/service/impl/LookupServiceImplTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/service/impl/LookupServiceImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.setup.dto.LookupResponse;
 import com.ejada.setup.model.Lookup;
 import com.ejada.setup.repository.LookupRepository;
 import java.util.List;
@@ -58,7 +59,7 @@ class LookupServiceImplTest {
   void getAllReturnsErrorWhenRepositoryFails() {
     when(lookupRepository.findAll()).thenThrow(new IllegalStateException("boom"));
 
-    BaseResponse<List<Lookup>> response = service.getAll();
+    BaseResponse<List<LookupResponse>> response = service.getAll();
 
     assertThat(response.isSuccess()).isFalse();
     assertThat(response.getCode()).isEqualTo("ERR_LOOKUP_ALL");
@@ -79,13 +80,13 @@ class LookupServiceImplTest {
         .when(lookupRepository)
         .findByLookupGroupCodeAndIsActiveTrueOrderByLookupItemEnNmAsc("ERR");
 
-    BaseResponse<List<Lookup>> error = service.getByGroup("ERR");
+    BaseResponse<List<LookupResponse>> error = service.getByGroup("ERR");
     assertThat(error.isSuccess()).isFalse();
     assertThat(error.getCode()).isEqualTo("ERR_LOOKUP_GROUP");
   }
 
   @Configuration
-  @EnableCaching
+  @EnableCaching(proxyTargetClass = true)
   static class TestConfig {
     @Bean
     LookupRepository lookupRepository() {
@@ -93,8 +94,8 @@ class LookupServiceImplTest {
     }
 
     @Bean
-    LookupServiceImpl lookupServiceImpl(LookupRepository repository) {
-      return new LookupServiceImpl(repository);
+    LookupServiceImpl lookupServiceImpl(LookupRepository repository, CacheManager cacheManager) {
+      return new LookupServiceImpl(repository, cacheManager);
     }
 
     @Bean

--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -4,10 +4,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.5</version>
-    <relativePath/>
+    <groupId>com.ejada</groupId>
+    <artifactId>shared-lib</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../shared-lib/pom.xml</relativePath>
   </parent>
 
   <groupId>com.ejada</groupId>
@@ -26,30 +26,7 @@
 
   <properties>
     <java.version>21</java.version>
-    <maven.min.version>3.9.6</maven.min.version>
-
-    <ejada.shared.version>1.0.0</ejada.shared.version>
-
-    <plugin.enforcer.version>3.5.0</plugin.enforcer.version>
-    <plugin.jacoco.version>0.8.12</plugin.jacoco.version>
-    <plugin.spotless.version>2.43.0</plugin.spotless.version>
-    <plugin.checkstyle.version>3.5.0</plugin.checkstyle.version>
-    <plugin.spotbugs.version>4.8.6.5</plugin.spotbugs.version>
-    <mockito.inline.version>5.2.0</mockito.inline.version>
-    <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.ejada</groupId>
-        <artifactId>shared-lib</artifactId>
-        <version>${ejada.shared.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -71,137 +48,16 @@
       <artifactId>starter-observability</artifactId>
     </dependency> 
   </dependencies>
-
   <build>
-    <pluginManagement>
-      <plugins>
-        <!-- Enforcer -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>${plugin.enforcer.version}</version>
-          <executions>
-            <execution>
-              <id>enforce</id>
-              <goals><goal>enforce</goal></goals>
-              <configuration>
-                <fail>true</fail>
-                <rules>
-                  <requireMavenVersion>
-                    <version>[${maven.min.version},)</version>
-                  </requireMavenVersion>
-                  <requireJavaVersion>
-                    <version>[${java.version},)</version>
-                  </requireJavaVersion>
-                  <dependencyConvergence/>
-                </rules>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${java.version}</release>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>${plugin.jacoco.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>com.diffplug.spotless</groupId>
-          <artifactId>spotless-maven-plugin</artifactId>
-          <version>${plugin.spotless.version}</version>
-        </plugin>
-
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>${plugin.checkstyle.version}</version>
-            <configuration>
-             <configLocation>
-          ${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/checkstyle.xml
-        </configLocation>
-        <suppressionsLocation>
-          ${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/suppressions.xml
-        </suppressionsLocation>
-              <consoleOutput>true</consoleOutput>
-              <failOnViolation>false</failOnViolation>
-            </configuration>
-          </plugin>
-
-          <plugin>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>${plugin.spotbugs.version}</version>
-            <configuration>
-              <effort>Max</effort>
-              <threshold>Low</threshold>
-              <xmlOutput>true</xmlOutput>
-              <htmlOutput>true</htmlOutput>
-              <outputDirectory>${project.build.directory}/spotbugs</outputDirectory>
-              <excludeFilterFile>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/spotbugs-exclude.xml</excludeFilterFile>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>com.h3xstream.findsecbugs</groupId>
-                <artifactId>findsecbugs-plugin</artifactId>
-                <version>1.12.0</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-
-        <plugin>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-maven-plugin</artifactId>
-        </plugin>
-        <plugin>
-  <groupId>org.apache.maven.plugins</groupId>
-  <artifactId>maven-compiler-plugin</artifactId>
-  <version>3.13.0</version>
-  <configuration>
-    <source>21</source>
-    <target>21</target>
-    <parameters>true</parameters>
-  </configuration>
-</plugin>
-      </plugins>
-    </pluginManagement>
-
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-checkstyle-plugin</artifactId>
-          <executions>
-            <execution>
-              <phase>verify</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>com.github.spotbugs</groupId>
-          <artifactId>spotbugs-maven-plugin</artifactId>
-          <executions>
-            <execution>
-              <phase>verify</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </build>
 </project>


### PR DESCRIPTION
## Summary
- use the shared-lib parent POM for sec-service, setup-service, and the tenant-platform aggregator so they inherit common dependency management
- trim local plugin management in favour of shared-lib defaults while preserving required compiler configuration
- adjust setup-service lookup tests to work with the shared DTO responses and caching proxy configuration

## Testing
- mvn -DskipTests install (in shared-lib)
- mvn test (in sec-service)
- mvn test (in setup-service)

------
https://chatgpt.com/codex/tasks/task_e_68d95d316684832f84d0973275a8275e