### PR TITLE
Fix subscription inbound service test transaction manager

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImplTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImplTest.java
@@ -47,7 +47,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.ResourcelessTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -75,7 +77,7 @@ class SubscriptionInboundServiceImplTest {
 
   @BeforeEach
   void setUp() {
-    transactionManager = new ResourcelessTransactionManager();
+    transactionManager = new NoOpTransactionManager();
     service = new SubscriptionInboundServiceImpl(
         subscriptionRepo,
         featureRepo,


### PR DESCRIPTION
## Summary
- replace the test transaction manager in `SubscriptionInboundServiceImplTest` with a simple no-op implementation
- add the missing Spring transaction imports required by the local test transaction manager

## Testing
- mvn -pl subscription-service test *(fails: repository references private artifacts such as com.ejada:shared-bom that are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da75462578832f8f8547d495795bcf