### PR TITLE
Avoid blocking event loop when decoding JWT

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityConfiguration.java
@@ -17,6 +17,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.CorsConfigurationSource;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Reactive security configuration that adapts the shared servlet-based starter
@@ -28,7 +29,8 @@ public class GatewaySecurityConfiguration {
 
   @Bean
   public ReactiveJwtDecoder reactiveJwtDecoder(JwtDecoder jwtDecoder) {
-    return token -> Mono.fromCallable(() -> jwtDecoder.decode(token));
+    return token -> Mono.fromCallable(() -> jwtDecoder.decode(token))
+        .subscribeOn(Schedulers.boundedElastic());
   }
 
   @Bean


### PR DESCRIPTION
## Summary
- ensure the reactive JWT decoder shifts blocking signature verification onto a bounded elastic scheduler to keep Netty threads responsive

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba197f4f0832fb0c8cc2df51c9d52