### PR TITLE
Fix addon service get response message

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/AddonServiceImpl.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/AddonServiceImpl.java
@@ -6,6 +6,7 @@ import com.ejada.catalog.model.Addon;
 import com.ejada.catalog.repository.AddonRepository;
 import com.ejada.catalog.service.AddonService;
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.exception.NotFoundException;
 import com.ejada.common.service.BaseCrudService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
@@ -59,7 +60,9 @@ public class AddonServiceImpl extends BaseCrudService<Addon, Integer, AddonCreat
     @Override
     @Cacheable(cacheNames = "addons", key = "#id")
     public BaseResponse<AddonRes> get(Integer id) {
-        return super.get(id);
+        Addon addon = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Addon not found", String.valueOf(id)));
+        return BaseResponse.success("OK", mapper.toRes(addon));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- ensure AddonService#get returns a success message of "OK" to align with unit test expectations
- return a NotFoundException with an explicit message when the addon id is missing

## Testing
- `mvn -pl catalog-service test` *(fails: missing shared-bom dependency and unspecified versions in the workspace Maven setup)*

------
https://chatgpt.com/codex/tasks/task_e_68da6e50d4f0832fbab3e054eef1997f