### PR TITLE
refactor: tidy shared BOM dependency pins

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,3 +21,5 @@ jobs:
         run: mvn -B -DskipTests=true verify -f tenant-platform/pom.xml
       - name: Build setup service
         run: mvn -B -DskipTests=true verify -f setup-service/pom.xml
+      - name: Report dependency updates for shared BOM
+        run: mvn -B -f shared-lib/shared-bom/pom.xml versions:display-dependency-updates

--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -12,44 +12,58 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
     <!-- Platforms -->
     <spring.boot.version>3.5.5</spring.boot.version>
     <spring.cloud.version>2024.0.2</spring.cloud.version> <!-- 2024.0.3 is not on Central -->
 
-    <!-- Libraries not fully managed by Boot -->
-    <flyway.version>11.8.2</flyway.version>
-
-    <!-- Observability / Testing -->
+    <!-- Observability & testing infrastructure -->
     <otel.version>1.45.0</otel.version>
+    <otel.instrumentation.version>2.7.0-alpha</otel.instrumentation.version>
     <testcontainers.version>1.20.4</testcontainers.version>
+    <testcontainers.redis.version>2.2.4</testcontainers.redis.version>
+
+    <!-- Database & persistence -->
+    <flyway.version>11.8.2</flyway.version>
+    <postgres.version>42.7.4</postgres.version>
+    <hibernate.types.version>2.21.1</hibernate.types.version>
+    <ehcache.version>3.10.8</ehcache.version>
+    <cache.api.version>1.1.1</cache.api.version>
 
     <!-- Messaging / schema -->
     <avro.version>1.11.3</avro.version>
     <confluent.version>7.6.1</confluent.version>
+    <kafka.clients.version>3.7.1</kafka.clients.version>
 
-    <!-- DB & misc -->
-    <postgres.version>42.7.4</postgres.version>
-    <hibernate.types.version>2.21.1</hibernate.types.version>
+    <!-- Serialization -->
     <jackson.version>2.19.2</jackson.version>
 
     <!-- Security / resilience -->
     <jjwt.version>0.13.0</jjwt.version> <!-- per jjwt install guide -->
     <resilience4j.version>2.2.0</resilience4j.version>
     <bucket4j.version>8.14.0</bucket4j.version>
+
+    <!-- API & documentation -->
     <springdoc.version>2.7.0</springdoc.version>
-   <money.api.version>1.1</money.api.version>
-   <moneta.version>1.4.5</moneta.version>
-   <mapstruct.version>1.6.3</mapstruct.version>
-  <lombok.version>1.18.32</lombok.version>
-  <lombokMapstruct.version>0.2.0</lombokMapstruct.version>
-  <logstashLogback.version>8.0</logstashLogback.version>
-  <mockito.inline.version>5.2.0</mockito.inline.version>
-  <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
-  <otel.instrumentation.version>2.7.0-alpha</otel.instrumentation.version>
-  <spotbugs-annotations.version>4.7.3</spotbugs-annotations.version>
-  <ehcache.version>3.10.8</ehcache.version>
-  <cache.api.version>1.1.1</cache.api.version>
-  <kafka.clients.version>3.7.1</kafka.clients.version>
+
+    <!-- Money & currency -->
+    <money.api.version>1.1</money.api.version>
+    <moneta.version>1.4.5</moneta.version>
+
+    <!-- Mapping & code generation -->
+    <mapstruct.version>1.6.3</mapstruct.version>
+    <lombok.version>1.18.32</lombok.version>
+    <lombok.mapstruct.version>0.2.0</lombok.mapstruct.version>
+
+    <!-- Testing utilities -->
+    <mockito.version>5.2.0</mockito.version>
+    <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
+
+    <!-- Static analysis -->
+    <spotbugs.annotations.version>4.7.3</spotbugs.annotations.version>
+
+    <!-- Logging -->
+    <logstash.logback.version>8.0</logstash.logback.version>
   </properties>
 
   <dependencyManagement>
@@ -59,28 +73,39 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring.boot.version}</version>
-        <type>pom</type><scope>import</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
         <version>${spring.cloud.version}</version>
-        <type>pom</type><scope>import</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
         <version>${testcontainers.version}</version>
-        <type>pom</type><scope>import</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
         <version>${otel.version}</version>
-        <type>pom</type><scope>import</scope>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.opentelemetry.instrumentation</groupId>
+        <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
+        <version>${otel.instrumentation.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
-      <!-- JJWT: pin artifacts directly (NO jjwt-bom import) -->
+      <!-- Security -->
       <dependency>
         <groupId>io.jsonwebtoken</groupId>
         <artifactId>jjwt-api</artifactId>
@@ -99,12 +124,19 @@
         <scope>runtime</scope>
       </dependency>
 
-      <!-- Specific pins -->
+      <!-- API & documentation -->
       <dependency>
         <groupId>org.springdoc</groupId>
         <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         <version>${springdoc.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-starter-common</artifactId>
+        <version>${springdoc.version}</version>
+      </dependency>
+
+      <!-- Mapping utilities -->
       <dependency>
         <groupId>org.mapstruct</groupId>
         <artifactId>mapstruct</artifactId>
@@ -115,9 +147,18 @@
         <artifactId>mapstruct-processor</artifactId>
         <version>${mapstruct.version}</version>
       </dependency>
-   <dependency><groupId>org.projectlombok</groupId><artifactId>lombok</artifactId><version>${lombok.version}</version></dependency>
-    <dependency><groupId>org.projectlombok</groupId><artifactId>lombok-mapstruct-binding</artifactId><version>${lombokMapstruct.version}</version></dependency>
- 
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok-mapstruct-binding</artifactId>
+        <version>${lombok.mapstruct.version}</version>
+      </dependency>
+
+      <!-- Database & persistence -->
       <dependency>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-core</artifactId>
@@ -128,44 +169,28 @@
         <artifactId>flyway-database-postgresql</artifactId>
         <version>${flyway.version}</version>
       </dependency>
-     <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
-        <version>${mockito.inline.version}</version>
-        <scope>test</scope>
-      </dependency>
-     <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${mockito.inline.version}</version>
-        <scope>test</scope>
-     </dependency>
-     <dependency>
-        <groupId>net.bytebuddy</groupId>
-        <artifactId>byte-buddy-agent</artifactId>
-        <version>${bytebuddy.agent.version}</version>
-        <scope>test</scope>
-     </dependency>
-     	
-     <dependency>
-    <groupId>com.redis</groupId>
-    <artifactId>testcontainers-redis</artifactId>
-    <version>2.2.4</version>
-    <scope>test</scope>
-  </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
         <version>${postgres.version}</version>
       </dependency>
-
       <dependency>
         <groupId>com.vladmihalcea</groupId>
         <artifactId>hibernate-types-60</artifactId>
         <version>${hibernate.types.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.ehcache</groupId>
+        <artifactId>ehcache</artifactId>
+        <version>${ehcache.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.cache</groupId>
+        <artifactId>cache-api</artifactId>
+        <version>${cache.api.version}</version>
+      </dependency>
 
-      <!-- Messaging / schema (needs Confluent repo in parent POM) -->
+      <!-- Messaging / schema -->
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
@@ -176,22 +201,13 @@
         <artifactId>kafka-schema-registry-client</artifactId>
         <version>${confluent.version}</version>
       </dependency>
-
-      <!-- Resilience -->
       <dependency>
-        <groupId>io.github.resilience4j</groupId>
-        <artifactId>resilience4j-spring-boot3</artifactId>
-        <version>${resilience4j.version}</version>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${kafka.clients.version}</version>
       </dependency>
 
-      <!-- Logging / misc pins -->
-      <dependency>
-        <groupId>net.logstash.logback</groupId>
-        <artifactId>logstash-logback-encoder</artifactId>
-        <version>${logstashLogback.version}</version>
-      </dependency>
-
-      <!-- Optional Jackson pins for non-Boot contexts -->
+      <!-- Serialization -->
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
@@ -202,44 +218,68 @@
         <artifactId>jackson-datatype-jdk8</artifactId>
         <version>${jackson.version}</version>
       </dependency>
-        <dependency>
-      <groupId>com.bucket4j</groupId>
-      <artifactId>bucket4j_jdk17-core</artifactId>
-      <version>${bucket4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-common</artifactId>
-      <version>${springdoc.version}</version>
-    </dependency>
-     <dependency><groupId>javax.money</groupId><artifactId>money-api</artifactId><version>${money.api.version}</version></dependency>
-    <dependency><groupId>org.javamoney.moneta</groupId><artifactId>moneta-core</artifactId><version>${moneta.version}</version></dependency>
- <dependency>
-        <groupId>io.opentelemetry.instrumentation</groupId>
-        <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
-        <version>${otel.instrumentation.version}</version>
-        <type>pom</type><scope>import</scope>
+
+      <!-- Resilience -->
+      <dependency>
+        <groupId>io.github.resilience4j</groupId>
+        <artifactId>resilience4j-spring-boot3</artifactId>
+        <version>${resilience4j.version}</version>
       </dependency>
       <dependency>
-    <groupId>com.github.spotbugs</groupId>
-    <artifactId>spotbugs-annotations</artifactId>
-    <version>${spotbugs-annotations.version}</version>
-</dependency>
-<dependency>
-    <groupId>org.ehcache</groupId>
-    <artifactId>ehcache</artifactId>
-    <version>${ehcache.version}</version>
-</dependency>
-  <dependency>
-        <groupId>javax.cache</groupId>
-        <artifactId>cache-api</artifactId>
-        <version>${cache.api.version}</version>
+        <groupId>com.bucket4j</groupId>
+        <artifactId>bucket4j_jdk17-core</artifactId>
+        <version>${bucket4j.version}</version>
       </dependency>
-    <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka-clients</artifactId>
-        <version>${kafka.clients.version}</version>
-    </dependency>
+
+      <!-- Money & currency -->
+      <dependency>
+        <groupId>javax.money</groupId>
+        <artifactId>money-api</artifactId>
+        <version>${money.api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.javamoney.moneta</groupId>
+        <artifactId>moneta-core</artifactId>
+        <version>${moneta.version}</version>
+      </dependency>
+
+      <!-- Observability / logging -->
+      <dependency>
+        <groupId>net.logstash.logback</groupId>
+        <artifactId>logstash-logback-encoder</artifactId>
+        <version>${logstash.logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>${spotbugs.annotations.version}</version>
+      </dependency>
+
+      <!-- Testing -->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>${bytebuddy.agent.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.redis</groupId>
+        <artifactId>testcontainers-redis</artifactId>
+        <version>${testcontainers.redis.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
## Summary
- group shared BOM properties by domain and ensure every managed dependency has an explicit version property
- normalize dependency management entries, including redis testcontainers pin, to use the shared properties
- extend the Maven CI workflow to report dependency update recommendations via the versions plugin

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8b36ad38832fb1913a21fcb6800b