### PR TITLE
Fix subscription inbound build errors

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/kafka/SubscriptionApprovalPublisher.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/kafka/SubscriptionApprovalPublisher.java
@@ -50,7 +50,6 @@ public class SubscriptionApprovalPublisher {
             SendResult<String, Object> result =
                     kafkaTemplate
                             .send(properties.getTopic(), requestId.toString(), message)
-                            .completable()
                             .join();
 
             log.info(

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImpl.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImpl.java
@@ -142,11 +142,10 @@ public class SubscriptionInboundServiceImpl implements SubscriptionInboundServic
             replaceAdditionalServices(sub, si.subscriptionAdditionalServicesLst());
             replaceProductProperties(sub, rq.productProperties());
 
-
-            ReceiveSubscriptionNotificationRs rs = new ReceiveSubscriptionNotificationRs(
+            List<SubscriptionEnvironmentIdentifier> envIds = fetchEnvironmentIdentifiers(sub);
+            ReceiveSubscriptionNotificationRs response = new ReceiveSubscriptionNotificationRs(
                     Boolean.TRUE,
-                    envIdMapper.toDtoList(envIds)
-            );
+                    envIdMapper.toDtoList(envIds));
 
             finalizeNotificationSuccess(audit, rqUid, rq, sub);
 
@@ -154,12 +153,7 @@ public class SubscriptionInboundServiceImpl implements SubscriptionInboundServic
                 approvalPublisher.publishApprovalRequest(rqUid, rq, sub);
             }
 
-            recordIdempotentRequest(rqUid, EP_NOTIFICATION, rq);
-            markAuditSuccess(audit.getInboundNotificationAuditId(), "I000000", "Successful Operation", null);
-
-            var rs = new ReceiveSubscriptionNotificationRs(Boolean.TRUE, envIdMapper.toDtoList(envIds));
-
-            return okNotification(rs);
+            return okNotification(response);
 
         } catch (Exception ex) {
             return handleNotificationFailure(audit, ex);


### PR DESCRIPTION
## Summary
- remove the invalid call to `completable()` on the Kafka send result and rely on `CompletableFuture.join()`
- build the subscription notification response from the fetched environment identifiers and drop duplicate bookkeeping calls

## Testing
- mvn -pl subscription-service -am test *(fails: build requires internal artifacts such as com.ejada:shared-bom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68da72528290832f8bdebafff05ff1ad