### PR TITLE
Add JWT integration tests and centralize REST error handling

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,42 @@
+# REST Error Handling Strategy
+
+To ensure consistent REST error payloads across microservices the shared libraries now expose
+utility components that standardise error codes and the HTTP status returned for each case.
+
+## Error codes
+
+`shared-lib/shared-common` keeps the canonical error codes inside
+[`ErrorCodes`](../shared-lib/shared-common/src/main/java/com/ejada/common/constants/ErrorCodes.java).
+New authentication-specific codes were introduced for common platform scenarios (invalid
+credentials, password history availability issues, data access failures). Services should
+re-use these constants instead of hard-coding string literals.
+
+## Status mapping
+
+[`ApiStatusMapper`](../shared-lib/shared-common/src/main/java/com/ejada/common/http/ApiStatusMapper.java)
+centralises the mapping between business codes and HTTP statuses. A new
+`fromErrorCode` helper resolves the status directly from an error code so that controllers
+and exception handlers do not need to duplicate switch statements.
+
+## Building responses
+
+[`RestErrorResponseFactory`](../shared-lib/shared-common/src/main/java/com/ejada/common/http/RestErrorResponseFactory.java)
+wraps the mapping logic and returns `ResponseEntity<ErrorResponse>` instances using the
+shared mapping. Services can build error responses with a single line whilst guaranteeing
+consistent codes/statuses and allowing optional detail lists.
+
+### Example usage
+
+```java
+return RestErrorResponseFactory.build(
+    ErrorCodes.AUTH_INVALID_CREDENTIALS,
+    "Invalid credentials"
+);
+```
+
+This will automatically render a `401` JSON response with the `ERR-AUTH-INVALID_CREDENTIALS`
+code. When the mapping does not contain a code a custom fallback `HttpStatus` can be
+provided, otherwise `500` is used.
+
+These utilities are now used by `sec-service` and are available to all other
+microservices via the shared libraries.

--- a/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
+++ b/sec-service/src/main/java/com/ejada/sec/handler/AuthExceptionHandler.java
@@ -1,15 +1,16 @@
 package com.ejada.sec.handler;
 
+import com.ejada.common.constants.ErrorCodes;
 import com.ejada.common.dto.ErrorResponse;
 import com.ejada.common.exception.ValidationException;
-
+import com.ejada.common.http.RestErrorResponseFactory;
 import com.ejada.sec.exception.PasswordHistoryUnavailableException;
 import java.util.List;
 import java.util.NoSuchElementException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
-import org.springframework.dao.DataAccessException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -21,20 +22,32 @@ public class AuthExceptionHandler {
 
     @ExceptionHandler({NoSuchElementException.class, IllegalStateException.class})
     public ResponseEntity<ErrorResponse> handleAuthExceptions(RuntimeException ex) {
-        ErrorResponse body = ErrorResponse.of("ERR_AUTH", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+        String message = safe(ex.getMessage(), "Invalid credentials");
+        return RestErrorResponseFactory.build(
+                ErrorCodes.AUTH_INVALID_CREDENTIALS,
+                message,
+                HttpStatus.UNAUTHORIZED
+        );
     }
 
     @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleMissingCredentials(AuthenticationCredentialsNotFoundException ex) {
-        ErrorResponse body = ErrorResponse.of("ERR_AUTH", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+        String message = safe(ex.getMessage(), "Authentication credentials are required");
+        return RestErrorResponseFactory.build(
+                ErrorCodes.AUTH_MISSING_CREDENTIALS,
+                message,
+                HttpStatus.BAD_REQUEST
+        );
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleBadRequest(IllegalArgumentException ex) {
-        ErrorResponse body = ErrorResponse.of("ERR_AUTH", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+        String message = safe(ex.getMessage(), "Invalid authentication request");
+        return RestErrorResponseFactory.build(
+                ErrorCodes.API_BAD_REQUEST,
+                message,
+                HttpStatus.BAD_REQUEST
+        );
     }
 
     @ExceptionHandler(ValidationException.class)
@@ -44,21 +57,32 @@ public class AuthExceptionHandler {
                 ? List.of()
                 : List.of(ex.getDetails());
 
-        ErrorResponse body = ErrorResponse.of(ex.getErrorCode(), ex.getMessage(), details);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+        return RestErrorResponseFactory.build(
+                ex.getErrorCode(),
+                safe(ex.getMessage(), "Validation failed"),
+                details,
+                HttpStatus.BAD_REQUEST
+        );
     }
     @ExceptionHandler(PasswordHistoryUnavailableException.class)
     public ResponseEntity<ErrorResponse> handlePasswordHistoryUnavailable(PasswordHistoryUnavailableException ex) {
-        ErrorResponse body = ErrorResponse.of("ERR_AUTH_HISTORY", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
+        return RestErrorResponseFactory.build(
+                ErrorCodes.AUTH_HISTORY_UNAVAILABLE,
+                safe(ex.getMessage(), "Password history service unavailable"),
+                HttpStatus.SERVICE_UNAVAILABLE
+        );
     }
 
     @ExceptionHandler(DataAccessException.class)
     public ResponseEntity<ErrorResponse> handleDataAccess(DataAccessException ex) {
-        ErrorResponse body = ErrorResponse.of(
-            "ERR_AUTH_DATA_ACCESS",
-            "Authentication data is temporarily unavailable. Please try again later.");
-        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
+        return RestErrorResponseFactory.build(
+                ErrorCodes.AUTH_DATA_ACCESS,
+                "Authentication data is temporarily unavailable. Please try again later.",
+                HttpStatus.SERVICE_UNAVAILABLE
+        );
     }
 
+    private static String safe(String value, String fallback) {
+        return (value == null || value.isBlank()) ? fallback : value;
+    }
 }

--- a/sec-service/src/test/java/com/ejada/sec/security/RoleControllerSecurityTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/security/RoleControllerSecurityTest.java
@@ -1,18 +1,28 @@
 package com.ejada.sec.security;
 
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ejada.common.constants.ErrorCodes;
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.sec.controller.RoleController;
 import com.ejada.sec.service.RoleService;
 import com.ejada.starter_security.SecurityAutoConfiguration;
+import com.ejada.testsupport.security.JwtTestTokens;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = RoleController.class)
 @Import(SecurityAutoConfiguration.class)
@@ -21,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "shared.security.mode=hs256",
     "shared.security.hs256.secret=test-secret",
     "shared.security.jwt.secret=test-secret",
+    "shared.security.issuer=" + RoleControllerSecurityTest.ISSUER,
     "shared.security.resource-server.enabled=true",
     "shared.security.resource-server.disable-csrf=true",
     "shared.security.resource-server.permit-all[0]=/actuator/health",
@@ -28,15 +39,68 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 class RoleControllerSecurityTest {
 
+    private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
+    static final String ISSUER = "test-issuer";
+
     @Autowired
     private MockMvc mockMvc;
 
     @MockBean
     private RoleService roleService;
 
+    @BeforeEach
+    void setup() {
+        when(roleService.listByTenant()).thenReturn(BaseResponse.success("Roles", List.of()));
+    }
+
     @Test
     void protectedEndpointsRequireAuthentication() throws Exception {
         mockMvc.perform(get("/sec/api/roles"))
             .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void validTokenWithRequiredRoleIsAccepted() throws Exception {
+        String token = JwtTestTokens.hs256(SECRET)
+                .issuer(ISSUER)
+                .roles(List.of("TENANT_ADMIN"))
+                .tenant("tenant-1")
+                .build();
+
+        mockMvc.perform(get("/sec/api/roles")
+                        .header(AUTHORIZATION, "Bearer " + token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS-200"));
+    }
+
+    @Test
+    void tokenWithoutRequiredRoleIsForbidden() throws Exception {
+        String token = JwtTestTokens.hs256(SECRET)
+                .issuer(ISSUER)
+                .roles(List.of("TENANT_VIEWER"))
+                .tenant("tenant-1")
+                .build();
+
+        mockMvc.perform(get("/sec/api/roles")
+                        .header(AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCodes.AUTH_FORBIDDEN));
+    }
+
+    @Test
+    void expiredTokenIsRejectedAsUnauthorized() throws Exception {
+        String token = JwtTestTokens.hs256(SECRET)
+                .issuer(ISSUER)
+                .roles(List.of("TENANT_ADMIN"))
+                .tenant("tenant-1")
+                .issuedAt(Instant.now().minusSeconds(7200))
+                .expiresAt(Instant.now().minusSeconds(3600))
+                .build();
+
+        mockMvc.perform(get("/sec/api/roles")
+                        .header(AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCodes.AUTH_UNAUTHORIZED));
     }
 }

--- a/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
@@ -1,18 +1,28 @@
 package com.ejada.setup.security;
 
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ejada.common.constants.ErrorCodes;
+import com.ejada.common.dto.BaseResponse;
 import com.ejada.setup.controller.CountryController;
 import com.ejada.setup.service.CountryService;
 import com.ejada.starter_security.SecurityAutoConfiguration;
+import com.ejada.testsupport.security.JwtTestTokens;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = CountryController.class)
 @Import(SecurityAutoConfiguration.class)
@@ -21,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "shared.security.mode=hs256",
     "shared.security.hs256.secret=test-secret",
     "shared.security.jwt.secret=test-secret",
+    "shared.security.issuer=" + CountryControllerSecurityTest.ISSUER,
     "shared.security.resource-server.enabled=true",
     "shared.security.resource-server.disable-csrf=true",
     "shared.security.resource-server.permit-all[0]=/actuator/health",
@@ -28,15 +39,69 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 class CountryControllerSecurityTest {
 
+    private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
+    static final String ISSUER = "test-issuer";
+
     @Autowired
     private MockMvc mockMvc;
 
     @MockBean
     private CountryService countryService;
 
+    @BeforeEach
+    void setup() {
+        when(countryService.list(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyBoolean()))
+                .thenReturn(BaseResponse.success("Countries", List.of()));
+    }
+
     @Test
     void protectedEndpointsReturnUnauthorizedWithoutToken() throws Exception {
         mockMvc.perform(get("/core/setup/countries"))
             .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void validTokenAllowsAccess() throws Exception {
+        String token = JwtTestTokens.hs256(SECRET)
+                .issuer(ISSUER)
+                .roles(List.of("TENANT_ADMIN"))
+                .tenant("tenant-1")
+                .build();
+
+        mockMvc.perform(get("/core/setup/countries")
+                        .header(AUTHORIZATION, "Bearer " + token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS-200"));
+    }
+
+    @Test
+    void tokenMissingRequiredRoleIsForbidden() throws Exception {
+        String token = JwtTestTokens.hs256(SECRET)
+                .issuer(ISSUER)
+                .roles(List.of("TENANT_VIEWER"))
+                .tenant("tenant-1")
+                .build();
+
+        mockMvc.perform(get("/core/setup/countries")
+                        .header(AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCodes.AUTH_FORBIDDEN));
+    }
+
+    @Test
+    void expiredTokenIsRejected() throws Exception {
+        String token = JwtTestTokens.hs256(SECRET)
+                .issuer(ISSUER)
+                .roles(List.of("TENANT_ADMIN"))
+                .tenant("tenant-1")
+                .issuedAt(Instant.now().minusSeconds(7200))
+                .expiresAt(Instant.now().minusSeconds(3600))
+                .build();
+
+        mockMvc.perform(get("/core/setup/countries")
+                        .header(AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCodes.AUTH_UNAUTHORIZED));
     }
 }

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/constants/ErrorCodes.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/constants/ErrorCodes.java
@@ -20,6 +20,9 @@ public final class ErrorCodes {
     public static final String AUTH_UNAUTHORIZED = "ERR-AUTH-UNAUTHORIZED";
     public static final String AUTH_FORBIDDEN = "ERR-AUTH-FORBIDDEN";
     public static final String AUTH_MISSING_CREDENTIALS = "ERR-AUTH-MISSING_CREDENTIALS";
+    public static final String AUTH_INVALID_CREDENTIALS = "ERR-AUTH-INVALID_CREDENTIALS";
+    public static final String AUTH_HISTORY_UNAVAILABLE = "ERR-AUTH-HISTORY_UNAVAILABLE";
+    public static final String AUTH_DATA_ACCESS = "ERR-AUTH-DATA_ACCESS";
 
     // 🏢 Multi-tenancy
     public static final String TENANT_NOT_FOUND = "ERR-TENANT-NOT_FOUND";

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/http/ApiStatusMapper.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/http/ApiStatusMapper.java
@@ -33,6 +33,9 @@ public final class ApiStatusMapper {
         exact.put(ErrorCodes.AUTH_UNAUTHORIZED, HttpStatus.UNAUTHORIZED);
         exact.put(ErrorCodes.AUTH_FORBIDDEN, HttpStatus.FORBIDDEN);
         exact.put(ErrorCodes.AUTH_MISSING_CREDENTIALS, HttpStatus.BAD_REQUEST);
+        exact.put(ErrorCodes.AUTH_INVALID_CREDENTIALS, HttpStatus.UNAUTHORIZED);
+        exact.put(ErrorCodes.AUTH_HISTORY_UNAVAILABLE, HttpStatus.SERVICE_UNAVAILABLE);
+        exact.put(ErrorCodes.AUTH_DATA_ACCESS, HttpStatus.SERVICE_UNAVAILABLE);
         exact.put(ErrorCodes.TENANT_NOT_FOUND, HttpStatus.NOT_FOUND);
         exact.put(ErrorCodes.TENANT_DISABLED, HttpStatus.FORBIDDEN);
         exact.put(ErrorCodes.TENANT_ACCESS_DENIED, HttpStatus.FORBIDDEN);
@@ -101,6 +104,21 @@ public final class ApiStatusMapper {
             return DEFAULT_STATUS.getOrDefault(apiStatus, HttpStatus.OK);
         }
         return HttpStatus.OK;
+    }
+
+    /**
+     * Resolve an HTTP status based solely on an error code.
+     *
+     * @param code          the business error code
+     * @param defaultStatus status to use when the code cannot be mapped
+     * @return resolved HTTP status
+     */
+    public static HttpStatus fromErrorCode(String code, HttpStatus defaultStatus) {
+        HttpStatus resolved = resolveFromCode(code);
+        if (resolved != null) {
+            return resolved;
+        }
+        return defaultStatus != null ? defaultStatus : HttpStatus.INTERNAL_SERVER_ERROR;
     }
 
     private static HttpStatus resolveFromCode(String code) {

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/http/RestErrorResponseFactory.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/http/RestErrorResponseFactory.java
@@ -1,0 +1,38 @@
+package com.ejada.common.http;
+
+import com.ejada.common.dto.ErrorResponse;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Factory for building {@link ResponseEntity} instances with {@link ErrorResponse} payloads
+ * that align with the shared {@link com.ejada.common.constants.ErrorCodes} to HTTP status
+ * mapping.
+ */
+public final class RestErrorResponseFactory {
+
+    private RestErrorResponseFactory() {
+    }
+
+    public static ResponseEntity<ErrorResponse> build(String code, String message) {
+        return build(code, message, List.of(), null);
+    }
+
+    public static ResponseEntity<ErrorResponse> build(String code, String message, HttpStatus fallbackStatus) {
+        return build(code, message, List.of(), fallbackStatus);
+    }
+
+    public static ResponseEntity<ErrorResponse> build(String code, String message, List<String> details) {
+        return build(code, message, details, null);
+    }
+
+    public static ResponseEntity<ErrorResponse> build(String code,
+                                                      String message,
+                                                      List<String> details,
+                                                      HttpStatus fallbackStatus) {
+        ErrorResponse body = ErrorResponse.of(code, message, details);
+        HttpStatus status = ApiStatusMapper.fromErrorCode(code, fallbackStatus);
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/security/JwtTestTokens.java
+++ b/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/security/JwtTestTokens.java
@@ -1,0 +1,175 @@
+package com.ejada.testsupport.security;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Convenience utilities for creating signed JWT tokens in integration tests.
+ *
+ * <p>The tokens generated here use the HS256 algorithm and can be customised with
+ * roles, scopes, tenant and arbitrary custom claims so that security filters in
+ * resource-server tests can exercise the full validation path.</p>
+ */
+public final class JwtTestTokens {
+
+    private JwtTestTokens() {
+    }
+
+    /**
+     * Start building an HS256 signed JWT using the provided shared secret.
+     *
+     * @param secret shared secret (will be padded to 32 bytes if needed)
+     * @return fluent builder for configuring claims
+     */
+    public static Hs256Builder hs256(String secret) {
+        return new Hs256Builder(secret);
+    }
+
+    /**
+     * Fluent builder for HS256 JWT tokens.
+     */
+    public static final class Hs256Builder {
+        private final byte[] secret;
+        private String subject = "test-user";
+        private String issuer = "test-issuer";
+        private Instant issuedAt = Instant.now();
+        private Instant expiresAt = Instant.now().plusSeconds(3600);
+        private Collection<String> roles = List.of();
+        private String scope;
+        private String tenant;
+        private Collection<String> audience = List.of();
+        private final Map<String, Object> additionalClaims = new LinkedHashMap<>();
+
+        private Hs256Builder(String secret) {
+            this.secret = normaliseSecret(secret);
+        }
+
+        public Hs256Builder subject(String subject) {
+            this.subject = subject;
+            return this;
+        }
+
+        public Hs256Builder issuer(String issuer) {
+            this.issuer = issuer;
+            return this;
+        }
+
+        public Hs256Builder issuedAt(Instant issuedAt) {
+            this.issuedAt = issuedAt;
+            return this;
+        }
+
+        public Hs256Builder expiresAt(Instant expiresAt) {
+            this.expiresAt = expiresAt;
+            return this;
+        }
+
+        public Hs256Builder roles(Collection<String> roles) {
+            if (roles == null) {
+                this.roles = List.of();
+            } else {
+                this.roles = roles.stream()
+                        .filter(Objects::nonNull)
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toCollection(ArrayList::new));
+            }
+            return this;
+        }
+
+        public Hs256Builder scope(String scope) {
+            this.scope = scope;
+            return this;
+        }
+
+        public Hs256Builder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        public Hs256Builder audience(Collection<String> audience) {
+            if (audience == null) {
+                this.audience = List.of();
+            } else {
+                this.audience = audience.stream()
+                        .filter(Objects::nonNull)
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toCollection(ArrayList::new));
+            }
+            return this;
+        }
+
+        public Hs256Builder claim(String name, Object value) {
+            if (name != null && !name.isBlank()) {
+                additionalClaims.put(name, value);
+            }
+            return this;
+        }
+
+        /**
+         * Serialize the configured token using HS256 signature.
+         *
+         * @return compact JWT representation (suitable for Bearer token header)
+         */
+        public String build() {
+            try {
+                JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
+                        .subject(subject)
+                        .issuer(issuer)
+                        .issueTime(Date.from(issuedAt))
+                        .expirationTime(Date.from(expiresAt));
+
+                if (!audience.isEmpty()) {
+                    builder.audience(new ArrayList<>(audience));
+                }
+                if (tenant != null && !tenant.isBlank()) {
+                    builder.claim("tenant", tenant);
+                }
+                if (roles != null && !roles.isEmpty()) {
+                    builder.claim("roles", new ArrayList<>(roles));
+                }
+                if (scope != null && !scope.isBlank()) {
+                    builder.claim("scope", scope);
+                }
+                additionalClaims.forEach(builder::claim);
+
+                SignedJWT jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), builder.build());
+                jwt.sign(new MACSigner(secret));
+                return jwt.serialize();
+            } catch (JOSEException ex) {
+                throw new IllegalStateException("Failed to sign test JWT", ex);
+            }
+        }
+    }
+
+    private static byte[] normaliseSecret(String secret) {
+        byte[] raw = secret == null ? new byte[0] : secret.getBytes(StandardCharsets.UTF_8);
+        if (raw.length >= 32) {
+            return raw;
+        }
+        byte[] padded = new byte[32];
+        System.arraycopy(raw, 0, padded, 0, Math.min(raw.length, 32));
+        if (raw.length == 0) {
+            // ensure deterministic secret when empty input provided
+            for (int i = 0; i < padded.length; i++) {
+                padded[i] = (byte) (i + 1);
+            }
+        }
+        return padded;
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable HS256 JWT builder for tests and use it to cover success/forbidden/expired-token scenarios in sec-service and setup-service MockMvc tests
- extend shared error code catalogue and HTTP status mapping with authentication-specific cases and introduce a factory for consistent ErrorResponse construction
- refactor sec-service AuthExceptionHandler to use the shared strategy and document the cross-service error-handling approach

## Testing
- mvn test *(fails: repository depends on private shared-bom and missing dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68db9d341ea0832f8998cbb0c6cea2ee