### PR TITLE
Add reactive API gateway and fix shared mapper wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository houses several components:
 - **shared-lib** – a collection of reusable Spring Boot starter modules and utilities.
 - **lms-setup** – a Spring Boot microservice for reference lookups and tenant/platform configuration.
 - **tenant-persistence** – central JPA entities, repositories, and Flyway migrations for the tenant domain.
+- **api-gateway** – Spring Cloud Gateway instance that fronts the services while reusing shared security and context modules.
 
 ## Getting Started
 

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,0 +1,21 @@
+FROM eclipse-temurin:21-jre-alpine
+
+RUN addgroup -g 1001 -S appgroup \
+    && adduser -u 1001 -S appuser -G appgroup
+
+WORKDIR /app
+
+COPY target/*.jar app.jar
+
+RUN chown -R appuser:appgroup /app
+
+USER appuser
+
+EXPOSE 8080
+
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]

--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -1,0 +1,127 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>shared-lib</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../shared-lib/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>api-gateway</artifactId>
+  <name>api-gateway</name>
+  <description>Spring Cloud Gateway for LMS platform reusing shared starters</description>
+
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+
+  <dependencies>
+    <!-- Spring Cloud Gateway (reactive stack) -->
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-gateway</artifactId>
+    </dependency>
+
+    <!-- Spring Security resource server (reactive) -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
+
+    <!-- Shared starters & libraries -->
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-ratelimit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>shared-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>shared-config</artifactId>
+    </dependency>
+
+    <!-- Reactive Redis for rate limiting -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis-reactive</artifactId>
+    </dependency>
+
+    <!-- Actuator for health endpoints -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <!-- Observability starter (metrics/tracing alignment) -->
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-observability</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${java.version}</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <layers>
+            <enabled>true</enabled>
+          </layers>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/api-gateway/src/main/java/com/ejada/gateway/ApiGatewayApplication.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ApiGatewayApplication.java
@@ -1,0 +1,15 @@
+package com.ejada.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Entry point for the LMS API Gateway.
+ */
+@SpringBootApplication
+public class ApiGatewayApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(ApiGatewayApplication.class, args);
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
@@ -1,0 +1,51 @@
+package com.ejada.gateway.config;
+
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+/**
+ * Programmatic route configuration so we can reuse the shared properties and
+ * enforce consistent filters across environments.
+ */
+@Configuration
+@EnableConfigurationProperties(GatewayRoutesProperties.class)
+public class GatewayRoutesConfiguration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GatewayRoutesConfiguration.class);
+
+  @Bean
+  RouteLocator gatewayRoutes(RouteLocatorBuilder builder, GatewayRoutesProperties properties) {
+    RouteLocatorBuilder.Builder routes = builder.routes();
+
+    for (Map.Entry<String, GatewayRoutesProperties.ServiceRoute> entry : properties.getRoutes().entrySet()) {
+      GatewayRoutesProperties.ServiceRoute route = entry.getValue();
+      route.validate(entry.getKey());
+
+      routes.route(route.getId(), predicate -> predicate
+          .path(route.getPaths().stream()
+              .filter(StringUtils::hasText)
+              .map(String::trim)
+              .toArray(String[]::new))
+          .filters(filters -> {
+            if (route.getStripPrefix() > 0) {
+              filters.stripPrefix(route.getStripPrefix());
+            }
+            return filters;
+          })
+          .uri(route.getUri()));
+
+      if (LOGGER.isInfoEnabled()) {
+        LOGGER.info("Registered route {} -> {} ({})", route.getId(), route.getUri(), route.getPaths());
+      }
+    }
+
+    return routes.build();
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
@@ -1,0 +1,138 @@
+package com.ejada.gateway.config;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration properties describing the downstream services that should be
+ * exposed through the gateway. The structure intentionally mirrors the
+ * documented plan so operators can declaratively manage routes per
+ * environment.
+ */
+@ConfigurationProperties(prefix = "gateway")
+public class GatewayRoutesProperties {
+
+  private final Map<String, ServiceRoute> routes = new LinkedHashMap<>();
+
+  public Map<String, ServiceRoute> getRoutes() {
+    return routes;
+  }
+
+  /**
+   * Route definition for a downstream service.
+   */
+  public static class ServiceRoute {
+
+    /** Identifier used for RouteLocator registration. */
+    private String id;
+
+    /** Downstream service URI (e.g. http://tenant-service:8080). */
+    private URI uri;
+
+    /** Paths that should map to the downstream service. */
+    private List<String> paths = new ArrayList<>();
+
+    /** Optional HTTP methods to restrict the route (empty = all). */
+    private List<String> methods = new ArrayList<>();
+
+    /** Number of path segments to strip before forwarding. */
+    private int stripPrefix = 1;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public URI getUri() {
+      return uri;
+    }
+
+    public void setUri(URI uri) {
+      this.uri = uri;
+    }
+
+    public void setUri(String value) {
+      if (StringUtils.hasText(value)) {
+        this.uri = URI.create(value.trim());
+      } else {
+        this.uri = null;
+      }
+    }
+
+    public List<String> getPaths() {
+      return paths;
+    }
+
+    public void setPaths(List<String> paths) {
+      this.paths = (paths == null) ? new ArrayList<>() : new ArrayList<>(paths);
+    }
+
+    public List<String> getMethods() {
+      return methods;
+    }
+
+    public void setMethods(List<String> methods) {
+      this.methods = (methods == null) ? new ArrayList<>() : new ArrayList<>(methods);
+    }
+
+    public int getStripPrefix() {
+      return stripPrefix;
+    }
+
+    public void setStripPrefix(int stripPrefix) {
+      this.stripPrefix = stripPrefix;
+    }
+
+    public void validate(String key) {
+      if (!StringUtils.hasText(id)) {
+        throw new IllegalStateException("gateway.routes." + key + ".id must not be blank");
+      }
+      if (uri == null) {
+        throw new IllegalStateException("gateway.routes." + key + ".uri must be provided");
+      }
+      if (paths == null || paths.isEmpty()) {
+        throw new IllegalStateException("gateway.routes." + key + ".paths must not be empty");
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "ServiceRoute{"
+          + "id='" + id + '\''
+          + ", uri=" + uri
+          + ", paths=" + paths
+          + ", methods=" + methods
+          + ", stripPrefix=" + stripPrefix
+          + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ServiceRoute that)) {
+        return false;
+      }
+      return stripPrefix == that.stripPrefix
+          && Objects.equals(id, that.id)
+          && Objects.equals(uri, that.uri)
+          && Objects.equals(paths, that.paths)
+          && Objects.equals(methods, that.methods);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, uri, paths, methods, stripPrefix);
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityConfiguration.java
@@ -1,0 +1,81 @@
+package com.ejada.gateway.config;
+
+import com.ejada.starter_security.SharedSecurityProps;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import java.util.List;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsConfigurationSource;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive security configuration that adapts the shared servlet-based starter
+ * to Spring WebFlux.
+ */
+@Configuration
+@EnableWebFluxSecurity
+public class GatewaySecurityConfiguration {
+
+  @Bean
+  public ReactiveJwtDecoder reactiveJwtDecoder(JwtDecoder jwtDecoder) {
+    return token -> Mono.fromCallable(() -> jwtDecoder.decode(token));
+  }
+
+  @Bean
+  public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http,
+      SharedSecurityProps props,
+      CorsConfigurationSource corsConfigurationSource,
+      ReactiveJwtDecoder reactiveJwtDecoder,
+      JwtAuthenticationConverter jwtAuthenticationConverter) {
+    var rs = props.getResourceServer();
+    http.securityContextRepository(NoOpServerSecurityContextRepository.getInstance());
+    if (rs.isDisableCsrf()) {
+      http.csrf(ServerHttpSecurity.CsrfSpec::disable);
+    }
+    http.cors(cors -> cors.configurationSource(corsConfigurationSource));
+    http.httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+        .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+        .logout(ServerHttpSecurity.LogoutSpec::disable);
+
+    http.authorizeExchange(spec -> {
+      String[] permitAll = rs.getPermitAll();
+      if (permitAll != null && permitAll.length > 0) {
+        spec.pathMatchers(permitAll).permitAll();
+      }
+      spec.pathMatchers(HttpMethod.OPTIONS).permitAll();
+      spec.anyExchange().authenticated();
+    });
+
+    http.oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt
+        .jwtDecoder(reactiveJwtDecoder)
+        .jwtAuthenticationConverter(new ReactiveJwtAuthenticationConverterAdapter(jwtAuthenticationConverter))));
+
+    return http.build();
+  }
+
+  @Bean
+  public CorsConfigurationSource gatewayCorsConfigurationSource(SharedSecurityProps props) {
+    CorsConfiguration configuration = new CorsConfiguration();
+    var allowedOrigins = props.getResourceServer().getAllowedOrigins();
+    if (!CollectionUtils.isEmpty(allowedOrigins)) {
+      configuration.setAllowedOrigins(allowedOrigins);
+    } else {
+      configuration.addAllowedOriginPattern("*");
+    }
+    configuration.addAllowedHeader("*");
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+    configuration.setAllowCredentials(false);
+    configuration.setMaxAge(3600L);
+    return exchange -> configuration;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/JacksonPrimaryAdjustmentConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/JacksonPrimaryAdjustmentConfiguration.java
@@ -1,0 +1,24 @@
+package com.ejada.gateway.config;
+
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Ensures that the shared {@code ObjectMapper} bean remains the single primary
+ * mapper by downgrading Spring Boot's default {@code jacksonObjectMapper}
+ * definition. This prevents duplicate primary ObjectMapper beans when the
+ * shared starter is present alongside Spring WebFlux auto-configuration.
+ */
+@Configuration
+public class JacksonPrimaryAdjustmentConfiguration {
+
+  @Bean
+  public static BeanFactoryPostProcessor jacksonPrimaryReconciler() {
+    return beanFactory -> {
+      if (beanFactory.containsBeanDefinition("jacksonObjectMapper")) {
+        beanFactory.getBeanDefinition("jacksonObjectMapper").setPrimary(false);
+      }
+    };
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/ReactiveContextConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/ReactiveContextConfiguration.java
@@ -1,0 +1,57 @@
+package com.ejada.gateway.config;
+
+import com.ejada.gateway.context.ReactiveRequestContextFilter;
+import com.ejada.gateway.ratelimit.ReactiveRateLimiterFilter;
+import com.ejada.shared_starter_ratelimit.RateLimitProps;
+import com.ejada.starter_core.config.CoreAutoConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.lang.Nullable;
+import org.springframework.web.server.WebFilter;
+
+/**
+ * Reactive equivalents for the servlet-based context/rate-limit filters.
+ */
+@Configuration
+@EnableConfigurationProperties({CoreAutoConfiguration.CoreProps.class, RateLimitProps.class})
+public class ReactiveContextConfiguration {
+
+  @Bean
+  @Order(Ordered.HIGHEST_PRECEDENCE)
+  @ConditionalOnMissingBean(ReactiveRequestContextFilter.class)
+  @ConditionalOnProperty(prefix = "shared.core.context", name = "enabled", havingValue = "true", matchIfMissing = true)
+  public WebFilter reactiveRequestContextFilter(CoreAutoConfiguration.CoreProps props,
+      @Qualifier("jacksonObjectMapper") @Nullable ObjectMapper jacksonObjectMapper,
+      ObjectProvider<ObjectMapper> objectMapperProvider) {
+    ObjectMapper mapper = (jacksonObjectMapper != null)
+        ? jacksonObjectMapper
+        : objectMapperProvider.getIfAvailable(ObjectMapper::new);
+    return new ReactiveRequestContextFilter(props, mapper);
+  }
+
+  @Bean
+  @ConditionalOnClass(ReactiveStringRedisTemplate.class)
+  @ConditionalOnBean(ReactiveStringRedisTemplate.class)
+  @ConditionalOnProperty(prefix = "shared.ratelimit", name = "enabled", havingValue = "true")
+  public ReactiveRateLimiterFilter reactiveRateLimiterFilter(
+      ReactiveStringRedisTemplate redisTemplate,
+      RateLimitProps props,
+      @Qualifier("jacksonObjectMapper") @Nullable ObjectMapper jacksonObjectMapper,
+      ObjectProvider<ObjectMapper> objectMapperProvider) {
+    ObjectMapper mapper = (jacksonObjectMapper != null)
+        ? jacksonObjectMapper
+        : objectMapperProvider.getIfAvailable();
+    return new ReactiveRateLimiterFilter(redisTemplate, props, mapper);
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/context/ReactiveRequestContextFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/ReactiveRequestContextFilter.java
@@ -1,0 +1,309 @@
+package com.ejada.gateway.context;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import com.ejada.common.context.TenantMdcUtil;
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.starter_core.config.CoreAutoConfiguration;
+import com.ejada.starter_core.tenant.TenantResolution;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
+
+/**
+ * Reactive equivalent of {@code ContextFilter}. It reuses the shared
+ * configuration properties to populate correlation and tenant details in MDC
+ * and {@link ContextManager}.
+ */
+public class ReactiveRequestContextFilter implements WebFilter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveRequestContextFilter.class);
+
+  private final CoreAutoConfiguration.CoreProps props;
+  private final ObjectMapper objectMapper;
+  private final String[] skipPatterns;
+
+  public ReactiveRequestContextFilter(CoreAutoConfiguration.CoreProps props, ObjectMapper objectMapper) {
+    this.props = Objects.requireNonNull(props, "props");
+    this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    Set<String> merged = new LinkedHashSet<>();
+    if (props.getCorrelation().getSkipPatterns() != null) {
+      Stream.of(props.getCorrelation().getSkipPatterns()).filter(StringUtils::hasText).forEach(merged::add);
+    }
+    if (props.getTenant().getSkipPatterns() != null) {
+      Stream.of(props.getTenant().getSkipPatterns()).filter(StringUtils::hasText).forEach(merged::add);
+    }
+    this.skipPatterns = merged.toArray(String[]::new);
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    String path = exchange.getRequest().getPath().pathWithinApplication().value();
+    if (shouldSkip(path)) {
+      return chain.filter(exchange);
+    }
+
+    Mono<Authentication> authentication = exchange.getPrincipal()
+        .filter(Authentication.class::isInstance)
+        .cast(Authentication.class)
+        .cache(Duration.ofSeconds(1));
+
+    RequestContextState state = new RequestContextState(props);
+    String correlationId = resolveCorrelationId(exchange);
+    state.setCorrelationId(correlationId);
+
+    return resolveTenant(exchange, authentication)
+        .flatMap(resolution -> {
+          if (resolution.isInvalid()) {
+            return rejectTenant(exchange, resolution.rawValue());
+          }
+          state.setTenant(resolution.hasTenant() ? resolution.tenantId() : null);
+          return authentication.defaultIfEmpty(null)
+              .flatMap(auth -> {
+                state.setAuthentication(auth);
+                state.apply(exchange);
+                return chain.filter(exchange)
+                    .contextWrite(ctx -> enrichContext(ctx, state))
+                    .doFinally(signal -> state.cleanup());
+              });
+        });
+  }
+
+  private Context enrichContext(Context context, RequestContextState state) {
+    Context updated = context;
+    if (state.getCorrelationId() != null) {
+      updated = updated.put(HeaderNames.CORRELATION_ID, state.getCorrelationId());
+    }
+    if (state.getTenant() != null) {
+      updated = updated.put(HeaderNames.X_TENANT_ID, state.getTenant());
+    }
+    if (state.getUserId() != null) {
+      updated = updated.put(HeaderNames.USER_ID, state.getUserId());
+    }
+    return updated;
+  }
+
+  private boolean shouldSkip(String path) {
+    if (!StringUtils.hasText(path)) {
+      return false;
+    }
+    return com.ejada.starter_core.web.FilterSkipUtils.shouldSkip(path, skipPatterns);
+  }
+
+  private String resolveCorrelationId(ServerWebExchange exchange) {
+    CoreAutoConfiguration.CoreProps.Correlation cfg = props.getCorrelation();
+    if (!cfg.isEnabled()) {
+      return null;
+    }
+    String headerName = cfg.getHeaderName();
+    String correlationId = trimToNull(exchange.getRequest().getHeaders().getFirst(headerName));
+    if (correlationId == null && cfg.isGenerateIfMissing()) {
+      correlationId = UUID.randomUUID().toString();
+    }
+    if (correlationId != null && cfg.isEchoResponseHeader()) {
+      exchange.getResponse().getHeaders().set(headerName, correlationId);
+    }
+    return correlationId;
+  }
+
+  private Mono<TenantResolution> resolveTenant(ServerWebExchange exchange, Mono<Authentication> authentication) {
+    CoreAutoConfiguration.CoreProps.Tenant cfg = props.getTenant();
+    if (!cfg.isEnabled()) {
+      return Mono.just(TenantResolution.absent());
+    }
+    String fromHeader = trimToNull(exchange.getRequest().getHeaders().getFirst(cfg.getHeaderName()));
+    String fromQuery = trimToNull(exchange.getRequest().getQueryParams().getFirst(cfg.getQueryParam()));
+
+    Mono<String> fromJwt = Mono.empty();
+    if (cfg.isResolveFromJwt()) {
+      fromJwt = authentication.flatMap(auth -> Mono.justOrEmpty(extractTenantFromJwt(auth, cfg.getJwtClaimNames())));
+    }
+
+    boolean preferHeader = cfg.isPreferHeaderOverJwt();
+    Mono<String> ordered = preferHeader
+        ? fromJwt.defaultIfEmpty(null).map(jwt -> selectTenant(fromHeader, fromQuery, jwt))
+        : fromJwt.defaultIfEmpty(null).map(jwt -> selectTenant(jwt, fromHeader, fromQuery));
+
+    return ordered.map(candidate -> {
+      if (candidate == null) {
+        return TenantResolution.absent();
+      }
+      return validateTenant(candidate);
+    });
+  }
+
+  private String selectTenant(String first, String second, String third) {
+    if (StringUtils.hasText(first)) {
+      return first.trim();
+    }
+    if (StringUtils.hasText(second)) {
+      return second.trim();
+    }
+    if (StringUtils.hasText(third)) {
+      return third.trim();
+    }
+    return null;
+  }
+
+  private String extractTenantFromJwt(Authentication auth, String[] claimNames) {
+    if (auth instanceof JwtAuthenticationToken jwtAuthenticationToken) {
+      for (String claim : claimNames) {
+        Object value = jwtAuthenticationToken.getToken().getClaims().get(claim);
+        if (value != null) {
+          String tenant = Objects.toString(value, null);
+          if (StringUtils.hasText(tenant)) {
+            return tenant.trim();
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private TenantResolution validateTenant(String candidate) {
+    if (!StringUtils.hasText(candidate)) {
+      return TenantResolution.absent();
+    }
+    String trimmed = candidate.trim();
+    if (!trimmed.matches("[A-Za-z0-9_-]{1,36}")) {
+      return TenantResolution.invalid(trimmed);
+    }
+    return TenantResolution.present(trimmed);
+  }
+
+  private Mono<Void> rejectTenant(ServerWebExchange exchange, String rawValue) {
+    LOGGER.warn("Invalid tenant identifier: {}", rawValue);
+    ServerHttpResponse response = exchange.getResponse();
+    response.setStatusCode(HttpStatus.BAD_REQUEST);
+    response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+    BaseResponse<Void> body = BaseResponse.error("ERR_INVALID_TENANT", "Invalid " + HeaderNames.X_TENANT_ID);
+    try {
+      byte[] bytes = objectMapper.writeValueAsBytes(body);
+      return response.writeWith(Mono.just(response.bufferFactory().wrap(bytes)));
+    } catch (JsonProcessingException ex) {
+      byte[] fallback = ("{\"status\":\"ERROR\",\"code\":\"ERR_INVALID_TENANT\",\"message\":\"Invalid "
+          + HeaderNames.X_TENANT_ID + "\"}").getBytes(StandardCharsets.UTF_8);
+      return response.writeWith(Mono.just(response.bufferFactory().wrap(fallback)));
+    }
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  /**
+   * Holds the request-scoped context and is responsible for applying and
+   * cleaning up MDC/thread-local state.
+   */
+  static final class RequestContextState {
+
+    private final CoreAutoConfiguration.CoreProps props;
+    private String correlationId;
+    private String tenant;
+    private Authentication authentication;
+    private ContextManager.Tenant.Scope tenantScope;
+
+    RequestContextState(CoreAutoConfiguration.CoreProps props) {
+      this.props = props;
+    }
+
+    void setCorrelationId(String correlationId) {
+      this.correlationId = correlationId;
+    }
+
+    void setTenant(String tenant) {
+      this.tenant = tenant;
+    }
+
+    void setAuthentication(Authentication authentication) {
+      this.authentication = authentication;
+    }
+
+    String getCorrelationId() {
+      return correlationId;
+    }
+
+    String getTenant() {
+      return tenant;
+    }
+
+    String getUserId() {
+      return authentication != null ? trimToNull(authentication.getName()) : null;
+    }
+
+    void apply(ServerWebExchange exchange) {
+      if (correlationId != null && props.getCorrelation().isEnabled()) {
+        MDC.put(props.getCorrelation().getMdcKey(), correlationId);
+        if (!HeaderNames.CORRELATION_ID.equals(props.getCorrelation().getMdcKey())) {
+          MDC.put(HeaderNames.CORRELATION_ID, correlationId);
+        }
+        ContextManager.setCorrelationId(correlationId);
+      }
+
+      if (tenant != null && props.getTenant().isEnabled()) {
+        MDC.put(props.getTenant().getMdcKey(), tenant);
+        TenantMdcUtil.setTenantId(tenant);
+        tenantScope = ContextManager.Tenant.openScope(tenant);
+        if (props.getTenant().isEchoResponseHeader()) {
+          exchange.getResponse().getHeaders().set(props.getTenant().getHeaderName(), tenant);
+        }
+      }
+
+      String userId = getUserId();
+      if (StringUtils.hasText(userId)) {
+        MDC.put(HeaderNames.USER_ID, userId);
+        ContextManager.setUserId(userId);
+      }
+    }
+
+    void cleanup() {
+      if (correlationId != null && props.getCorrelation().isEnabled()) {
+        MDC.remove(props.getCorrelation().getMdcKey());
+        if (!HeaderNames.CORRELATION_ID.equals(props.getCorrelation().getMdcKey())) {
+          MDC.remove(HeaderNames.CORRELATION_ID);
+        }
+        ContextManager.clearCorrelationId();
+      }
+      if (tenantScope != null) {
+        try {
+          tenantScope.close();
+        } catch (Exception ex) {
+          LOGGER.warn("Failed to close tenant scope", ex);
+        }
+      }
+      if (props.getTenant().isEnabled()) {
+        MDC.remove(props.getTenant().getMdcKey());
+        TenantMdcUtil.clear();
+      }
+      String userId = getUserId();
+      if (StringUtils.hasText(userId)) {
+        MDC.remove(HeaderNames.USER_ID);
+        ContextManager.clearUserId();
+      }
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/error/GatewayErrorWebExceptionHandler.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/error/GatewayErrorWebExceptionHandler.java
@@ -1,0 +1,103 @@
+package com.ejada.gateway.error;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.exception.BusinessException;
+import com.ejada.common.exception.BusinessRuleException;
+import com.ejada.common.exception.DuplicateResourceException;
+import com.ejada.common.exception.NotFoundException;
+import com.ejada.common.exception.ValidationException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive exception handler that mirrors the behaviour of
+ * {@code GlobalExceptionHandler} from the shared servlet stack.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class GatewayErrorWebExceptionHandler implements ErrorWebExceptionHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GatewayErrorWebExceptionHandler.class);
+
+  private final ObjectMapper objectMapper;
+  public GatewayErrorWebExceptionHandler(
+      @Qualifier("jacksonObjectMapper") ObjectMapper jacksonObjectMapper,
+      ObjectProvider<ObjectMapper> objectMapperProvider) {
+    this.objectMapper = (jacksonObjectMapper != null) ? jacksonObjectMapper
+        : objectMapperProvider.getIfAvailable(ObjectMapper::new);
+  }
+
+  @Override
+  public @NonNull Mono<Void> handle(ServerWebExchange exchange, @NonNull Throwable ex) {
+    if (exchange.getResponse().isCommitted()) {
+      return Mono.error(ex);
+    }
+
+    ErrorResponse errorResponse = mapException(ex);
+    exchange.getResponse().setStatusCode(errorResponse.status());
+    exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+    try {
+      byte[] bytes = objectMapper.writeValueAsBytes(errorResponse.body());
+      return exchange.getResponse().writeWith(Mono.just(exchange.getResponse().bufferFactory().wrap(bytes)));
+    } catch (JsonProcessingException e) {
+      LOGGER.error("Failed to serialize error response", e);
+      return exchange.getResponse().setComplete();
+    }
+  }
+
+  private ErrorResponse mapException(Throwable ex) {
+    if (ex instanceof ResponseStatusException rse) {
+      HttpStatusCode status = rse.getStatusCode();
+      String code = status.value() >= 500 ? "ERR_INTERNAL" : "ERR_STATUS";
+      return new ErrorResponse(status, BaseResponse.error(code, rse.getReason()));
+    }
+    if (ex instanceof NotFoundException || ex instanceof java.util.NoSuchElementException) {
+      return new ErrorResponse(HttpStatus.NOT_FOUND, BaseResponse.error("ERR_RESOURCE_NOT_FOUND", ex.getMessage()));
+    }
+    if (ex instanceof DuplicateResourceException) {
+      return new ErrorResponse(HttpStatus.CONFLICT, BaseResponse.error("ERR_DATA_CONFLICT", ex.getMessage()));
+    }
+    if (ex instanceof DataIntegrityViolationException) {
+      return new ErrorResponse(HttpStatus.CONFLICT, BaseResponse.error("ERR_DATA_CONFLICT", "Data conflict occurred"));
+    }
+    if (ex instanceof ValidationException) {
+      return new ErrorResponse(HttpStatus.BAD_REQUEST, BaseResponse.error("ERR_VALIDATION", ex.getMessage()));
+    }
+    if (ex instanceof BusinessRuleException) {
+      return new ErrorResponse(HttpStatus.BAD_REQUEST, BaseResponse.error("ERR_BUSINESS_RULE", ex.getMessage()));
+    }
+    if (ex instanceof BusinessException) {
+      return new ErrorResponse(HttpStatus.BAD_REQUEST, BaseResponse.error("ERR_BUSINESS_LOGIC", ex.getMessage()));
+    }
+    if (ex instanceof IllegalArgumentException) {
+      return new ErrorResponse(HttpStatus.BAD_REQUEST, BaseResponse.error("ERR_INVALID_ARGUMENT", ex.getMessage()));
+    }
+    if (ex instanceof IllegalStateException) {
+      return new ErrorResponse(HttpStatus.CONFLICT, BaseResponse.error("ERR_ILLEGAL_STATE", ex.getMessage()));
+    }
+    if (ex instanceof org.springframework.security.access.AccessDeniedException) {
+      return new ErrorResponse(HttpStatus.FORBIDDEN, BaseResponse.error("ERR_ACCESS_DENIED", "Access denied"));
+    }
+    LOGGER.error("Unexpected gateway error", ex);
+    return new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, BaseResponse.error("ERR_INTERNAL", "An unexpected error occurred"));
+  }
+
+  private record ErrorResponse(HttpStatusCode status, BaseResponse<?> body) {}
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
@@ -1,0 +1,133 @@
+package com.ejada.gateway.ratelimit;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.shared_starter_ratelimit.RateLimitProps;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive adaptation of the servlet {@code RateLimitFilter}. It uses Redis
+ * atomic increments to enforce a simple fixed window rate limit per strategy.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 20)
+public class ReactiveRateLimiterFilter implements WebFilter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveRateLimiterFilter.class);
+
+  private final ReactiveStringRedisTemplate redisTemplate;
+  private final RateLimitProps props;
+  private final ObjectMapper objectMapper;
+
+  @Autowired
+  public ReactiveRateLimiterFilter(ReactiveStringRedisTemplate redisTemplate,
+      RateLimitProps props,
+      @Qualifier("jacksonObjectMapper") ObjectProvider<ObjectMapper> jacksonObjectMapper,
+      ObjectProvider<ObjectMapper> objectMapperProvider) {
+    this(redisTemplate, props, resolveObjectMapper(jacksonObjectMapper, objectMapperProvider));
+  }
+
+  public ReactiveRateLimiterFilter(ReactiveStringRedisTemplate redisTemplate,
+      RateLimitProps props,
+      @Nullable ObjectMapper objectMapper) {
+    this.redisTemplate = Objects.requireNonNull(redisTemplate, "redisTemplate");
+    this.props = Objects.requireNonNull(props, "props");
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    String key = keyFor(exchange);
+    String bucket = "rl:" + key;
+    return redisTemplate.opsForValue().increment(bucket)
+        .flatMap(count -> setExpiry(bucket, count)
+            .then(Mono.defer(() -> {
+              int capacity = Math.max(1, props.getCapacity());
+              exchange.getResponse().getHeaders().set("X-RateLimit-Limit", String.valueOf(capacity));
+              exchange.getResponse().getHeaders().set("X-RateLimit-Remaining",
+                  String.valueOf(Math.max(0, capacity - count.intValue())));
+              if (count > capacity) {
+                return reject(exchange);
+              }
+              return chain.filter(exchange);
+            })))
+        .onErrorResume(ex -> {
+          LOGGER.warn("Rate limiter failed, allowing request", ex);
+          return chain.filter(exchange);
+        });
+  }
+
+  private Mono<Boolean> setExpiry(String bucket, Long count) {
+    if (count != null && count == 1L) {
+      return redisTemplate.expire(bucket, Duration.ofMinutes(1));
+    }
+    return Mono.just(Boolean.TRUE);
+  }
+
+  private String keyFor(ServerWebExchange exchange) {
+    return switch (props.getKeyStrategy()) {
+      case "ip" -> {
+        String forwarded = exchange.getRequest().getHeaders().getFirst(HeaderNames.CLIENT_IP);
+        yield StringUtils.hasText(forwarded)
+            ? forwarded
+            : Objects.toString(exchange.getRequest().getRemoteAddress(), "anonymous");
+      }
+      case "user" -> {
+        String userId = ContextManager.getUserId();
+        yield StringUtils.hasText(userId) ? userId : "anonymous";
+      }
+      default -> {
+        String tenant = ContextManager.Tenant.get();
+        yield StringUtils.hasText(tenant) ? tenant : "public";
+      }
+    };
+  }
+
+  private Mono<Void> reject(ServerWebExchange exchange) {
+    LOGGER.debug("Rate limit exceeded for request to {}", exchange.getRequest().getPath());
+    var response = exchange.getResponse();
+    response.setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
+    response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+    BaseResponse<Void> body = BaseResponse.error("ERR_RATE_LIMIT", "Rate limit exceeded");
+    byte[] payload;
+    try {
+      payload = (objectMapper != null)
+          ? objectMapper.writeValueAsBytes(body)
+          : body.toString().getBytes(StandardCharsets.UTF_8);
+    } catch (JsonProcessingException e) {
+      payload = body.toString().getBytes(StandardCharsets.UTF_8);
+    }
+    return response.writeWith(Mono.just(response.bufferFactory().wrap(payload)));
+  }
+
+  private static ObjectMapper resolveObjectMapper(ObjectProvider<ObjectMapper> primary,
+      ObjectProvider<ObjectMapper> fallback) {
+    ObjectMapper mapper = (primary != null) ? primary.getIfAvailable() : null;
+    if (mapper != null) {
+      return mapper;
+    }
+    return (fallback != null) ? fallback.getIfAvailable() : null;
+  }
+}

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -1,0 +1,77 @@
+spring:
+  application:
+    name: api-gateway
+  main:
+    web-application-type: reactive
+  autoconfigure:
+    exclude:
+      - com.ejada.shared_starter_ratelimit.RateLimitAutoConfiguration
+  cloud:
+    compatibility-verifier:
+      enabled: false
+    gateway:
+      httpclient:
+        connect-timeout: 5000
+        response-timeout: 10s
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: always
+
+# Disable servlet security auto configuration (we provide reactive equivalent)
+shared:
+  security:
+    resource-server:
+      enabled: false
+
+  core:
+    tenant:
+      enabled: true
+    correlation:
+      enabled: true
+
+  ratelimit:
+    enabled: false
+
+# Declarative downstream routes consumed by GatewayRoutesConfiguration
+gateway:
+  routes:
+    setup:
+      id: setup-service
+      uri: http://setup-service:8080
+      paths:
+        - /api/setup/**
+      strip-prefix: 1
+    tenant:
+      id: tenant-service
+      uri: http://tenant-service:8080
+      paths:
+        - /api/tenant/**
+      strip-prefix: 1
+    catalog:
+      id: catalog-service
+      uri: http://catalog-service:8080
+      paths:
+        - /api/catalog/**
+      strip-prefix: 1
+    subscription:
+      id: subscription-service
+      uri: http://subscription-service:8080
+      paths:
+        - /api/subscription/**
+      strip-prefix: 1
+    billing:
+      id: billing-service
+      uri: http://billing-service:8080
+      paths:
+        - /api/billing/**
+      strip-prefix: 1
+
+logging:
+  level:
+    root: INFO
+    com.ejada.gateway: DEBUG

--- a/api-gateway/src/test/java/com/ejada/gateway/ApiGatewayApplicationTests.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/ApiGatewayApplicationTests.java
@@ -1,0 +1,32 @@
+package com.ejada.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+    "shared.security.mode=hs256",
+    "shared.security.hs256.secret=unit-test-secret",
+    "shared.security.resource-server.enabled=false",
+    "gateway.routes.test.id=test-route",
+    "gateway.routes.test.uri=http://example.org",
+    "gateway.routes.test.paths[0]=/test/**",
+    "shared.ratelimit.enabled=false",
+    "spring.autoconfigure.exclude=com.ejada.shared_starter_ratelimit.RateLimitAutoConfiguration"
+})
+class ApiGatewayApplicationTests {
+
+  @Autowired
+  private RouteLocator routeLocator;
+
+  @Test
+  void contextLoads() {
+    assertThat(routeLocator).isNotNull();
+    assertThat(routeLocator.getRoutes().collectList().block()).isNotEmpty();
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -256,3 +256,27 @@ services:
       - "8085:8080"
     networks:
       backend:
+
+  api-gateway:
+    build: ./api-gateway
+    <<: [*restart_policy]
+    depends_on:
+      setup-service: { condition: service_started }
+      tenant-service: { condition: service_started }
+      catalog-service: { condition: service_started }
+      subscription-service: { condition: service_started }
+      billing-service: { condition: service_started }
+      security-service: { condition: service_started }
+      redis: { condition: service_healthy }
+      otel-collector: { condition: service_started }
+    environment:
+      TZ: Asia/Riyadh
+      <<: [*redis_env, *otel_env]
+      OTEL_SERVICE_NAME: api-gateway
+      SHARED_SECURITY_MODE: hs256
+      SHARED_SECURITY_HS256_SECRET: ${JWT_SECRET:-local-dev-secret}
+      SHARED_SECURITY_RESOURCE_SERVER_ENABLED: "false"
+    ports:
+      - "8088:8080"
+    networks:
+      backend:

--- a/docs/api-gateway-plan.md
+++ b/docs/api-gateway-plan.md
@@ -1,0 +1,107 @@
+# API Gateway Codebase Assessment & Plan
+
+## Phase 1 – Shared Library Inventory
+
+| Capability | Component(s) | Location | Notes |
+| --- | --- | --- | --- |
+| Security & JWT | `SecurityAutoConfiguration`, `JwtAuthenticationConverter`, `JwtDecoder`, tenant propagation via `JwtTenantFilter` | `shared-lib/shared-starters/starter-security` | Provides resource-server defaults, claim-to-authority mapping, pluggable CSRF/CORS handling, and JWT decoder options (HS256/JWKS/issuer) suitable for reuse in the gateway. 【F:shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java†L59-L199】 |
+| JWT token services | `JwtTokenService`, `JwtTokenAutoConfiguration` | `shared-lib/shared-lib-crypto` | Offers HMAC-based token generation with configurable TTL for service-to-service calls or admin flows. 【F:shared-lib/shared-lib-crypto/src/main/java/com/ejada/crypto/JwtTokenService.java†L13-L92】 |
+| Exception handling | `GlobalExceptionHandler`, `CoreExceptionAutoConfiguration` | `shared-lib/shared-starters/starter-core` | Centralizes REST error responses using `BaseResponse` wrappers and shared error codes. Gateway should extend to produce reactive responses. 【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java†L29-L185】 |
+| Logging | `LoggingAutoConfiguration` | `shared-lib/shared-starters/starter-core` | Configures Logback console with MDC propagation and optional JSON encoder tied to correlation/tenant IDs. 【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/logging/LoggingAutoConfiguration.java†L17-L58】 |
+| Request context propagation | `CoreAutoConfiguration`, `ContextFilter`, `CorrelationContextContributor`, `TenantContextContributor` | `shared-lib/shared-starters/starter-core` | Handles correlation ID generation, tenant resolution, and filter registration for servlet stack. Requires reactive equivalents for WebFlux. 【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/config/CoreAutoConfiguration.java†L44-L200】【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/ContextFilter.java†L20-L118】【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/CorrelationContextContributor.java†L15-L74】 |
+| DTOs & response wrappers | `BaseResponse`, `ErrorResponse`, request metadata models | `shared-lib/shared-common/dto` | Standardizes API envelopes; gateway responses should continue using them. 【F:shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseResponse.java†L14-L137】 |
+| Common exceptions | `BusinessException`, `ValidationException`, etc. | `shared-lib/shared-common/exception` | Shared hierarchy underpinning GlobalExceptionHandler. |
+| Events & messaging | Tenant provisioning & subscription approval records | `shared-lib/shared-common/events/*` | Shared Kafka payload contracts referenced by catalog/subscription listeners; gateway can reuse for orchestration or pass-through. 【F:shared-lib/shared-common/src/main/java/com/ejada/common/events/provisioning/TenantProvisioningMessage.java†L7-L18】【F:shared-lib/shared-common/src/main/java/com/ejada/common/events/subscription/SubscriptionApprovalMessage.java†L6-L25】 |
+| Rate limiting | `RateLimitAutoConfiguration`, `RateLimitFilter`, `RateLimitProps` | `shared-lib/shared-starters/starter-ratelimit` | Servlet filter backed by Redis; behavior needs adaptation for WebFlux. 【F:shared-lib/shared-starters/starter-ratelimit/src/main/java/com/ejada/shared_starter_ratelimit/RateLimitAutoConfiguration.java†L1-L16】【F:shared-lib/shared-starters/starter-ratelimit/src/main/java/com/ejada/shared_starter_ratelimit/RateLimitFilter.java†L1-L27】【F:shared-lib/shared-starters/starter-ratelimit/src/main/java/com/ejada/shared_starter_ratelimit/RateLimitProps.java†L8-L24】 |
+| Configuration baseline | `AppProperties`, `CentralConfigAutoConfiguration` | `shared-lib/shared-config` | Provides centralized `app.*` properties that downstream services import. 【F:shared-lib/shared-config/src/main/java/com/ejada/config/CentralConfigAutoConfiguration.java†L6-L13】【F:shared-lib/shared-config/src/main/java/com/ejada/config/AppProperties.java†L6-L17】 |
+
+**Usage patterns & compatibility**
+
+* All starters target servlet-based Spring Boot (Spring MVC) applications, relying on servlet filters. Adapting for Spring Cloud Gateway (reactive stack) will require wrapper components for filters and exception handlers.
+* DTOs, error codes, and logging rely on shared enums/contexts; ensure the gateway exposes the same MDC keys (correlationId, tenantId) and response formats to remain compatible.
+* Redis, Kafka, and security starters assume Spring Boot 3 / Java 21 (matching microservices), so version compatibility is aligned for gateway implementation.
+
+## Phase 2 – Microservice Architectural Patterns
+
+| Area | Observations | Evidence |
+| --- | --- | --- |
+| Authentication & authorization | REST controllers return `BaseResponse` envelopes and delegate to shared security starter; endpoints require JWT with role enforcement. | `AuthController` endpoints use shared DTOs and responses. 【F:sec-service/src/main/java/com/ejada/sec/controller/AuthController.java†L16-L59】 Configuration enables shared security props. 【F:sec-service/src/main/resources/application.yaml†L29-L56】 |
+| Service communication | Predominantly RESTful; Kafka used for cross-service orchestration (tenant provisioning, subscription approvals). No Feign clients detected. | Billing controller handles synchronous REST requests. 【F:tenant-platform/billing-service/src/main/java/com/ejada/billing/controller/ConsumptionController.java†L20-L45】 Kafka listeners consume shared events. 【F:tenant-platform/catalog-service/src/main/java/com/ejada/catalog/kafka/TenantProvisioningListener.java†L13-L29】 |
+| Circuit breaking & resilience | No explicit Resilience4j annotations in services; reliance on gateway/starter-resilience still to be leveraged (starter exists but not widely used). |
+| Service discovery | No evidence of Eureka/Consul annotations; services appear to run behind static routing (likely via API gateway/load balancer). |
+| Configuration management | Services import `shared-config` and define layered `application-*.yaml` profiles for environment overrides. 【F:sec-service/src/main/resources/application.yaml†L1-L61】 |
+| Logging & tracing | Use SLF4J loggers combined with shared correlation/tenant context from starters. 【F:setup-service/src/main/java/com/ejada/setup/service/impl/LookupServiceImpl.java†L29-L125】 |
+| Error handling | Controllers return `BaseResponse` via service layer; shared `GlobalExceptionHandler` ensures consistent codes for validation/data errors. 【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java†L51-L185】 |
+| API versioning | No explicit versioning; controllers mount under `/api/...` prefixes, version likely handled via routing or header conventions. |
+| Database transactions | Extensive use of `@Transactional` for service methods, mixing read-only and default propagation. 【F:setup-service/src/main/java/com/ejada/setup/service/impl/LookupServiceImpl.java†L29-L125】 |
+| Caching strategies | Redis-backed caching via `@Cacheable` with explicit cache names (lookups, addons, etc.). 【F:setup-service/src/main/java/com/ejada/setup/service/impl/LookupServiceImpl.java†L43-L85】 |
+| Observability & headers | Shared security headers and actuator SLA reporting enabled through configuration. 【F:sec-service/src/main/resources/application.yaml†L29-L56】 |
+
+## Phase 3 – Gateway Integration Opportunities
+
+1. **Direct reuse**
+   * Security auto-configuration & shared security properties for JWT validation and role mapping. 【F:shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java†L59-L199】
+   * Global error DTOs and error codes via `BaseResponse` and shared exceptions. 【F:shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseResponse.java†L14-L137】
+   * Logging conventions (Logback encoder, MDC keys) and configuration properties to keep logs consistent. 【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/logging/LoggingAutoConfiguration.java†L17-L58】
+   * Shared event payloads so the gateway can forward or publish Kafka messages without redefining schemas. 【F:shared-lib/shared-common/src/main/java/com/ejada/common/events/provisioning/TenantProvisioningMessage.java†L7-L18】
+
+2. **Adaptation needs**
+   * Servlet-based filters (`ContextFilter`, `RateLimitFilter`, `JwtTenantFilter`) require reactive equivalents for `GatewayFilter` / `WebFilter`. 【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/ContextFilter.java†L20-L118】【F:shared-lib/shared-starters/starter-ratelimit/src/main/java/com/ejada/shared_starter_ratelimit/RateLimitFilter.java†L1-L27】
+   * `GlobalExceptionHandler` should be wrapped by a Spring Cloud Gateway `ErrorWebExceptionHandler` to emit reactive `BaseResponse`. 【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java†L51-L185】
+   * Rate limiting uses `StringRedisTemplate` (blocking); gateway will need `ReactiveStringRedisTemplate` or reactive script execution.
+
+3. **Gaps to address**
+   * Gateway-specific routing configuration (Spring Cloud Gateway `RouteLocator`) and predicate definitions are absent.
+   * No reactive authentication manager or token relay in shared library; gateway needs to bridge shared JWT decoder into reactive security.
+   * Aggregation/fallback logic (e.g., resilience, circuit breaking) is not implemented in existing services; gateway should introduce Resilience4j Reactor operators if required.
+
+4. **Potential conflicts**
+   * Mixing servlet-based starters inside a reactive gateway may autoconfigure incompatible beans (e.g., `FilterRegistrationBean`). Need to conditionally disable servlet-only auto-configurations when running on WebFlux.
+   * Rate limiting semantics rely on tenant context from servlet `ContextManager`; reactive context propagation must align to avoid mismatched keys.
+
+## Phase 4 – API Gateway Implementation Plan
+
+### ✅ Components to REUSE from shared-lib
+- [ ] `SecurityAutoConfiguration` beans (reuse JWT decoder, role conversion, and shared security props)【F:shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java†L59-L199】
+- [ ] `JwtTokenService` for administrative token issuance if needed【F:shared-lib/shared-lib-crypto/src/main/java/com/ejada/crypto/JwtTokenService.java†L13-L92】
+- [ ] `GlobalExceptionHandler` error codes & DTOs (wrap for WebFlux responses)【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java†L51-L185】
+- [ ] `LoggingAutoConfiguration` MDC strategy (ensure MDC population via Reactor context)【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/logging/LoggingAutoConfiguration.java†L17-L58】
+- [ ] `BaseResponse` / shared DTOs for consistent payloads【F:shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseResponse.java†L14-L137】
+- [ ] Kafka event records for pass-through messaging【F:shared-lib/shared-common/src/main/java/com/ejada/common/events/provisioning/TenantProvisioningMessage.java†L7-L18】
+
+### 🔧 Components to ADAPT
+- [ ] Wrap servlet `ContextFilter` & contributors into reactive `WebFilter` to maintain correlation/tenant IDs via Reactor context and `ServerWebExchange`【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/ContextFilter.java†L20-L118】
+- [ ] Re-implement `RateLimitFilter` as `GatewayFilter` using `ReactiveStringRedisTemplate` while honoring existing configuration properties【F:shared-lib/shared-starters/starter-ratelimit/src/main/java/com/ejada/shared_starter_ratelimit/RateLimitFilter.java†L1-L27】【F:shared-lib/shared-starters/starter-ratelimit/src/main/java/com/ejada/shared_starter_ratelimit/RateLimitProps.java†L8-L24】
+- [ ] Translate `GlobalExceptionHandler` mappings into a reactive `ErrorAttributes`/`ErrorWebExceptionHandler` pipeline that still emits `BaseResponse` structures【F:shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/GlobalExceptionHandler.java†L51-L185】
+- [ ] Bridge shared JWT decoder into `ReactiveAuthenticationManager` for Spring Security WebFlux, preserving claim-to-authority conversion【F:shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java†L84-L163】
+
+### ⭐ Components to CREATE NEW
+- [ ] Spring Cloud Gateway `RouteLocator` definitions for microservice routing, including path-based predicates and load-balanced URIs
+- [ ] Gateway-level aggregation/forwarding handlers for endpoints that combine multiple downstream calls (if required)
+- [ ] Resilience policies (timeouts, retries, circuit breakers) using Resilience4j Reactor operators tailored to critical routes
+- [ ] Reactive tenant & correlation context propagators integrated with Reactor context to keep MDC/logging consistent
+- [ ] API documentation (OpenAPI) describing gateway endpoints referencing shared DTOs
+
+### ⚠️ Components to AVOID duplicating
+- [ ] Do **not** reimplement JWT parsing/validation; rely on shared decoder and token service
+- [ ] Do **not** redefine error codes or DTOs; use `BaseResponse` and shared enums
+- [ ] Do **not** introduce alternative logging formats; reuse shared MDC conventions
+- [ ] Do **not** create new Kafka payload models; reuse shared event records
+
+## Phase 5 – Next Steps & Validation Checklist
+
+1. **Dependency setup**: Add `spring-cloud-starter-gateway` alongside existing shared starters; ensure servlet-only starters are excluded or conditioned when running on WebFlux.
+2. **Reactive adapters**: Implement adapters for context propagation, rate limiting, and exception handling before adding new functionality.
+3. **Route configuration**: Define route predicates and filters (auth, rate limit, logging) referencing shared configuration properties.
+4. **Security hardening**: Integrate shared JWT decoder, align CORS/security headers with microservices, and ensure tenant/role checks align with downstream expectations.
+5. **Testing**: Create contract tests validating error envelopes, correlation header echo, and rate limiting counters against Redis.
+6. **Deployment alignment**: Mirror microservice `application.yaml` structure for environment-specific settings (profiles, shared.* namespaces) to ease operations consistency.【F:sec-service/src/main/resources/application.yaml†L1-L61】
+
+## Phase 6 – Validation Checklist for Implementation
+
+- [ ] Confirm every gateway utility is backed by a shared component or adapter.
+- [ ] Verify reactive filters populate MDC and propagate tenant/correlation IDs.
+- [ ] Ensure error responses remain `BaseResponse` with shared error codes.
+- [ ] Validate rate limiting honors tenant/user/IP strategies defined in `RateLimitProps`.
+- [ ] Align gateway logging/output with `LoggingAutoConfiguration` expectations.
+- [ ] Reuse shared configuration namespaces (`shared.security`, `shared.core`, `shared.ratelimit`, etc.) for consistency across services.


### PR DESCRIPTION
## Summary
- add the reactive `api-gateway` module wired to shared security, context, and rate limiting components
- resolve ObjectMapper bean ambiguity by qualifying reactive filters and downgrading Spring Boot's default mapper
- disable the Spring Cloud compatibility verifier and document the gateway module in README and docker-compose

## Testing
- mvn -f api-gateway/pom.xml test

------
https://chatgpt.com/codex/tasks/task_e_68da96491ca8832fa725a398783e8be4