### PR TITLE
Tighten dev security and enforce API status codes

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/controller/AuthController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/AuthController.java
@@ -1,7 +1,8 @@
 package com.ejada.sec.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.dto.admin.SuperadminAuthResponse;
 import com.ejada.sec.dto.admin.SuperadminLoginRequest;
@@ -11,6 +12,7 @@ import com.ejada.sec.service.SuperadminService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,43 +29,43 @@ public class AuthController {
   @PostMapping("/register")
   public ResponseEntity<BaseResponse<AuthResponse>> register(@Valid @RequestBody RegisterRequest req) {
     BaseResponse<AuthResponse> response = authService.register(req);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response, HttpStatus.CREATED);
   }
 
   @PostMapping("/login")
   public ResponseEntity<BaseResponse<AuthResponse>> login(@Valid @RequestBody AuthRequest req) {
     BaseResponse<AuthResponse> response = authService.login(req);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @PostMapping("/refresh")
   public ResponseEntity<BaseResponse<AuthResponse>> refresh(@Valid @RequestBody RefreshTokenRequest req) {
     BaseResponse<AuthResponse> response = authService.refresh(req);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @PostMapping("/logout")
   public ResponseEntity<BaseResponse<Void>> logout(@Valid @RequestBody RefreshTokenRequest request) {
     BaseResponse<Void> response = authService.logout(request.getRefreshToken());
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @PostMapping("/forgot-password")
   public ResponseEntity<BaseResponse<Void>> forgotPassword(@Valid @RequestBody ForgotPasswordRequest req) {
     BaseResponse<Void> response = passwordResetService.createToken(req);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @PostMapping("/reset-password")
   public ResponseEntity<BaseResponse<Void>> resetPassword(@Valid @RequestBody ResetPasswordRequest req) {
     BaseResponse<Void> response = passwordResetService.reset(req);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
   
   @PostMapping("admin/login")
   public ResponseEntity<BaseResponse<SuperadminAuthResponse>> Adminlogin(@Valid @RequestBody SuperadminLoginRequest request) {
     BaseResponse<SuperadminAuthResponse> response = superadminService.login(request);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/EffectivePrivilegesController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/EffectivePrivilegesController.java
@@ -1,7 +1,8 @@
 package com.ejada.sec.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.domain.EffectivePrivilegeProjection;
 import com.ejada.sec.repository.EffectivePrivilegeViewRepository;
 import com.ejada.starter_core.tenant.RequireTenant;
@@ -27,6 +28,6 @@ public class EffectivePrivilegesController {
         BaseResponse.success(
             "Effective privileges listed",
             viewRepo.findEffectiveByUserAndTenant(userId, TenantContextResolver.requireTenantId()));
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/PrivilegeController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/PrivilegeController.java
@@ -1,7 +1,8 @@
 package com.ejada.sec.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.PrivilegeService;
 import com.ejada.starter_core.tenant.RequireTenant;
@@ -9,6 +10,7 @@ import com.ejada.sec.security.SecAuthorized;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,31 +26,31 @@ public class PrivilegeController {
   @GetMapping
   public ResponseEntity<BaseResponse<List<PrivilegeDto>>> list() {
     BaseResponse<List<PrivilegeDto>> response = privilegeService.listByTenant();
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<BaseResponse<PrivilegeDto>> get(@PathVariable("id") Long id) {
     BaseResponse<PrivilegeDto> response = privilegeService.get(id);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @PostMapping
   public ResponseEntity<BaseResponse<PrivilegeDto>> create(@Valid @RequestBody CreatePrivilegeRequest req) {
     BaseResponse<PrivilegeDto> response = privilegeService.create(req);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response, HttpStatus.CREATED);
   }
 
   @PatchMapping("/{id}")
   public ResponseEntity<BaseResponse<PrivilegeDto>> update(@PathVariable("id") Long id,
                                              @Valid @RequestBody UpdatePrivilegeRequest req) {
     BaseResponse<PrivilegeDto> response = privilegeService.update(id, req);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @DeleteMapping("/{id}")
   public ResponseEntity<BaseResponse<Void>> delete(@PathVariable("id") Long id) {
     BaseResponse<Void> response = privilegeService.delete(id);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
-  }
+    return build(response);
+}
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/RoleController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/RoleController.java
@@ -1,7 +1,8 @@
 package com.ejada.sec.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.RoleService;
 import com.ejada.starter_core.tenant.RequireTenant;
@@ -9,6 +10,7 @@ import com.ejada.sec.security.SecAuthorized;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,31 +26,31 @@ public class RoleController {
   @GetMapping
   public ResponseEntity<BaseResponse<List<RoleDto>>> list() {
     BaseResponse<List<RoleDto>> response = roleService.listByTenant();
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<BaseResponse<RoleDto>> get(@PathVariable("id") Long id) {
     BaseResponse<RoleDto> response = roleService.get(id);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @PostMapping
   public ResponseEntity<BaseResponse<RoleDto>> create(@Valid @RequestBody CreateRoleRequest req) {
     BaseResponse<RoleDto> response = roleService.create(req);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response, HttpStatus.CREATED);
   }
 
   @PatchMapping("/{id}")
   public ResponseEntity<BaseResponse<RoleDto>> update(@PathVariable("id") Long id,
                                         @Valid @RequestBody UpdateRoleRequest req) {
     BaseResponse<RoleDto> response = roleService.update(id, req);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @DeleteMapping("/{id}")
   public ResponseEntity<BaseResponse<Void>> delete(@PathVariable("id") Long id) {
     BaseResponse<Void> response = roleService.delete(id);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
-  }
+    return build(response);
+}
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/SuperadminController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/SuperadminController.java
@@ -1,7 +1,8 @@
 package com.ejada.sec.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.dto.admin.*;
 import com.ejada.sec.service.SuperadminService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -29,7 +31,7 @@ public class SuperadminController {
     public ResponseEntity<BaseResponse<SuperadminDto>> createSuperadmin(
             @Valid @RequestBody CreateSuperadminRequest request) {
         BaseResponse<SuperadminDto> response = superadminService.createSuperadmin(request);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response, HttpStatus.CREATED);
     }
     
     @PutMapping("/{id}")
@@ -39,7 +41,7 @@ public class SuperadminController {
             @PathVariable Long id,
             @Valid @RequestBody UpdateSuperadminRequest request) {
         BaseResponse<SuperadminDto> response = superadminService.updateSuperadmin(id, request);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
     
     @DeleteMapping("/{id}")
@@ -47,7 +49,7 @@ public class SuperadminController {
                description = "Disables a superadmin account. Cannot delete your own account or the last active superadmin.")
     public ResponseEntity<BaseResponse<Void>> deleteSuperadmin(@PathVariable Long id) {
         BaseResponse<Void> response = superadminService.deleteSuperadmin(id);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
     
     @GetMapping("/{id}")
@@ -55,7 +57,7 @@ public class SuperadminController {
                description = "Retrieves details of a specific superadmin")
     public ResponseEntity<BaseResponse<SuperadminDto>> getSuperadmin(@PathVariable Long id) {
         BaseResponse<SuperadminDto> response = superadminService.getSuperadmin(id);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
     
     @GetMapping
@@ -63,7 +65,7 @@ public class SuperadminController {
                description = "Retrieves a paginated list of all superadmin accounts")
     public ResponseEntity<BaseResponse<Page<SuperadminDto>>> listSuperadmins(Pageable pageable) {
         BaseResponse<Page<SuperadminDto>> response = superadminService.listSuperadmins(pageable);
-        return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+        return build(response);
     }
     
 
@@ -71,13 +73,13 @@ public class SuperadminController {
     @PreAuthorize("hasRole('EJADA_OFFICER')")
     public ResponseEntity<BaseResponse<Void>> completeFirstLogin(@Valid @RequestBody FirstLoginRequest request) {
       BaseResponse<Void> response = superadminService.completeFirstLogin(request);
-      return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+      return build(response);
     }
 
     @PostMapping("/change-password")
     @PreAuthorize("hasRole('EJADA_OFFICER')")
     public ResponseEntity<BaseResponse<Void>> changeSuperadminPassword(@Valid @RequestBody ChangePasswordRequest request) {
       BaseResponse<Void> response = superadminService.changePassword(request);
-      return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+      return build(response);
     }
 }

--- a/sec-service/src/main/java/com/ejada/sec/controller/UserController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/UserController.java
@@ -1,7 +1,8 @@
 package com.ejada.sec.controller;
 
+import static com.ejada.common.http.BaseResponseEntityFactory.build;
+
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.service.UserService;
 import com.ejada.starter_core.tenant.RequireTenant;
@@ -9,6 +10,7 @@ import com.ejada.sec.security.SecAuthorized;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,55 +26,55 @@ public class UserController {
   @GetMapping
   public ResponseEntity<BaseResponse<List<UserDto>>> list() {
     BaseResponse<List<UserDto>> response = userService.listByTenant();
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<BaseResponse<UserDto>> get(@PathVariable("id") Long id) {
     BaseResponse<UserDto> response = userService.get(id);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @PostMapping
   public ResponseEntity<BaseResponse<UserDto>> create(@Valid @RequestBody CreateUserRequest req) {
     BaseResponse<UserDto> response = userService.create(req);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response, HttpStatus.CREATED);
   }
 
   @PatchMapping("/{id}")
   public ResponseEntity<BaseResponse<UserDto>> update(@PathVariable("id") Long id,
                                         @Valid @RequestBody UpdateUserRequest req) {
     BaseResponse<UserDto> response = userService.update(id, req);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @DeleteMapping("/{id}")
   public ResponseEntity<BaseResponse<Void>> delete(@PathVariable("id") Long id) {
     BaseResponse<Void> response = userService.delete(id);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @PostMapping("/{id}/enable")
   public ResponseEntity<BaseResponse<Void>> enable(@PathVariable("id") Long id) {
     BaseResponse<Void> response = userService.enable(id);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @PostMapping("/{id}/disable")
   public ResponseEntity<BaseResponse<Void>> disable(@PathVariable("id") Long id) {
     BaseResponse<Void> response = userService.disable(id);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @PostMapping("/{id}/lock")
   public ResponseEntity<BaseResponse<Void>> lock(@PathVariable("id") Long id) {
     BaseResponse<Void> response = userService.lock(id);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 
   @PostMapping("/{id}/unlock")
   public ResponseEntity<BaseResponse<Void>> unlock(@PathVariable("id") Long id) {
     BaseResponse<Void> response = userService.unlock(id);
-    return ResponseEntity.status(ApiStatusMapper.toHttpStatus(response)).body(response);
+    return build(response);
   }
 }

--- a/sec-service/src/test/java/com/ejada/sec/security/RoleControllerSecurityTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/security/RoleControllerSecurityTest.java
@@ -1,0 +1,42 @@
+package com.ejada.sec.security;
+
+import com.ejada.sec.controller.RoleController;
+import com.ejada.sec.service.RoleService;
+import com.ejada.starter_security.SecurityAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = RoleController.class)
+@Import(SecurityAutoConfiguration.class)
+@TestPropertySource(properties = {
+    "spring.main.allow-bean-definition-overriding=true",
+    "shared.security.mode=hs256",
+    "shared.security.hs256.secret=test-secret",
+    "shared.security.jwt.secret=test-secret",
+    "shared.security.resource-server.enabled=true",
+    "shared.security.resource-server.disable-csrf=true",
+    "shared.security.resource-server.permit-all[0]=/actuator/health",
+    "server.servlet.context-path=/sec"
+})
+class RoleControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RoleService roleService;
+
+    @Test
+    void protectedEndpointsRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/sec/api/roles"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/sec-service/src/test/java/com/ejada/sec/security/SuperadminControllerSecurityTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/security/SuperadminControllerSecurityTest.java
@@ -1,0 +1,42 @@
+package com.ejada.sec.security;
+
+import com.ejada.sec.controller.SuperadminController;
+import com.ejada.sec.service.SuperadminService;
+import com.ejada.starter_security.SecurityAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SuperadminController.class)
+@Import(SecurityAutoConfiguration.class)
+@TestPropertySource(properties = {
+    "spring.main.allow-bean-definition-overriding=true",
+    "shared.security.mode=hs256",
+    "shared.security.hs256.secret=test-secret",
+    "shared.security.jwt.secret=test-secret",
+    "shared.security.resource-server.enabled=true",
+    "shared.security.resource-server.disable-csrf=true",
+    "shared.security.resource-server.permit-all[0]=/actuator/health",
+    "server.servlet.context-path=/sec"
+})
+class SuperadminControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SuperadminService superadminService;
+
+    @Test
+    void superadminEndpointsRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/sec/api/superadmin/admins"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/setup-service/src/main/java/com/ejada/setup/controller/SystemParameterController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/SystemParameterController.java
@@ -3,7 +3,6 @@ package com.ejada.setup.controller;
 import static com.ejada.common.http.BaseResponseEntityFactory.build;
 
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.http.ApiStatusMapper;
 import com.ejada.setup.dto.SystemParameterRequest;
 import com.ejada.setup.dto.SystemParameterResponse;
 
@@ -24,6 +23,7 @@ import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -65,7 +65,7 @@ public class SystemParameterController {
 
     public ResponseEntity<BaseResponse<SystemParameterResponse>> add(@Valid @RequestBody final SystemParameterRequest body) {
         BaseResponse<SystemParameterResponse> response = systemParameterService.add(body);
-        return build(response);
+        return build(response, HttpStatus.CREATED);
     }
 
     @PutMapping("/{paramId}")

--- a/setup-service/src/test/java/com/ejada/setup/security/SystemParameterControllerSecurityTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/security/SystemParameterControllerSecurityTest.java
@@ -1,0 +1,42 @@
+package com.ejada.setup.security;
+
+import com.ejada.setup.controller.SystemParameterController;
+import com.ejada.setup.service.SystemParameterService;
+import com.ejada.starter_security.SecurityAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SystemParameterController.class)
+@Import(SecurityAutoConfiguration.class)
+@TestPropertySource(properties = {
+    "spring.main.allow-bean-definition-overriding=true",
+    "shared.security.mode=hs256",
+    "shared.security.hs256.secret=test-secret",
+    "shared.security.jwt.secret=test-secret",
+    "shared.security.resource-server.enabled=true",
+    "shared.security.resource-server.disable-csrf=true",
+    "shared.security.resource-server.permit-all[0]=/actuator/health",
+    "server.servlet.context-path=/core"
+})
+class SystemParameterControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SystemParameterService systemParameterService;
+
+    @Test
+    void protectedEndpointsReturnUnauthorizedWithoutToken() throws Exception {
+        mockMvc.perform(get("/core/setup/systemParameters"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
@@ -195,13 +195,12 @@ shared:
       secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
     resource-server:
       enabled: true
-      permit-all:
-        - "/actuator/health"
+      permit-all: []
       disable-csrf: false
     stateless: true
     roles-claim: roles
     tenant-claim: tenant
-    enable-role-check: false
+    enable-role-check: true
 
 logging:
   level:
@@ -216,4 +215,4 @@ logging:
     org.springframework.cache: ERROR
     org.springframework.cache.interceptor.CacheAspectSupport: ERROR
 
-debug: true
+debug: false

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantControllerSecurityTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantControllerSecurityTest.java
@@ -1,0 +1,42 @@
+package com.ejada.tenant.security;
+
+import com.ejada.starter_security.SecurityAutoConfiguration;
+import com.ejada.tenant.controller.TenantController;
+import com.ejada.tenant.service.TenantService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = TenantController.class)
+@Import({SecurityAutoConfiguration.class, TenantAccessPolicy.class})
+@TestPropertySource(properties = {
+    "spring.main.allow-bean-definition-overriding=true",
+    "shared.security.mode=hs256",
+    "shared.security.hs256.secret=test-secret",
+    "shared.security.jwt.secret=test-secret",
+    "shared.security.resource-server.enabled=true",
+    "shared.security.resource-server.disable-csrf=true",
+    "shared.security.resource-server.permit-all[0]=/actuator/health",
+    "server.servlet.context-path=/tenant"
+})
+class TenantControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TenantService tenantService;
+
+    @Test
+    void tenantEndpointsRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/tenant/api/tenants"))
+            .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary
- tighten shared dev security defaults by removing blanket permit-all entries, re-enabling role checks, and disabling debug logging
- update sec-service and setup-service controllers to delegate status handling to the shared response factory and return 201 on creates
- add MockMvc security smoke tests for role, superadmin, system-parameter, and tenant endpoints to ensure unauthenticated requests are rejected

## Testing
- mvn test -DskipITs *(fails: project depends on shared-lib BOM that must be installed from the private multi-module build)*

------
https://chatgpt.com/codex/tasks/task_e_68db92e7981c832f978e607a670dc348