### PR TITLE
Adopt DTO mapping for system parameters and enable static analysis gates

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,5 +47,9 @@ jobs:
         run: mvn -B -DskipTests=true verify -f tenant-platform/pom.xml
       - name: Build setup service
         run: mvn -B -DskipTests=true verify -f setup-service/pom.xml
+      - name: Run static analysis gates
+        run: |
+          mvn -B -Pquality -DskipTests=true verify -f setup-service/pom.xml
+          mvn -B -Pquality -DskipTests=true verify -f tenant-platform/pom.xml
       - name: Report dependency updates for shared BOM
         run: mvn -B -f shared-lib/shared-bom/pom.xml versions:display-dependency-updates

--- a/setup-service/src/main/java/com/ejada/setup/controller/CountryController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/CountryController.java
@@ -3,7 +3,6 @@ package com.ejada.setup.controller;
 import com.ejada.common.dto.BaseResponse;
 import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.dto.CountryDto;
-import com.ejada.setup.model.Country;
 import com.ejada.setup.constants.ValidationConstants;
 import com.ejada.setup.security.SetupAuthorized;
 import com.ejada.setup.service.CountryService;
@@ -57,8 +56,8 @@ public class CountryController {
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "409", description = "Country code already exists")
     })
-    public ResponseEntity<BaseResponse<Country>> add(@Valid @RequestBody final CountryDto body) {
-        BaseResponse<Country> response = countryService.add(body);
+    public ResponseEntity<BaseResponse<CountryDto>> add(@Valid @RequestBody final CountryDto body) {
+        BaseResponse<CountryDto> response = countryService.add(body);
         return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
@@ -72,11 +71,11 @@ public class CountryController {
         @ApiResponse(responseCode = "404", description = "Country not found"),
         @ApiResponse(responseCode = "409", description = "Country code already exists")
     })
-    public ResponseEntity<BaseResponse<Country>> update(
+    public ResponseEntity<BaseResponse<CountryDto>> update(
             @Parameter(description = "ID of the country to update", required = true)
             @PathVariable @Min(1) final Integer countryId,
             @Valid @RequestBody final CountryDto body) {
-        BaseResponse<Country> response = countryService.update(countryId, body);
+        BaseResponse<CountryDto> response = countryService.update(countryId, body);
         return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
@@ -88,10 +87,10 @@ public class CountryController {
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "404", description = "Country not found")
     })
-    public ResponseEntity<BaseResponse<Country>> get(
+    public ResponseEntity<BaseResponse<CountryDto>> get(
             @Parameter(description = "ID of the country to retrieve", required = true)
             @PathVariable @Min(1) final Integer countryId) {
-        BaseResponse<Country> response = countryService.get(countryId);
+        BaseResponse<CountryDto> response = countryService.get(countryId);
         return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
@@ -121,8 +120,8 @@ public class CountryController {
         @ApiResponse(responseCode = "200", description = "Active countries retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<BaseResponse<List<Country>>> listActive() {
-        BaseResponse<List<Country>> response = countryService.listActive();
+    public ResponseEntity<BaseResponse<List<CountryDto>>> listActive() {
+        BaseResponse<List<CountryDto>> response = countryService.listActive();
         return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/controller/SystemParameterController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/SystemParameterController.java
@@ -2,7 +2,8 @@ package com.ejada.setup.controller;
 
 import com.ejada.common.dto.BaseResponse;
 import com.ejada.common.http.ApiStatusMapper;
-import com.ejada.setup.model.SystemParameter;
+import com.ejada.setup.dto.SystemParameterRequest;
+import com.ejada.setup.dto.SystemParameterResponse;
 import com.ejada.setup.security.SetupAuthorized;
 import com.ejada.setup.service.SystemParameterService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -57,8 +58,8 @@ public class SystemParameterController {
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "409", description = "System parameter already exists")
     })
-    public ResponseEntity<BaseResponse<SystemParameter>> add(@Valid @RequestBody final SystemParameter body) {
-        BaseResponse<SystemParameter> response = systemParameterService.add(body);
+    public ResponseEntity<BaseResponse<SystemParameterResponse>> add(@Valid @RequestBody final SystemParameterRequest body) {
+        BaseResponse<SystemParameterResponse> response = systemParameterService.add(body);
         return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
@@ -71,11 +72,11 @@ public class SystemParameterController {
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "404", description = "System parameter not found")
     })
-    public ResponseEntity<BaseResponse<SystemParameter>> update(
+    public ResponseEntity<BaseResponse<SystemParameterResponse>> update(
             @Parameter(description = "ID of the system parameter to update", required = true)
             @PathVariable @Min(1) final Integer paramId,
-            @Valid @RequestBody final SystemParameter body) {
-        BaseResponse<SystemParameter> response = systemParameterService.update(paramId, body);
+            @Valid @RequestBody final SystemParameterRequest body) {
+        BaseResponse<SystemParameterResponse> response = systemParameterService.update(paramId, body);
         return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
@@ -87,10 +88,10 @@ public class SystemParameterController {
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "404", description = "System parameter not found")
     })
-    public ResponseEntity<BaseResponse<SystemParameter>> get(
+    public ResponseEntity<BaseResponse<SystemParameterResponse>> get(
             @Parameter(description = "ID of the system parameter to retrieve", required = true)
             @PathVariable @Min(1) final Integer paramId) {
-        BaseResponse<SystemParameter> response = systemParameterService.get(paramId);
+        BaseResponse<SystemParameterResponse> response = systemParameterService.get(paramId);
         return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
@@ -101,7 +102,7 @@ public class SystemParameterController {
         @ApiResponse(responseCode = "200", description = "System parameters retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<BaseResponse<Page<SystemParameter>>> list(
+    public ResponseEntity<BaseResponse<Page<SystemParameterResponse>>> list(
             @PageableDefault(size = DEFAULT_PAGE_SIZE) final Pageable pageable,
             @Parameter(description = "Group filter for parameters")
             @RequestParam(required = false) final String group,
@@ -110,7 +111,7 @@ public class SystemParameterController {
             @Parameter(description = "Whether to retrieve all parameters (ignores pagination)")
             @RequestParam(name = "unpaged", defaultValue = "false") final boolean unpaged) {
         final Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
-        BaseResponse<Page<SystemParameter>> response =
+        BaseResponse<Page<SystemParameterResponse>> response =
                 systemParameterService.list(effectivePageable, group, onlyActive);
         return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
@@ -123,10 +124,10 @@ public class SystemParameterController {
         @ApiResponse(responseCode = "403", description = "Access denied"),
         @ApiResponse(responseCode = "404", description = "System parameter not found")
     })
-    public ResponseEntity<BaseResponse<SystemParameter>> getByKey(
+    public ResponseEntity<BaseResponse<SystemParameterResponse>> getByKey(
             @Parameter(description = "Key of the parameter to retrieve", required = true)
             @PathVariable @NotBlank final String paramKey) {
-        BaseResponse<SystemParameter> response = systemParameterService.getByKey(paramKey);
+        BaseResponse<SystemParameterResponse> response = systemParameterService.getByKey(paramKey);
         return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 
@@ -137,10 +138,10 @@ public class SystemParameterController {
         @ApiResponse(responseCode = "200", description = "System parameters retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<BaseResponse<List<SystemParameter>>> getByKeys(
+    public ResponseEntity<BaseResponse<List<SystemParameterResponse>>> getByKeys(
             @Parameter(description = "List of parameter keys to retrieve", required = true)
             @RequestBody final List<String> keys) {
-        BaseResponse<List<SystemParameter>> response = systemParameterService.getByKeys(keys);
+        BaseResponse<List<SystemParameterResponse>> response = systemParameterService.getByKeys(keys);
         return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
     }
 }

--- a/setup-service/src/main/java/com/ejada/setup/dto/SystemParameterRequest.java
+++ b/setup-service/src/main/java/com/ejada/setup/dto/SystemParameterRequest.java
@@ -1,0 +1,33 @@
+package com.ejada.setup.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SystemParameterRequest {
+
+    private static final int KEY_LENGTH = 150;
+    private static final int VALUE_LENGTH = 1000;
+
+    @NotBlank
+    @Size(max = KEY_LENGTH)
+    private String paramKey;
+
+    @NotBlank
+    @Size(max = VALUE_LENGTH)
+    private String paramValue;
+
+    @Size(max = VALUE_LENGTH)
+    private String description;
+
+    @Size(max = KEY_LENGTH)
+    private String paramGroup;
+
+    @NotNull
+    private Boolean isActive;
+}

--- a/setup-service/src/main/java/com/ejada/setup/dto/SystemParameterResponse.java
+++ b/setup-service/src/main/java/com/ejada/setup/dto/SystemParameterResponse.java
@@ -1,0 +1,15 @@
+package com.ejada.setup.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SystemParameterResponse {
+    private Integer paramId;
+    private String paramKey;
+    private String paramValue;
+    private String description;
+    private String paramGroup;
+    private Boolean isActive;
+}

--- a/setup-service/src/main/java/com/ejada/setup/mapper/CountryMapper.java
+++ b/setup-service/src/main/java/com/ejada/setup/mapper/CountryMapper.java
@@ -1,0 +1,33 @@
+package com.ejada.setup.mapper;
+
+import com.ejada.setup.dto.CountryDto;
+import com.ejada.setup.model.Country;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.lang.NonNull;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface CountryMapper {
+
+    Country toEntity(@NonNull CountryDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntity(@NonNull CountryDto dto, @MappingTarget Country entity);
+
+    CountryDto toDto(@NonNull Country entity);
+
+    List<CountryDto> toDtoList(@NonNull List<Country> entities);
+
+    default Page<CountryDto> toDtoPage(Page<Country> page) {
+        if (page == null) {
+            return Page.empty();
+        }
+        return new PageImpl<>(toDtoList(page.getContent()), page.getPageable(), page.getTotalElements());
+    }
+}

--- a/setup-service/src/main/java/com/ejada/setup/mapper/SystemParameterMapper.java
+++ b/setup-service/src/main/java/com/ejada/setup/mapper/SystemParameterMapper.java
@@ -1,0 +1,34 @@
+package com.ejada.setup.mapper;
+
+import com.ejada.setup.dto.SystemParameterRequest;
+import com.ejada.setup.dto.SystemParameterResponse;
+import com.ejada.setup.model.SystemParameter;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.lang.NonNull;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface SystemParameterMapper {
+
+    SystemParameter toEntity(@NonNull SystemParameterRequest request);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntity(@NonNull SystemParameterRequest request, @MappingTarget SystemParameter entity);
+
+    SystemParameterResponse toResponse(@NonNull SystemParameter entity);
+
+    List<SystemParameterResponse> toResponseList(@NonNull List<SystemParameter> entities);
+
+    default Page<SystemParameterResponse> toResponsePage(Page<SystemParameter> page) {
+        if (page == null) {
+            return Page.empty();
+        }
+        return new PageImpl<>(toResponseList(page.getContent()), page.getPageable(), page.getTotalElements());
+    }
+}

--- a/setup-service/src/main/java/com/ejada/setup/service/CountryService.java
+++ b/setup-service/src/main/java/com/ejada/setup/service/CountryService.java
@@ -1,7 +1,6 @@
 package com.ejada.setup.service;
 
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.setup.model.Country;
 import com.ejada.setup.dto.CountryDto;
 import org.springframework.data.domain.Pageable;
 
@@ -9,13 +8,13 @@ import java.util.List;
 
 public interface CountryService {
 
-    BaseResponse<Country> add(CountryDto request);
+    BaseResponse<CountryDto> add(CountryDto request);
 
-    BaseResponse<Country> update(Integer countryId, CountryDto request);
+    BaseResponse<CountryDto> update(Integer countryId, CountryDto request);
 
-    BaseResponse<Country> get(Integer countryId);
+    BaseResponse<CountryDto> get(Integer countryId);
 
     BaseResponse<?> list(Pageable pageable, String q, boolean unpaged);
 
-    BaseResponse<List<Country>> listActive();
+    BaseResponse<List<CountryDto>> listActive();
 }

--- a/setup-service/src/main/java/com/ejada/setup/service/SystemParameterService.java
+++ b/setup-service/src/main/java/com/ejada/setup/service/SystemParameterService.java
@@ -1,7 +1,8 @@
 package com.ejada.setup.service;
 
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.setup.model.SystemParameter;
+import com.ejada.setup.dto.SystemParameterRequest;
+import com.ejada.setup.dto.SystemParameterResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -9,16 +10,16 @@ import java.util.List;
 
 public interface SystemParameterService {
 
-    BaseResponse<SystemParameter> add(SystemParameter request);
+    BaseResponse<SystemParameterResponse> add(SystemParameterRequest request);
 
-    BaseResponse<SystemParameter> update(Integer paramId, SystemParameter request);
+    BaseResponse<SystemParameterResponse> update(Integer paramId, SystemParameterRequest request);
 
-    BaseResponse<SystemParameter> get(Integer paramId);
+    BaseResponse<SystemParameterResponse> get(Integer paramId);
 
-    BaseResponse<Page<SystemParameter>> list(Pageable pageable, String group, Boolean onlyActive);
+    BaseResponse<Page<SystemParameterResponse>> list(Pageable pageable, String group, Boolean onlyActive);
 
-    BaseResponse<List<SystemParameter>> getByKeys(List<String> keys);
-    
-    BaseResponse<SystemParameter> getByKey(String paramKey);
+    BaseResponse<List<SystemParameterResponse>> getByKeys(List<String> keys);
+
+    BaseResponse<SystemParameterResponse> getByKey(String paramKey);
 
 }

--- a/setup-service/src/test/java/com/ejada/setup/TestBase.java
+++ b/setup-service/src/test/java/com/ejada/setup/TestBase.java
@@ -6,6 +6,7 @@ import com.ejada.setup.model.Country;
 import com.ejada.setup.model.City;
 import com.ejada.setup.model.Lookup;
 import com.ejada.setup.model.Resource;
+import com.ejada.setup.dto.SystemParameterRequest;
 import com.ejada.setup.model.SystemParameter;
 import com.ejada.setup.dto.CountryDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -117,6 +118,16 @@ public abstract class TestBase {
         param.setIsActive(true);
         param.setDescription("Application version");
         return param;
+    }
+
+    protected SystemParameterRequest createTestSystemParameterRequest() {
+        SystemParameterRequest request = new SystemParameterRequest();
+        request.setParamKey("APP_VERSION");
+        request.setParamValue("1.0.0");
+        request.setParamGroup("SYSTEM");
+        request.setIsActive(true);
+        request.setDescription("Application version");
+        return request;
     }
 
     // Helper methods for building requests

--- a/setup-service/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
@@ -1,7 +1,6 @@
 package com.ejada.setup.controller;
 
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.setup.model.Country;
 import com.ejada.setup.dto.CountryDto;
 import com.ejada.setup.service.CountryService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -59,20 +58,6 @@ class CountryControllerTest {
         @Bean CountryService countryService() { return mock(CountryService.class); }
     }
 
-    private Country createTestCountry() {
-        Country country = new Country();
-        country.setCountryCd("US");
-        country.setCountryEnNm("United States");
-        country.setCountryArNm("الولايات المتحدة");
-        country.setDialingCode("+1");
-        country.setNationalityEn("American");
-        country.setNationalityAr("أمريكي");
-        country.setIsActive(true);
-        country.setEnDescription("United States of America");
-        country.setArDescription("الولايات المتحدة الأمريكية");
-        return country;
-    }
-
     private CountryDto createTestCountryDto() {
         CountryDto dto = new CountryDto();
         dto.setCountryCd("US");
@@ -91,8 +76,9 @@ class CountryControllerTest {
     @WithMockUser(roles = "ADMIN")
     void add_shouldCreateCountry_whenValidRequest() throws Exception {
         CountryDto request = createTestCountryDto();
-        Country country = createTestCountry();
-        BaseResponse<Country> response = BaseResponse.success("Country created", country);
+        CountryDto responseBody = createTestCountryDto();
+        responseBody.setCountryId(1);
+        BaseResponse<CountryDto> response = BaseResponse.success("Country created", responseBody);
         when(countryService.add(any(CountryDto.class))).thenReturn(response);
 
         mockMvc.perform(post(BASE_URL)
@@ -112,9 +98,9 @@ class CountryControllerTest {
     @WithMockUser(roles = "ADMIN")
     void update_shouldUpdateCountry_whenValidRequest() throws Exception {
         CountryDto request = createTestCountryDto();
-        Country country = createTestCountry();
-        country.setCountryId(1);
-        BaseResponse<Country> response = BaseResponse.success("Country updated", country);
+        CountryDto responseBody = createTestCountryDto();
+        responseBody.setCountryId(1);
+        BaseResponse<CountryDto> response = BaseResponse.success("Country updated", responseBody);
         when(countryService.update(eq(1), any(CountryDto.class))).thenReturn(response);
 
         mockMvc.perform(put(BASE_URL + "/1")
@@ -132,9 +118,9 @@ class CountryControllerTest {
     @Test
     @WithMockUser(roles = "USER")
     void get_shouldReturnCountry_whenValidId() throws Exception {
-        Country country = createTestCountry();
+        CountryDto country = createTestCountryDto();
         country.setCountryId(1);
-        BaseResponse<Country> response = BaseResponse.success("Country", country);
+        BaseResponse<CountryDto> response = BaseResponse.success("Country", country);
         when(countryService.get(1)).thenReturn(response);
 
         mockMvc.perform(get(BASE_URL + "/1")
@@ -150,8 +136,8 @@ class CountryControllerTest {
     @Test
     @WithMockUser(roles = "USER")
     void list_shouldReturnPaginatedCountries_whenValidRequest() throws Exception {
-        List<Country> countries = Arrays.asList(createTestCountry());
-        Page<Country> page = new PageImpl<>(countries, PageRequest.of(0, 20), 1);
+        List<CountryDto> countries = Arrays.asList(createTestCountryDto());
+        Page<CountryDto> page = new PageImpl<>(countries, PageRequest.of(0, 20), 1);
         BaseResponse<?> response = BaseResponse.success("Countries page", page);
         doReturn(response).when(countryService).list(any(Pageable.class), nullable(String.class), anyBoolean());
 
@@ -169,8 +155,8 @@ class CountryControllerTest {
     @Test
     @WithMockUser(roles = "USER")
     void listActive_shouldReturnActiveCountries() throws Exception {
-        List<Country> countries = Arrays.asList(createTestCountry());
-        BaseResponse<List<Country>> response = BaseResponse.success("Active countries", countries);
+        List<CountryDto> countries = Arrays.asList(createTestCountryDto());
+        BaseResponse<List<CountryDto>> response = BaseResponse.success("Active countries", countries);
         when(countryService.listActive()).thenReturn(response);
 
         mockMvc.perform(get(BASE_URL + "/active")
@@ -186,7 +172,7 @@ class CountryControllerTest {
     @Test
     @WithMockUser(roles = "USER")
     void get_shouldReturn404_whenCountryNotFound() throws Exception {
-        BaseResponse<Country> response = BaseResponse.error("ERR_COUNTRY_NOT_FOUND", "Country not found");
+        BaseResponse<CountryDto> response = BaseResponse.error("ERR_COUNTRY_NOT_FOUND", "Country not found");
         when(countryService.get(999)).thenReturn(response);
 
         mockMvc.perform(get(BASE_URL + "/999")

--- a/setup-service/src/test/java/com/ejada/setup/controller/SystemParameterControllerTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/controller/SystemParameterControllerTest.java
@@ -1,7 +1,7 @@
 package com.ejada.setup.controller;
 
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.setup.model.SystemParameter;
+import com.ejada.setup.dto.SystemParameterResponse;
 import com.ejada.setup.service.SystemParameterService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +37,7 @@ class SystemParameterControllerTest {
 
     @Test
     void list_ok() throws Exception {
-        BaseResponse<Page<SystemParameter>> resp = BaseResponse.success("ok", Page.<SystemParameter>empty());
+        BaseResponse<Page<SystemParameterResponse>> resp = BaseResponse.success("ok", Page.<SystemParameterResponse>empty());
 
         doReturn(resp)
                 .when(systemParameterService)
@@ -51,7 +51,7 @@ class SystemParameterControllerTest {
 
     @Test
     void get_notFound_translatesHttpStatus() throws Exception {
-        BaseResponse<SystemParameter> resp = BaseResponse.error("ERR_PARAM_NOT_FOUND", "System parameter not found");
+        BaseResponse<SystemParameterResponse> resp = BaseResponse.error("ERR_PARAM_NOT_FOUND", "System parameter not found");
 
         doReturn(resp)
                 .when(systemParameterService)

--- a/setup-service/src/test/java/com/ejada/setup/service/SystemParameterServiceImplTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/service/SystemParameterServiceImplTest.java
@@ -1,14 +1,16 @@
 package com.ejada.setup.service;
 
+import com.ejada.setup.mapper.SystemParameterMapper;
+import com.ejada.setup.model.SystemParameter;
 import com.ejada.setup.repository.SystemParameterRepository;
 import com.ejada.setup.service.impl.SystemParameterServiceImpl;
-import com.ejada.setup.model.SystemParameter;
+import org.junit.jupiter.api.BeforeEach;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mapstruct.factory.Mappers;
 
 import java.util.Optional;
 
@@ -19,14 +21,28 @@ import static org.mockito.Mockito.*;
 class SystemParameterServiceImplTest {
 
   @Mock SystemParameterRepository repository;
-  @InjectMocks SystemParameterServiceImpl service;
+  private SystemParameterMapper mapper;
+  private SystemParameterServiceImpl service;
+
+  @BeforeEach
+  void setUp() {
+    mapper = Mappers.getMapper(SystemParameterMapper.class);
+    service = new SystemParameterServiceImpl(repository, mapper);
+  }
 
   @Test
   void getByKey_ok() {
+    SystemParameter entity = new SystemParameter();
+    entity.setParamId(1);
+    entity.setParamKey("SITE_NAME");
+    entity.setParamValue("Portal");
+    entity.setParamGroup("UI");
+    entity.setIsActive(true);
     when(repository.findByParamKey("SITE_NAME"))
-        .thenReturn(Optional.of(new SystemParameter(/* init fields */)));
+        .thenReturn(Optional.of(entity));
 
     var res = service.getByKey("SITE_NAME");
     assertNotNull(res);
+    assertEquals("SITE_NAME", res.getData().getParamKey());
   }
 }


### PR DESCRIPTION
## Summary
- add MapStruct mappers plus request/response DTOs so system parameter and country flows return DTOs instead of entities
- refactor controllers, services, and tests to consume the new DTO mappings for safer audit-heavy responses
- run the shared quality profile in CI so Checkstyle and SpotBugs gates execute on setup-service and tenant-platform builds

## Testing
- `mvn -f setup-service/pom.xml test` *(fails: missing internal shared-bom artifacts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db8eb77b48832f8e29416f8f8bfc52