### PR TITLE
refactor: replace legacy tenant header usage

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
@@ -21,11 +21,6 @@ public final class HeaderNames {
      * header only and avoid using any legacy variants.
      */
     public static final String X_TENANT_ID = "X-Tenant-Id";
-    /**
-     * Legacy tenant header variant kept for backwards compatibility with
-     * services that still emit/expect the underscore format.
-     */
-    public static final String X_TENANT_ID_LEGACY = "x_tenant_id";
     public static final String TENANT_KEY = "X-Tenant-Key";
     public static final String MESSAGE_ID = "x-msg-id";
 

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/core/dispatch/sinks/DatabaseSink.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/core/dispatch/sinks/DatabaseSink.java
@@ -24,7 +24,7 @@ public class DatabaseSink implements Sink {
     this.table = (schema == null || schema.isBlank() ? "public" : schema) + "." + table;
     this.insertSql =
         "INSERT INTO " + this.table + " (" +
-        " id, ts_utc, " + HeaderNames.X_TENANT_ID_LEGACY + ", actor_id, actor_username, action, entity_type, entity_id, outcome," +
+        " id, ts_utc, " + HeaderNames.X_TENANT_ID + ", actor_id, actor_username, action, entity_type, entity_id, outcome," +
         " data_class, sensitivity, resource_path, resource_method, correlation_id, span_id, message, payload) " +
         "VALUES (? , ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, cast(? as jsonb))";
   }

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/persistence/entity/AuditEventEntity.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/persistence/entity/AuditEventEntity.java
@@ -11,7 +11,7 @@ public class AuditEventEntity {
   @Id
   private UUID id;
   @Column(name="ts_utc") private Instant tsUtc;
-  @Column(name = HeaderNames.X_TENANT_ID_LEGACY) private String xTenantId;
+  @Column(name = HeaderNames.X_TENANT_ID) private String xTenantId;
   @Column(name="actor_id") private String actorId;
   @Column(name="actor_username") private String actorUsername;
   @Column(name="action") private String action;


### PR DESCRIPTION
## Summary
- replace audit entity and sink references to the legacy tenant header with the canonical `X_TENANT_ID`
- remove the unused `X_TENANT_ID_LEGACY` constant from the shared header names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da90f32434832fa25f51a3410ddd2f