### PR TITLE
Fix superadmin token freshness precision check

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -568,7 +569,10 @@ public class SuperadminServiceImpl implements SuperadminService {
         }
 
         Instant issuedAt = jwt.getIssuedAt();
-        Instant passwordChangedInstant = passwordChangedAt.atZone(ZoneId.systemDefault()).toInstant();
+        Instant passwordChangedInstant = passwordChangedAt
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+            .truncatedTo(ChronoUnit.MILLIS);
 
         if (issuedAt == null || issuedAt.isBefore(passwordChangedInstant)) {
             log.info("Rejecting stale JWT for superadmin {} issued at {} (password changed at {})",

--- a/sec-service/src/test/java/com/ejada/sec/service/impl/SuperadminServiceImplTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/service/impl/SuperadminServiceImplTest.java
@@ -308,4 +308,23 @@ class SuperadminServiceImplTest {
             }
         }
     }
+
+    @Test
+    void ensureTokenFreshnessAllowsTokenIssuedInSameMillisecond() {
+        Superadmin superadmin = Superadmin.builder()
+            .id(17L)
+            .username("admin")
+            .passwordChangedAt(LocalDateTime.of(2025, 9, 29, 16, 6, 56, 216_129_505))
+            .build();
+
+        Jwt jwt = Jwt.withTokenValue("token")
+            .header("alg", "HS256")
+            .claim("uid", 17)
+            .issuedAt(Instant.parse("2025-09-29T13:06:56.216Z"))
+            .expiresAt(Instant.parse("2025-09-29T14:06:56.216Z"))
+            .build();
+
+        assertDoesNotThrow(() ->
+            ReflectionTestUtils.invokeMethod(service, "ensureTokenFreshness", jwt, superadmin));
+    }
 }


### PR DESCRIPTION
## Summary
- truncate stored password change timestamps to millisecond precision when validating JWT issuance
- add a regression test ensuring tokens issued in the same millisecond as a password change remain valid

## Testing
- `mvn test -q` *(fails: project depends on internal BOM and missing dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68da89141bf4832fb97c8be4141dbb6d