### PR TITLE
Ensure integration tests use Flyway schema

### DIFF
--- a/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/IntegrationTestSupport.java
+++ b/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/IntegrationTestSupport.java
@@ -34,6 +34,13 @@ public abstract class IntegrationTestSupport {
         registry.add("spring.datasource.password", POSTGRES::getPassword);
         registry.add("spring.data.redis.host", REDIS::getHost);
         registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+        registry.add("spring.jpa.properties.hibernate.default_schema", () -> "setup");
+        registry.add("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces", () -> "true");
+        registry.add("spring.jpa.properties.hibernate.format_sql", () -> "true");
+        registry.add("spring.flyway.enabled", () -> true);
+        registry.add("spring.flyway.schemas", () -> "public,setup");
+        registry.add("spring.flyway.default-schema", () -> "setup");
+        registry.add("spring.flyway.locations", () -> "classpath:db/migration/common,classpath:db/migration/{vendor}");
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the shared integration test support configures the Postgres container datasource with the setup schema
- enable Flyway migrations and schema defaults so ITs create the expected tables when running against Testcontainers

## Testing
- mvn -f setup-service/pom.xml -DskipTests -Dit.test=CountryRepositoryIT failsafe:integration-test failsafe:verify *(fails: missing internal parent BOM artifacts in public Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68da637a2198832f8fef656d7aff04cc