### PR TITLE
Remove duplicate ContextFilter registration

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/ContextFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/ContextFilter.java
@@ -4,7 +4,6 @@ import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.lang.NonNull;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.ejada.common.constants.HeaderNames;
@@ -19,7 +18,6 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-@Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class ContextFilter extends OncePerRequestFilter {
 


### PR DESCRIPTION
## Summary
- remove the @Component stereotype from ContextFilter to rely on the auto-configuration bean definition
- avoid duplicate bean registration when component scanning is enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8afcb044832f9a173750a0b22eeb