### PR TITLE
Restrict dev permit-all entries and add unauthorized access tests

### DIFF
--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -214,15 +214,8 @@ shared:
     resource-server:
       enabled: true
       permit-all:
-        - "/api/auth/**"
-        - "/v3/api-docs/**"
-        - "/swagger-ui/**"
-        - "/actuator/health/**"
+        - "/actuator/health"
       disable-csrf: false
-      csrf-ignore:
-        - "/api/auth/**"
-        - "/v3/api-docs/**"
-        - "/swagger-ui/**"
     stateless: true
     roles-claim: roles
     tenant-claim: tenant

--- a/sec-service/src/test/java/com/ejada/sec/security/UserControllerSecurityTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/security/UserControllerSecurityTest.java
@@ -1,0 +1,42 @@
+package com.ejada.sec.security;
+
+import com.ejada.sec.controller.UserController;
+import com.ejada.sec.service.UserService;
+import com.ejada.starter_security.SecurityAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = UserController.class)
+@Import(SecurityAutoConfiguration.class)
+@TestPropertySource(properties = {
+    "spring.main.allow-bean-definition-overriding=true",
+    "shared.security.mode=hs256",
+    "shared.security.hs256.secret=test-secret",
+    "shared.security.jwt.secret=test-secret",
+    "shared.security.resource-server.enabled=true",
+    "shared.security.resource-server.disable-csrf=true",
+    "shared.security.resource-server.permit-all[0]=/actuator/health",
+    "server.servlet.context-path=/sec"
+})
+class UserControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void userEndpointsRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/sec/api/users"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/setup-service/src/main/resources/application-dev.yaml
+++ b/setup-service/src/main/resources/application-dev.yaml
@@ -200,7 +200,7 @@ shared:
     resource-server:
       enabled: true
       permit-all:
-        - "/**"
+        - "/actuator/health"
       disable-csrf: false
     stateless: true
     roles-claim: roles

--- a/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
@@ -1,0 +1,42 @@
+package com.ejada.setup.security;
+
+import com.ejada.setup.controller.CountryController;
+import com.ejada.setup.service.CountryService;
+import com.ejada.starter_security.SecurityAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CountryController.class)
+@Import(SecurityAutoConfiguration.class)
+@TestPropertySource(properties = {
+    "spring.main.allow-bean-definition-overriding=true",
+    "shared.security.mode=hs256",
+    "shared.security.hs256.secret=test-secret",
+    "shared.security.jwt.secret=test-secret",
+    "shared.security.resource-server.enabled=true",
+    "shared.security.resource-server.disable-csrf=true",
+    "shared.security.resource-server.permit-all[0]=/actuator/health",
+    "server.servlet.context-path=/core"
+})
+class CountryControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CountryService countryService;
+
+    @Test
+    void protectedEndpointsReturnUnauthorizedWithoutToken() throws Exception {
+        mockMvc.perform(get("/core/setup/countries"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
@@ -196,7 +196,7 @@ shared:
     resource-server:
       enabled: true
       permit-all:
-        - "/**"
+        - "/actuator/health"
       disable-csrf: false
     stateless: true
     roles-claim: roles

--- a/tenant-platform/billing-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-dev.yaml
@@ -197,7 +197,7 @@ shared:
     resource-server:
       enabled: true
       permit-all:
-        - "/**"
+        - "/actuator/health"
       disable-csrf: false
     stateless: true
     roles-claim: roles

--- a/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
@@ -199,7 +199,7 @@ shared:
     resource-server:
       enabled: true
       permit-all:
-        - "/**"
+        - "/actuator/health"
       disable-csrf: false
     stateless: true
     roles-claim: roles

--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -199,7 +199,7 @@ shared:
     resource-server:
       enabled: true
       permit-all:
-        - "/**"
+        - "/actuator/health"
       disable-csrf: false
     stateless: true
     roles-claim: roles

--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -199,7 +199,7 @@ shared:
     resource-server:
       enabled: true
       permit-all:
-        - "/**"
+        - "/actuator/health"
       disable-csrf: false
     stateless: true
     roles-claim: roles


### PR DESCRIPTION
## Summary
- limit shared and service-specific dev permit-all settings to the actuator health endpoint
- add MockMvc security tests in sec-service and setup-service to assert unauthorized access without credentials

## Testing
- `mvn test` (fails: missing internal com.ejada starter dependencies in the local environment)
- `mvn test` (fails: missing internal com.ejada starter dependencies in the local environment)


------
https://chatgpt.com/codex/tasks/task_e_68db00261b24832f8f011790c673a161