### PR TITLE
refactor: centralize default filter skip patterns

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/config/CoreAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/config/CoreAutoConfiguration.java
@@ -189,9 +189,7 @@ public class CoreAutoConfiguration {
       private boolean generateIfMissing = true;
       private boolean echoResponseHeader = true;
       private int order = Integer.MIN_VALUE + 5; // effectively Ordered.HIGHEST_PRECEDENCE
-      private String[] skipPatterns = new String[]{
-        "/actuator/**","/swagger-ui/**","/v3/api-docs/**","/static/**","/webjars/**","/error","/favicon.ico"
-      };
+      private String[] skipPatterns = SkipPatternDefaults.correlationAndTenantSkipPatterns();
 
       public boolean isEnabled() { return enabled; }
       public void setEnabled(boolean enabled) { this.enabled = enabled; }
@@ -240,10 +238,7 @@ public class CoreAutoConfiguration {
       private int order = Integer.MIN_VALUE + 10;
 
       /** Skip patterns */
-      private String[] skipPatterns = new String[]{
-          "/actuator/**","/swagger-ui/**","/v3/api-docs/**",
-          "/static/**","/webjars/**","/error","/favicon.ico"
-      };
+      private String[] skipPatterns = SkipPatternDefaults.correlationAndTenantSkipPatterns();
 
       public boolean isEnabled() { return enabled; }
       public void setEnabled(boolean enabled) { this.enabled = enabled; }

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/config/SkipPatternDefaults.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/config/SkipPatternDefaults.java
@@ -1,0 +1,49 @@
+package com.ejada.starter_core.config;
+
+import java.util.Set;
+
+/**
+ * Central place for default skip-pattern configuration used by multiple filters.
+ */
+public final class SkipPatternDefaults {
+
+    private SkipPatternDefaults() {
+    }
+
+    private static final String[] CORRELATION_AND_TENANT_SKIP_PATTERNS = new String[] {
+        "/actuator/**",
+        "/swagger-ui/**",
+        "/v3/api-docs/**",
+        "/static/**",
+        "/webjars/**",
+        "/error",
+        "/favicon.ico"
+    };
+
+    private static final Set<String> CONTEXT_SKIP_PREFIXES = Set.of(
+        "/actuator",
+        "/health",
+        "/error",
+        "/v3/api-docs",
+        "/swagger",
+        "/swagger-ui",
+        "/docs"
+    );
+
+    /**
+     * Default Ant-style skip patterns shared by correlation and tenant filters.
+     *
+     * @return a defensive copy of the defaults to avoid accidental mutation
+     */
+    public static String[] correlationAndTenantSkipPatterns() {
+        return CORRELATION_AND_TENANT_SKIP_PATTERNS.clone();
+    }
+
+    /**
+     * Default path prefixes that should not go through the context filter.
+     */
+    public static Set<String> contextSkipPrefixes() {
+        return CONTEXT_SKIP_PREFIXES;
+    }
+}
+

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/ContextFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/ContextFilter.java
@@ -10,6 +10,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import com.ejada.common.constants.HeaderNames;
 import com.ejada.common.context.ContextManager;
 import com.ejada.common.context.CorrelationContextUtil;
+import com.ejada.starter_core.config.SkipPatternDefaults;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -25,9 +26,7 @@ public class ContextFilter extends OncePerRequestFilter {
 
 
     // Paths we don't want to enforce tenant/correlation for
-    private static final Set<String> SKIP_PREFIXES = Set.of(
-        "/actuator", "/health", "/error", "/v3/api-docs", "/swagger", "/swagger-ui", "/docs"
-    );
+    private static final Set<String> SKIP_PREFIXES = SkipPatternDefaults.contextSkipPrefixes();
 
     @Override
     protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/logging/CorrelationIdFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/logging/CorrelationIdFilter.java
@@ -2,6 +2,7 @@ package com.ejada.starter_core.logging;
 
 import com.ejada.common.constants.HeaderNames;
 import com.ejada.common.context.CorrelationContextUtil;
+import com.ejada.starter_core.config.SkipPatternDefaults;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,7 +37,7 @@ public class CorrelationIdFilter extends OncePerRequestFilter {
         this.echoResponseHeader = echoResponseHeader;
         this.skipPatterns = (skipPatterns != null && skipPatterns.length > 0)
                 ? skipPatterns
-                : new String[]{"/actuator/**", "/swagger-ui/**", "/v3/api-docs/**", "/static/**", "/webjars/**", "/error", "/favicon.ico"};
+                : SkipPatternDefaults.correlationAndTenantSkipPatterns();
     }
 
     @Override

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/props/CoreProps.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/props/CoreProps.java
@@ -1,14 +1,12 @@
 package com.ejada.starter_core.props;
 
 import com.ejada.common.BaseStarterProperties;
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.starter_core.config.SkipPatternDefaults;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.Ordered;
-
-// If you already have this constant elsewhere, keep using it.
-// Otherwise create the simple HeaderNames class shown below.
-import com.ejada.common.constants.HeaderNames;
 
 @Getter
 @ConfigurationProperties(prefix = "shared.core")
@@ -36,10 +34,7 @@ public class CoreProps implements BaseStarterProperties {
         private int order = Ordered.HIGHEST_PRECEDENCE + 5; // -2147483643
 
         /** URL patterns to skip */
-        private String[] skipPatterns = new String[] {
-                "/actuator/**", "/swagger-ui/**", "/v3/api-docs/**",
-                "/static/**", "/webjars/**", "/error", "/favicon.ico"
-        };
+        private String[] skipPatterns = SkipPatternDefaults.correlationAndTenantSkipPatterns();
     }
 
     @Getter
@@ -74,9 +69,6 @@ public class CoreProps implements BaseStarterProperties {
         private int order = Ordered.HIGHEST_PRECEDENCE + 10;
 
         /** Skip patterns */
-        private String[] skipPatterns = new String[]{
-            "/actuator/**","/swagger-ui/**","/v3/api-docs/**",
-            "/static/**","/webjars/**","/error","/favicon.ico"
-        };
+        private String[] skipPatterns = SkipPatternDefaults.correlationAndTenantSkipPatterns();
     }
 }


### PR DESCRIPTION
## Summary
- introduce `SkipPatternDefaults` to maintain shared filter skip prefixes and patterns
- update context, correlation, and tenant filter configuration to reuse the centralized defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8b1addc4832fa2bafe2fdac6d260