### PR TITLE
feat: map BaseResponse codes to HTTP statuses

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/controller/AuthController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.ejada.sec.controller;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.dto.admin.SuperadminAuthResponse;
 import com.ejada.sec.dto.admin.SuperadminLoginRequest;
@@ -25,37 +26,44 @@ public class AuthController {
 
   @PostMapping("/register")
   public ResponseEntity<BaseResponse<AuthResponse>> register(@Valid @RequestBody RegisterRequest req) {
-    return ResponseEntity.ok(authService.register(req));
+    BaseResponse<AuthResponse> response = authService.register(req);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping("/login")
   public ResponseEntity<BaseResponse<AuthResponse>> login(@Valid @RequestBody AuthRequest req) {
-    return ResponseEntity.ok(authService.login(req));
+    BaseResponse<AuthResponse> response = authService.login(req);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping("/refresh")
   public ResponseEntity<BaseResponse<AuthResponse>> refresh(@Valid @RequestBody RefreshTokenRequest req) {
-    return ResponseEntity.ok(authService.refresh(req));
+    BaseResponse<AuthResponse> response = authService.refresh(req);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping("/logout")
   public ResponseEntity<BaseResponse<Void>> logout(@Valid @RequestBody RefreshTokenRequest request) {
-    return ResponseEntity.ok(authService.logout(request.getRefreshToken()));
+    BaseResponse<Void> response = authService.logout(request.getRefreshToken());
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping("/forgot-password")
   public ResponseEntity<BaseResponse<Void>> forgotPassword(@Valid @RequestBody ForgotPasswordRequest req) {
-    return ResponseEntity.ok(passwordResetService.createToken(req));
+    BaseResponse<Void> response = passwordResetService.createToken(req);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping("/reset-password")
   public ResponseEntity<BaseResponse<Void>> resetPassword(@Valid @RequestBody ResetPasswordRequest req) {
-    return ResponseEntity.ok(passwordResetService.reset(req));
+    BaseResponse<Void> response = passwordResetService.reset(req);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
   
   @PostMapping("admin/login")
   public ResponseEntity<BaseResponse<SuperadminAuthResponse>> Adminlogin(@Valid @RequestBody SuperadminLoginRequest request) {
-    return ResponseEntity.ok(superadminService.login(request));
+    BaseResponse<SuperadminAuthResponse> response = superadminService.login(request);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/EffectivePrivilegesController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/EffectivePrivilegesController.java
@@ -1,6 +1,7 @@
 package com.ejada.sec.controller;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.domain.EffectivePrivilegeProjection;
 import com.ejada.sec.repository.EffectivePrivilegeViewRepository;
 import com.ejada.starter_core.tenant.RequireTenant;
@@ -22,8 +23,10 @@ public class EffectivePrivilegesController {
 
   @GetMapping("/{userId}")
   public ResponseEntity<BaseResponse<List<EffectivePrivilegeProjection>>> list(@PathVariable Long userId) {
-    return ResponseEntity.ok(
-        BaseResponse.success("Effective privileges listed",
-            viewRepo.findEffectiveByUserAndTenant(userId, TenantContextResolver.requireTenantId())));
+    BaseResponse<List<EffectivePrivilegeProjection>> response =
+        BaseResponse.success(
+            "Effective privileges listed",
+            viewRepo.findEffectiveByUserAndTenant(userId, TenantContextResolver.requireTenantId()));
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/PrivilegeController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/PrivilegeController.java
@@ -1,6 +1,7 @@
 package com.ejada.sec.controller;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.PrivilegeService;
 import com.ejada.starter_core.tenant.RequireTenant;
@@ -22,27 +23,32 @@ public class PrivilegeController {
 
   @GetMapping
   public ResponseEntity<BaseResponse<List<PrivilegeDto>>> list() {
-    return ResponseEntity.ok(privilegeService.listByTenant());
+    BaseResponse<List<PrivilegeDto>> response = privilegeService.listByTenant();
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<BaseResponse<PrivilegeDto>> get(@PathVariable("id") Long id) {
-    return ResponseEntity.ok(privilegeService.get(id));
+    BaseResponse<PrivilegeDto> response = privilegeService.get(id);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping
   public ResponseEntity<BaseResponse<PrivilegeDto>> create(@Valid @RequestBody CreatePrivilegeRequest req) {
-    return ResponseEntity.ok(privilegeService.create(req));
+    BaseResponse<PrivilegeDto> response = privilegeService.create(req);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PatchMapping("/{id}")
   public ResponseEntity<BaseResponse<PrivilegeDto>> update(@PathVariable("id") Long id,
                                              @Valid @RequestBody UpdatePrivilegeRequest req) {
-    return ResponseEntity.ok(privilegeService.update(id, req));
+    BaseResponse<PrivilegeDto> response = privilegeService.update(id, req);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @DeleteMapping("/{id}")
   public ResponseEntity<BaseResponse<Void>> delete(@PathVariable("id") Long id) {
-    return ResponseEntity.ok(privilegeService.delete(id));
+    BaseResponse<Void> response = privilegeService.delete(id);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/RoleController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/RoleController.java
@@ -1,6 +1,7 @@
 package com.ejada.sec.controller;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.RoleService;
 import com.ejada.starter_core.tenant.RequireTenant;
@@ -22,27 +23,32 @@ public class RoleController {
 
   @GetMapping
   public ResponseEntity<BaseResponse<List<RoleDto>>> list() {
-    return ResponseEntity.ok(roleService.listByTenant());
+    BaseResponse<List<RoleDto>> response = roleService.listByTenant();
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<BaseResponse<RoleDto>> get(@PathVariable("id") Long id) {
-    return ResponseEntity.ok(roleService.get(id));
+    BaseResponse<RoleDto> response = roleService.get(id);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping
   public ResponseEntity<BaseResponse<RoleDto>> create(@Valid @RequestBody CreateRoleRequest req) {
-    return ResponseEntity.ok(roleService.create(req));
+    BaseResponse<RoleDto> response = roleService.create(req);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PatchMapping("/{id}")
   public ResponseEntity<BaseResponse<RoleDto>> update(@PathVariable("id") Long id,
                                         @Valid @RequestBody UpdateRoleRequest req) {
-    return ResponseEntity.ok(roleService.update(id, req));
+    BaseResponse<RoleDto> response = roleService.update(id, req);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @DeleteMapping("/{id}")
   public ResponseEntity<BaseResponse<Void>> delete(@PathVariable("id") Long id) {
-    return ResponseEntity.ok(roleService.delete(id));
+    BaseResponse<Void> response = roleService.delete(id);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/SuperadminController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/SuperadminController.java
@@ -1,6 +1,7 @@
 package com.ejada.sec.controller;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.dto.admin.*;
 import com.ejada.sec.service.SuperadminService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,7 +10,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -28,10 +28,8 @@ public class SuperadminController {
                description = "Creates a new superadmin account. Only existing superadmins can perform this action.")
     public ResponseEntity<BaseResponse<SuperadminDto>> createSuperadmin(
             @Valid @RequestBody CreateSuperadminRequest request) {
-        return new ResponseEntity<>(
-            superadminService.createSuperadmin(request), 
-            HttpStatus.CREATED
-        );
+        BaseResponse<SuperadminDto> response = superadminService.createSuperadmin(request);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
     
     @PutMapping("/{id}")
@@ -40,40 +38,46 @@ public class SuperadminController {
     public ResponseEntity<BaseResponse<SuperadminDto>> updateSuperadmin(
             @PathVariable Long id,
             @Valid @RequestBody UpdateSuperadminRequest request) {
-        return ResponseEntity.ok(superadminService.updateSuperadmin(id, request));
+        BaseResponse<SuperadminDto> response = superadminService.updateSuperadmin(id, request);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
     
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete superadmin", 
                description = "Disables a superadmin account. Cannot delete your own account or the last active superadmin.")
     public ResponseEntity<BaseResponse<Void>> deleteSuperadmin(@PathVariable Long id) {
-        return ResponseEntity.ok(superadminService.deleteSuperadmin(id));
+        BaseResponse<Void> response = superadminService.deleteSuperadmin(id);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
     
     @GetMapping("/{id}")
     @Operation(summary = "Get superadmin details", 
                description = "Retrieves details of a specific superadmin")
     public ResponseEntity<BaseResponse<SuperadminDto>> getSuperadmin(@PathVariable Long id) {
-        return ResponseEntity.ok(superadminService.getSuperadmin(id));
+        BaseResponse<SuperadminDto> response = superadminService.getSuperadmin(id);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
     
     @GetMapping
     @Operation(summary = "List all superadmins", 
                description = "Retrieves a paginated list of all superadmin accounts")
     public ResponseEntity<BaseResponse<Page<SuperadminDto>>> listSuperadmins(Pageable pageable) {
-        return ResponseEntity.ok(superadminService.listSuperadmins(pageable));
+        BaseResponse<Page<SuperadminDto>> response = superadminService.listSuperadmins(pageable);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
     
 
     @PostMapping("/first-login")
     @PreAuthorize("hasRole('EJADA_OFFICER')")
     public ResponseEntity<BaseResponse<Void>> completeFirstLogin(@Valid @RequestBody FirstLoginRequest request) {
-      return ResponseEntity.ok(superadminService.completeFirstLogin(request));
+      BaseResponse<Void> response = superadminService.completeFirstLogin(request);
+      return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @PostMapping("/change-password")
     @PreAuthorize("hasRole('EJADA_OFFICER')")
     public ResponseEntity<BaseResponse<Void>> changeSuperadminPassword(@Valid @RequestBody ChangePasswordRequest request) {
-      return ResponseEntity.ok(superadminService.changePassword(request));
+      BaseResponse<Void> response = superadminService.changePassword(request);
+      return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/UserController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.ejada.sec.controller;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.UserService;
 import com.ejada.starter_core.tenant.RequireTenant;
@@ -22,47 +23,56 @@ public class UserController {
 
   @GetMapping
   public ResponseEntity<BaseResponse<List<UserDto>>> list() {
-    return ResponseEntity.ok(userService.listByTenant());
+    BaseResponse<List<UserDto>> response = userService.listByTenant();
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<BaseResponse<UserDto>> get(@PathVariable("id") Long id) {
-    return ResponseEntity.ok(userService.get(id));
+    BaseResponse<UserDto> response = userService.get(id);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping
   public ResponseEntity<BaseResponse<UserDto>> create(@Valid @RequestBody CreateUserRequest req) {
-    return ResponseEntity.ok(userService.create(req));
+    BaseResponse<UserDto> response = userService.create(req);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PatchMapping("/{id}")
   public ResponseEntity<BaseResponse<UserDto>> update(@PathVariable("id") Long id,
                                         @Valid @RequestBody UpdateUserRequest req) {
-    return ResponseEntity.ok(userService.update(id, req));
+    BaseResponse<UserDto> response = userService.update(id, req);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @DeleteMapping("/{id}")
   public ResponseEntity<BaseResponse<Void>> delete(@PathVariable("id") Long id) {
-    return ResponseEntity.ok(userService.delete(id));
+    BaseResponse<Void> response = userService.delete(id);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping("/{id}/enable")
   public ResponseEntity<BaseResponse<Void>> enable(@PathVariable("id") Long id) {
-    return ResponseEntity.ok(userService.enable(id));
+    BaseResponse<Void> response = userService.enable(id);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping("/{id}/disable")
   public ResponseEntity<BaseResponse<Void>> disable(@PathVariable("id") Long id) {
-    return ResponseEntity.ok(userService.disable(id));
+    BaseResponse<Void> response = userService.disable(id);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping("/{id}/lock")
   public ResponseEntity<BaseResponse<Void>> lock(@PathVariable("id") Long id) {
-    return ResponseEntity.ok(userService.lock(id));
+    BaseResponse<Void> response = userService.lock(id);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 
   @PostMapping("/{id}/unlock")
   public ResponseEntity<BaseResponse<Void>> unlock(@PathVariable("id") Long id) {
-    return ResponseEntity.ok(userService.unlock(id));
+    BaseResponse<Void> response = userService.unlock(id);
+    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/SuperadminServiceImpl.java
@@ -126,7 +126,9 @@ public class SuperadminServiceImpl implements SuperadminService {
         
         // Map to DTO and return
         SuperadminDto dto = superadminMapper.toDto(superadmin);
-        return BaseResponse.success("Superadmin created successfully", dto);
+        BaseResponse<SuperadminDto> response = BaseResponse.success("Superadmin created successfully", dto);
+        response.setCode("SUCCESS-201");
+        return response;
     }
     
     @Override

--- a/sec-service/src/test/java/com/ejada/sec/controller/AuthControllerTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/controller/AuthControllerTest.java
@@ -1,0 +1,85 @@
+package com.ejada.sec.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.sec.dto.AuthRequest;
+import com.ejada.sec.dto.AuthResponse;
+import com.ejada.sec.service.AuthService;
+import com.ejada.sec.service.PasswordResetService;
+import com.ejada.sec.service.SuperadminService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class AuthControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockBean AuthService authService;
+    @MockBean SuperadminService superadminService;
+    @MockBean PasswordResetService passwordResetService;
+
+    @BeforeEach
+    void resetMocks() {
+        reset(authService, superadminService, passwordResetService);
+    }
+
+    @Test
+    void login_success_returnsOk() throws Exception {
+        AuthResponse tokens = AuthResponse.builder()
+                .accessToken("access-token")
+                .refreshToken("refresh-token")
+                .expiresInSeconds(3600)
+                .build();
+        when(authService.login(any(AuthRequest.class)))
+                .thenReturn(BaseResponse.success("Login successful", tokens));
+
+        AuthRequest request = AuthRequest.builder()
+                .tenantId(UUID.fromString("11111111-1111-1111-1111-111111111111"))
+                .identifier("user@example.com")
+                .password("password")
+                .build();
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS-200"));
+    }
+
+    @Test
+    void login_failure_returnsUnauthorized() throws Exception {
+        when(authService.login(any(AuthRequest.class)))
+                .thenReturn(BaseResponse.error("ERR-AUTH-INVALID", "Invalid credentials"));
+
+        AuthRequest request = AuthRequest.builder()
+                .tenantId(UUID.fromString("22222222-2222-2222-2222-222222222222"))
+                .identifier("user@example.com")
+                .password("wrong")
+                .build();
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("ERR-AUTH-INVALID"));
+    }
+}

--- a/setup-service/src/main/java/com/ejada/setup/controller/CityController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/CityController.java
@@ -1,6 +1,7 @@
 package com.ejada.setup.controller;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.dto.CityDto;
 import com.ejada.setup.constants.ValidationConstants;
 import com.ejada.setup.security.SetupAuthorized;
@@ -54,7 +55,8 @@ public class CityController {
         @ApiResponse(responseCode = "409", description = "City already exists")
     })
     public ResponseEntity<BaseResponse<CityDto>> add(@Valid @RequestBody final CityDto body) {
-        return ResponseEntity.ok(cityService.add(body));
+        BaseResponse<CityDto> response = cityService.add(body);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @PutMapping("/{cityId}")
@@ -70,7 +72,8 @@ public class CityController {
             @Parameter(description = "ID of the city to update", required = true)
             @PathVariable @Min(1) final Integer cityId,
             @Valid @RequestBody final CityDto body) {
-        return ResponseEntity.ok(cityService.update(cityId, body));
+        BaseResponse<CityDto> response = cityService.update(cityId, body);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping("/{cityId}")
@@ -84,7 +87,8 @@ public class CityController {
     public ResponseEntity<BaseResponse<CityDto>> get(
             @Parameter(description = "ID of the city to retrieve", required = true)
             @PathVariable @Min(1) final Integer cityId) {
-        return ResponseEntity.ok(cityService.get(cityId));
+        BaseResponse<CityDto> response = cityService.get(cityId);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping
@@ -101,7 +105,8 @@ public class CityController {
             @Parameter(description = "Whether to retrieve all cities (ignores pagination)")
             @RequestParam(name = "unpaged", defaultValue = "false") final boolean unpaged) {
         Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
-        return ResponseEntity.ok(cityService.list(effectivePageable, q, unpaged));
+        BaseResponse<Page<CityDto>> response = cityService.list(effectivePageable, q, unpaged);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping("/active")
@@ -114,6 +119,7 @@ public class CityController {
     public ResponseEntity<BaseResponse<List<CityDto>>> listActive(
             @Parameter(description = "Country ID to filter cities", required = true)
             @RequestParam @Min(1) final Integer countryId) {
-        return ResponseEntity.ok(cityService.listActiveByCountry(countryId));
+        BaseResponse<List<CityDto>> response = cityService.listActiveByCountry(countryId);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/controller/CountryController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/CountryController.java
@@ -1,6 +1,7 @@
 package com.ejada.setup.controller;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.dto.CountryDto;
 import com.ejada.setup.model.Country;
 import com.ejada.setup.constants.ValidationConstants;
@@ -57,7 +58,8 @@ public class CountryController {
         @ApiResponse(responseCode = "409", description = "Country code already exists")
     })
     public ResponseEntity<BaseResponse<Country>> add(@Valid @RequestBody final CountryDto body) {
-        return ResponseEntity.ok(countryService.add(body));
+        BaseResponse<Country> response = countryService.add(body);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @PutMapping("/{countryId}")
@@ -74,7 +76,8 @@ public class CountryController {
             @Parameter(description = "ID of the country to update", required = true)
             @PathVariable @Min(1) final Integer countryId,
             @Valid @RequestBody final CountryDto body) {
-        return ResponseEntity.ok(countryService.update(countryId, body));
+        BaseResponse<Country> response = countryService.update(countryId, body);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping("/{countryId}")
@@ -88,7 +91,8 @@ public class CountryController {
     public ResponseEntity<BaseResponse<Country>> get(
             @Parameter(description = "ID of the country to retrieve", required = true)
             @PathVariable @Min(1) final Integer countryId) {
-        return ResponseEntity.ok(countryService.get(countryId));
+        BaseResponse<Country> response = countryService.get(countryId);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping
@@ -99,14 +103,15 @@ public class CountryController {
         @ApiResponse(responseCode = "200", description = "Countries retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<?> list(
+    public ResponseEntity<BaseResponse<?>> list(
             @PageableDefault(size = ValidationConstants.PAGE_SIZE_DEFAULT) final Pageable pageable,
             @Parameter(description = "Search query for country names")
             @RequestParam(required = false) final String q,
             @Parameter(description = "Whether to retrieve all countries (ignores pagination)")
             @RequestParam(name = "unpaged", defaultValue = "false") final boolean unpaged) {
         Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
-        return ResponseEntity.ok(countryService.list(effectivePageable, q, unpaged));
+        BaseResponse<?> response = countryService.list(effectivePageable, q, unpaged);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping("/active")
@@ -117,6 +122,7 @@ public class CountryController {
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
     public ResponseEntity<BaseResponse<List<Country>>> listActive() {
-        return ResponseEntity.ok(countryService.listActive());
+        BaseResponse<List<Country>> response = countryService.listActive();
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/controller/LookupController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/LookupController.java
@@ -1,6 +1,7 @@
 package com.ejada.setup.controller;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.dto.LookupCreateRequest;
 import com.ejada.setup.dto.LookupResponse;
 import com.ejada.setup.dto.LookupUpdateRequest;
@@ -55,7 +56,8 @@ public class LookupController {
     })
     public ResponseEntity<BaseResponse<LookupResponse>> add(
             @Valid @RequestBody final LookupCreateRequest body) {
-        return ResponseEntity.ok(lookupService.add(body));
+        BaseResponse<LookupResponse> response = lookupService.add(body);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @PutMapping("/{lookupItemId}")
@@ -71,7 +73,8 @@ public class LookupController {
             @Parameter(description = "ID of the lookup to update", required = true)
             @PathVariable @Min(1) final Integer lookupItemId,
             @Valid @RequestBody final LookupUpdateRequest body) {
-        return ResponseEntity.ok(lookupService.update(lookupItemId, body));
+        BaseResponse<LookupResponse> response = lookupService.update(lookupItemId, body);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping
@@ -82,7 +85,8 @@ public class LookupController {
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
     public ResponseEntity<BaseResponse<List<LookupResponse>>> getAllLookups() {
-        return ResponseEntity.ok(lookupService.getAllLookups());
+        BaseResponse<List<LookupResponse>> response = lookupService.getAllLookups();
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping("/group/{groupCode}")
@@ -95,7 +99,8 @@ public class LookupController {
     public ResponseEntity<BaseResponse<List<LookupResponse>>> getByGroup(
             @Parameter(description = "Group code of lookups to retrieve", required = true)
             @PathVariable @NotBlank final String groupCode) {
-        return ResponseEntity.ok(lookupService.getByGroup(groupCode));
+        BaseResponse<List<LookupResponse>> response = lookupService.getByGroup(groupCode);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping("/all")
@@ -109,6 +114,7 @@ public class LookupController {
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
     public ResponseEntity<BaseResponse<List<LookupResponse>>> getAll() {
-        return ResponseEntity.ok(lookupService.getAll());
+        BaseResponse<List<LookupResponse>> response = lookupService.getAll();
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/controller/ResourceController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/ResourceController.java
@@ -1,6 +1,7 @@
 package com.ejada.setup.controller;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.dto.ResourceDto;
 import com.ejada.setup.security.SetupAuthorized;
 import com.ejada.setup.service.ResourceService;
@@ -55,7 +56,8 @@ public class ResourceController {
         @ApiResponse(responseCode = "409", description = "Resource already exists")
     })
     public ResponseEntity<BaseResponse<ResourceDto>> add(final @Valid @RequestBody ResourceDto body) {
-        return ResponseEntity.ok(resourceService.add(body));
+        BaseResponse<ResourceDto> response = resourceService.add(body);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @PutMapping("/{resourceId}")
@@ -71,7 +73,8 @@ public class ResourceController {
             @Parameter(description = "ID of the resource to update", required = true)
             @PathVariable @Min(1) final Integer resourceId,
             final @Valid @RequestBody ResourceDto body) {
-        return ResponseEntity.ok(resourceService.update(resourceId, body));
+        BaseResponse<ResourceDto> response = resourceService.update(resourceId, body);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping("/{resourceId}")
@@ -85,7 +88,8 @@ public class ResourceController {
     public ResponseEntity<BaseResponse<ResourceDto>> get(
             @Parameter(description = "ID of the resource to retrieve", required = true)
             @PathVariable @Min(1) final Integer resourceId) {
-        return ResponseEntity.ok(resourceService.get(resourceId));
+        BaseResponse<ResourceDto> response = resourceService.get(resourceId);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping
@@ -102,7 +106,8 @@ public class ResourceController {
             @Parameter(description = "Whether to retrieve all resources (ignores pagination)")
             @RequestParam(name = "unpaged", defaultValue = "false") final boolean unpaged) {
         final Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
-        return ResponseEntity.ok(resourceService.list(effectivePageable, q, unpaged));
+        BaseResponse<Page<ResourceDto>> response = resourceService.list(effectivePageable, q, unpaged);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping("/active")
@@ -113,6 +118,7 @@ public class ResourceController {
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
     public ResponseEntity<BaseResponse<List<ResourceDto>>> listActive() {
-        return ResponseEntity.ok(resourceService.listActive());
+        BaseResponse<List<ResourceDto>> response = resourceService.listActive();
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/controller/SystemParameterController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/SystemParameterController.java
@@ -1,6 +1,7 @@
 package com.ejada.setup.controller;
 
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.model.SystemParameter;
 import com.ejada.setup.security.SetupAuthorized;
 import com.ejada.setup.service.SystemParameterService;
@@ -57,7 +58,8 @@ public class SystemParameterController {
         @ApiResponse(responseCode = "409", description = "System parameter already exists")
     })
     public ResponseEntity<BaseResponse<SystemParameter>> add(@Valid @RequestBody final SystemParameter body) {
-        return ResponseEntity.ok(systemParameterService.add(body));
+        BaseResponse<SystemParameter> response = systemParameterService.add(body);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @PutMapping("/{paramId}")
@@ -73,7 +75,8 @@ public class SystemParameterController {
             @Parameter(description = "ID of the system parameter to update", required = true)
             @PathVariable @Min(1) final Integer paramId,
             @Valid @RequestBody final SystemParameter body) {
-        return ResponseEntity.ok(systemParameterService.update(paramId, body));
+        BaseResponse<SystemParameter> response = systemParameterService.update(paramId, body);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping("/{paramId}")
@@ -87,7 +90,8 @@ public class SystemParameterController {
     public ResponseEntity<BaseResponse<SystemParameter>> get(
             @Parameter(description = "ID of the system parameter to retrieve", required = true)
             @PathVariable @Min(1) final Integer paramId) {
-        return ResponseEntity.ok(systemParameterService.get(paramId));
+        BaseResponse<SystemParameter> response = systemParameterService.get(paramId);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping
@@ -106,7 +110,9 @@ public class SystemParameterController {
             @Parameter(description = "Whether to retrieve all parameters (ignores pagination)")
             @RequestParam(name = "unpaged", defaultValue = "false") final boolean unpaged) {
         final Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
-        return ResponseEntity.ok(systemParameterService.list(effectivePageable, group, onlyActive));
+        BaseResponse<Page<SystemParameter>> response =
+                systemParameterService.list(effectivePageable, group, onlyActive);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @GetMapping("/by-key/{paramKey}")
@@ -120,7 +126,8 @@ public class SystemParameterController {
     public ResponseEntity<BaseResponse<SystemParameter>> getByKey(
             @Parameter(description = "Key of the parameter to retrieve", required = true)
             @PathVariable @NotBlank final String paramKey) {
-        return ResponseEntity.ok(systemParameterService.getByKey(paramKey));
+        BaseResponse<SystemParameter> response = systemParameterService.getByKey(paramKey);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
     @PostMapping("/by-keys")
@@ -133,6 +140,7 @@ public class SystemParameterController {
     public ResponseEntity<BaseResponse<List<SystemParameter>>> getByKeys(
             @Parameter(description = "List of parameter keys to retrieve", required = true)
             @RequestBody final List<String> keys) {
-        return ResponseEntity.ok(systemParameterService.getByKeys(keys));
+        BaseResponse<List<SystemParameter>> response = systemParameterService.getByKeys(keys);
+        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 }

--- a/setup-service/src/test/java/com/ejada/setup/controller/SystemParameterControllerTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/controller/SystemParameterControllerTest.java
@@ -48,4 +48,17 @@ class SystemParameterControllerTest {
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.message").value("ok"));
     }
+
+    @Test
+    void get_notFound_translatesHttpStatus() throws Exception {
+        BaseResponse<SystemParameter> resp = BaseResponse.error("ERR_PARAM_NOT_FOUND", "System parameter not found");
+
+        doReturn(resp)
+                .when(systemParameterService)
+                .get(999);
+
+        mockMvc.perform(get("/setup/systemParameters/{paramId}", 999).accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("ERR_PARAM_NOT_FOUND"));
+    }
 }

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/http/ApiStatusMapper.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/http/ApiStatusMapper.java
@@ -1,0 +1,138 @@
+package com.ejada.common.http;
+
+import com.ejada.common.constants.ErrorCodes;
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.enums.StatusEnums.ApiStatus;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Utility for mapping {@link BaseResponse} status codes to HTTP {@link HttpStatus} values.
+ */
+public final class ApiStatusMapper {
+
+    private static final Pattern TRAILING_HTTP_STATUS = Pattern.compile("-(\\d{3})$");
+
+    private static final Map<ApiStatus, HttpStatus> DEFAULT_STATUS = Map.of(
+            ApiStatus.SUCCESS, HttpStatus.OK,
+            ApiStatus.ERROR, HttpStatus.INTERNAL_SERVER_ERROR,
+            ApiStatus.WARNING, HttpStatus.BAD_REQUEST);
+
+    private static final Map<String, HttpStatus> EXACT_CODE_STATUS;
+    private static final Map<String, HttpStatus> KEYWORD_STATUS;
+
+    static {
+        Map<String, HttpStatus> exact = new LinkedHashMap<>();
+        exact.put(ErrorCodes.AUTH_INVALID_TOKEN, HttpStatus.UNAUTHORIZED);
+        exact.put(ErrorCodes.AUTH_EXPIRED_TOKEN, HttpStatus.UNAUTHORIZED);
+        exact.put(ErrorCodes.AUTH_UNAUTHORIZED, HttpStatus.UNAUTHORIZED);
+        exact.put(ErrorCodes.AUTH_FORBIDDEN, HttpStatus.FORBIDDEN);
+        exact.put(ErrorCodes.AUTH_MISSING_CREDENTIALS, HttpStatus.BAD_REQUEST);
+        exact.put(ErrorCodes.TENANT_NOT_FOUND, HttpStatus.NOT_FOUND);
+        exact.put(ErrorCodes.TENANT_DISABLED, HttpStatus.FORBIDDEN);
+        exact.put(ErrorCodes.TENANT_ACCESS_DENIED, HttpStatus.FORBIDDEN);
+        exact.put(ErrorCodes.VALIDATION_ERROR, HttpStatus.BAD_REQUEST);
+        exact.put(ErrorCodes.DATA_NOT_FOUND, HttpStatus.NOT_FOUND);
+        exact.put(ErrorCodes.DATA_DUPLICATE, HttpStatus.CONFLICT);
+        exact.put(ErrorCodes.DATA_INTEGRITY, HttpStatus.CONFLICT);
+        exact.put(ErrorCodes.INTERNAL_ERROR, HttpStatus.INTERNAL_SERVER_ERROR);
+        exact.put(ErrorCodes.SERVICE_UNAVAILABLE, HttpStatus.SERVICE_UNAVAILABLE);
+        exact.put(ErrorCodes.TIMEOUT, HttpStatus.GATEWAY_TIMEOUT);
+        exact.put(ErrorCodes.DEPENDENCY_FAILURE, HttpStatus.BAD_GATEWAY);
+        exact.put(ErrorCodes.API_BAD_REQUEST, HttpStatus.BAD_REQUEST);
+        exact.put(ErrorCodes.API_UNSUPPORTED_MEDIA, HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        exact.put(ErrorCodes.API_RATE_LIMIT_EXCEEDED, HttpStatus.TOO_MANY_REQUESTS);
+        exact.put(ErrorCodes.API_UNPROCESSABLE_ENTITY, HttpStatus.UNPROCESSABLE_ENTITY);
+        exact.put(ErrorCodes.PAYMENT_FAILED, HttpStatus.PAYMENT_REQUIRED);
+        exact.put(ErrorCodes.PAYMENT_DECLINED, HttpStatus.PAYMENT_REQUIRED);
+        exact.put(ErrorCodes.PAYMENT_TIMEOUT, HttpStatus.GATEWAY_TIMEOUT);
+        exact.put(ErrorCodes.BUSINESS_RULE_VIOLATION, HttpStatus.UNPROCESSABLE_ENTITY);
+        exact.put(ErrorCodes.NOT_FOUND, HttpStatus.NOT_FOUND);
+        exact.put("ERR-AUTH-INVALID", HttpStatus.UNAUTHORIZED);
+        exact.put("ERR-AUTH-LOCKED", HttpStatus.LOCKED);
+        EXACT_CODE_STATUS = Collections.unmodifiableMap(exact);
+
+        Map<String, HttpStatus> keyword = new LinkedHashMap<>();
+        keyword.put("NOT_FOUND", HttpStatus.NOT_FOUND);
+        keyword.put("ACCESS_DENIED", HttpStatus.FORBIDDEN);
+        keyword.put("FORBIDDEN", HttpStatus.FORBIDDEN);
+        keyword.put("UNAUTHORIZED", HttpStatus.UNAUTHORIZED);
+        keyword.put("INVALID", HttpStatus.BAD_REQUEST);
+        keyword.put("REQUIRED", HttpStatus.BAD_REQUEST);
+        keyword.put("DUP", HttpStatus.CONFLICT);
+        keyword.put("CONFLICT", HttpStatus.CONFLICT);
+        keyword.put("LOCKED", HttpStatus.LOCKED);
+        keyword.put("TIMEOUT", HttpStatus.GATEWAY_TIMEOUT);
+        keyword.put("UNAVAILABLE", HttpStatus.SERVICE_UNAVAILABLE);
+        keyword.put("RATE_LIMIT", HttpStatus.TOO_MANY_REQUESTS);
+        keyword.put("TOO_MANY_REQUESTS", HttpStatus.TOO_MANY_REQUESTS);
+        keyword.put("UNPROCESSABLE", HttpStatus.UNPROCESSABLE_ENTITY);
+        keyword.put("UNSUPPORTED_MEDIA", HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        keyword.put("BAD_REQUEST", HttpStatus.BAD_REQUEST);
+        KEYWORD_STATUS = Collections.unmodifiableMap(keyword);
+    }
+
+    private ApiStatusMapper() {
+    }
+
+    /**
+     * Resolve an appropriate {@link HttpStatus} for the provided {@link BaseResponse}.
+     *
+     * @param response the API response payload
+     * @return the HTTP status that best represents the response
+     */
+    public static HttpStatus toHttpStatus(BaseResponse<?> response) {
+        if (response == null) {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+
+        HttpStatus resolved = resolveFromCode(response.getCode());
+        if (resolved != null) {
+            return resolved;
+        }
+
+        ApiStatus apiStatus = response.getStatus();
+        if (apiStatus != null) {
+            return DEFAULT_STATUS.getOrDefault(apiStatus, HttpStatus.OK);
+        }
+        return HttpStatus.OK;
+    }
+
+    private static HttpStatus resolveFromCode(String code) {
+        if (code == null || code.isBlank()) {
+            return null;
+        }
+
+        HttpStatus fromExact = EXACT_CODE_STATUS.get(code);
+        if (fromExact != null) {
+            return fromExact;
+        }
+
+        String upper = code.toUpperCase(Locale.ROOT);
+        fromExact = EXACT_CODE_STATUS.get(upper);
+        if (fromExact != null) {
+            return fromExact;
+        }
+
+        Matcher matcher = TRAILING_HTTP_STATUS.matcher(code);
+        if (matcher.find()) {
+            int statusCode = Integer.parseInt(matcher.group(1));
+            HttpStatus httpStatus = HttpStatus.resolve(statusCode);
+            if (httpStatus != null) {
+                return httpStatus;
+            }
+        }
+
+        for (Map.Entry<String, HttpStatus> entry : KEYWORD_STATUS.entrySet()) {
+            if (upper.contains(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/shared-lib/shared-common/src/test/java/com/ejada/common/http/ApiStatusMapperTest.java
+++ b/shared-lib/shared-common/src/test/java/com/ejada/common/http/ApiStatusMapperTest.java
@@ -1,0 +1,58 @@
+package com.ejada.common.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.enums.StatusEnums.ApiStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class ApiStatusMapperTest {
+
+    @Test
+    void successCodeWithHttpStatusSuffix_mapsToStatus() {
+        BaseResponse<Void> response = BaseResponse.<Void>builder()
+                .status(ApiStatus.SUCCESS)
+                .code("SUCCESS-200")
+                .build();
+
+        assertEquals(HttpStatus.OK, ApiStatusMapper.toHttpStatus(response));
+    }
+
+    @Test
+    void errorCodeWithKeyword_mapsToNotFound() {
+        BaseResponse<Void> response = BaseResponse.<Void>builder()
+                .status(ApiStatus.ERROR)
+                .code("ERR_PARAM_NOT_FOUND")
+                .build();
+
+        assertEquals(HttpStatus.NOT_FOUND, ApiStatusMapper.toHttpStatus(response));
+    }
+
+    @Test
+    void exactCodeMappingTakesPrecedence() {
+        BaseResponse<Void> response = BaseResponse.error("ERR-AUTH-INVALID", "Invalid credentials");
+
+        assertEquals(HttpStatus.UNAUTHORIZED, ApiStatusMapper.toHttpStatus(response));
+    }
+
+    @Test
+    void fallbackToApiStatusWhenUnknownCode() {
+        BaseResponse<Void> response = BaseResponse.<Void>builder()
+                .status(ApiStatus.ERROR)
+                .code("ERR-UNKNOWN")
+                .build();
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ApiStatusMapper.toHttpStatus(response));
+    }
+
+    @Test
+    void warningDefaultsToBadRequest() {
+        BaseResponse<Void> response = BaseResponse.<Void>builder()
+                .status(ApiStatus.WARNING)
+                .code("WARN-LIMIT")
+                .build();
+
+        assertEquals(HttpStatus.BAD_REQUEST, ApiStatusMapper.toHttpStatus(response));
+    }
+}


### PR DESCRIPTION
## Summary
- add an `ApiStatusMapper` in shared-common to derive HTTP statuses from `BaseResponse` codes
- switch setup-service and sec-service controllers to build `ResponseEntity` instances via the mapper instead of always returning 200 OK
- extend existing controller tests and add `AuthController` MockMvc tests to cover both success and error status mappings

## Testing
- `mvn -f shared-lib/pom.xml -pl shared-common test` *(fails: missing ByteBuddy agent jar in offline environment)*
- `mvn -f setup-service/pom.xml test -Dtest=SystemParameterControllerTest` *(fails: shared BOM dependency unavailable offline)*
- `mvn -f sec-service/pom.xml test -Dtest=AuthControllerTest` *(fails: shared BOM dependency unavailable offline)*

------
https://chatgpt.com/codex/tasks/task_e_68db002cbb00832f9fec05186d4e6f5f