### PR TITLE
Consolidate request context handling

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/CorrelationContextContributor.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/CorrelationContextContributor.java
@@ -1,0 +1,70 @@
+package com.ejada.starter_core.context;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import com.ejada.common.context.CorrelationContextUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Handles correlation id propagation: reads from incoming headers, generates if
+ * missing (configurable) and ensures both MDC and response headers are updated.
+ */
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CorrelationContextContributor implements RequestContextContributor {
+
+    private final String headerName;
+    private final String mdcKey;
+    private final boolean generateIfMissing;
+    private final boolean echoResponseHeader;
+
+    public CorrelationContextContributor(String headerName,
+                                         String mdcKey,
+                                         boolean generateIfMissing,
+                                         boolean echoResponseHeader) {
+        this.headerName = Objects.requireNonNullElse(headerName, HeaderNames.CORRELATION_ID);
+        this.mdcKey = Objects.requireNonNullElse(mdcKey, HeaderNames.CORRELATION_ID);
+        this.generateIfMissing = generateIfMissing;
+        this.echoResponseHeader = echoResponseHeader;
+    }
+
+    @Override
+    public ContextScope contribute(HttpServletRequest request, HttpServletResponse response) {
+        String correlationId = trimToNull(request.getHeader(headerName));
+        if (correlationId == null && generateIfMissing) {
+            correlationId = UUID.randomUUID().toString();
+        }
+        if (correlationId == null) {
+            return ContextScope.noop();
+        }
+
+        final String cid = correlationId;
+        MDC.put(mdcKey, cid);
+        MDC.put(HeaderNames.CORRELATION_ID, cid);
+        CorrelationContextUtil.put(HeaderNames.CORRELATION_ID, cid);
+        ContextManager.setCorrelationId(cid);
+        if (echoResponseHeader) {
+            response.setHeader(headerName, cid);
+        }
+
+        return () -> {
+            MDC.remove(mdcKey);
+            MDC.remove(HeaderNames.CORRELATION_ID);
+            ContextManager.clearCorrelationId();
+        };
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/RequestContextContributor.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/RequestContextContributor.java
@@ -1,0 +1,37 @@
+package com.ejada.starter_core.context;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+/**
+ * Strategy interface allowing modules to participate in request context enrichment.
+ * Implementations can populate MDC, thread-locals or other context carriers and
+ * return a {@link ContextScope} that performs the corresponding cleanup.
+ */
+@FunctionalInterface
+public interface RequestContextContributor {
+
+    /**
+     * Apply contribution to the current request/response pair.
+     *
+     * @return a {@link ContextScope} used to cleanup state after the filter chain completes
+     */
+    ContextScope contribute(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException;
+
+    /**
+     * Cleanup handle returned by contributors so the filter can perform deterministic teardown.
+     */
+    @FunctionalInterface
+    interface ContextScope extends AutoCloseable {
+        @Override
+        void close();
+
+        static ContextScope noop() {
+            return () -> { };
+        }
+    }
+}

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/TenantContextContributor.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/TenantContextContributor.java
@@ -1,0 +1,70 @@
+package com.ejada.starter_core.context;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import com.ejada.starter_core.config.CoreAutoConfiguration;
+import com.ejada.starter_core.tenant.TenantResolver;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Tenant contributor responsible for resolving tenant identifiers and exposing
+ * them via {@link ContextManager} as well as MDC entries.
+ */
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
+public class TenantContextContributor implements RequestContextContributor {
+
+    private static final Pattern TENANT_PATTERN = Pattern.compile("[A-Za-z0-9_-]{1,36}");
+
+    private final TenantResolver tenantResolver;
+    private final CoreAutoConfiguration.CoreProps.Tenant properties;
+
+    public TenantContextContributor(TenantResolver tenantResolver,
+                                    CoreAutoConfiguration.CoreProps.Tenant properties) {
+        this.tenantResolver = Objects.requireNonNull(tenantResolver, "tenantResolver");
+        this.properties = Objects.requireNonNull(properties, "properties");
+    }
+
+    @Override
+    public ContextScope contribute(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String tenant = trimToNull(tenantResolver.resolve(request));
+        if (tenant == null) {
+            return ContextScope.noop();
+        }
+        if (!TENANT_PATTERN.matcher(tenant).matches()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid " + HeaderNames.X_TENANT_ID);
+            return () -> { };
+        }
+
+        if (properties.isEchoResponseHeader()) {
+            response.setHeader(properties.getHeaderName(), tenant);
+        }
+
+        MDC.put(properties.getMdcKey(), tenant);
+        MDC.put(HeaderNames.X_TENANT_ID, tenant);
+        ContextManager.Tenant.Scope scope = ContextManager.Tenant.openScope(tenant);
+
+        return () -> {
+            MDC.remove(properties.getMdcKey());
+            MDC.remove(HeaderNames.X_TENANT_ID);
+            scope.close();
+        };
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/UserContextContributor.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/UserContextContributor.java
@@ -1,0 +1,49 @@
+package com.ejada.starter_core.context;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+/**
+ * Captures the authenticated user identifier (if present) and publishes it to
+ * both MDC and {@link ContextManager}.
+ */
+@Order(Ordered.HIGHEST_PRECEDENCE + 20)
+public class UserContextContributor implements RequestContextContributor {
+
+    @Override
+    public ContextScope contribute(HttpServletRequest request, HttpServletResponse response) {
+        String headerUser = trimToNull(request.getHeader(HeaderNames.USER_ID));
+        String attributeUser = request.getAttribute(HeaderNames.USER_ID) instanceof String
+                ? trimToNull((String) request.getAttribute(HeaderNames.USER_ID))
+                : null;
+        String userId = firstNonNull(headerUser, attributeUser);
+        if (userId == null) {
+            return ContextScope.noop();
+        }
+
+        MDC.put(HeaderNames.USER_ID, userId);
+        ContextManager.setUserId(userId);
+
+        return () -> {
+            MDC.remove(HeaderNames.USER_ID);
+            ContextManager.clearUserId();
+        };
+    }
+
+    private static String firstNonNull(String first, String second) {
+        return first != null ? first : second;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}


### PR DESCRIPTION
## Summary
- replace the separate correlation and tenant servlet filters with a single ContextFilter that delegates to ordered RequestContextContributors
- add a RequestContextContributor SPI with default correlation, tenant, and user implementations to manage MDC and thread-local cleanup in one place
- update the core auto-configuration to wire the new contributors, compute a unified filter order, and expose an extension point for downstream MDC enrichment

## Testing
- mvn -pl shared-lib/shared-starters/starter-core -am test *(fails: module not present in the Maven reactor)*

------
https://chatgpt.com/codex/tasks/task_e_68da8abf3eec832f9415473d5fdf5d2f