### PR TITLE
Add Kafka tenant provisioning pipeline

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/events/provisioning/ProvisionedAddon.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/events/provisioning/ProvisionedAddon.java
@@ -1,0 +1,17 @@
+package com.ejada.common.events.provisioning;
+
+import java.math.BigDecimal;
+
+/** Representation of an addon assigned to a tenant subscription. */
+public record ProvisionedAddon(
+        Long productAdditionalServiceId,
+        String code,
+        String nameEn,
+        String nameAr,
+        BigDecimal servicePrice,
+        BigDecimal totalAmount,
+        String currency,
+        Boolean countable,
+        Long requestedCount,
+        String paymentType) {
+}

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/events/provisioning/ProvisionedFeature.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/events/provisioning/ProvisionedFeature.java
@@ -1,0 +1,5 @@
+package com.ejada.common.events.provisioning;
+
+/** Simple feature entitlement for a provisioned tenant. */
+public record ProvisionedFeature(String code, Integer quantity) {
+}

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/events/provisioning/TenantProvisioningMessage.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/events/provisioning/TenantProvisioningMessage.java
@@ -1,0 +1,19 @@
+package com.ejada.common.events.provisioning;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Payload broadcast after a tenant has been provisioned so downstream services can
+ * synchronize entitlements (features, addons, etc.).
+ */
+public record TenantProvisioningMessage(
+        UUID requestId,
+        Long subscriptionId,
+        String tenantCode,
+        String tenantName,
+        List<ProvisionedFeature> features,
+        List<ProvisionedAddon> addons,
+        OffsetDateTime timestamp) {
+}

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/events/provisioning/TenantProvisioningProperties.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/events/provisioning/TenantProvisioningProperties.java
@@ -1,0 +1,32 @@
+package com.ejada.common.events.provisioning;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for tenant provisioning Kafka topic & consumer group.
+ */
+@ConfigurationProperties(prefix = "app.tenant-provisioning")
+public class TenantProvisioningProperties {
+
+    /** Kafka topic carrying tenant provisioning messages. */
+    private String topic = "tenant.provisioning";
+
+    /** Consumer group used by services reacting to tenant provisioning. */
+    private String consumerGroup = "tenant-provisioning-listener";
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(final String topic) {
+        this.topic = topic;
+    }
+
+    public String getConsumerGroup() {
+        return consumerGroup;
+    }
+
+    public void setConsumerGroup(final String consumerGroup) {
+        this.consumerGroup = consumerGroup;
+    }
+}

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/config/TenantProvisioningConfiguration.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/config/TenantProvisioningConfiguration.java
@@ -1,0 +1,10 @@
+package com.ejada.catalog.config;
+
+import com.ejada.common.events.provisioning.TenantProvisioningProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(TenantProvisioningProperties.class)
+public class TenantProvisioningConfiguration {
+}

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/kafka/TenantProvisioningListener.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/kafka/TenantProvisioningListener.java
@@ -1,0 +1,30 @@
+package com.ejada.catalog.kafka;
+
+import com.ejada.catalog.service.TenantProvisioningService;
+import com.ejada.common.events.provisioning.TenantProvisioningMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TenantProvisioningListener {
+
+    private final ObjectMapper objectMapper;
+    private final TenantProvisioningService provisioningService;
+
+    @KafkaListener(
+            topics = "#{@tenantProvisioningProperties.topic}",
+            groupId = "#{@tenantProvisioningProperties.consumerGroup}"
+    )
+    public void onMessage(@Payload final Map<String, Object> payload) {
+        TenantProvisioningMessage message = objectMapper.convertValue(payload, TenantProvisioningMessage.class);
+        log.info("Applying provisioning update for tenant {}", message.tenantCode());
+        provisioningService.applyProvisioning(message);
+    }
+}

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TenantAddonEntitlement.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TenantAddonEntitlement.java
@@ -1,0 +1,73 @@
+package com.ejada.catalog.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Table(
+        name = "tenant_addon_entitlement",
+        uniqueConstraints = @UniqueConstraint(name = "uk_tenant_addon", columnNames = {"tenant_code", "addon_cd"}),
+        indexes = @Index(name = "idx_tenant_addon_code", columnList = "tenant_code")
+)
+@DynamicUpdate
+@Getter
+@Setter
+@NoArgsConstructor
+public class TenantAddonEntitlement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tenant_addon_entitlement_id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(name = "tenant_code", length = 64, nullable = false)
+    private String tenantCode;
+
+    @Column(name = "addon_cd", length = 128, nullable = false)
+    private String addonCode;
+
+    @Column(name = "product_additional_service_id")
+    private Long productAdditionalServiceId;
+
+    @Column(name = "service_name_en", length = 256)
+    private String serviceNameEn;
+
+    @Column(name = "service_name_ar", length = 256)
+    private String serviceNameAr;
+
+    @Column(name = "service_price", precision = 18, scale = 4)
+    private BigDecimal servicePrice;
+
+    @Column(name = "total_amount", precision = 18, scale = 4)
+    private BigDecimal totalAmount;
+
+    @Column(name = "currency", length = 3)
+    private String currency;
+
+    @Column(name = "is_countable")
+    private Boolean countable;
+
+    @Column(name = "requested_count")
+    private Long requestedCount;
+
+    @Column(name = "payment_type_cd", length = 32)
+    private String paymentTypeCd;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false)
+    private OffsetDateTime updatedAt;
+}

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TenantFeatureEntitlement.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TenantFeatureEntitlement.java
@@ -1,0 +1,48 @@
+package com.ejada.catalog.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Table(
+        name = "tenant_feature_entitlement",
+        uniqueConstraints = @UniqueConstraint(name = "uk_tenant_feature", columnNames = {"tenant_code", "feature_cd"}),
+        indexes = @Index(name = "idx_tenant_feature_code", columnList = "tenant_code")
+)
+@DynamicUpdate
+@Getter
+@Setter
+@NoArgsConstructor
+public class TenantFeatureEntitlement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tenant_feature_entitlement_id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(name = "tenant_code", length = 64, nullable = false)
+    private String tenantCode;
+
+    @Column(name = "feature_cd", length = 128, nullable = false)
+    private String featureCode;
+
+    @Column(name = "feature_count")
+    private Integer featureCount;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false)
+    private OffsetDateTime updatedAt;
+}

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/TenantAddonEntitlementRepository.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/TenantAddonEntitlementRepository.java
@@ -1,0 +1,11 @@
+package com.ejada.catalog.repository;
+
+import com.ejada.catalog.model.TenantAddonEntitlement;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TenantAddonEntitlementRepository extends JpaRepository<TenantAddonEntitlement, Long> {
+    Optional<TenantAddonEntitlement> findByTenantCodeAndAddonCode(String tenantCode, String addonCode);
+    List<TenantAddonEntitlement> findByTenantCode(String tenantCode);
+}

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/TenantFeatureEntitlementRepository.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/repository/TenantFeatureEntitlementRepository.java
@@ -1,0 +1,11 @@
+package com.ejada.catalog.repository;
+
+import com.ejada.catalog.model.TenantFeatureEntitlement;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TenantFeatureEntitlementRepository extends JpaRepository<TenantFeatureEntitlement, Long> {
+    Optional<TenantFeatureEntitlement> findByTenantCodeAndFeatureCode(String tenantCode, String featureCode);
+    List<TenantFeatureEntitlement> findByTenantCode(String tenantCode);
+}

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/TenantProvisioningService.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/TenantProvisioningService.java
@@ -1,0 +1,7 @@
+package com.ejada.catalog.service;
+
+import com.ejada.common.events.provisioning.TenantProvisioningMessage;
+
+public interface TenantProvisioningService {
+    void applyProvisioning(TenantProvisioningMessage message);
+}

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/TenantProvisioningServiceImpl.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/service/impl/TenantProvisioningServiceImpl.java
@@ -1,0 +1,100 @@
+package com.ejada.catalog.service.impl;
+
+import com.ejada.catalog.model.TenantAddonEntitlement;
+import com.ejada.catalog.model.TenantFeatureEntitlement;
+import com.ejada.catalog.repository.TenantAddonEntitlementRepository;
+import com.ejada.catalog.repository.TenantFeatureEntitlementRepository;
+import com.ejada.catalog.service.TenantProvisioningService;
+import com.ejada.common.events.provisioning.ProvisionedAddon;
+import com.ejada.common.events.provisioning.ProvisionedFeature;
+import com.ejada.common.events.provisioning.TenantProvisioningMessage;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TenantProvisioningServiceImpl implements TenantProvisioningService {
+
+    private final TenantFeatureEntitlementRepository featureRepository;
+    private final TenantAddonEntitlementRepository addonRepository;
+
+    @Override
+    @Transactional
+    public void applyProvisioning(final TenantProvisioningMessage message) {
+        if (message == null || message.tenantCode() == null) {
+            log.warn("Ignoring provisioning message with missing tenant code");
+            return;
+        }
+
+        synchronizeFeatures(message.tenantCode(), message.features());
+        synchronizeAddons(message.tenantCode(), message.addons());
+    }
+
+    private void synchronizeFeatures(final String tenantCode, final List<ProvisionedFeature> features) {
+        Map<String, TenantFeatureEntitlement> existing = new HashMap<>();
+        for (TenantFeatureEntitlement entitlement : featureRepository.findByTenantCode(tenantCode)) {
+            existing.put(entitlement.getFeatureCode(), entitlement);
+        }
+
+        if (features != null) {
+            for (ProvisionedFeature feature : features) {
+                if (feature == null || feature.code() == null) {
+                    continue;
+                }
+                TenantFeatureEntitlement entitlement = existing.remove(feature.code());
+                if (entitlement == null) {
+                    entitlement = new TenantFeatureEntitlement();
+                    entitlement.setTenantCode(tenantCode);
+                    entitlement.setFeatureCode(feature.code());
+                }
+                entitlement.setFeatureCount(feature.quantity());
+                featureRepository.save(entitlement);
+            }
+        }
+
+        if (!existing.isEmpty()) {
+            featureRepository.deleteAll(existing.values());
+        }
+    }
+
+    private void synchronizeAddons(final String tenantCode, final List<ProvisionedAddon> addons) {
+        Map<String, TenantAddonEntitlement> existing = new HashMap<>();
+        for (TenantAddonEntitlement entitlement : addonRepository.findByTenantCode(tenantCode)) {
+            existing.put(entitlement.getAddonCode(), entitlement);
+        }
+
+        if (addons != null) {
+            for (ProvisionedAddon addon : addons) {
+                if (addon == null || addon.code() == null) {
+                    continue;
+                }
+                TenantAddonEntitlement entitlement = existing.remove(addon.code());
+                if (entitlement == null) {
+                    entitlement = new TenantAddonEntitlement();
+                    entitlement.setTenantCode(tenantCode);
+                    entitlement.setAddonCode(addon.code());
+                }
+                entitlement.setProductAdditionalServiceId(addon.productAdditionalServiceId());
+                entitlement.setServiceNameEn(addon.nameEn());
+                entitlement.setServiceNameAr(addon.nameAr());
+                entitlement.setServicePrice(addon.servicePrice());
+                entitlement.setTotalAmount(addon.totalAmount());
+                entitlement.setCurrency(addon.currency());
+                entitlement.setCountable(addon.countable());
+                entitlement.setRequestedCount(addon.requestedCount());
+                entitlement.setPaymentTypeCd(addon.paymentType());
+                addonRepository.save(entitlement);
+            }
+        }
+
+        if (!existing.isEmpty()) {
+            addonRepository.deleteAll(existing.values());
+        }
+    }
+}

--- a/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
@@ -219,4 +219,9 @@ logging:
     org.springframework.cache: ERROR
     org.springframework.cache.interceptor.CacheAspectSupport: ERROR
 
+app:
+  tenant-provisioning:
+    topic: tenant.provisioning
+    consumer-group: catalog-tenant-provisioning
+
 debug: true

--- a/tenant-platform/catalog-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-qa.yaml
@@ -206,11 +206,17 @@ shared:
 
 logging:
   level:
-    root: ERROR                
+    root: ERROR
     com.ejada: ERROR
-    org.hibernate.SQL: ERROR   
+    org.hibernate.SQL: ERROR
     org.hibernate.orm.jdbc.bind: ERROR
     org.springframework.cache: ERROR
     org.springframework.cache.interceptor.CacheAspectSupport: ERROR
 
+app:
+  tenant-provisioning:
+    topic: tenant.provisioning
+    consumer-group: catalog-tenant-provisioning
+
 debug: false
+

--- a/tenant-platform/catalog-service/src/main/resources/db/migration/common/V5__tenant_entitlements.sql
+++ b/tenant-platform/catalog-service/src/main/resources/db/migration/common/V5__tenant_entitlements.sql
@@ -1,0 +1,28 @@
+-- Tenant-specific feature and addon entitlements provisioned via Kafka
+create table if not exists tenant_feature_entitlement (
+    tenant_feature_entitlement_id serial primary key,
+    tenant_code                  varchar(64)  not null,
+    feature_cd                   varchar(128) not null,
+    feature_count                integer,
+    created_at                   timestamptz not null default now(),
+    updated_at                   timestamptz,
+    unique (tenant_code, feature_cd)
+);
+
+create table if not exists tenant_addon_entitlement (
+    tenant_addon_entitlement_id serial primary key,
+    tenant_code                 varchar(64)  not null,
+    addon_cd                    varchar(128) not null,
+    product_additional_service_id bigint,
+    service_name_en             varchar(256),
+    service_name_ar             varchar(256),
+    service_price               numeric(18,4),
+    total_amount                numeric(18,4),
+    currency                    varchar(3),
+    is_countable                boolean,
+    requested_count             bigint,
+    payment_type_cd             varchar(32),
+    created_at                  timestamptz not null default now(),
+    updated_at                  timestamptz,
+    unique (tenant_code, addon_cd)
+);

--- a/tenant-platform/catalog-service/src/test/java/com/ejada/catalog/service/impl/TenantProvisioningServiceImplTest.java
+++ b/tenant-platform/catalog-service/src/test/java/com/ejada/catalog/service/impl/TenantProvisioningServiceImplTest.java
@@ -1,0 +1,106 @@
+package com.ejada.catalog.service.impl;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ejada.catalog.model.TenantAddonEntitlement;
+import com.ejada.catalog.model.TenantFeatureEntitlement;
+import com.ejada.catalog.repository.TenantAddonEntitlementRepository;
+import com.ejada.catalog.repository.TenantFeatureEntitlementRepository;
+import com.ejada.common.events.provisioning.ProvisionedAddon;
+import com.ejada.common.events.provisioning.ProvisionedFeature;
+import com.ejada.common.events.provisioning.TenantProvisioningMessage;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TenantProvisioningServiceImplTest {
+
+    @Mock private TenantFeatureEntitlementRepository featureRepository;
+    @Mock private TenantAddonEntitlementRepository addonRepository;
+
+    private TenantProvisioningServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TenantProvisioningServiceImpl(featureRepository, addonRepository);
+    }
+
+    @Test
+    void applyProvisioningUpsertsEntitlements() {
+        TenantFeatureEntitlement existingFeature = new TenantFeatureEntitlement();
+        existingFeature.setTenantCode("TEN-1");
+        existingFeature.setFeatureCode("FEATURE_A");
+        existingFeature.setFeatureCount(1);
+
+        TenantAddonEntitlement existingAddon = new TenantAddonEntitlement();
+        existingAddon.setTenantCode("TEN-1");
+        existingAddon.setAddonCode("ADDON_A");
+
+        when(featureRepository.findByTenantCode("TEN-1")).thenReturn(List.of(existingFeature));
+        when(addonRepository.findByTenantCode("TEN-1")).thenReturn(List.of(existingAddon));
+
+        TenantProvisioningMessage message = new TenantProvisioningMessage(
+                UUID.randomUUID(),
+                123L,
+                "TEN-1",
+                "Tenant",
+                List.of(new ProvisionedFeature("FEATURE_A", 5)),
+                List.of(new ProvisionedAddon(
+                        99L,
+                        "ADDON_A",
+                        "Addon EN",
+                        "Addon AR",
+                        BigDecimal.TEN,
+                        BigDecimal.ONE,
+                        "USD",
+                        Boolean.TRUE,
+                        2L,
+                        "ONE_TIME")),
+                OffsetDateTime.now());
+
+        service.applyProvisioning(message);
+
+        verify(featureRepository).save(argThat(ent -> ent.getFeatureCode().equals("FEATURE_A")
+                && ent.getFeatureCount().equals(5)));
+
+        verify(addonRepository).save(argThat(ent -> ent.getAddonCode().equals("ADDON_A")
+                && ent.getRequestedCount().equals(2L)
+                && ent.getServicePrice().equals(BigDecimal.TEN)));
+    }
+
+    @Test
+    void applyProvisioningRemovesMissingEntitlements() {
+        TenantFeatureEntitlement staleFeature = new TenantFeatureEntitlement();
+        staleFeature.setTenantCode("TEN-1");
+        staleFeature.setFeatureCode("FEATURE_OLD");
+        when(featureRepository.findByTenantCode("TEN-1")).thenReturn(List.of(staleFeature));
+
+        TenantAddonEntitlement staleAddon = new TenantAddonEntitlement();
+        staleAddon.setTenantCode("TEN-1");
+        staleAddon.setAddonCode("ADDON_OLD");
+        when(addonRepository.findByTenantCode("TEN-1")).thenReturn(List.of(staleAddon));
+
+        TenantProvisioningMessage message = new TenantProvisioningMessage(
+                UUID.randomUUID(),
+                123L,
+                "TEN-1",
+                "Tenant",
+                List.of(),
+                List.of(),
+                OffsetDateTime.now());
+
+        service.applyProvisioning(message);
+
+        verify(featureRepository).deleteAll(List.of(staleFeature));
+        verify(addonRepository).deleteAll(List.of(staleAddon));
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/TenantProvisioningConfiguration.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/TenantProvisioningConfiguration.java
@@ -1,0 +1,10 @@
+package com.ejada.subscription.config;
+
+import com.ejada.common.events.provisioning.TenantProvisioningProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(TenantProvisioningProperties.class)
+public class TenantProvisioningConfiguration {
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumer.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumer.java
@@ -1,0 +1,96 @@
+package com.ejada.subscription.kafka;
+
+import com.ejada.common.events.provisioning.ProvisionedAddon;
+import com.ejada.common.events.provisioning.ProvisionedFeature;
+import com.ejada.common.events.subscription.SubscriptionApprovalAction;
+import com.ejada.common.events.subscription.SubscriptionApprovalMessage;
+import com.ejada.subscription.model.Subscription;
+import com.ejada.subscription.model.SubscriptionAdditionalService;
+import com.ejada.subscription.model.SubscriptionFeature;
+import com.ejada.subscription.repository.SubscriptionAdditionalServiceRepository;
+import com.ejada.subscription.repository.SubscriptionFeatureRepository;
+import com.ejada.subscription.repository.SubscriptionRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Reacts to administrator subscription approvals by publishing provisioning payloads for
+ * downstream services (catalog, billing, etc.).
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SubscriptionApprovalConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionFeatureRepository featureRepository;
+    private final SubscriptionAdditionalServiceRepository additionalServiceRepository;
+    private final TenantProvisioningPublisher provisioningPublisher;
+
+    @KafkaListener(
+            topics = "#{@subscriptionApprovalProperties.topic}",
+            groupId = "#{@subscriptionApprovalProperties.consumerGroup}"
+    )
+    @Transactional(readOnly = true)
+    public void onApproval(@Payload final Map<String, Object> payload) {
+        SubscriptionApprovalMessage message = objectMapper.convertValue(payload, SubscriptionApprovalMessage.class);
+
+        if (message.action() != SubscriptionApprovalAction.APPROVED) {
+            log.debug(
+                    "Skipping approval event {} because action is {}",
+                    message.requestId(),
+                    message.action());
+            return;
+        }
+
+        if (message.subscriptionId() == null) {
+            log.warn("Approval message {} lacks subscriptionId, unable to provision", message.requestId());
+            return;
+        }
+
+        Subscription subscription = subscriptionRepository
+                .findByExtSubscriptionId(message.subscriptionId())
+                .orElseThrow(() -> new IllegalStateException(
+                        "Unknown subscription " + message.subscriptionId() + " in approval event"));
+
+        List<ProvisionedFeature> features = featureRepository
+                .findBySubscriptionSubscriptionId(subscription.getSubscriptionId())
+                .stream()
+                .map(this::mapFeature)
+                .toList();
+
+        List<ProvisionedAddon> addons = additionalServiceRepository
+                .findBySubscriptionSubscriptionId(subscription.getSubscriptionId())
+                .stream()
+                .map(this::mapAddon)
+                .toList();
+
+        provisioningPublisher.publish(message, features, addons);
+    }
+
+    private ProvisionedFeature mapFeature(final SubscriptionFeature entity) {
+        return new ProvisionedFeature(entity.getFeatureCd(), entity.getFeatureCount());
+    }
+
+    private ProvisionedAddon mapAddon(final SubscriptionAdditionalService entity) {
+        return new ProvisionedAddon(
+                entity.getProductAdditionalServiceId(),
+                entity.getServiceCd(),
+                entity.getServiceNameEn(),
+                entity.getServiceNameAr(),
+                entity.getServicePrice(),
+                entity.getTotalAmount(),
+                entity.getCurrency(),
+                entity.getIsCountable(),
+                entity.getRequestedCount(),
+                entity.getPaymentTypeCd());
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/kafka/TenantProvisioningPublisher.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/kafka/TenantProvisioningPublisher.java
@@ -1,0 +1,59 @@
+package com.ejada.subscription.kafka;
+
+import com.ejada.common.events.provisioning.ProvisionedAddon;
+import com.ejada.common.events.provisioning.ProvisionedFeature;
+import com.ejada.common.events.provisioning.TenantProvisioningMessage;
+import com.ejada.common.events.provisioning.TenantProvisioningProperties;
+import com.ejada.common.events.subscription.SubscriptionApprovalMessage;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+/** Publishes tenant provisioning payloads once an approval decision is received. */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TenantProvisioningPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final TenantProvisioningProperties properties;
+
+    public void publish(
+            final SubscriptionApprovalMessage approval,
+            final List<ProvisionedFeature> features,
+            final List<ProvisionedAddon> addons) {
+
+        UUID key = approval.requestId() != null ? approval.requestId() : UUID.randomUUID();
+        TenantProvisioningMessage message = new TenantProvisioningMessage(
+                approval.requestId(),
+                approval.subscriptionId(),
+                approval.tenantCode(),
+                approval.tenantName(),
+                features,
+                addons,
+                OffsetDateTime.now());
+
+        try {
+            SendResult<String, Object> result =
+                    kafkaTemplate.send(properties.getTopic(), key.toString(), message).join();
+            log.info(
+                    "Published tenant provisioning event for tenant {} on topic {} (partition={}, offset={})",
+                    approval.tenantCode(),
+                    properties.getTopic(),
+                    result.getRecordMetadata().partition(),
+                    result.getRecordMetadata().offset());
+        } catch (Exception ex) {
+            Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+            log.error("Failed to publish tenant provisioning message for tenant {}", approval.tenantCode(), cause);
+            if (cause instanceof RuntimeException runtime) {
+                throw runtime;
+            }
+            throw new IllegalStateException("Unable to publish tenant provisioning message", cause);
+        }
+    }
+}

--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -210,7 +210,10 @@ app:
   subscription-approval:
     topic: tenant.subscription-approvals
     approval-role: ejada-officer
-    consumer-group: tenant-approval-listener
+    consumer-group: tenant-approval-provisioner
+  tenant-provisioning:
+    topic: tenant.provisioning
+    consumer-group: tenant-provisioning-publisher
 
 logging:
   level:

--- a/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
@@ -208,7 +208,10 @@ app:
   subscription-approval:
     topic: tenant.subscription-approvals
     approval-role: ejada-officer
-    consumer-group: tenant-approval-listener
+    consumer-group: tenant-approval-provisioner
+  tenant-provisioning:
+    topic: tenant.provisioning
+    consumer-group: tenant-provisioning-publisher
 
 logging:
   level:

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerTest.java
@@ -1,0 +1,139 @@
+package com.ejada.subscription.kafka;
+
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ejada.common.events.provisioning.ProvisionedAddon;
+import com.ejada.common.events.provisioning.ProvisionedFeature;
+import com.ejada.common.events.subscription.SubscriptionApprovalAction;
+import com.ejada.common.events.subscription.SubscriptionApprovalMessage;
+import com.ejada.subscription.model.Subscription;
+import com.ejada.subscription.model.SubscriptionAdditionalService;
+import com.ejada.subscription.model.SubscriptionFeature;
+import com.ejada.subscription.repository.SubscriptionAdditionalServiceRepository;
+import com.ejada.subscription.repository.SubscriptionFeatureRepository;
+import com.ejada.subscription.repository.SubscriptionRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionApprovalConsumerTest {
+
+    @Mock private SubscriptionRepository subscriptionRepository;
+    @Mock private SubscriptionFeatureRepository featureRepository;
+    @Mock private SubscriptionAdditionalServiceRepository additionalServiceRepository;
+    @Mock private TenantProvisioningPublisher provisioningPublisher;
+
+    private SubscriptionApprovalConsumer consumer;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        consumer = new SubscriptionApprovalConsumer(
+                objectMapper,
+                subscriptionRepository,
+                featureRepository,
+                additionalServiceRepository,
+                provisioningPublisher);
+    }
+
+    @Test
+    void approvedMessagePublishesProvisioningPayload() {
+        UUID requestId = UUID.randomUUID();
+        SubscriptionApprovalMessage message = new SubscriptionApprovalMessage(
+                SubscriptionApprovalAction.APPROVED,
+                requestId,
+                123L,
+                456L,
+                "Customer EN",
+                "Customer AR",
+                "admin@example.com",
+                "0500000000",
+                "TEN-123",
+                "Tenant Inc",
+                "ops@example.com",
+                "0500000001",
+                "role",
+                OffsetDateTime.now(),
+                null);
+        Map<String, Object> payload = objectMapper.convertValue(message, Map.class);
+
+        Subscription subscription = new Subscription();
+        subscription.setSubscriptionId(10L);
+        subscription.setExtSubscriptionId(123L);
+        when(subscriptionRepository.findByExtSubscriptionId(123L)).thenReturn(Optional.of(subscription));
+
+        SubscriptionFeature feature = new SubscriptionFeature();
+        feature.setFeatureCd("FEATURE_A");
+        feature.setFeatureCount(5);
+        when(featureRepository.findBySubscriptionSubscriptionId(10L)).thenReturn(List.of(feature));
+
+        SubscriptionAdditionalService addon = new SubscriptionAdditionalService();
+        addon.setProductAdditionalServiceId(99L);
+        addon.setServiceCd("ADDON_A");
+        addon.setServiceNameEn("Addon English");
+        addon.setServiceNameAr("Addon Arabic");
+        addon.setServicePrice(BigDecimal.TEN);
+        addon.setTotalAmount(BigDecimal.ONE);
+        addon.setCurrency("USD");
+        addon.setIsCountable(Boolean.TRUE);
+        addon.setRequestedCount(3L);
+        addon.setPaymentTypeCd("ONE_TIME");
+        when(additionalServiceRepository.findBySubscriptionSubscriptionId(10L)).thenReturn(List.of(addon));
+
+        consumer.onApproval(payload);
+
+        List<ProvisionedFeature> expectedFeatures = List.of(new ProvisionedFeature("FEATURE_A", 5));
+        List<ProvisionedAddon> expectedAddons = List.of(new ProvisionedAddon(
+                99L,
+                "ADDON_A",
+                "Addon English",
+                "Addon Arabic",
+                BigDecimal.TEN,
+                BigDecimal.ONE,
+                "USD",
+                Boolean.TRUE,
+                3L,
+                "ONE_TIME"));
+
+        verify(provisioningPublisher).publish(eq(message), eq(expectedFeatures), eq(expectedAddons));
+    }
+
+    @Test
+    void nonApprovedMessagesAreIgnored() {
+        SubscriptionApprovalMessage message = new SubscriptionApprovalMessage(
+                SubscriptionApprovalAction.REQUEST,
+                UUID.randomUUID(),
+                123L,
+                456L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                OffsetDateTime.now(),
+                null);
+        Map<String, Object> payload = objectMapper.convertValue(message, Map.class);
+
+        consumer.onApproval(payload);
+
+        verify(provisioningPublisher, never())
+                .publish(org.mockito.Mockito.any(), org.mockito.Mockito.anyList(), org.mockito.Mockito.anyList());
+    }
+}


### PR DESCRIPTION
## Summary
- add shared tenant provisioning event payloads/configuration for downstream services
- publish tenant provisioning events from subscription-service when approvals arrive via Kafka
- persist tenant feature/addon entitlements in catalog-service by consuming the new provisioning events

## Testing
- mvn -pl subscription-service,catalog-service test *(fails: missing shared BOM artifacts in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da89fb0eac832f99eac1fe405e329e