### PR TITLE
Fix CountryRepositoryIT to set required Arabic name

### DIFF
--- a/setup-service/src/test/java/com/ejada/setup/repository/CountryRepositoryIT.java
+++ b/setup-service/src/test/java/com/ejada/setup/repository/CountryRepositoryIT.java
@@ -21,6 +21,7 @@ class CountryRepositoryIT extends IntegrationTestSupport {
         Country country = new Country();
         country.setCountryCd("US");
         country.setCountryEnNm("United States");
+        country.setCountryArNm("الولايات المتحدة");
         country.setIsActive(true);
 
         Country saved = repository.save(country);


### PR DESCRIPTION
## Summary
- set the mandatory Arabic country name in `CountryRepositoryIT` so the entity satisfies validation before persisting

## Testing
- mvn verify

------
https://chatgpt.com/codex/tasks/task_e_68da5fefd748832fb5c7e745f6ab3c8f