### PR TITLE
Refactor shared context pipeline and MDC helpers

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/context/TenantMdcUtil.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/context/TenantMdcUtil.java
@@ -1,0 +1,41 @@
+package com.ejada.common.context;
+
+import com.ejada.common.constants.HeaderNames;
+import org.slf4j.MDC;
+
+/**
+ * Helper for interacting with the tenant identifier stored inside the SLF4J MDC.
+ * Keeping this logic separate from {@link CorrelationContextUtil} avoids
+ * accidentally clearing tenant data when only the correlation identifier should
+ * be touched.
+ */
+public final class TenantMdcUtil {
+
+    private TenantMdcUtil() {
+        // utility class
+    }
+
+    /**
+     * Store the given tenant identifier inside MDC using the canonical key.
+     * Passing {@code null} clears the entry.
+     */
+    public static void setTenantId(String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            MDC.remove(HeaderNames.X_TENANT_ID);
+        } else {
+            MDC.put(HeaderNames.X_TENANT_ID, tenantId);
+        }
+    }
+
+    /**
+     * @return the tenant identifier currently stored in MDC or {@code null} if missing.
+     */
+    public static String getTenantId() {
+        return MDC.get(HeaderNames.X_TENANT_ID);
+    }
+
+    /** Remove the tenant identifier from MDC. */
+    public static void clear() {
+        MDC.remove(HeaderNames.X_TENANT_ID);
+    }
+}

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/ContextFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/ContextFilter.java
@@ -1,20 +1,5 @@
 package com.ejada.starter_core.context;
 
-import org.slf4j.MDC;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
-import org.springframework.lang.NonNull;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import com.ejada.common.constants.HeaderNames;
-import com.ejada.common.context.ContextManager;
-import com.ejada.common.context.CorrelationContextUtil;
-import com.ejada.starter_core.tenant.TenantResolution;
-import com.ejada.starter_core.tenant.TenantResolver;
-import com.ejada.starter_core.web.FilterSkipUtils;
-
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/CorrelationContextContributor.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/CorrelationContextContributor.java
@@ -46,8 +46,10 @@ public class CorrelationContextContributor implements RequestContextContributor 
 
         final String cid = correlationId;
         MDC.put(mdcKey, cid);
-        MDC.put(HeaderNames.CORRELATION_ID, cid);
-        CorrelationContextUtil.put(HeaderNames.CORRELATION_ID, cid);
+        if (!HeaderNames.CORRELATION_ID.equals(mdcKey)) {
+            MDC.put(HeaderNames.CORRELATION_ID, cid);
+        }
+        CorrelationContextUtil.setCorrelationId(cid);
         ContextManager.setCorrelationId(cid);
         if (echoResponseHeader) {
             response.setHeader(headerName, cid);
@@ -55,7 +57,10 @@ public class CorrelationContextContributor implements RequestContextContributor 
 
         return () -> {
             MDC.remove(mdcKey);
-            MDC.remove(HeaderNames.CORRELATION_ID);
+            if (!HeaderNames.CORRELATION_ID.equals(mdcKey)) {
+                MDC.remove(HeaderNames.CORRELATION_ID);
+            }
+            CorrelationContextUtil.clear();
             ContextManager.clearCorrelationId();
         };
     }

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/logging/CorrelationIdFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/logging/CorrelationIdFilter.java
@@ -15,6 +15,12 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.UUID;
 
+/**
+ * @deprecated Use {@link com.ejada.starter_core.context.ContextFilter} with a
+ * {@link com.ejada.starter_core.context.CorrelationContextContributor}
+ * instead. The dedicated filter will be removed in a future release.
+ */
+@Deprecated(since = "1.6.0", forRemoval = true)
 public class CorrelationIdFilter extends OncePerRequestFilter {
 
     private final String headerName;
@@ -52,9 +58,11 @@ public class CorrelationIdFilter extends OncePerRequestFilter {
             correlationId = UUID.randomUUID().toString();
         }
 
+        boolean correlationApplied = false;
         if (!isBlank(correlationId)) {
+            correlationApplied = true;
             MDC.put(mdcKey, correlationId);
-            CorrelationContextUtil.put(CorrelationContextUtil.CORRELATION_ID, correlationId);
+            CorrelationContextUtil.setCorrelationId(correlationId);
             // Set early to ensure response always has the header (even on exceptions)
             if (echoResponseHeader) {
                 res.setHeader(headerName, correlationId);
@@ -65,7 +73,9 @@ public class CorrelationIdFilter extends OncePerRequestFilter {
             chain.doFilter(req, res);
         } finally {
             MDC.remove(mdcKey);
-            CorrelationContextUtil.clear();
+            if (correlationApplied) {
+                CorrelationContextUtil.clear();
+            }
         }
     }
 

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantFilter.java
@@ -13,6 +13,13 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+/**
+ * @deprecated The tenant responsibilities now live in
+ * {@link com.ejada.starter_core.context.ContextFilter} via
+ * {@link com.ejada.starter_core.context.TenantContextContributor}. This legacy
+ * filter will be removed in a future release.
+ */
+@Deprecated(since = "1.6.0", forRemoval = true)
 public class TenantFilter extends OncePerRequestFilter {
 
     private final TenantResolver resolver;


### PR DESCRIPTION
## Summary
- streamline the context filter to orchestrate ordered contributors without duplicate MDC clearing
- scope the correlation MDC helper to correlation-only concerns and add a dedicated tenant MDC utility
- update crypto/correlation filters to use the new helpers and deprecate legacy standalone servlet filters

## Testing
- mvn -pl shared-starters/starter-core -am -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68da919aa800832fa526ee99a2fab221