### PR TITLE
Align gateway routing and marketplace error handling

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityConfiguration.java
@@ -1,11 +1,12 @@
 package com.ejada.gateway.config;
 
+import com.ejada.gateway.security.BlockingReactiveJwtDecoder;
 import com.ejada.starter_security.SharedSecurityProps;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
-import java.util.List;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
@@ -16,8 +17,6 @@ import org.springframework.security.web.server.context.NoOpServerSecurityContext
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.CorsConfigurationSource;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 /**
  * Reactive security configuration that adapts the shared servlet-based starter
@@ -29,8 +28,7 @@ public class GatewaySecurityConfiguration {
 
   @Bean
   public ReactiveJwtDecoder reactiveJwtDecoder(JwtDecoder jwtDecoder) {
-    return token -> Mono.fromCallable(() -> jwtDecoder.decode(token))
-        .subscribeOn(Schedulers.boundedElastic());
+    return new BlockingReactiveJwtDecoder(jwtDecoder);
   }
 
   @Bean

--- a/api-gateway/src/main/java/com/ejada/gateway/config/ReactiveContextConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/ReactiveContextConfiguration.java
@@ -41,6 +41,7 @@ public class ReactiveContextConfiguration {
   }
 
   @Bean
+  @Order(Ordered.HIGHEST_PRECEDENCE + 20)
   @ConditionalOnClass(ReactiveStringRedisTemplate.class)
   @ConditionalOnBean(ReactiveStringRedisTemplate.class)
   @ConditionalOnProperty(prefix = "shared.ratelimit", name = "enabled", havingValue = "true")

--- a/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
@@ -11,16 +11,12 @@ import java.time.Duration;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.lang.Nullable;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
@@ -31,8 +27,6 @@ import reactor.core.publisher.Mono;
  * Reactive adaptation of the servlet {@code RateLimitFilter}. It uses Redis
  * atomic increments to enforce a simple fixed window rate limit per strategy.
  */
-@Component
-@Order(Ordered.HIGHEST_PRECEDENCE + 20)
 public class ReactiveRateLimiterFilter implements WebFilter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveRateLimiterFilter.class);
@@ -41,7 +35,6 @@ public class ReactiveRateLimiterFilter implements WebFilter {
   private final RateLimitProps props;
   private final ObjectMapper objectMapper;
 
-  @Autowired
   public ReactiveRateLimiterFilter(ReactiveStringRedisTemplate redisTemplate,
       RateLimitProps props,
       @Qualifier("jacksonObjectMapper") ObjectProvider<ObjectMapper> jacksonObjectMapper,

--- a/api-gateway/src/main/java/com/ejada/gateway/security/BlockingReactiveJwtDecoder.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/security/BlockingReactiveJwtDecoder.java
@@ -1,0 +1,34 @@
+package com.ejada.gateway.security;
+
+import java.util.Objects;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Adapts a blocking {@link JwtDecoder} so it can be used safely in a reactive pipeline.
+ */
+public class BlockingReactiveJwtDecoder implements ReactiveJwtDecoder {
+
+  private final JwtDecoder delegate;
+  private final Scheduler scheduler;
+
+  public BlockingReactiveJwtDecoder(JwtDecoder delegate) {
+    this(delegate, Schedulers.boundedElastic());
+  }
+
+  public BlockingReactiveJwtDecoder(JwtDecoder delegate, Scheduler scheduler) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+    this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
+  }
+
+  @Override
+  public Mono<Jwt> decode(String token) {
+    return Mono.defer(() -> Mono.fromCallable(() -> delegate.decode(token)))
+        .subscribeOn(scheduler);
+  }
+}
+

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/ServiceResultHttpStatusMapper.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/ServiceResultHttpStatusMapper.java
@@ -1,0 +1,44 @@
+package com.ejada.common.dto;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility for translating marketplace {@link ServiceResult} status codes into HTTP status codes.
+ */
+public final class ServiceResultHttpStatusMapper {
+
+  private static final Pattern MARKETPLACE_ERROR_PATTERN = Pattern.compile("^E(\\d{3}).*");
+
+  private ServiceResultHttpStatusMapper() {
+  }
+
+  /**
+   * Resolves the HTTP status that should be returned for the provided marketplace status code.
+   *
+   * @param statusCode marketplace status code
+   * @return resolved HTTP status (defaults to {@link HttpStatus#BAD_REQUEST} for non-internal errors)
+   */
+  public static HttpStatus resolve(String statusCode) {
+    if (!StringUtils.hasText(statusCode)) {
+      return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+    if (statusCode.startsWith("EINT")) {
+      return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    Matcher matcher = MARKETPLACE_ERROR_PATTERN.matcher(statusCode);
+    if (matcher.matches()) {
+      int code = Integer.parseInt(matcher.group(1));
+      HttpStatus resolved = HttpStatus.resolve(code);
+      if (resolved != null && resolved.is4xxClientError()) {
+        return resolved;
+      }
+    }
+
+    return HttpStatus.BAD_REQUEST;
+  }
+}
+

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/controller/ConsumptionController.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/controller/ConsumptionController.java
@@ -5,6 +5,7 @@ import com.ejada.billing.dto.TrackProductConsumptionRs;
 import com.ejada.billing.exception.ServiceResultException;
 import com.ejada.billing.service.ConsumptionService;
 import com.ejada.common.dto.ServiceResult;
+import com.ejada.common.dto.ServiceResultHttpStatusMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -56,14 +57,7 @@ public class ConsumptionController {
         }
         HttpStatus status = Boolean.TRUE.equals(result.success())
                 ? HttpStatus.OK
-                : resolveErrorStatus(result.statusCode());
+                : ServiceResultHttpStatusMapper.resolve(result.statusCode());
         return ResponseEntity.status(status).body(result);
-    }
-
-    private HttpStatus resolveErrorStatus(final String statusCode) {
-        if (statusCode == null || statusCode.startsWith("EINT")) {
-            return HttpStatus.INTERNAL_SERVER_ERROR;
-        }
-        return HttpStatus.BAD_REQUEST;
     }
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionInboundController.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionInboundController.java
@@ -1,11 +1,12 @@
 package com.ejada.subscription.controller;
 
+import com.ejada.common.dto.ServiceResult;
+import com.ejada.common.dto.ServiceResultHttpStatusMapper;
 import com.ejada.subscription.dto.ReceiveSubscriptionNotificationRq;
 import com.ejada.subscription.dto.ReceiveSubscriptionNotificationRs;
 import com.ejada.subscription.dto.ReceiveSubscriptionUpdateRq;
 import com.ejada.subscription.exception.ServiceResultException;
 import com.ejada.subscription.service.SubscriptionInboundService;
-import com.ejada.common.dto.ServiceResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -69,14 +70,7 @@ public class SubscriptionInboundController {
         }
         HttpStatus status = result.success()
                 ? HttpStatus.OK
-                : resolveErrorStatus(result.statusCode());
+                : ServiceResultHttpStatusMapper.resolve(result.statusCode());
         return ResponseEntity.status(status).body(result);
-    }
-
-    private HttpStatus resolveErrorStatus(final String statusCode) {
-        if (statusCode == null || statusCode.startsWith("EINT")) {
-            return HttpStatus.INTERNAL_SERVER_ERROR;
-        }
-        return HttpStatus.BAD_REQUEST;
     }
 }


### PR DESCRIPTION
## Summary
- enforce validated HTTP method restrictions when building gateway routes and normalize configured methods
- adapt the blocking JwtDecoder for reactive use while wiring the rate limiter filter only when the shared flag enables it
- centralize marketplace status-to-HTTP mapping for reuse and return 4xx responses from subscription and billing controllers

## Testing
- mvn -f shared-lib/shared-common/pom.xml test *(fails: missing com.ejada:shared-bom parent in local Maven cache)*
- mvn -f api-gateway/pom.xml test *(fails: missing com.ejada:shared-bom parent in local Maven cache)*

------
https://chatgpt.com/codex/tasks/task_e_68dba3be0b7c832fafa11321a2b431be