### PR TITLE
Propagate BaseResponse status codes across services

### DIFF
--- a/setup-service/src/main/java/com/ejada/setup/controller/CityController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/CityController.java
@@ -1,7 +1,8 @@
 package com.ejada.setup.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.dto.CityDto;
 import com.ejada.setup.constants.ValidationConstants;
 import com.ejada.setup.security.SetupAuthorized;
@@ -56,7 +57,7 @@ public class CityController {
     })
     public ResponseEntity<BaseResponse<CityDto>> add(@Valid @RequestBody final CityDto body) {
         BaseResponse<CityDto> response = cityService.add(body);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @PutMapping("/{cityId}")
@@ -73,7 +74,7 @@ public class CityController {
             @PathVariable @Min(1) final Integer cityId,
             @Valid @RequestBody final CityDto body) {
         BaseResponse<CityDto> response = cityService.update(cityId, body);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping("/{cityId}")
@@ -88,7 +89,7 @@ public class CityController {
             @Parameter(description = "ID of the city to retrieve", required = true)
             @PathVariable @Min(1) final Integer cityId) {
         BaseResponse<CityDto> response = cityService.get(cityId);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping
@@ -106,7 +107,7 @@ public class CityController {
             @RequestParam(name = "unpaged", defaultValue = "false") final boolean unpaged) {
         Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
         BaseResponse<Page<CityDto>> response = cityService.list(effectivePageable, q, unpaged);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping("/active")
@@ -120,6 +121,6 @@ public class CityController {
             @Parameter(description = "Country ID to filter cities", required = true)
             @RequestParam @Min(1) final Integer countryId) {
         BaseResponse<List<CityDto>> response = cityService.listActiveByCountry(countryId);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/controller/CountryController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/CountryController.java
@@ -1,7 +1,8 @@
 package com.ejada.setup.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.dto.CountryDto;
 import com.ejada.setup.model.Country;
 import com.ejada.setup.constants.ValidationConstants;
@@ -59,7 +60,7 @@ public class CountryController {
     })
     public ResponseEntity<BaseResponse<Country>> add(@Valid @RequestBody final CountryDto body) {
         BaseResponse<Country> response = countryService.add(body);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @PutMapping("/{countryId}")
@@ -77,7 +78,7 @@ public class CountryController {
             @PathVariable @Min(1) final Integer countryId,
             @Valid @RequestBody final CountryDto body) {
         BaseResponse<Country> response = countryService.update(countryId, body);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping("/{countryId}")
@@ -92,7 +93,7 @@ public class CountryController {
             @Parameter(description = "ID of the country to retrieve", required = true)
             @PathVariable @Min(1) final Integer countryId) {
         BaseResponse<Country> response = countryService.get(countryId);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping
@@ -111,7 +112,7 @@ public class CountryController {
             @RequestParam(name = "unpaged", defaultValue = "false") final boolean unpaged) {
         Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
         BaseResponse<?> response = countryService.list(effectivePageable, q, unpaged);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping("/active")
@@ -123,6 +124,6 @@ public class CountryController {
     })
     public ResponseEntity<BaseResponse<List<Country>>> listActive() {
         BaseResponse<List<Country>> response = countryService.listActive();
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/controller/LookupController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/LookupController.java
@@ -1,7 +1,8 @@
 package com.ejada.setup.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.dto.LookupCreateRequest;
 import com.ejada.setup.dto.LookupResponse;
 import com.ejada.setup.dto.LookupUpdateRequest;
@@ -57,7 +58,7 @@ public class LookupController {
     public ResponseEntity<BaseResponse<LookupResponse>> add(
             @Valid @RequestBody final LookupCreateRequest body) {
         BaseResponse<LookupResponse> response = lookupService.add(body);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @PutMapping("/{lookupItemId}")
@@ -74,7 +75,7 @@ public class LookupController {
             @PathVariable @Min(1) final Integer lookupItemId,
             @Valid @RequestBody final LookupUpdateRequest body) {
         BaseResponse<LookupResponse> response = lookupService.update(lookupItemId, body);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping
@@ -86,7 +87,7 @@ public class LookupController {
     })
     public ResponseEntity<BaseResponse<List<LookupResponse>>> getAllLookups() {
         BaseResponse<List<LookupResponse>> response = lookupService.getAllLookups();
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping("/group/{groupCode}")
@@ -100,7 +101,7 @@ public class LookupController {
             @Parameter(description = "Group code of lookups to retrieve", required = true)
             @PathVariable @NotBlank final String groupCode) {
         BaseResponse<List<LookupResponse>> response = lookupService.getByGroup(groupCode);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping("/all")
@@ -115,6 +116,6 @@ public class LookupController {
     })
     public ResponseEntity<BaseResponse<List<LookupResponse>>> getAll() {
         BaseResponse<List<LookupResponse>> response = lookupService.getAll();
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/controller/ResourceController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/ResourceController.java
@@ -1,7 +1,8 @@
 package com.ejada.setup.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.dto.ResourceDto;
 import com.ejada.setup.security.SetupAuthorized;
 import com.ejada.setup.service.ResourceService;
@@ -57,7 +58,7 @@ public class ResourceController {
     })
     public ResponseEntity<BaseResponse<ResourceDto>> add(final @Valid @RequestBody ResourceDto body) {
         BaseResponse<ResourceDto> response = resourceService.add(body);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @PutMapping("/{resourceId}")
@@ -74,7 +75,7 @@ public class ResourceController {
             @PathVariable @Min(1) final Integer resourceId,
             final @Valid @RequestBody ResourceDto body) {
         BaseResponse<ResourceDto> response = resourceService.update(resourceId, body);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping("/{resourceId}")
@@ -89,7 +90,7 @@ public class ResourceController {
             @Parameter(description = "ID of the resource to retrieve", required = true)
             @PathVariable @Min(1) final Integer resourceId) {
         BaseResponse<ResourceDto> response = resourceService.get(resourceId);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping
@@ -107,7 +108,7 @@ public class ResourceController {
             @RequestParam(name = "unpaged", defaultValue = "false") final boolean unpaged) {
         final Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
         BaseResponse<Page<ResourceDto>> response = resourceService.list(effectivePageable, q, unpaged);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping("/active")
@@ -119,6 +120,6 @@ public class ResourceController {
     })
     public ResponseEntity<BaseResponse<List<ResourceDto>>> listActive() {
         BaseResponse<List<ResourceDto>> response = resourceService.listActive();
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/controller/SystemParameterController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/SystemParameterController.java
@@ -1,7 +1,8 @@
 package com.ejada.setup.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.model.SystemParameter;
 import com.ejada.setup.security.SetupAuthorized;
 import com.ejada.setup.service.SystemParameterService;
@@ -59,7 +60,7 @@ public class SystemParameterController {
     })
     public ResponseEntity<BaseResponse<SystemParameter>> add(@Valid @RequestBody final SystemParameter body) {
         BaseResponse<SystemParameter> response = systemParameterService.add(body);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @PutMapping("/{paramId}")
@@ -76,7 +77,7 @@ public class SystemParameterController {
             @PathVariable @Min(1) final Integer paramId,
             @Valid @RequestBody final SystemParameter body) {
         BaseResponse<SystemParameter> response = systemParameterService.update(paramId, body);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping("/{paramId}")
@@ -91,7 +92,7 @@ public class SystemParameterController {
             @Parameter(description = "ID of the system parameter to retrieve", required = true)
             @PathVariable @Min(1) final Integer paramId) {
         BaseResponse<SystemParameter> response = systemParameterService.get(paramId);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping
@@ -112,7 +113,7 @@ public class SystemParameterController {
         final Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
         BaseResponse<Page<SystemParameter>> response =
                 systemParameterService.list(effectivePageable, group, onlyActive);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @GetMapping("/by-key/{paramKey}")
@@ -127,7 +128,7 @@ public class SystemParameterController {
             @Parameter(description = "Key of the parameter to retrieve", required = true)
             @PathVariable @NotBlank final String paramKey) {
         BaseResponse<SystemParameter> response = systemParameterService.getByKey(paramKey);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 
     @PostMapping("/by-keys")
@@ -141,6 +142,6 @@ public class SystemParameterController {
             @Parameter(description = "List of parameter keys to retrieve", required = true)
             @RequestBody final List<String> keys) {
         BaseResponse<List<SystemParameter>> response = systemParameterService.getByKeys(keys);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
 }

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/http/BaseResponseEntityFactory.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/http/BaseResponseEntityFactory.java
@@ -1,0 +1,35 @@
+package com.ejada.common.http;
+
+import com.ejada.common.dto.BaseResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Utility methods for converting {@link BaseResponse} payloads to {@link ResponseEntity} instances
+ * with HTTP statuses derived from the response metadata.
+ */
+public final class BaseResponseEntityFactory {
+
+    private BaseResponseEntityFactory() {
+    }
+
+    public static <T> ResponseEntity<BaseResponse<T>> build(final BaseResponse<T> response) {
+        return build(response, null);
+    }
+
+    public static <T> ResponseEntity<BaseResponse<T>> build(
+            final BaseResponse<T> response,
+            final HttpStatus successStatusOverride) {
+
+        HttpStatus status = ApiStatusMapper.toHttpStatus(response);
+        if (response == null) {
+            return ResponseEntity.status(status).build();
+        }
+
+        if (successStatusOverride != null && response.isSuccess() && status.is2xxSuccessful()) {
+            status = successStatusOverride;
+        }
+
+        return ResponseEntity.status(status).body(response);
+    }
+}

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/controller/ConsumptionController.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/controller/ConsumptionController.java
@@ -7,6 +7,7 @@ import com.ejada.billing.exception.ServiceResultException;
 import com.ejada.billing.service.ConsumptionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,9 +40,23 @@ public class ConsumptionController {
             @Valid @RequestBody final TrackProductConsumptionRq body) {
 
         try {
-            return ResponseEntity.ok(service.trackProductConsumption(rqUid, token, body));
+            ServiceResult<TrackProductConsumptionRs> result =
+                    service.trackProductConsumption(rqUid, token, body);
+            return respond(result);
         } catch (ServiceResultException ex) {
-            return ResponseEntity.ok(ex.getResult());
+            return respond(ex.getResult());
         }
+    }
+
+    private ResponseEntity<ServiceResult<TrackProductConsumptionRs>> respond(
+            final ServiceResult<TrackProductConsumptionRs> result) {
+
+        if (result == null) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+        HttpStatus status = Boolean.TRUE.equals(result.success())
+                ? HttpStatus.OK
+                : HttpStatus.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(status).body(result);
     }
 }

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/AddonController.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/AddonController.java
@@ -1,5 +1,7 @@
 package com.ejada.catalog.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.catalog.dto.*;
 import com.ejada.catalog.security.CatalogAuthorized;
 import com.ejada.catalog.service.AddonService;
@@ -16,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import org.springframework.validation.annotation.Validated;
@@ -43,8 +46,7 @@ public class AddonController {
     public ResponseEntity<BaseResponse<AddonRes>> create(@Valid @RequestBody AddonCreateReq req) {
         log.info("Request to create addon: {}", req);
         BaseResponse<AddonRes> res = service.create(req);
-        return ResponseEntity.status(201).body(res);
-
+        return build(res, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
@@ -59,7 +61,7 @@ public class AddonController {
     public ResponseEntity<BaseResponse<AddonRes>> update(@PathVariable @Min(1) Integer id,
                                                          @Valid @RequestBody AddonUpdateReq req) {
         log.info("Updating addon {} with {}", id, req);
-        return ResponseEntity.ok(service.update(id, req));
+        return build(service.update(id, req));
     }
 
     @GetMapping("/{id}")
@@ -67,7 +69,7 @@ public class AddonController {
     @Operation(summary = "Get addon by ID", description = "Retrieves the addon with the specified ID")
     public ResponseEntity<BaseResponse<AddonRes>> get(@PathVariable @Min(1) Integer id) {
         log.debug("Fetching addon {}", id);
-        return ResponseEntity.ok(service.get(id));
+        return build(service.get(id));
     }
 
     @GetMapping
@@ -76,7 +78,7 @@ public class AddonController {
     public ResponseEntity<BaseResponse<Page<AddonRes>>> list(@RequestParam(required = false) String category,
                                                              @ParameterObject Pageable pageable) {
         log.debug("Listing addons for category={} page={}", category, pageable);
-        return ResponseEntity.ok(service.list(category, pageable));
+        return build(service.list(category, pageable));
     }
 
     @DeleteMapping("/{id}")

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/AddonFeatureController.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/AddonFeatureController.java
@@ -1,5 +1,7 @@
 package com.ejada.catalog.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.catalog.dto.*;
 import com.ejada.catalog.security.CatalogAuthorized;
 import com.ejada.catalog.service.AddonFeatureService;
@@ -56,7 +58,8 @@ public class AddonFeatureController {
             req.overageCurrency(),
             req.meta()
         );
-        return ResponseEntity.ok(service.attach(normalized));
+        BaseResponse<AddonFeatureRes> response = service.attach(normalized);
+        return build(response, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
@@ -71,7 +74,7 @@ public class AddonFeatureController {
     public ResponseEntity<BaseResponse<AddonFeatureRes>> update(@PathVariable @Min(1) Integer addonId,
                                                                 @PathVariable @Min(1) Integer id,
                                                                 @Valid @RequestBody AddonFeatureUpdateReq req) {
-        return ResponseEntity.ok(service.update(id, req));
+        return build(service.update(id, req));
     }
 
     @GetMapping
@@ -84,7 +87,7 @@ public class AddonFeatureController {
     })
     public ResponseEntity<BaseResponse<Page<AddonFeatureRes>>> listByAddon(@PathVariable @Min(1) Integer addonId,
                                                                            @ParameterObject Pageable pageable) {
-        return ResponseEntity.ok(service.listByAddon(addonId, pageable));
+        return build(service.listByAddon(addonId, pageable));
     }
 
     @DeleteMapping("/{id}")

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/FeatureController.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/FeatureController.java
@@ -1,5 +1,7 @@
 package com.ejada.catalog.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.catalog.dto.*;
 import com.ejada.catalog.security.CatalogAuthorized;
 import com.ejada.catalog.service.FeatureService;
@@ -40,7 +42,8 @@ public class FeatureController {
         @ApiResponse(responseCode = "409", description = "featureKey already exists")
     })
     public ResponseEntity<BaseResponse<FeatureRes>> create(@Valid @RequestBody FeatureCreateReq req) {
-        return ResponseEntity.ok(service.create(req));
+        BaseResponse<FeatureRes> response = service.create(req);
+        return build(response, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
@@ -54,7 +57,7 @@ public class FeatureController {
     })
     public ResponseEntity<BaseResponse<FeatureRes>> update(@PathVariable @Min(1) Integer id,
                                                            @Valid @RequestBody FeatureUpdateReq req) {
-        return ResponseEntity.ok(service.update(id, req));
+        return build(service.update(id, req));
     }
 
     @GetMapping("/{id}")
@@ -66,7 +69,7 @@ public class FeatureController {
         @ApiResponse(responseCode = "404", description = "Feature not found")
     })
     public ResponseEntity<BaseResponse<FeatureRes>> get(@PathVariable @Min(1) Integer id) {
-        return ResponseEntity.ok(service.get(id));
+        return build(service.get(id));
     }
 
     @GetMapping
@@ -78,7 +81,7 @@ public class FeatureController {
     })
     public ResponseEntity<BaseResponse<Page<FeatureRes>>> list(@RequestParam(required = false) String category,
                                                                @ParameterObject Pageable pageable) {
-        return ResponseEntity.ok(service.list(category, pageable));
+        return build(service.list(category, pageable));
     }
 
     @DeleteMapping("/{id}")

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/TierAddonController.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/TierAddonController.java
@@ -1,5 +1,7 @@
 package com.ejada.catalog.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.catalog.dto.*;
 import com.ejada.catalog.security.CatalogAuthorized;
 import com.ejada.catalog.service.TierAddonService;
@@ -50,7 +52,8 @@ public class TierAddonController {
             req.basePrice(),
             req.currency()
         );
-        return ResponseEntity.ok(service.allow(normalized));
+        BaseResponse<TierAddonRes> response = service.allow(normalized);
+        return build(response, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
@@ -65,7 +68,7 @@ public class TierAddonController {
     public ResponseEntity<BaseResponse<TierAddonRes>> update(@PathVariable @Min(1) Integer tierId,
                                                               @PathVariable @Min(1) Integer id,
                                                               @Valid @RequestBody TierAddonUpdateReq req) {
-        return ResponseEntity.ok(service.update(id, req));
+        return build(service.update(id, req));
     }
 
     @GetMapping
@@ -78,7 +81,7 @@ public class TierAddonController {
     })
     public ResponseEntity<BaseResponse<Page<TierAddonRes>>> listByTier(@PathVariable @Min(1) Integer tierId,
                                                                        @ParameterObject Pageable pageable) {
-        return ResponseEntity.ok(service.listByTier(tierId, pageable));
+        return build(service.listByTier(tierId, pageable));
     }
 
     @DeleteMapping("/{id}")

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/TierController.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/TierController.java
@@ -1,5 +1,7 @@
 package com.ejada.catalog.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.catalog.dto.*;
 import com.ejada.catalog.security.CatalogAuthorized;
 import com.ejada.catalog.service.TierService;
@@ -40,7 +42,8 @@ public class TierController {
         @ApiResponse(responseCode = "409", description = "Tier already exists")
     })
     public ResponseEntity<BaseResponse<TierRes>> create(@Valid @RequestBody TierCreateReq req) {
-        return ResponseEntity.ok(service.create(req));
+        BaseResponse<TierRes> response = service.create(req);
+        return build(response, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
@@ -54,7 +57,7 @@ public class TierController {
     })
     public ResponseEntity<BaseResponse<TierRes>> update(@PathVariable @Min(1) Integer id,
                                                         @Valid @RequestBody TierUpdateReq req) {
-        return ResponseEntity.ok(service.update(id, req));
+        return build(service.update(id, req));
     }
 
     @CatalogAuthorized
@@ -66,7 +69,7 @@ public class TierController {
     })
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<TierRes>> get(@PathVariable @Min(1) Integer id) {
-        return ResponseEntity.ok(service.get(id));
+        return build(service.get(id));
     }
 
     @CatalogAuthorized
@@ -78,7 +81,7 @@ public class TierController {
     @GetMapping
     public ResponseEntity<BaseResponse<Page<TierRes>>> list(@RequestParam(required = false) Boolean active,
                                                             @ParameterObject Pageable pageable) {
-        return ResponseEntity.ok(service.list(active, pageable));
+        return build(service.list(active, pageable));
     }
 
     @DeleteMapping("/{id}")

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/TierFeatureController.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/controller/TierFeatureController.java
@@ -1,5 +1,7 @@
 package com.ejada.catalog.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.catalog.dto.TierFeatureCreateReq;
 import com.ejada.catalog.dto.TierFeatureRes;
 import com.ejada.catalog.dto.TierFeatureUpdateReq;
@@ -18,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -66,7 +69,8 @@ public class TierFeatureController {
             req.overageCurrency(),
             req.meta()
         );
-        return ResponseEntity.ok(service.attach(normalized));
+        BaseResponse<TierFeatureRes> response = service.attach(normalized);
+        return build(response, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
@@ -82,7 +86,7 @@ public class TierFeatureController {
                                                                @PathVariable @Min(1) final Integer id,
                                                                @Valid @RequestBody final TierFeatureUpdateReq req) {
         // tierId is only for routing; service validates existence internally
-        return ResponseEntity.ok(service.update(id, req));
+        return build(service.update(id, req));
     }
 
     @CatalogAuthorized
@@ -95,7 +99,7 @@ public class TierFeatureController {
     @GetMapping
     public ResponseEntity<BaseResponse<Page<TierFeatureRes>>> listByTier(@PathVariable @Min(1) final Integer tierId,
                                                                          @ParameterObject final Pageable pageable) {
-        return ResponseEntity.ok(service.listByTier(tierId, pageable));
+        return build(service.listByTier(tierId, pageable));
     }
 
     @DeleteMapping("/{id}")

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionInboundController.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionInboundController.java
@@ -8,6 +8,7 @@ import com.ejada.subscription.exception.ServiceResultException;
 import com.ejada.subscription.service.SubscriptionInboundService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -39,9 +40,9 @@ public class SubscriptionInboundController {
         try {
             ServiceResult<ReceiveSubscriptionNotificationRs> result =
                     service.receiveSubscriptionNotification(rqUid, token, body);
-            return ResponseEntity.ok(result);
+            return respond(result);
         } catch (ServiceResultException ex) {
-            return ResponseEntity.ok(ex.getResult());
+            return respond(ex.getResult());
         }
     }
 
@@ -56,9 +57,19 @@ public class SubscriptionInboundController {
 
         try {
             ServiceResult<Void> result = service.receiveSubscriptionUpdate(rqUid, token, body);
-            return ResponseEntity.ok(result);
+            return respond(result);
         } catch (ServiceResultException ex) {
-            return ResponseEntity.ok(ex.getResult());
+            return respond(ex.getResult());
         }
+    }
+
+    private <T> ResponseEntity<ServiceResult<T>> respond(final ServiceResult<T> result) {
+        if (result == null) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+        HttpStatus status = Boolean.TRUE.equals(result.success())
+                ? HttpStatus.OK
+                : HttpStatus.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(status).body(result);
     }
 }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/controller/TenantController.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/controller/TenantController.java
@@ -1,5 +1,7 @@
 package com.ejada.tenant.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.tenant.dto.TenantCreateReq;
 import com.ejada.tenant.dto.TenantRes;
 import com.ejada.tenant.dto.TenantUpdateReq;
@@ -52,7 +54,8 @@ public class TenantController {
             @ApiResponse(responseCode = "409", description = "Tenant already exists")
     })
     public ResponseEntity<BaseResponse<TenantRes>> create(@Valid @RequestBody final TenantCreateReq req) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(service.create(req));
+        BaseResponse<TenantRes> response = service.create(req);
+        return build(response, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
@@ -66,7 +69,7 @@ public class TenantController {
     })
     public ResponseEntity<BaseResponse<TenantRes>> update(@PathVariable @Min(1) final Integer id,
                                                           @Valid @RequestBody final TenantUpdateReq req) {
-        return ResponseEntity.ok(service.update(id, req));
+        return build(service.update(id, req));
     }
 
     @TenantAuthorized
@@ -78,7 +81,7 @@ public class TenantController {
     })
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<TenantRes>> get(@PathVariable @Min(1) final Integer id) {
-        return ResponseEntity.ok(service.get(id));
+        return build(service.get(id));
     }
 
     @TenantAuthorized
@@ -92,7 +95,7 @@ public class TenantController {
             @RequestParam(required = false) final String name,
             @RequestParam(required = false) final Boolean active,
             @ParameterObject final Pageable pageable) {
-        return ResponseEntity.ok(service.list(name, active, pageable));
+        return build(service.list(name, active, pageable));
     }
 
     @TenantAuthorized

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/controller/TenantIntegrationKeyController.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/controller/TenantIntegrationKeyController.java
@@ -1,5 +1,7 @@
 package com.ejada.tenant.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.tenant.dto.TenantIntegrationKeyCreateReq;
 import com.ejada.tenant.dto.TenantIntegrationKeyRes;
 import com.ejada.tenant.dto.TenantIntegrationKeyUpdateReq;
@@ -19,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -51,7 +54,8 @@ public class TenantIntegrationKeyController {
     })
     public ResponseEntity<BaseResponse<TenantIntegrationKeyRes>> create(
             @Valid @RequestBody final TenantIntegrationKeyCreateReq req) {
-        return ResponseEntity.ok(service.create(req));
+        BaseResponse<TenantIntegrationKeyRes> response = service.create(req);
+        return build(response, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
@@ -66,7 +70,7 @@ public class TenantIntegrationKeyController {
     public ResponseEntity<BaseResponse<TenantIntegrationKeyRes>> update(
             @PathVariable("id") @Min(1) final Long tikId,
             @Valid @RequestBody final TenantIntegrationKeyUpdateReq req) {
-        return ResponseEntity.ok(service.update(tikId, req));
+        return build(service.update(tikId, req));
     }
 
     @TenantAuthorized
@@ -79,7 +83,7 @@ public class TenantIntegrationKeyController {
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<TenantIntegrationKeyRes>> get(
             @PathVariable("id") @Min(1) final Long tikId) {
-        return ResponseEntity.ok(service.get(tikId));
+        return build(service.get(tikId));
     }
 
     @TenantAuthorized
@@ -94,7 +98,7 @@ public class TenantIntegrationKeyController {
     public ResponseEntity<BaseResponse<Page<TenantIntegrationKeyRes>>> listByTenant(
             @PathVariable @Min(1) final Integer tenantId,
             @ParameterObject final Pageable pageable) {
-        return ResponseEntity.ok(service.listByTenant(tenantId, pageable));
+        return build(service.listByTenant(tenantId, pageable));
     }
 
     @TenantAuthorized


### PR DESCRIPTION
## Summary
- add a shared BaseResponseEntityFactory that uses the existing ApiStatusMapper and allows custom success overrides
- switch catalog, tenant, and setup service controllers to build ResponseEntity instances via the shared factory so BaseResponse errors return non-200 statuses

## Testing
- mvn -f tenant-platform/pom.xml -pl tenant-service test *(fails: Non-resolvable import POM com.ejada:shared-bom:1.0.0 and missing dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68db8e66bd04832f9f1af24ca0e075f9