### PR TITLE
Add Nimbus JOSE dependency to shared test support

### DIFF
--- a/shared-lib/shared-test-support/pom.xml
+++ b/shared-lib/shared-test-support/pom.xml
@@ -58,17 +58,23 @@
     </dependency>
 
     <!-- JJWT: versions come from jjwt-bom imported in shared-bom -->
-     <dependency>
-    <groupId>io.jsonwebtoken</groupId>
-    <artifactId>jjwt-api</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>io.jsonwebtoken</groupId>
-    <artifactId>jjwt-impl</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>io.jsonwebtoken</groupId>
-    <artifactId>jjwt-jackson</artifactId>
-  </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+    </dependency>
+
+    <!-- Nimbus JOSE + JWT used by JwtTestTokens helper -->
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-jose</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- add the Spring Security OAuth2 JOSE dependency so JwtTestTokens compiles against the Nimbus JWT APIs

## Testing
- mvn -f shared-lib/pom.xml -pl shared-test-support -am test

------
https://chatgpt.com/codex/tasks/task_e_68dba00fd9d0832fb55f0678a92cd9ae