### PR TITLE
Fix failsafe classpath for integration tests

### DIFF
--- a/setup-service/pom.xml
+++ b/setup-service/pom.xml
@@ -164,6 +164,16 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <useModulePath>false</useModulePath>
+          <additionalClasspathElements>
+            <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
+          </additionalClasspathElements>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
## Summary
- add a module-local failsafe plugin configuration so integration tests run against the compiled classes rather than the repackaged jar
- disable the module path during failsafe executions to match the surefire setup

## Testing
- `mvn -DskipITs verify`


------
https://chatgpt.com/codex/tasks/task_e_68da5a4c5c9c832f9bd3441ee2209b2c