### PR TITLE
Refactor shared dev config and harden listener safeguards

### DIFF
--- a/shared-lib/shared-config/src/main/resources/application-shared-platform-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-platform-dev.yaml
@@ -15,6 +15,34 @@ spring:
       compression-type: gzip
       properties:
         linger.ms: 5
+  data:
+    redis:
+      repositories:
+        enabled: false
+
+management:
+  endpoints:
+    web:
+      base-path: /actuator
+      exposure:
+        include: health,info,metrics,prometheus,beans,conditions,configprops,loggers,threaddump
+  endpoint:
+    health:
+      show-details: always
+  tracing:
+    sampling:
+      probability: 1.0
+
+springdoc:
+  api-docs:
+    enabled: true
+    path: /v3/api-docs
+  swagger-ui:
+    enabled: true
+    display-request-duration: true
+    filter: true
+    operationsSorter: method
+    tagsSorter: alpha
 
 shared:
   security:
@@ -32,4 +60,143 @@ shared:
     stateless: true
     roles-claim: roles
     tenant-claim: tenant
-    enable-role-check: false
+
+  core:
+    correlation:
+      header-name: X-Correlation-Id
+      generate-if-missing: true
+      echo-response-header: true
+    tenant:
+      enabled: true
+      header-name: X-Tenant-Id
+      query-param: tenantId
+      default-policy: OPTIONAL
+      echo-response-header: true
+    subscription:
+      enabled: true
+      header-name: x_subscription_id
+      query-param: subscriptionId
+      default-policy: OPTIONAL
+      echo-response-header: true
+    billing:
+      enabled: true
+      header-name: x_billing_id
+      query-param: billingId
+      default-policy: OPTIONAL
+      echo-response-header: true
+    cors:
+      enabled: true
+      allowed-origins: http://localhost:3000
+      allowed-methods: GET,POST,PUT,DELETE,OPTIONS
+      allowed-headers: "*"
+
+  headers:
+    enabled: true
+    correlation:
+      header: X-Correlation-Id
+      auto-generate: true
+      mandatory: true
+    request:
+      header: X-Request-ID
+      auto-generate: true
+      mandatory: true
+    tenant:
+      header: X-Tenant-Id
+      auto-generate: false
+      mandatory: false
+    subscription:
+      header: x_subscription_id
+      auto-generate: false
+      mandatory: false
+    billing:
+      header: x_billing_id
+      auto-generate: false
+      mandatory: false
+    user:
+      header: X-User-Id
+      auto-generate: false
+      mandatory: false
+    mdc:
+      enabled: true
+    security:
+      enabled: true
+      hsts:
+        enabled: true
+        max-age: 31536000
+        include-subdomains: true
+      frame-options: SAMEORIGIN
+      content-type-options: nosniff
+      referrer-policy: no-referrer
+      xss-protection: "0"
+    propagation:
+      enabled: true
+      include:
+        - X-Correlation-Id
+        - X-Request-ID
+        - X-Tenant-Id
+        - x_subscription_id
+        - x_billing_id
+        - X-User-Id
+
+  audit:
+    enabled: true
+    web:
+      enabled: true
+      include-headers: true
+      track-bodies: true
+    aop:
+      enabled: true
+    dispatcher:
+      async: true
+    retention:
+      enabled: true
+      days: 90
+    masking:
+      enabled: true
+      fields-by-key:
+        - password
+        - secret
+        - token
+        - ssn
+    sinks:
+      db:
+        enabled: true
+        schema: ${app.schema:${APP_SCHEMA:public}}
+        table: audit_logs
+      kafka:
+        enabled: true
+        topic: audit_logs
+      otlp:
+        enabled: false
+      outbox:
+        enabled: true
+
+  redis:
+    host: ${REDIS_HOST:redis}
+    port: ${REDIS_PORT:6379}
+    timeout: ${REDIS_TIMEOUT:2s}
+    key-prefix: ${app.cache-prefix:${APP_CACHE_PREFIX:${spring.application.name}}}
+    default-ttl: ${REDIS_DEFAULT_TTL:600s}
+    reactive: false
+
+  crypto:
+    algorithm: AES_GCM
+    in-memory:
+      activeKid: ${CRYPTO_ACTIVE_KID:local-dev-key}
+      keys:
+        local-dev-key: ${CRYPTO_LOCAL_DEV_KEY:4J8bfqUaEqzJCQakoJPM3w==}
+
+logging:
+  level:
+    root: ERROR
+    com.ejada: ERROR
+    com.ejada.audit.starter: ERROR
+    com.ejada.audit.starter.core.dispatch: ERROR
+    com.ejada.audit.starter.core.dispatch.sinks: ERROR
+    org.hibernate.tool.schema: ERROR
+    org.hibernate.SQL: ERROR
+    org.hibernate.orm.jdbc.bind: ERROR
+    org.springframework.cache: ERROR
+    org.springframework.cache.interceptor.CacheAspectSupport: ERROR
+
+debug: true

--- a/tenant-platform/billing-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-dev.yaml
@@ -34,121 +34,8 @@ spring:
   kafka:
     client-id: ejada-billing-dev
 
-  data:
-    redis:
-      repositories:
-        enabled: false
-
-management:
-  endpoints:
-    web:
-      base-path: /actuator
-      exposure:
-        include: health,info,metrics,prometheus,beans,conditions,configprops,loggers,threaddump
-  endpoint:
-    health:
-      show-details: always
-  tracing:
-    sampling:
-      probability: 1.0
-
-springdoc:
-  api-docs:
-    enabled: true
-    path: /v3/api-docs
-  swagger-ui:
-    enabled: true
-    display-request-duration: true
-    filter: true
-    operationsSorter: method
-    tagsSorter: alpha
 
 shared:
-  core:
-    correlation:
-      header-name: X-Correlation-Id
-      generate-if-missing: true
-      echo-response-header: true
-    billing:
-      enabled: true
-      header-name: x_billing_id
-      query-param: billingId
-      default-policy: OPTIONAL
-      echo-response-header: true
-    cors:
-      enabled: true
-      allowed-origins: http://localhost:3000
-      allowed-methods: GET,POST,PUT,DELETE,OPTIONS
-      allowed-headers: "*"
-  headers:
-    enabled: true
-    correlation:
-      header: X-Correlation-Id
-      auto-generate: true
-      mandatory: true
-    request:
-      header: X-Request-ID
-      auto-generate: true
-      mandatory: true
-    billing:
-      header: x_billing_id
-      auto-generate: false
-      mandatory: false
-    user:
-      header: X-User-Id
-      auto-generate: false
-      mandatory: false
-    mdc:
-      enabled: true
-    security:
-      enabled: true
-      hsts:
-        enabled: true
-        max-age: 31536000
-        include-subdomains: true
-      frame-options: SAMEORIGIN
-      content-type-options: nosniff
-      referrer-policy: no-referrer
-      xss-protection: "0"
-    propagation:
-      enabled: true
-      include:
-        - X-Correlation-Id
-        - X-Request-ID
-        - x_billing_id
-        - X-User-Id
-  audit:
-    enabled: true
-    web:
-      enabled: true
-      include-headers: true
-      track-bodies: true
-    aop:
-      enabled: true
-    dispatcher:
-      async: true
-    retention:
-      enabled: true
-      days: 90
-    masking:
-      enabled: true
-      fields-by-key:
-        - password
-        - secret
-        - token
-        - ssn
-    sinks:
-      db:
-        enabled: true
-        schema: billing
-        table: audit_logs
-      kafka:
-        enabled: true
-        topic: audit_logs
-      otlp:
-        enabled: false
-      outbox:
-        enabled: true
   openapi:
     enabled: true
     title: " billing Service API"
@@ -161,47 +48,20 @@ shared:
       packages-to-scan:
         - com.ejada.billing
     jwt-security: false
-  redis:
-    host: redis
-    port: 6379
-    timeout: 2s
-    key-prefix: billing
-    default-ttl: 600s
-    reactive: false
-  crypto:
-    algorithm: AES_GCM
-    in-memory:
-      activeKid: ${CRYPTO_ACTIVE_KID:local-dev-key}
-      keys:
-        local-dev-key: ${CRYPTO_LOCAL_DEV_KEY:4J8bfqUaEqzJCQakoJPM3w==}
   security:
-    mode: hs256
-    jwt:
-      secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
-      token-period: 15m
-    hs256:
-      secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
-    resource-server:
-      enabled: true
-      permit-all:
-        - "/actuator/health"
-      disable-csrf: false
-    stateless: true
-    roles-claim: roles
     billing-claim: billing
     enable-role-check: false
 
-logging:
-  level:
-    root: ERROR
-    com.ejada: ERROR
-    com.ejada.audit.starter: ERROR
-    com.ejada.audit.starter.core.dispatch: ERROR
-    com.ejada.audit.starter.core.dispatch.sinks: ERROR
-    org.hibernate.tool.schema: ERROR
-    org.hibernate.SQL: ERROR
-    org.hibernate.orm.jdbc.bind: ERROR
-    org.springframework.cache: ERROR
-    org.springframework.cache.interceptor.CacheAspectSupport: ERROR
-
-debug: true
+app:
+  schema: billing
+  cache-prefix: billing
+  billing:
+    approval:
+      topic: tenant.subscription-approvals
+      consumer-group: billing-approval-listener
+    provisioning:
+      topic: billing.provisioning
+      consumer-group: billing-provisioning-listener
+    consumption:
+      topic: billing.consumption
+      consumer-group: billing-consumption-listener

--- a/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
@@ -35,122 +35,7 @@ spring:
 
   kafka:
     client-id: ejada-catalog-dev
-
-  data:
-    redis:
-      repositories:
-        enabled: false
-
-management:
-  endpoints:
-    web:
-      base-path: /actuator
-      exposure:
-        include: health,info,metrics,prometheus,beans,conditions,configprops,loggers,threaddump
-  endpoint:
-    health:
-      show-details: always
-  tracing:
-    sampling:
-      probability: 1.0
-
-springdoc:
-  api-docs:
-    enabled: true
-    path: /v3/api-docs
-  swagger-ui:
-    enabled: true
-    display-request-duration: true
-    filter: true
-    operationsSorter: method
-    tagsSorter: alpha
-
 shared:
-  core:
-    correlation:
-      header-name: X-Correlation-Id
-      generate-if-missing: true
-      echo-response-header: true
-    tenant:
-      enabled: true
-      header-name: X-Tenant-Id
-      query-param: tenantId
-      default-policy: OPTIONAL
-      echo-response-header: true
-    cors:
-      enabled: true
-      allowed-origins: http://localhost:3000
-      allowed-methods: GET,POST,PUT,DELETE,OPTIONS
-      allowed-headers: "*"
-  headers:
-    enabled: true
-    correlation:
-      header: X-Correlation-Id
-      auto-generate: true
-      mandatory: true
-    request:
-      header: X-Request-ID
-      auto-generate: true
-      mandatory: true
-    tenant:
-      header: X-Tenant-Id
-      auto-generate: false
-      mandatory: false
-    user:
-      header: X-User-Id
-      auto-generate: false
-      mandatory: false
-    mdc:
-      enabled: true
-    security:
-      enabled: true
-      hsts:
-        enabled: true
-        max-age: 31536000
-        include-subdomains: true
-      frame-options: SAMEORIGIN
-      content-type-options: nosniff
-      referrer-policy: no-referrer
-      xss-protection: "0"
-    propagation:
-      enabled: true
-      include:
-        - X-Correlation-Id
-        - X-Request-ID
-        - X-Tenant-Id
-        - X-User-Id
-  audit:
-    enabled: true
-    web:
-      enabled: true
-      include-headers: true
-      track-bodies: true
-    aop:
-      enabled: true
-    dispatcher:
-      async: true
-    retention:
-      enabled: true
-      days: 90
-    masking:
-      enabled: true
-      fields-by-key:
-        - password
-        - secret
-        - token
-        - ssn
-    sinks:
-      db:
-        enabled: true
-        schema: catalog
-        table: audit_logs
-      kafka:
-        enabled: true
-        topic: audit_logs
-      otlp:
-        enabled: false
-      outbox:
-        enabled: true
   openapi:
     enabled: true
     title: " catalog Service API"
@@ -163,36 +48,10 @@ shared:
       packages-to-scan:
         - com.ejada.catalog
     jwt-security: false
-  redis:
-    host: redis
-    port: 6379
-    timeout: 2s
-    key-prefix: catalog
-    default-ttl: 600s
-    reactive: false
-  crypto:
-    algorithm: AES_GCM
-    in-memory:
-      activeKid: ${CRYPTO_ACTIVE_KID:local-dev-key}
-      keys:
-        local-dev-key: ${CRYPTO_LOCAL_DEV_KEY:4J8bfqUaEqzJCQakoJPM3w==}
-
-logging:
-  level:
-    root: ERROR
-    com.ejada: ERROR
-    com.ejada.audit.starter: ERROR
-    com.ejada.audit.starter.core.dispatch: ERROR
-    com.ejada.audit.starter.core.dispatch.sinks: ERROR
-    org.hibernate.tool.schema: ERROR
-    org.hibernate.SQL: ERROR
-    org.hibernate.orm.jdbc.bind: ERROR
-    org.springframework.cache: ERROR
-    org.springframework.cache.interceptor.CacheAspectSupport: ERROR
 
 app:
+  schema: catalog
+  cache-prefix: catalog
   tenant-provisioning:
     topic: tenant.provisioning
     consumer-group: catalog-tenant-provisioning
-
-debug: true

--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -36,121 +36,18 @@ spring:
   kafka:
     client-id: ejada-subscription-dev
 
-  data:
-    redis:
-      repositories:
-        enabled: false
-
-management:
-  endpoints:
-    web:
-      base-path: /actuator
-      exposure:
-        include: health,info,metrics,prometheus,beans,conditions,configprops,loggers,threaddump
-  endpoint:
-    health:
-      show-details: always
-  tracing:
-    sampling:
-      probability: 1.0
-
-springdoc:
-  api-docs:
-    enabled: true
-    path: /v3/api-docs
-  swagger-ui:
-    enabled: true
-    display-request-duration: true
-    filter: true
-    operationsSorter: method
-    tagsSorter: alpha
+app:
+  schema: subscription
+  cache-prefix: subscription
+  subscription-approval:
+    topic: tenant.subscription-approvals
+    approval-role: ejada-officer
+    consumer-group: tenant-approval-provisioner
+  tenant-provisioning:
+    topic: tenant.provisioning
+    consumer-group: tenant-provisioning-publisher
 
 shared:
-  core:
-    correlation:
-      header-name: X-Correlation-Id
-      generate-if-missing: true
-      echo-response-header: true
-    subscription:
-      enabled: true
-      header-name: x_subscription_id
-      query-param: subscriptionId
-      default-policy: OPTIONAL
-      echo-response-header: true
-    cors:
-      enabled: true
-      allowed-origins: http://localhost:3000
-      allowed-methods: GET,POST,PUT,DELETE,OPTIONS
-      allowed-headers: "*"
-  headers:
-    enabled: true
-    correlation:
-      header: X-Correlation-Id
-      auto-generate: true
-      mandatory: true
-    request:
-      header: X-Request-ID
-      auto-generate: true
-      mandatory: true
-    subscription:
-      header: x_subscription_id
-      auto-generate: false
-      mandatory: false
-    user:
-      header: X-User-Id
-      auto-generate: false
-      mandatory: false
-    mdc:
-      enabled: true
-    security:
-      enabled: true
-      hsts:
-        enabled: true
-        max-age: 31536000
-        include-subdomains: true
-      frame-options: SAMEORIGIN
-      content-type-options: nosniff
-      referrer-policy: no-referrer
-      xss-protection: "0"
-    propagation:
-      enabled: true
-      include:
-        - X-Correlation-Id
-        - X-Request-ID
-        - x_subscription_id
-        - X-User-Id
-  audit:
-    enabled: true
-    web:
-      enabled: true
-      include-headers: true
-      track-bodies: true
-    aop:
-      enabled: true
-    dispatcher:
-      async: true
-    retention:
-      enabled: true
-      days: 90
-    masking:
-      enabled: true
-      fields-by-key:
-        - password
-        - secret
-        - token
-        - ssn
-    sinks:
-      db:
-        enabled: true
-        schema: subscription
-        table: audit_logs
-      kafka:
-        enabled: true
-        topic: audit_logs
-      otlp:
-        enabled: false
-      outbox:
-        enabled: true
   openapi:
     enabled: true
     title: " subscription Service API"
@@ -163,56 +60,6 @@ shared:
       packages-to-scan:
         - com.ejada.subscription
     jwt-security: false
-  redis:
-    host: redis
-    port: 6379
-    timeout: 2s
-    key-prefix: subscription
-    default-ttl: 600s
-    reactive: false
-  crypto:
-    algorithm: AES_GCM
-    in-memory:
-      activeKid: ${CRYPTO_ACTIVE_KID:local-dev-key}
-      keys:
-        local-dev-key: ${CRYPTO_LOCAL_DEV_KEY:4J8bfqUaEqzJCQakoJPM3w==}
   security:
-    mode: hs256
-    jwt:
-      secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
-      token-period: 15m
-    hs256:
-      secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
-    resource-server:
-      enabled: true
-      permit-all:
-        - "/actuator/health"
-      disable-csrf: false
-    stateless: true
-    roles-claim: roles
     subscription-claim: subscription
     enable-role-check: false
-
-app:
-  subscription-approval:
-    topic: tenant.subscription-approvals
-    approval-role: ejada-officer
-    consumer-group: tenant-approval-provisioner
-  tenant-provisioning:
-    topic: tenant.provisioning
-    consumer-group: tenant-provisioning-publisher
-
-logging:
-  level:
-    root: ERROR
-    com.ejada: ERROR
-    com.ejada.audit.starter: ERROR
-    com.ejada.audit.starter.core.dispatch: ERROR
-    com.ejada.audit.starter.core.dispatch.sinks: ERROR
-    org.hibernate.tool.schema: ERROR
-    org.hibernate.SQL: ERROR
-    org.hibernate.orm.jdbc.bind: ERROR
-    org.springframework.cache: ERROR
-    org.springframework.cache.interceptor.CacheAspectSupport: ERROR
-
-debug: true

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerTest.java
@@ -1,8 +1,10 @@
 package com.ejada.subscription.kafka;
 
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.ejada.common.events.provisioning.ProvisionedAddon;
@@ -135,5 +137,32 @@ class SubscriptionApprovalConsumerTest {
 
         verify(provisioningPublisher, never())
                 .publish(org.mockito.Mockito.any(), org.mockito.Mockito.anyList(), org.mockito.Mockito.anyList());
+    }
+
+    @Test
+    void missingSubscriptionIdSkipsRepositoryLookups() {
+        SubscriptionApprovalMessage message = new SubscriptionApprovalMessage(
+                SubscriptionApprovalAction.APPROVED,
+                UUID.randomUUID(),
+                null,
+                456L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                OffsetDateTime.now(),
+                null);
+
+        Map<String, Object> payload = objectMapper.convertValue(message, Map.class);
+
+        consumer.onApproval(payload);
+
+        verify(subscriptionRepository, never()).findByExtSubscriptionId(anyLong());
+        verifyNoInteractions(featureRepository, additionalServiceRepository, provisioningPublisher);
     }
 }

--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -35,122 +35,7 @@ spring:
 
   kafka:
     client-id: ejada-tenant-dev
-
-  data:
-    redis:
-      repositories:
-        enabled: false
-
-management:
-  endpoints:
-    web:
-      base-path: /actuator
-      exposure:
-        include: health,info,metrics,prometheus,beans,conditions,configprops,loggers,threaddump
-  endpoint:
-    health:
-      show-details: always
-  tracing:
-    sampling:
-      probability: 1.0
-
-springdoc:
-  api-docs:
-    enabled: true
-    path: /v3/api-docs
-  swagger-ui:
-    enabled: true
-    display-request-duration: true
-    filter: true
-    operationsSorter: method
-    tagsSorter: alpha
-
 shared:
-  core:
-    correlation:
-      header-name: X-Correlation-Id
-      generate-if-missing: true
-      echo-response-header: true
-    tenant:
-      enabled: true
-      header-name: X-Tenant-Id
-      query-param: tenantId
-      default-policy: OPTIONAL
-      echo-response-header: true
-    cors:
-      enabled: true
-      allowed-origins: http://localhost:3000
-      allowed-methods: GET,POST,PUT,DELETE,OPTIONS
-      allowed-headers: "*"
-  headers:
-    enabled: true
-    correlation:
-      header: X-Correlation-Id
-      auto-generate: true
-      mandatory: true
-    request:
-      header: X-Request-ID
-      auto-generate: true
-      mandatory: true
-    tenant:
-      header: X-Tenant-Id
-      auto-generate: false
-      mandatory: false
-    user:
-      header: X-User-Id
-      auto-generate: false
-      mandatory: false
-    mdc:
-      enabled: true
-    security:
-      enabled: true
-      hsts:
-        enabled: true
-        max-age: 31536000
-        include-subdomains: true
-      frame-options: SAMEORIGIN
-      content-type-options: nosniff
-      referrer-policy: no-referrer
-      xss-protection: "0"
-    propagation:
-      enabled: true
-      include:
-        - X-Correlation-Id
-        - X-Request-ID
-        - X-Tenant-Id
-        - X-User-Id
-  audit:
-    enabled: true
-    web:
-      enabled: true
-      include-headers: true
-      track-bodies: true
-    aop:
-      enabled: true
-    dispatcher:
-      async: true
-    retention:
-      enabled: true
-      days: 90
-    masking:
-      enabled: true
-      fields-by-key:
-        - password
-        - secret
-        - token
-        - ssn
-    sinks:
-      db:
-        enabled: true
-        schema: tenant
-        table: audit_logs
-      kafka:
-        enabled: true
-        topic: audit_logs
-      otlp:
-        enabled: false
-      outbox:
-        enabled: true
   openapi:
     enabled: true
     title: " tenant Service API"
@@ -163,37 +48,11 @@ shared:
       packages-to-scan:
         - com.ejada.tenant
     jwt-security: false
-  redis:
-    host: redis
-    port: 6379
-    timeout: 2s
-    key-prefix: tenant
-    default-ttl: 600s
-    reactive: false
-  crypto:
-    algorithm: AES_GCM
-    in-memory:
-      activeKid: ${CRYPTO_ACTIVE_KID:local-dev-key}
-      keys:
-        local-dev-key: ${CRYPTO_LOCAL_DEV_KEY:4J8bfqUaEqzJCQakoJPM3w==}
 
 app:
+  schema: tenant
+  cache-prefix: tenant
   subscription-approval:
     topic: tenant.subscription-approvals
     approval-role: ejada-officer
     consumer-group: tenant-approval-listener
-
-logging:
-  level:
-    root: ERROR
-    com.ejada: ERROR
-    com.ejada.audit.starter: ERROR
-    com.ejada.audit.starter.core.dispatch: ERROR
-    com.ejada.audit.starter.core.dispatch.sinks: ERROR
-    org.hibernate.tool.schema: ERROR
-    org.hibernate.SQL: ERROR
-    org.hibernate.orm.jdbc.bind: ERROR
-    org.springframework.cache: ERROR
-    org.springframework.cache.interceptor.CacheAspectSupport: ERROR
-
-debug: true

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/kafka/SubscriptionApprovalListenerTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/kafka/SubscriptionApprovalListenerTest.java
@@ -1,0 +1,153 @@
+package com.ejada.tenant.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.ejada.common.events.subscription.SubscriptionApprovalAction;
+import com.ejada.common.events.subscription.SubscriptionApprovalMessage;
+import com.ejada.tenant.dto.TenantCreateReq;
+import com.ejada.tenant.exception.TenantConflictException;
+import com.ejada.tenant.service.TenantService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionApprovalListenerTest {
+
+    @Mock private TenantService tenantService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private SubscriptionApprovalListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new SubscriptionApprovalListener(objectMapper, tenantService);
+    }
+
+    @Test
+    void ignoresNonApprovedMessages() {
+        SubscriptionApprovalMessage message = new SubscriptionApprovalMessage(
+                SubscriptionApprovalAction.REQUEST,
+                UUID.randomUUID(),
+                123L,
+                456L,
+                "Customer EN",
+                "Customer AR",
+                "admin@example.com",
+                "+966500000000",
+                "TEN-1",
+                "Tenant",
+                "ops@example.com",
+                "+966500000001",
+                "role",
+                OffsetDateTime.now(),
+                null);
+
+        listener.onMessage(toPayload(message));
+
+        verifyNoInteractions(tenantService);
+    }
+
+    @Test
+    void throwsWhenTenantDetailsMissing() {
+        SubscriptionApprovalMessage message = new SubscriptionApprovalMessage(
+                SubscriptionApprovalAction.APPROVED,
+                UUID.randomUUID(),
+                123L,
+                456L,
+                "Customer EN",
+                "Customer AR",
+                "admin@example.com",
+                "+966500000000",
+                null,
+                "",
+                "ops@example.com",
+                "+966500000001",
+                "role",
+                OffsetDateTime.now(),
+                null);
+
+        assertThatThrownBy(() -> listener.onMessage(toPayload(message)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Missing tenant details");
+
+        verifyNoInteractions(tenantService);
+    }
+
+    @Test
+    void provisionsTenantWhenApproved() {
+        SubscriptionApprovalMessage message = new SubscriptionApprovalMessage(
+                SubscriptionApprovalAction.APPROVED,
+                UUID.randomUUID(),
+                123L,
+                456L,
+                "Customer EN",
+                "Customer AR",
+                "admin@example.com",
+                "+966500000000",
+                "TEN-42",
+                "Tenant Corp",
+                "ops@example.com",
+                "+966500000001",
+                "role",
+                OffsetDateTime.now(),
+                null);
+
+        listener.onMessage(toPayload(message));
+
+        ArgumentCaptor<TenantCreateReq> captor = ArgumentCaptor.forClass(TenantCreateReq.class);
+        verify(tenantService).create(captor.capture());
+
+        assertThat(captor.getValue())
+                .isEqualTo(new TenantCreateReq(
+                        "TEN-42",
+                        "Tenant Corp",
+                        "ops@example.com",
+                        "+966500000001",
+                        null,
+                        Boolean.TRUE));
+    }
+
+    @Test
+    void swallowsTenantConflict() {
+        SubscriptionApprovalMessage message = new SubscriptionApprovalMessage(
+                SubscriptionApprovalAction.APPROVED,
+                UUID.randomUUID(),
+                123L,
+                456L,
+                "Customer EN",
+                "Customer AR",
+                "admin@example.com",
+                "+966500000000",
+                "TEN-42",
+                "Tenant Corp",
+                "ops@example.com",
+                "+966500000001",
+                "role",
+                OffsetDateTime.now(),
+                null);
+
+        when(tenantService.create(any())).thenThrow(new TenantConflictException("duplicate"));
+
+        assertThatCode(() -> listener.onMessage(toPayload(message))).doesNotThrowAnyException();
+
+        verify(tenantService).create(any());
+    }
+
+    private Map<String, Object> toPayload(final SubscriptionApprovalMessage message) {
+        return objectMapper.convertValue(message, Map.class);
+    }
+}

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantAccessPolicyTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantAccessPolicyTest.java
@@ -32,4 +32,24 @@ class TenantAccessPolicyTest {
 
         assertThat(policy.isAllowed(null)).isFalse();
     }
+
+    @Test
+    void trimsAndIgnoresBlankConfiguration() {
+        TenantAccessPolicy policy = new TenantAccessPolicy("   ");
+        TestingAuthenticationToken auth = new TestingAuthenticationToken("user", "pwd", "EJADA_OFFICER");
+        auth.setAuthenticated(true);
+
+        assertThat(policy.getAllowedRoles()).isEmpty();
+        assertThat(policy.isAllowed(auth)).isFalse();
+    }
+
+    @Test
+    void nullConfigurationDisablesAccess() {
+        TenantAccessPolicy policy = new TenantAccessPolicy(null);
+        TestingAuthenticationToken auth = new TestingAuthenticationToken("user", "pwd", "EJADA_OFFICER");
+        auth.setAuthenticated(true);
+
+        assertThat(policy.getAllowedRoles()).isEmpty();
+        assertThat(policy.isAllowed(auth)).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary
- centralize platform-wide dev YAML into shared-config with profile import hooks and service-specific overrides
- streamline service application-dev.yaml files to lean on shared defaults while exposing schema/cache customization
- add guard-rail unit tests for Kafka subscription listeners and tenant security policy edge cases

## Testing
- `mvn test` *(fails: missing internal BOM/dependency versions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db9af1df28832fb08fe0883ac5fbfd