### PR TITLE
Ensure JaCoCo agent is not overridden by ByteBuddy

### DIFF
--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -142,7 +142,7 @@
           <configuration>
             <useModulePath>false</useModulePath>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
+            <argLine>${argLine} -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
           </configuration>
         </plugin>
 
@@ -159,7 +159,7 @@
                   <include>**/*IT.java</include>
                   <include>**/*ITCase.java</include>
                 </includes>
-                <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
+                <argLine>${argLine} -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.agent.version}/byte-buddy-agent-${bytebuddy.agent.version}.jar</argLine>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
## Summary
- append the JaCoCo-supplied argument line when configuring Surefire and Failsafe so the ByteBuddy agent no longer overwrites it

## Testing
- mvn test -DskipITs

------
https://chatgpt.com/codex/tasks/task_e_68da6ba6bc64832fad95a0fd05085f5d