### PR TITLE
Normalize tenant header naming

### DIFF
--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -87,7 +87,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: false
-      header-name: x_tenant_id
+      header-name: X-Tenant-Id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -110,7 +110,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: x_tenant_id
+      header: X-Tenant-Id
       auto-generate: false
       mandatory: false
     user:
@@ -144,7 +144,7 @@ shared:
       include:
         - X-Correlation-Id
         - X-Request-ID
-        - x_tenant_id
+        - X-Tenant-Id
         - X-User-Id
   audit:
     enabled: true

--- a/sec-service/src/main/resources/application-qa.yaml
+++ b/sec-service/src/main/resources/application-qa.yaml
@@ -82,7 +82,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: true
-      header-name: x_tenant_id
+      header-name: X-Tenant-Id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -106,7 +106,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: x_tenant_id
+      header: X-Tenant-Id
       auto-generate: false
       mandatory: false
     user:
@@ -140,7 +140,7 @@ shared:
       include:
         - X-Correlation-Id
         - X-Request-ID
-        - x_tenant_id
+        - X-Tenant-Id
         - X-User-Id
   audit:
     enabled: true

--- a/setup-service/src/main/resources/application-dev.yaml
+++ b/setup-service/src/main/resources/application-dev.yaml
@@ -87,7 +87,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: true
-      header-name: x_tenant_id
+      header-name: X-Tenant-Id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -107,7 +107,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: x_tenant_id
+      header: X-Tenant-Id
       auto-generate: false
       mandatory: false
     user:
@@ -131,7 +131,7 @@ shared:
       include:
         - X-Correlation-Id
         - X-Request-ID
-        - x_tenant_id
+        - X-Tenant-Id
         - X-User-Id
   audit:
     enabled: true

--- a/setup-service/src/main/resources/application-local.yaml
+++ b/setup-service/src/main/resources/application-local.yaml
@@ -87,7 +87,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: true
-      header-name: x_tenant_id
+      header-name: X-Tenant-Id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -107,7 +107,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: x_tenant_id
+      header: X-Tenant-Id
       auto-generate: false
       mandatory: false
     user:
@@ -131,7 +131,7 @@ shared:
       include:
         - X-Correlation-Id
         - X-Request-ID
-        - x_tenant_id
+        - X-Tenant-Id
         - X-User-Id
   audit:
     enabled: true

--- a/setup-service/src/main/resources/application-qa.yaml
+++ b/setup-service/src/main/resources/application-qa.yaml
@@ -82,7 +82,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: true
-      header-name: x_tenant_id
+      header-name: X-Tenant-Id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -103,7 +103,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: x_tenant_id
+      header: X-Tenant-Id
       auto-generate: false
       mandatory: false
     user:
@@ -127,7 +127,7 @@ shared:
       include:
         - X-Correlation-Id
         - X-Request-ID
-        - x_tenant_id
+        - X-Tenant-Id
         - X-User-Id
   audit:
     enabled: true

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
@@ -20,7 +20,12 @@ public final class HeaderNames {
      * Canonical tenant identifier header. All services should read/write this
      * header only and avoid using any legacy variants.
      */
-    public static final String X_TENANT_ID = "x_tenant_id";
+    public static final String X_TENANT_ID = "X-Tenant-Id";
+    /**
+     * Legacy tenant header variant kept for backwards compatibility with
+     * services that still emit/expect the underscore format.
+     */
+    public static final String X_TENANT_ID_LEGACY = "x_tenant_id";
     public static final String TENANT_KEY = "X-Tenant-Key";
     public static final String MESSAGE_ID = "x-msg-id";
 

--- a/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
@@ -83,7 +83,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: true
-      header-name: x_tenant_id
+      header-name: X-Tenant-Id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -103,7 +103,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: x_tenant_id
+      header: X-Tenant-Id
       auto-generate: false
       mandatory: false
     user:
@@ -127,7 +127,7 @@ shared:
       include:
         - X-Correlation-Id
         - X-Request-ID
-        - x_tenant_id
+        - X-Tenant-Id
         - X-User-Id
   audit:
     enabled: true

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/core/dispatch/sinks/DatabaseSink.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/core/dispatch/sinks/DatabaseSink.java
@@ -24,7 +24,7 @@ public class DatabaseSink implements Sink {
     this.table = (schema == null || schema.isBlank() ? "public" : schema) + "." + table;
     this.insertSql =
         "INSERT INTO " + this.table + " (" +
-        " id, ts_utc, " + HeaderNames.X_TENANT_ID + ", actor_id, actor_username, action, entity_type, entity_id, outcome," +
+        " id, ts_utc, " + HeaderNames.X_TENANT_ID_LEGACY + ", actor_id, actor_username, action, entity_type, entity_id, outcome," +
         " data_class, sensitivity, resource_path, resource_method, correlation_id, span_id, message, payload) " +
         "VALUES (? , ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, cast(? as jsonb))";
   }

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/persistence/entity/AuditEventEntity.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/persistence/entity/AuditEventEntity.java
@@ -11,7 +11,7 @@ public class AuditEventEntity {
   @Id
   private UUID id;
   @Column(name="ts_utc") private Instant tsUtc;
-  @Column(name = HeaderNames.X_TENANT_ID) private String xTenantId;
+  @Column(name = HeaderNames.X_TENANT_ID_LEGACY) private String xTenantId;
   @Column(name="actor_id") private String actorId;
   @Column(name="actor_username") private String actorUsername;
   @Column(name="action") private String action;

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/config/CoreAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/config/CoreAutoConfiguration.java
@@ -215,7 +215,7 @@ public class CoreAutoConfiguration {
       private boolean enabled = true;
 
       /** Header and query parameter names */
-      private String headerName = HeaderNames.X_TENANT_ID;   // "x_tenant_id"
+      private String headerName = HeaderNames.X_TENANT_ID;   // "X-Tenant-Id"
       private String queryParam = "tenantId";
 
       /** MDC key for logs */

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/ContextFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/ContextFilter.java
@@ -47,7 +47,9 @@ public class ContextFilter extends OncePerRequestFilter {
 
         String tenantId      = trimToNull(firstNonNull(
                 request.getHeader(HeaderNames.X_TENANT_ID),
-                request.getParameter(HeaderNames.X_TENANT_ID)           // optional fallback
+                request.getHeader(HeaderNames.X_TENANT_ID_LEGACY),
+                request.getParameter(HeaderNames.X_TENANT_ID),           // optional fallback
+                request.getParameter(HeaderNames.X_TENANT_ID_LEGACY)
         ));
         if (tenantId != null && !TENANT_PATTERN.matcher(tenantId).matches()) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid " + HeaderNames.X_TENANT_ID);
@@ -97,8 +99,16 @@ public class ContextFilter extends OncePerRequestFilter {
 
     // ---------- Helpers
 
-    private static String firstNonNull(String a, String b) {
-        return a != null ? a : b;
+    private static String firstNonNull(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
     }
 
     private static String trimToNull(String s) {

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/props/CoreProps.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/props/CoreProps.java
@@ -49,7 +49,7 @@ public class CoreProps implements BaseStarterProperties {
         private boolean enabled = true;
 
         /** Header and query parameter names */
-        private String headerName = HeaderNames.X_TENANT_ID;   // "x_tenant_id"
+        private String headerName = HeaderNames.X_TENANT_ID;   // "X-Tenant-Id"
         private String queryParam = "tenantId";
 
         /** MDC key for logs */

--- a/shared-lib/shared-starters/starter-headers/src/main/resources/com/ejada/headers/starter/headers-defaults.properties
+++ b/shared-lib/shared-starters/starter-headers/src/main/resources/com/ejada/headers/starter/headers-defaults.properties
@@ -2,7 +2,7 @@
 shared.headers.enabled=true
 shared.headers.correlation.header=X-Correlation-Id
 shared.headers.request.header=X-Request-Id
-shared.headers.tenant.header=x_tenant_id
+shared.headers.tenant.header=X-Tenant-Id
 shared.headers.user.header=X-User-Id
 shared.headers.correlation.auto-generate=true
 shared.headers.request.auto-generate=true
@@ -38,4 +38,4 @@ shared.headers.forwarded.enabled=true
 
 # Outbound propagation
 shared.headers.propagation.enabled=true
-shared.headers.propagation.include=X-Correlation-Id,X-Request-Id,x_tenant_id,X-User-Id
+shared.headers.propagation.include=X-Correlation-Id,X-Request-Id,X-Tenant-Id,x_tenant_id,X-User-Id

--- a/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
@@ -86,7 +86,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: true
-      header-name: x_tenant_id
+      header-name: X-Tenant-Id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -106,7 +106,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: x_tenant_id
+      header: X-Tenant-Id
       auto-generate: false
       mandatory: false
     user:
@@ -130,7 +130,7 @@ shared:
       include:
         - X-Correlation-Id
         - X-Request-ID
-        - x_tenant_id
+        - X-Tenant-Id
         - X-User-Id
   audit:
     enabled: true

--- a/tenant-platform/catalog-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-qa.yaml
@@ -82,7 +82,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: true
-      header-name: x_tenant_id
+      header-name: X-Tenant-Id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -103,7 +103,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: x_tenant_id
+      header: X-Tenant-Id
       auto-generate: false
       mandatory: false
     user:
@@ -127,7 +127,7 @@ shared:
       include:
         - X-Correlation-Id
         - X-Request-ID
-        - x_tenant_id
+        - X-Tenant-Id
         - X-User-Id
   audit:
     enabled: true

--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -86,7 +86,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: true
-      header-name: x_tenant_id
+      header-name: X-Tenant-Id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -106,7 +106,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: x_tenant_id
+      header: X-Tenant-Id
       auto-generate: false
       mandatory: false
     user:
@@ -130,7 +130,7 @@ shared:
       include:
         - X-Correlation-Id
         - X-Request-ID
-        - x_tenant_id
+        - X-Tenant-Id
         - X-User-Id
   audit:
     enabled: true

--- a/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
@@ -82,7 +82,7 @@ shared:
       echo-response-header: true
     tenant:
       enabled: true
-      header-name: x_tenant_id
+      header-name: X-Tenant-Id
       query-param: tenantId
       default-policy: OPTIONAL
       echo-response-header: true
@@ -103,7 +103,7 @@ shared:
       auto-generate: true
       mandatory: true
     tenant:
-      header: x_tenant_id
+      header: X-Tenant-Id
       auto-generate: false
       mandatory: false
     user:
@@ -127,7 +127,7 @@ shared:
       include:
         - X-Correlation-Id
         - X-Request-ID
-        - x_tenant_id
+        - X-Tenant-Id
         - X-User-Id
   audit:
     enabled: true


### PR DESCRIPTION
## Summary
- update the shared header catalog to advertise `X-Tenant-Id` as the canonical tenant header while keeping a legacy alias
- adjust tenant context handling and audit persistence to support both canonical and legacy header/column names
- refresh starter defaults and service configurations to propagate the canonical header name

## Testing
- `mvn -pl shared-lib/shared-common -am test` *(fails: selected project not found in reactor)*

------
https://chatgpt.com/codex/tasks/task_e_68da8b0d97e0832f9294d87dbc1153ec