### PR TITLE
Define Spotless plugin version in shared parent POM

### DIFF
--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -44,6 +44,7 @@
     <plugin.site.version>3.12.1</plugin.site.version>
     <plugin.checkstyle.version>3.5.0</plugin.checkstyle.version>
     <plugin.spotbugs.version>4.8.6.5</plugin.spotbugs.version>
+    <plugin.spotless.version>2.44.0</plugin.spotless.version>
     <plugin.pmd.version>3.25.0</plugin.pmd.version>
     <findsecbugs.version>1.13.0</findsecbugs.version>
     <jacoco.coverage.minimum>0.00</jacoco.coverage.minimum>
@@ -260,6 +261,12 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${spring.boot.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${plugin.spotless.version}</version>
         </plugin>
         
         <!-- SonarQube integration -->


### PR DESCRIPTION
## Summary
- declare a dedicated property for the Spotless Maven plugin version in the shared parent POM
- manage the Spotless Maven plugin version via pluginManagement so module builds satisfy the enforcer rule

## Testing
- mvn -pl catalog-service -am validate *(fails: repository-private dependencies are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da5055a73c832f8e6b95367aba692c