### PR TITLE
Enhance SortUtils sanitization

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/sort/SortUtils.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/sort/SortUtils.java
@@ -7,7 +7,11 @@ import org.springframework.data.domain.Sort;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -34,17 +38,54 @@ public final class SortUtils {
      * @return sanitized Sort never {@code null}
      */
     public static Sort sanitize(Sort sort, String defaultProperty, String... allowedProps) {
+        return sanitize(sort, defaultProperty, Sort.Direction.ASC, allowedProps);
+    }
+
+    /**
+     * Overload allowing the caller to control the default direction used when the
+     * incoming sort is {@code null}, empty or contains only disallowed
+     * properties. The method is defensive against {@code null} values in
+     * {@code allowedProps} and ensures case insensitive comparison of property
+     * names so callers do not need to worry about request casing.
+     *
+     * @param sort             sort to sanitize (can be {@code null})
+     * @param defaultProperty  property to use when sort is empty or invalid
+     * @param defaultDirection direction to apply for the default property
+     * @param allowedProps     properties allowed for sorting; {@code null} entries
+     *                         are ignored
+     * @return sanitized Sort never {@code null}
+     */
+    public static Sort sanitize(Sort sort,
+                                String defaultProperty,
+                                Sort.Direction defaultDirection,
+                                String... allowedProps) {
+        Objects.requireNonNull(defaultProperty, "defaultProperty must not be null");
+        Objects.requireNonNull(defaultDirection, "defaultDirection must not be null");
+
         Sort safeSort = sort == null ? Sort.unsorted() : sort;
-        Set<String> allowed = new HashSet<>(Arrays.asList(allowedProps));
-        allowed.add(defaultProperty);
-        List<Sort.Order> orders = new ArrayList<>();
-        safeSort.stream()
-                .filter(order -> allowed.isEmpty() || allowed.contains(order.getProperty()))
-                .forEach(orders::add);
-        if (orders.isEmpty()) {
-            return Sort.by(defaultProperty).ascending();
+        Set<String> allowed = new HashSet<>();
+        if (allowedProps != null) {
+            Arrays.stream(allowedProps)
+                    .filter(prop -> prop != null && !prop.isBlank())
+                    .map(prop -> prop.toLowerCase(Locale.ROOT))
+                    .forEach(allowed::add);
         }
-        return Sort.by(orders);
+        String defaultKey = defaultProperty.toLowerCase(Locale.ROOT);
+        allowed.add(defaultKey);
+
+        Map<String, Sort.Order> orders = new LinkedHashMap<>();
+        safeSort.stream()
+                .filter(order -> order != null && order.getProperty() != null && !order.getProperty().isBlank())
+                .forEach(order -> {
+                    String key = order.getProperty().toLowerCase(Locale.ROOT);
+                    if (allowed.contains(key)) {
+                        orders.putIfAbsent(key, order);
+                    }
+                });
+        if (orders.isEmpty()) {
+            return Sort.by(new Sort.Order(defaultDirection, defaultProperty));
+        }
+        return Sort.by(new ArrayList<>(orders.values()));
     }
 
     /**
@@ -57,12 +98,37 @@ public final class SortUtils {
      * @return sanitized pageable
      */
     public static Pageable sanitize(Pageable pageable, String defaultProperty, String... allowedProps) {
+        return sanitize(pageable, defaultProperty, Sort.Direction.ASC, DEFAULT_PAGE_SIZE, allowedProps);
+    }
+
+    /**
+     * Variant of {@link #sanitize(Pageable, String, String...)} that additionally
+     * lets the caller control the default direction and the default page size to
+     * use when the incoming pageable is {@code null} or unpaged.
+     *
+     * @param pageable         pageable to sanitize (can be {@code null})
+     * @param defaultProperty  property to use when sort is empty or invalid
+     * @param defaultDirection direction to apply for the default property
+     * @param defaultPageSize  page size to use when pageable is {@code null} or has
+     *                         a non-positive size
+     * @param allowedProps     properties allowed for sorting
+     * @return sanitized pageable
+     */
+    public static Pageable sanitize(Pageable pageable,
+                                     String defaultProperty,
+                                     Sort.Direction defaultDirection,
+                                     int defaultPageSize,
+                                     String... allowedProps) {
+        Objects.requireNonNull(defaultProperty, "defaultProperty must not be null");
+        Objects.requireNonNull(defaultDirection, "defaultDirection must not be null");
+        int safePageSize = defaultPageSize > 0 ? defaultPageSize : DEFAULT_PAGE_SIZE;
+
         if (pageable == null || pageable.isUnpaged()) {
-            Sort sort = sanitize(Sort.unsorted(), defaultProperty, allowedProps);
-            return PageRequest.of(0, DEFAULT_PAGE_SIZE, sort);
+            Sort sort = sanitize(Sort.unsorted(), defaultProperty, defaultDirection, allowedProps);
+            return PageRequest.of(0, safePageSize, sort);
         }
-        Sort sort = sanitize(pageable.getSort(), defaultProperty, allowedProps);
-        int size = pageable.getPageSize() > 0 ? pageable.getPageSize() : DEFAULT_PAGE_SIZE;
+        Sort sort = sanitize(pageable.getSort(), defaultProperty, defaultDirection, allowedProps);
+        int size = pageable.getPageSize() > 0 ? pageable.getPageSize() : safePageSize;
         return PageRequest.of(pageable.getPageNumber(), size, sort);
     }
 }

--- a/shared-lib/shared-common/src/test/java/com/ejada/common/sort/SortUtilsTest.java
+++ b/shared-lib/shared-common/src/test/java/com/ejada/common/sort/SortUtilsTest.java
@@ -1,9 +1,14 @@
 package com.ejada.common.sort;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SortUtilsTest {
     @Test
@@ -11,5 +16,60 @@ class SortUtilsTest {
         Sort invalid = Sort.by("unknown");
         Sort sanitized = SortUtils.sanitize(invalid, "name");
         assertEquals("name", sanitized.stream().findFirst().orElseThrow().getProperty());
+    }
+
+    @Test
+    void sanitize_respectsDefaultDirectionWhenFallbackNeeded() {
+        Sort invalid = Sort.by("unknown");
+        Sort sanitized = SortUtils.sanitize(invalid, "createdAt", Sort.Direction.DESC, "name");
+
+        Sort.Order order = sanitized.stream().findFirst().orElseThrow();
+        assertEquals("createdAt", order.getProperty());
+        assertEquals(Sort.Direction.DESC, order.getDirection());
+    }
+
+    @Test
+    void sanitize_ignoresCaseAndDuplicateProperties() {
+        Sort raw = Sort.by(Sort.Order.desc("Name"), Sort.Order.asc("NAME"), Sort.Order.asc("other"));
+
+        Sort sanitized = SortUtils.sanitize(raw, "createdAt", Sort.Direction.ASC, "name");
+        List<Sort.Order> orders = sanitized.stream().toList();
+
+        assertEquals(1, orders.size(), "Duplicate properties should be collapsed");
+        Sort.Order order = orders.get(0);
+        assertEquals("Name", order.getProperty());
+        assertEquals(Sort.Direction.DESC, order.getDirection(), "Original direction should be preserved");
+    }
+
+    @Test
+    void sanitize_allowsNullAllowedProps() {
+        Sort sanitized = SortUtils.sanitize(null, "createdAt", Sort.Direction.ASC, (String[]) null);
+        Sort.Order order = sanitized.stream().findFirst().orElseThrow();
+
+        assertEquals("createdAt", order.getProperty());
+        assertEquals(Sort.Direction.ASC, order.getDirection());
+    }
+
+    @Test
+    void sanitizePageable_unpagedUsesDefaults() {
+        Pageable sanitized = SortUtils.sanitize(Pageable.unpaged(), "createdAt", Sort.Direction.DESC, 50, "createdAt");
+
+        assertEquals(0, sanitized.getPageNumber());
+        assertEquals(50, sanitized.getPageSize());
+        Sort.Order order = sanitized.getSort().stream().findFirst().orElseThrow();
+        assertEquals("createdAt", order.getProperty());
+        assertEquals(Sort.Direction.DESC, order.getDirection());
+    }
+
+    @Test
+    void sanitizePageable_preservesPageRequestValues() {
+        Pageable pageable = PageRequest.of(2, 10, Sort.by(Sort.Order.desc("name"), Sort.Order.asc("other")));
+
+        Pageable sanitized = SortUtils.sanitize(pageable, "createdAt", Sort.Direction.ASC, 25, "name");
+
+        assertEquals(2, sanitized.getPageNumber());
+        assertEquals(10, sanitized.getPageSize());
+        assertTrue(sanitized.getSort().getOrderFor("name").isDescending());
+        assertEquals(1, sanitized.getSort().stream().count(), "Only allowed property should remain");
     }
 }


### PR DESCRIPTION
## Summary
- add overloads to SortUtils so callers can control default sort direction and pageable fallback behaviour
- harden sanitisation logic to ignore null/blank inputs, deduplicate case-insensitively and preserve order direction
- expand unit tests that exercise the new sort and pageable sanitisation paths

## Testing
- mvn -q test *(fails: missing internal shared-bom import prevents dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68da86a14e18832f94c345da243f1112