### PR TITLE
Add convenience status helpers to subscription ServiceResult

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/ServiceResult.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/ServiceResult.java
@@ -8,4 +8,27 @@ public record ServiceResult<T>(
     @NotNull String statusDescription, // e.g., Successful Operation
     String statusDetails,              // optional details (JSON string if needed)
     T payload                          // response body (or null)
-) { }
+) {
+
+    /**
+     * Convenience accessor indicating whether the result represents a successful operation.
+     *
+     * <p>Marketplace success codes follow the pattern {@code Ixxxxxx}. We therefore treat any
+     * status code starting with {@code I} as a success response.</p>
+     *
+     * @return {@code true} when the {@link #statusCode()} denotes a success, {@code false}
+     *     otherwise.
+     */
+    public boolean success() {
+        return statusCode != null && statusCode.startsWith("I");
+    }
+
+    /**
+     * Convenience accessor that negates {@link #success()} for readability at call sites.
+     *
+     * @return {@code true} when the result is not successful.
+     */
+    public boolean failure() {
+        return !success();
+    }
+}


### PR DESCRIPTION
## Summary
- add success() and failure() helpers to the subscription ServiceResult DTO for easier status checks
- document the semantics of success codes within the ServiceResult record

## Testing
- mvn -pl subscription-service test *(fails: missing shared-bom and dependency versions in the multi-module build configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68da779b44c8832f84af2f4c3baf865e