### PR TITLE
Adjust marketplace controllers to return client errors for business failures

### DIFF
--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/controller/ConsumptionController.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/controller/ConsumptionController.java
@@ -56,7 +56,14 @@ public class ConsumptionController {
         }
         HttpStatus status = Boolean.TRUE.equals(result.success())
                 ? HttpStatus.OK
-                : HttpStatus.INTERNAL_SERVER_ERROR;
+                : resolveErrorStatus(result.statusCode());
         return ResponseEntity.status(status).body(result);
+    }
+
+    private HttpStatus resolveErrorStatus(final String statusCode) {
+        if (statusCode == null || statusCode.startsWith("EINT")) {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return HttpStatus.BAD_REQUEST;
     }
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionInboundController.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionInboundController.java
@@ -67,9 +67,16 @@ public class SubscriptionInboundController {
         if (result == null) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
         }
-        HttpStatus status = Boolean.TRUE.equals(result.success())
+        HttpStatus status = result.success()
                 ? HttpStatus.OK
-                : HttpStatus.INTERNAL_SERVER_ERROR;
+                : resolveErrorStatus(result.statusCode());
         return ResponseEntity.status(status).body(result);
+    }
+
+    private HttpStatus resolveErrorStatus(final String statusCode) {
+        if (statusCode == null || statusCode.startsWith("EINT")) {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return HttpStatus.BAD_REQUEST;
     }
 }


### PR DESCRIPTION
## Summary
- return 4xx responses for marketplace validation/business failures instead of 500s
- treat internal error status codes (EINT***) as server errors while defaulting other failures to 400

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dba1152224832fbecc0f99a61a7983