### PR TITLE
Fix unit tests and services for API signature changes

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/service/impl/PrivilegeServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/PrivilegeServiceImpl.java
@@ -67,9 +67,9 @@ public class PrivilegeServiceImpl implements PrivilegeService {
               if (tenantId != null) {
                 redisTemplate.delete(privListKey(tenantId));
               }
-              return BaseResponse.success("Privilege deleted", null);
+              return BaseResponse.<Void>success("Privilege deleted", null);
             })
-        .orElseGet(() -> BaseResponse.success("Privilege deleted", null));
+        .orElseGet(() -> BaseResponse.<Void>success("Privilege deleted", null));
   }
 
   @Override

--- a/setup-service/src/main/java/com/ejada/setup/service/impl/CityServiceImpl.java
+++ b/setup-service/src/main/java/com/ejada/setup/service/impl/CityServiceImpl.java
@@ -24,7 +24,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/tenant-platform/billing-service/src/test/java/com/ejada/billing/service/impl/ConsumptionServiceImplTest.java
+++ b/tenant-platform/billing-service/src/test/java/com/ejada/billing/service/impl/ConsumptionServiceImplTest.java
@@ -33,6 +33,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 @ExtendWith(MockitoExtension.class)
 class ConsumptionServiceImplTest {
@@ -53,7 +57,8 @@ class ConsumptionServiceImplTest {
         counterMapper,
         responseMapper,
         eventMapper,
-        new ObjectMapper());
+        new ObjectMapper(),
+        new NoOpTransactionManager());
   }
 
   @Test
@@ -136,6 +141,23 @@ class ConsumptionServiceImplTest {
       return sb.toString();
     } catch (Exception e) {
       throw new AssertionError("Hash failure", e);
+    }
+  }
+
+  private static final class NoOpTransactionManager implements PlatformTransactionManager {
+    @Override
+    public TransactionStatus getTransaction(TransactionDefinition definition) {
+      return new SimpleTransactionStatus();
+    }
+
+    @Override
+    public void commit(TransactionStatus status) {
+      // no-op
+    }
+
+    @Override
+    public void rollback(TransactionStatus status) {
+      // no-op
     }
   }
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/exception/ServiceResultException.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/exception/ServiceResultException.java
@@ -14,12 +14,12 @@ public class ServiceResultException extends RuntimeException {
     private final transient ServiceResult<?> result;
 
     public ServiceResultException(final ServiceResult<?> result) {
-        super(result != null ? result.statusDesc() : null);
+        super(result != null ? result.statusDescription() : null);
         this.result = result;
     }
 
     public ServiceResultException(final ServiceResult<?> result, final Throwable cause) {
-        super(result != null ? result.statusDesc() : null, cause);
+        super(result != null ? result.statusDescription() : null, cause);
         this.result = result;
     }
 

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/impl/TenantIntegrationKeyServiceImplTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/impl/TenantIntegrationKeyServiceImplTest.java
@@ -47,7 +47,8 @@ class TenantIntegrationKeyServiceImplTest {
     existing.setExpiresAt(OffsetDateTime.now().plusDays(2));
     when(repository.findByTikIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(existing));
 
-    TenantIntegrationKeyUpdateReq req = new TenantIntegrationKeyUpdateReq(null, null, OffsetDateTime.now());
+    TenantIntegrationKeyUpdateReq req =
+        new TenantIntegrationKeyUpdateReq(null, null, null, null, OffsetDateTime.now(), null, null, null, null);
 
     assertThatThrownBy(() -> service.update(1L, req))
         .isInstanceOf(IllegalArgumentException.class)
@@ -79,10 +80,14 @@ class TenantIntegrationKeyServiceImplTest {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         null);
     when(mapper.toRes(any(TenantIntegrationKey.class))).thenReturn(mapped);
 
-    BaseResponse<TenantIntegrationKeyRes> response = service.update(2L, new TenantIntegrationKeyUpdateReq(null, null, null));
+    BaseResponse<TenantIntegrationKeyRes> response =
+        service.update(2L, new TenantIntegrationKeyUpdateReq(null, null, null, null, null, null, null, null, null));
 
     assertThat(response.isSuccess()).isTrue();
     assertThat(response.getData().status()).isEqualTo(TikStatus.EXPIRED);
@@ -92,7 +97,8 @@ class TenantIntegrationKeyServiceImplTest {
   void updateThrowsWhenKeyMissing() {
     when(repository.findByTikIdAndIsDeletedFalse(55L)).thenReturn(Optional.empty());
 
-    TenantIntegrationKeyUpdateReq req = new TenantIntegrationKeyUpdateReq(null, null, null);
+    TenantIntegrationKeyUpdateReq req =
+        new TenantIntegrationKeyUpdateReq(null, null, null, null, null, null, null, null, null);
 
     assertThatThrownBy(() -> service.update(55L, req))
         .isInstanceOf(EntityNotFoundException.class);

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/impl/TenantServiceImplTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/impl/TenantServiceImplTest.java
@@ -57,7 +57,7 @@ class TenantServiceImplTest {
   @Test
   void updateRejectsDuplicateCodeForDifferentTenant() {
     Tenant existing = new Tenant();
-    existing.setTenantId(5);
+    existing.setId(5);
     existing.setCode("OLD");
     when(repository.findByIdAndIsDeletedFalse(5)).thenReturn(Optional.of(existing));
     when(repository.existsByCodeAndIdNot("NEW", 5)).thenReturn(true);
@@ -72,7 +72,7 @@ class TenantServiceImplTest {
   @Test
   void updateRejectsDuplicateNameForDifferentTenant() {
     Tenant existing = new Tenant();
-    existing.setTenantId(7);
+    existing.setId(7);
     existing.setName("Current");
     when(repository.findByIdAndIsDeletedFalse(7)).thenReturn(Optional.of(existing));
     when(repository.existsByNameIgnoreCaseAndIdNot("NewName", 7)).thenReturn(true);
@@ -87,7 +87,7 @@ class TenantServiceImplTest {
   @Test
   void updateReturnsSuccessWhenNoConflicts() {
     Tenant existing = new Tenant();
-    existing.setTenantId(11);
+    existing.setId(11);
     existing.setCode("CODE");
     existing.setName("Name");
     when(repository.findByIdAndIsDeletedFalse(11)).thenReturn(Optional.of(existing));


### PR DESCRIPTION
## Summary
- ensure subscription inbound audit records remain effectively final and adjust exception messaging
- update billing and subscription unit tests to provide a no-op transaction manager and assert against the new ServiceResult shape
- align tenant-related tests with the expanded DTO constructors, fix privilege delete generics, and drop an unused import

## Testing
- mvn -pl subscription-service,billing-service,tenant-service test -DskipITs *(fails: missing internal shared-bom and dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68da53fe6ecc832f8c13c28c39aba038