### PR TITLE
Add integration tests for marketplace flows and gateway filters

### DIFF
--- a/api-gateway/src/test/java/com/ejada/gateway/context/ReactiveRequestContextFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/context/ReactiveRequestContextFilterTest.java
@@ -1,0 +1,85 @@
+package com.ejada.gateway.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import com.ejada.starter_core.config.CoreAutoConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.util.context.ContextView;
+
+class ReactiveRequestContextFilterTest {
+
+    private ReactiveRequestContextFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        CoreAutoConfiguration.CoreProps props = new CoreAutoConfiguration.CoreProps();
+        props.getCorrelation().setSkipPatterns(new String[0]);
+        props.getTenant().setSkipPatterns(new String[0]);
+        filter = new ReactiveRequestContextFilter(props, new ObjectMapper());
+    }
+
+    @AfterEach
+    void tearDown() {
+        ContextManager.clearHeaders();
+    }
+
+    @Test
+    void populatesContextAndReactorContext() {
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/data")
+                .header(HeaderNames.CORRELATION_ID, "corr-123")
+                .header(HeaderNames.X_TENANT_ID, "tenant-1")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        AtomicReference<ContextView> contextRef = new AtomicReference<>();
+
+        WebFilterChain chain = serverExchange -> Mono.deferContextual(ctx -> {
+            contextRef.set(ctx);
+            assertThat(ContextManager.getCorrelationId()).isEqualTo("corr-123");
+            assertThat(ContextManager.Tenant.get()).isEqualTo("tenant-1");
+            return Mono.empty();
+        });
+
+        StepVerifier.create(filter.filter(exchange, chain)).verifyComplete();
+
+        assertThat(exchange.getResponse().getHeaders().getFirst(HeaderNames.CORRELATION_ID)).isEqualTo("corr-123");
+        assertThat(contextRef.get()).isNotNull();
+        assertThat(contextRef.get().get(HeaderNames.CORRELATION_ID)).isEqualTo("corr-123");
+        assertThat(contextRef.get().get(HeaderNames.X_TENANT_ID)).isEqualTo("tenant-1");
+    }
+
+    @Test
+    void rejectsInvalidTenantIdentifier() {
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/data")
+                .header(HeaderNames.CORRELATION_ID, "corr-789")
+                .header(HeaderNames.X_TENANT_ID, "tenant@!invalid")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        AtomicBoolean invoked = new AtomicBoolean(false);
+
+        WebFilterChain chain = serverExchange -> {
+            invoked.set(true);
+            return Mono.empty();
+        };
+
+        StepVerifier.create(filter.filter(exchange, chain)).verifyComplete();
+
+        assertThat(invoked).isFalse();
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        String body = exchange.getResponse().getBodyAsString().block(Duration.ofSeconds(3));
+        assertThat(body).contains("ERR_INVALID_TENANT");
+    }
+}

--- a/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
@@ -1,0 +1,78 @@
+package com.ejada.gateway.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.shared_starter_ratelimit.RateLimitProps;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class ReactiveRateLimiterFilterTest {
+
+    @Container
+    static final GenericContainer<?> REDIS = new GenericContainer<>("redis:7").withExposedPorts(6379);
+
+    private ReactiveRateLimiterFilter filter;
+    private ReactiveRedisConnectionFactory connectionFactory;
+
+    @BeforeEach
+    void setUp() {
+        LettuceConnectionFactory factory =
+                new LettuceConnectionFactory(REDIS.getHost(), REDIS.getMappedPort(6379));
+        factory.afterPropertiesSet();
+        this.connectionFactory = factory;
+        ReactiveStringRedisTemplate template = new ReactiveStringRedisTemplate(factory);
+        RateLimitProps props = new RateLimitProps();
+        props.setCapacity(2);
+        props.setRefillPerMinute(2);
+        props.setKeyStrategy("tenant");
+        this.filter = new ReactiveRateLimiterFilter(template, props, new ObjectMapper());
+        flushRedis();
+    }
+
+    @Test
+    void allowsRequestsWithinCapacity() {
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/api/items").build());
+        WebFilterChain chain = serverWebExchange -> Mono.empty();
+
+        StepVerifier.create(filter.filter(exchange, chain)).verifyComplete();
+
+        assertThat(exchange.getResponse().getStatusCode()).isNull();
+        assertThat(exchange.getResponse().getHeaders().getFirst("X-RateLimit-Limit")).isEqualTo("2");
+        assertThat(exchange.getResponse().getHeaders().getFirst("X-RateLimit-Remaining")).isEqualTo("1");
+    }
+
+    @Test
+    void rejectsWhenCapacityExceeded() {
+        MockServerWebExchange exchange1 = MockServerWebExchange.from(MockServerHttpRequest.get("/api/data").build());
+        MockServerWebExchange exchange2 = MockServerWebExchange.from(MockServerHttpRequest.get("/api/data").build());
+        MockServerWebExchange exchange3 = MockServerWebExchange.from(MockServerHttpRequest.get("/api/data").build());
+        WebFilterChain chain = serverWebExchange -> Mono.empty();
+
+        StepVerifier.create(filter.filter(exchange1, chain)).verifyComplete();
+        StepVerifier.create(filter.filter(exchange2, chain)).verifyComplete();
+
+        StepVerifier.create(filter.filter(exchange3, chain)).verifyComplete();
+
+        assertThat(exchange3.getResponse().getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        String body = exchange3.getResponse().getBodyAsString().block();
+        assertThat(body).contains("ERR_RATE_LIMIT");
+    }
+
+    private void flushRedis() {
+        connectionFactory.getReactiveConnection().serverCommands().flushAll().block();
+    }
+}

--- a/setup-service/src/test/java/com/ejada/setup/service/LookupServiceCachingIT.java
+++ b/setup-service/src/test/java/com/ejada/setup/service/LookupServiceCachingIT.java
@@ -1,0 +1,86 @@
+package com.ejada.setup.service;
+
+import static com.ejada.testsupport.assertions.ResponseAssertions.assertThatBaseResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.setup.SetupApplication;
+import com.ejada.setup.dto.LookupResponse;
+import com.ejada.setup.model.Lookup;
+import com.ejada.setup.repository.LookupRepository;
+import com.ejada.setup.service.impl.LookupServiceImpl;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(classes = SetupApplication.class)
+@Testcontainers
+@ActiveProfiles("test")
+class LookupServiceCachingIT {
+
+    @Container
+    static final GenericContainer<?> REDIS = new GenericContainer<>("redis:7").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void configureRedis(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+        registry.add("spring.cache.type", () -> "redis");
+    }
+
+    @MockBean
+    private LookupRepository lookupRepository;
+
+    @Autowired
+    private LookupServiceImpl lookupService;
+
+    @Autowired
+    private RedisConnectionFactory redisConnectionFactory;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @BeforeEach
+    void flushRedis() {
+        redisConnectionFactory.getConnection().serverCommands().flushAll();
+    }
+
+    @Test
+    void getAllCachesResponsesInRedis() {
+        Lookup entity = Lookup.builder()
+                .lookupItemId(1)
+                .lookupItemCd("CODE")
+                .lookupGroupCode("GENERAL")
+                .lookupItemEnNm("General")
+                .lookupItemArNm("عام")
+                .isActive(true)
+                .build();
+        when(lookupRepository.findAll()).thenReturn(List.of(entity));
+
+        BaseResponse<List<LookupResponse>> first = lookupService.getAll();
+        BaseResponse<List<LookupResponse>> second = lookupService.getAll();
+
+        verify(lookupRepository, times(1)).findAll();
+        assertThatBaseResponse(first)
+                .isSuccess()
+                .hasDataSatisfying(list -> assertThat(list).hasSize(1));
+        assertThatBaseResponse(second).isSuccess();
+
+        Object cached = redisTemplate.opsForValue().get("lookups:all::all");
+        assertThat(cached).isInstanceOf(List.class);
+    }
+}

--- a/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/assertions/ResponseAssertions.java
+++ b/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/assertions/ResponseAssertions.java
@@ -1,0 +1,108 @@
+package com.ejada.testsupport.assertions;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.dto.ServiceResult;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+
+import java.util.Objects;
+
+/**
+ * Fluent AssertJ helpers for verifying shared response wrappers in tests.
+ */
+public final class ResponseAssertions {
+
+    private ResponseAssertions() {
+        // utility
+    }
+
+    public static <T> BaseResponseAssert<T> assertThatBaseResponse(BaseResponse<T> actual) {
+        return new BaseResponseAssert<>(actual);
+    }
+
+    public static <T> ServiceResultAssert<T> assertThatServiceResult(ServiceResult<T> actual) {
+        return new ServiceResultAssert<>(actual);
+    }
+
+    public static final class BaseResponseAssert<T> extends AbstractAssert<BaseResponseAssert<T>, BaseResponse<T>> {
+
+        BaseResponseAssert(BaseResponse<T> actual) {
+            super(actual, BaseResponseAssert.class);
+        }
+
+        public BaseResponseAssert<T> isSuccess() {
+            isNotNull();
+            if (!actual.isSuccess()) {
+                failWithMessage("Expected BaseResponse to be successful but was %s", actual);
+            }
+            return this;
+        }
+
+        public BaseResponseAssert<T> isError() {
+            isNotNull();
+            if (!actual.isError()) {
+                failWithMessage("Expected BaseResponse to be error but was %s", actual);
+            }
+            return this;
+        }
+
+        public BaseResponseAssert<T> hasCode(String code) {
+            isNotNull();
+            if (!Objects.equals(actual.getCode(), code)) {
+                failWithMessage("Expected code to be <%s> but was <%s>", code, actual.getCode());
+            }
+            return this;
+        }
+
+        public BaseResponseAssert<T> hasMessage(String message) {
+            isNotNull();
+            if (!Objects.equals(actual.getMessage(), message)) {
+                failWithMessage("Expected message to be <%s> but was <%s>", message, actual.getMessage());
+            }
+            return this;
+        }
+
+        public BaseResponseAssert<T> hasDataSatisfying(java.util.function.Consumer<T> consumer) {
+            isNotNull();
+            Assertions.assertThat(actual.getData()).satisfies(consumer);
+            return this;
+        }
+    }
+
+    public static final class ServiceResultAssert<T> extends AbstractAssert<ServiceResultAssert<T>, ServiceResult<T>> {
+
+        ServiceResultAssert(ServiceResult<T> actual) {
+            super(actual, ServiceResultAssert.class);
+        }
+
+        public ServiceResultAssert<T> isSuccess() {
+            isNotNull();
+            if (!actual.success()) {
+                failWithMessage("Expected ServiceResult to be success but statusCode was <%s>", actual.statusCode());
+            }
+            return this;
+        }
+
+        public ServiceResultAssert<T> isFailure() {
+            isNotNull();
+            if (!actual.failure()) {
+                failWithMessage("Expected ServiceResult to be failure but statusCode was <%s>", actual.statusCode());
+            }
+            return this;
+        }
+
+        public ServiceResultAssert<T> hasStatusCode(String code) {
+            isNotNull();
+            if (!Objects.equals(actual.statusCode(), code)) {
+                failWithMessage("Expected status code to be <%s> but was <%s>", code, actual.statusCode());
+            }
+            return this;
+        }
+
+        public ServiceResultAssert<T> hasPayloadSatisfying(java.util.function.Consumer<T> consumer) {
+            isNotNull();
+            Assertions.assertThat(actual.payload()).satisfies(consumer);
+            return this;
+        }
+    }
+}

--- a/tenant-platform/billing-service/src/test/java/com/ejada/billing/controller/ConsumptionControllerTest.java
+++ b/tenant-platform/billing-service/src/test/java/com/ejada/billing/controller/ConsumptionControllerTest.java
@@ -1,0 +1,96 @@
+package com.ejada.billing.controller;
+
+import static com.ejada.testsupport.assertions.ResponseAssertions.assertThatServiceResult;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.ejada.billing.dto.ConsumptionType;
+import com.ejada.billing.dto.ProductConsumption;
+import com.ejada.billing.dto.ProductSubscription;
+import com.ejada.billing.dto.TrackProductConsumptionRq;
+import com.ejada.billing.dto.TrackProductConsumptionRs;
+import com.ejada.billing.exception.ServiceResultException;
+import com.ejada.billing.service.ConsumptionService;
+import com.ejada.common.dto.ServiceResult;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class ConsumptionControllerTest {
+
+    @Mock
+    private ConsumptionService service;
+
+    private ConsumptionController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new ConsumptionController(service);
+    }
+
+    @Test
+    void trackReturnsOkWhenServiceSucceeds() {
+        TrackProductConsumptionRq request = request();
+        TrackProductConsumptionRs payload = new TrackProductConsumptionRs(10L, List.of());
+        when(service.trackProductConsumption(any(), any(), eq(request))).thenReturn(ServiceResult.ok(payload));
+
+        ResponseEntity<ServiceResult<TrackProductConsumptionRs>> response =
+                controller.track(UUID.randomUUID(), "token", request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThatServiceResult(response.getBody())
+                .isSuccess()
+                .hasPayloadSatisfying(result -> assertThat(result.productId()).isEqualTo(10L));
+    }
+
+    @Test
+    void trackMapsBusinessErrorToBadRequest() {
+        TrackProductConsumptionRq request = request();
+        ServiceResult<TrackProductConsumptionRs> failure =
+                ServiceResult.error(null, "EBUS001", "Business validation", List.of("quota exceeded"));
+        when(service.trackProductConsumption(any(), any(), eq(request))).thenReturn(failure);
+
+        ResponseEntity<ServiceResult<TrackProductConsumptionRs>> response =
+                controller.track(UUID.randomUUID(), "token", request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThatServiceResult(response.getBody())
+                .isFailure()
+                .hasStatusCode("EBUS001");
+    }
+
+    @Test
+    void trackMapsExceptionToInternalServerError() {
+        TrackProductConsumptionRq request = request();
+        ServiceResult<TrackProductConsumptionRs> failure =
+                ServiceResult.error(null, "EINT999", "Unexpected", List.of("boom"));
+        doThrow(new ServiceResultException(failure))
+                .when(service)
+                .trackProductConsumption(any(), any(), eq(request));
+
+        ResponseEntity<ServiceResult<TrackProductConsumptionRs>> response =
+                controller.track(UUID.randomUUID(), "token", request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThatServiceResult(response.getBody())
+                .isFailure()
+                .hasStatusCode("EINT999");
+    }
+
+    private TrackProductConsumptionRq request() {
+        ProductConsumption consumption = new ProductConsumption(ConsumptionType.TRANSACTION);
+        ProductSubscription subscription =
+                new ProductSubscription(100L, 200L, "2023-01-01", "2023-12-31", List.of(consumption));
+        return new TrackProductConsumptionRq(10L, List.of(subscription));
+    }
+}

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/controller/SubscriptionInboundControllerTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/controller/SubscriptionInboundControllerTest.java
@@ -1,0 +1,149 @@
+package com.ejada.subscription.controller;
+
+import static com.ejada.testsupport.assertions.ResponseAssertions.assertThatServiceResult;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.ejada.common.dto.ServiceResult;
+import com.ejada.subscription.dto.AdminUserInfoDto;
+import com.ejada.subscription.dto.CustomerInfoDto;
+import com.ejada.subscription.dto.EnvironmentIdentifierDto;
+import com.ejada.subscription.dto.ReceiveSubscriptionNotificationRq;
+import com.ejada.subscription.dto.ReceiveSubscriptionNotificationRs;
+import com.ejada.subscription.dto.ReceiveSubscriptionUpdateRq;
+import com.ejada.subscription.dto.SubscriptionInfoDto;
+import com.ejada.subscription.dto.SubscriptionUpdateType;
+import com.ejada.subscription.exception.ServiceResultException;
+import com.ejada.subscription.service.SubscriptionInboundService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionInboundControllerTest {
+
+    @Mock
+    private SubscriptionInboundService service;
+
+    private SubscriptionInboundController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new SubscriptionInboundController(service);
+    }
+
+    @Test
+    void receiveSubscriptionNotificationReturnsOkWhenServiceSucceeds() {
+        ReceiveSubscriptionNotificationRq request = notificationRequest();
+        ReceiveSubscriptionNotificationRs payload =
+                new ReceiveSubscriptionNotificationRs(Boolean.TRUE, List.of(new EnvironmentIdentifierDto("DB_ID", "10.0.0.1")));
+        when(service.receiveSubscriptionNotification(any(), any(), eq(request)))
+                .thenReturn(ServiceResult.ok(payload));
+
+        ResponseEntity<ServiceResult<ReceiveSubscriptionNotificationRs>> response =
+                controller.receiveSubscriptionNotification(UUID.randomUUID(), "token", request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThatServiceResult(response.getBody())
+                .isSuccess()
+                .hasPayloadSatisfying(body -> assertThat(body.environmentIdentiferLst()).hasSize(1));
+    }
+
+    @Test
+    void receiveSubscriptionNotificationMapsServiceFailureToBadRequest() {
+        ReceiveSubscriptionNotificationRq request = notificationRequest();
+        ServiceResult<ReceiveSubscriptionNotificationRs> failure =
+                ServiceResult.error(null, "EVAL100", "Validation failed", List.of("missing tenant"));
+        when(service.receiveSubscriptionNotification(any(), any(), eq(request))).thenReturn(failure);
+
+        ResponseEntity<ServiceResult<ReceiveSubscriptionNotificationRs>> response =
+                controller.receiveSubscriptionNotification(UUID.randomUUID(), "token", request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThatServiceResult(response.getBody())
+                .isFailure()
+                .hasStatusCode("EVAL100");
+    }
+
+    @Test
+    void receiveSubscriptionNotificationMapsServiceExceptionToHttpStatusFromResult() {
+        ReceiveSubscriptionNotificationRq request = notificationRequest();
+        ServiceResult<ReceiveSubscriptionNotificationRs> failure =
+                ServiceResult.error(null, "EINT000", "Unexpected", List.of("boom"));
+        doThrow(new ServiceResultException(failure))
+                .when(service)
+                .receiveSubscriptionNotification(any(), any(), eq(request));
+
+        ResponseEntity<ServiceResult<ReceiveSubscriptionNotificationRs>> response =
+                controller.receiveSubscriptionNotification(UUID.randomUUID(), "token", request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThatServiceResult(response.getBody())
+                .isFailure()
+                .hasStatusCode("EINT000");
+    }
+
+    @Test
+    void receiveSubscriptionUpdateReturnsStatusFromServiceResult() {
+        ReceiveSubscriptionUpdateRq request = updateRequest();
+        ServiceResult<Void> failure = ServiceResult.error(null, "EUPDATE", "invalid state", List.of("not active"));
+        when(service.receiveSubscriptionUpdate(any(), any(), eq(request))).thenReturn(failure);
+
+        ResponseEntity<ServiceResult<Void>> response =
+                controller.receiveSubscriptionUpdate(UUID.randomUUID(), "token", request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThatServiceResult(response.getBody())
+                .isFailure()
+                .hasStatusCode("EUPDATE");
+    }
+
+    private ReceiveSubscriptionNotificationRq notificationRequest() {
+        SubscriptionInfoDto subscriptionInfo = new SubscriptionInfoDto(
+                11L,
+                22L,
+                33L,
+                44L,
+                "Tier",
+                "طبقة",
+                LocalDate.now(),
+                LocalDate.now().plusDays(30),
+                BigDecimal.TEN,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                "ACTIVE",
+                "PORTAL",
+                Boolean.TRUE,
+                5L,
+                "FULL",
+                Boolean.TRUE,
+                10L,
+                "PERIOD",
+                BigDecimal.ONE,
+                "MONTH",
+                "L",
+                Boolean.TRUE,
+                null,
+                null,
+                List.of(),
+                List.of());
+        CustomerInfoDto customer = new CustomerInfoDto("Ejada", "اجادة", null, null, null, null, null, null, "ops@example.com", "+966");
+        AdminUserInfoDto admin = new AdminUserInfoDto("admin", "EN", "1234567890", "admin@example.com");
+        return new ReceiveSubscriptionNotificationRq(customer, admin, subscriptionInfo, List.of());
+    }
+
+    private ReceiveSubscriptionUpdateRq updateRequest() {
+        return new ReceiveSubscriptionUpdateRq(UUID.randomUUID().toString(), SubscriptionUpdateType.SUSPEND, "tenant-1", "reason");
+    }
+}

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -1,0 +1,136 @@
+package com.ejada.subscription.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+
+import com.ejada.common.events.provisioning.ProvisionedAddon;
+import com.ejada.common.events.provisioning.ProvisionedFeature;
+import com.ejada.common.events.subscription.SubscriptionApprovalAction;
+import com.ejada.common.events.subscription.SubscriptionApprovalMessage;
+import com.ejada.subscription.SubscriptionApplication;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(classes = SubscriptionApplication.class)
+@Testcontainers
+@ActiveProfiles("test")
+class SubscriptionApprovalConsumerIT {
+
+    private static final String APPROVAL_TOPIC = "subscription-approvals-it";
+    private static final String CONSUMER_GROUP = "subscription-approvals-it-group";
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:15-alpine"));
+
+    @Container
+    static final KafkaContainer KAFKA =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3"));
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        registry.add("spring.jpa.properties.hibernate.default_schema", () -> "subscription");
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add(
+                "spring.flyway.locations",
+                () -> "classpath:db/migration/postgresql,classpath:db/testdata/subscription");
+        registry.add("spring.flyway.schemas", () -> "subscription");
+        registry.add("spring.flyway.default-schema", () -> "subscription");
+        registry.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+        registry.add("spring.kafka.consumer.auto-offset-reset", () -> "earliest");
+        registry.add("app.subscription-approval.topic", () -> APPROVAL_TOPIC);
+        registry.add("app.subscription-approval.consumer-group", () -> CONSUMER_GROUP);
+    }
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @MockBean
+    private TenantProvisioningPublisher provisioningPublisher;
+
+    @Test
+    void approvedMessageTriggersProvisioningPublish() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                    latch.countDown();
+                    return null;
+                })
+                .when(provisioningPublisher)
+                .publish(any(), any(), any());
+
+        UUID requestId = UUID.randomUUID();
+        SubscriptionApprovalMessage message = new SubscriptionApprovalMessage(
+                SubscriptionApprovalAction.APPROVED,
+                requestId,
+                9000L,
+                7000L,
+                "Ejada Corp",
+                "إجادة",
+                "admin@example.com",
+                "+966500000000",
+                "TEN-9000",
+                "Ejada Corp",
+                "ops@example.com",
+                "+966500000000",
+                "ejada-officer",
+                OffsetDateTime.now(),
+                null);
+
+        kafkaTemplate.send(APPROVAL_TOPIC, message.requestId().toString(), message).get(10, TimeUnit.SECONDS);
+
+        assertThat(latch.await(15, TimeUnit.SECONDS)).as("listener should publish provisioning payload").isTrue();
+
+        ArgumentCaptor<SubscriptionApprovalMessage> messageCaptor = ArgumentCaptor.forClass(SubscriptionApprovalMessage.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ProvisionedFeature>> featuresCaptor = ArgumentCaptor.forClass(List.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ProvisionedAddon>> addonsCaptor = ArgumentCaptor.forClass(List.class);
+
+        verify(provisioningPublisher)
+                .publish(messageCaptor.capture(), featuresCaptor.capture(), addonsCaptor.capture());
+
+        SubscriptionApprovalMessage consumed = messageCaptor.getValue();
+        assertThat(consumed.subscriptionId()).isEqualTo(9000L);
+        List<ProvisionedFeature> features = featuresCaptor.getValue();
+        assertThat(features)
+                .hasSize(1)
+                .first()
+                .satisfies(feature -> {
+                    assertThat(feature.code()).isEqualTo("API_CALLS");
+                    assertThat(feature.quantity()).isEqualTo(25);
+                });
+
+        List<ProvisionedAddon> addons = addonsCaptor.getValue();
+        assertThat(addons)
+                .hasSize(1)
+                .first()
+                .satisfies(addon -> {
+                    assertThat(addon.code()).isEqualTo("LOGS");
+                    assertThat(addon.productAdditionalServiceId()).isEqualTo(9901L);
+                    assertThat(addon.requestedCount()).isEqualTo(5L);
+                });
+    }
+}

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
@@ -1,0 +1,98 @@
+package com.ejada.subscription.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.subscription.kafka.SubscriptionApprovalPublisher;
+import com.ejada.subscription.repository.OutboxEventRepository;
+import com.ejada.subscription.service.impl.SubscriptionInboundServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(FlywayAutoConfiguration.class)
+class SubscriptionOutboxPersistenceIT {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:15-alpine"));
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.jpa.properties.hibernate.default_schema", () -> "subscription");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add("spring.flyway.locations", () -> "classpath:db/migration/postgresql");
+        registry.add("spring.flyway.schemas", () -> "subscription");
+        registry.add("spring.flyway.default-schema", () -> "subscription");
+    }
+
+    private SubscriptionInboundServiceImpl service;
+    private OutboxEventRepository outboxRepo;
+
+    @BeforeEach
+    void setUp(OutboxEventRepository outboxRepo, PlatformTransactionManager txManager) {
+        service = new SubscriptionInboundServiceImpl(
+                Mockito.mock(com.ejada.subscription.repository.SubscriptionRepository.class),
+                Mockito.mock(com.ejada.subscription.repository.SubscriptionFeatureRepository.class),
+                Mockito.mock(com.ejada.subscription.repository.SubscriptionAdditionalServiceRepository.class),
+                Mockito.mock(com.ejada.subscription.repository.SubscriptionProductPropertyRepository.class),
+                Mockito.mock(com.ejada.subscription.repository.SubscriptionEnvironmentIdentifierRepository.class),
+                Mockito.mock(com.ejada.subscription.repository.InboundNotificationAuditRepository.class),
+                Mockito.mock(com.ejada.subscription.repository.SubscriptionUpdateEventRepository.class),
+                outboxRepo,
+                Mockito.mock(com.ejada.subscription.repository.IdempotentRequestRepository.class),
+                Mockito.mock(com.ejada.subscription.mapper.SubscriptionMapper.class),
+                Mockito.mock(com.ejada.subscription.mapper.SubscriptionFeatureMapper.class),
+                Mockito.mock(com.ejada.subscription.mapper.SubscriptionAdditionalServiceMapper.class),
+                Mockito.mock(com.ejada.subscription.mapper.SubscriptionProductPropertyMapper.class),
+                Mockito.mock(com.ejada.subscription.mapper.SubscriptionEnvironmentIdentifierMapper.class),
+                Mockito.mock(com.ejada.subscription.mapper.SubscriptionUpdateEventMapper.class),
+                new ObjectMapper(),
+                txManager,
+                Mockito.mock(SubscriptionApprovalPublisher.class));
+        this.outboxRepo = outboxRepo;
+        outboxRepo.deleteAll();
+    }
+
+    @Test
+    void emitOutboxPersistsEventsUsingTransactionalOutbox() {
+        Map<String, Object> payload = Map.of("status", "CREATED", "rqUid", UUID.randomUUID().toString());
+
+        ReflectionTestUtils.invokeMethod(
+                service, "emitOutbox", "SUBSCRIPTION", "ext-123", "CREATED_OR_UPDATED", payload);
+
+        List<com.ejada.subscription.model.OutboxEvent> events = outboxRepo.findAll();
+
+        assertThat(events)
+                .hasSize(1)
+                .first()
+                .satisfies(event -> {
+                    assertThat(event.getAggregateType()).isEqualTo("SUBSCRIPTION");
+                    assertThat(event.getAggregateId()).isEqualTo("ext-123");
+                    assertThat(event.getEventType()).isEqualTo("CREATED_OR_UPDATED");
+                    assertThat(event.getPayload()).contains("\"status\":\"CREATED\"");
+                });
+    }
+}

--- a/tenant-platform/subscription-service/src/test/resources/db/testdata/subscription/V900__approval_consumer_data.sql
+++ b/tenant-platform/subscription-service/src/test/resources/db/testdata/subscription/V900__approval_consumer_data.sql
@@ -1,0 +1,89 @@
+insert into subscription.subscription (
+    subscription_id,
+    ext_subscription_id,
+    ext_customer_id,
+    ext_product_id,
+    ext_tier_id,
+    tier_nm_en,
+    tier_nm_ar,
+    start_dt,
+    end_dt,
+    subscription_amount,
+    total_billed_amount,
+    total_paid_amount,
+    subscription_stts_cd,
+    create_channel,
+    unlimited_users_flag,
+    unlimited_trans_flag,
+    environment_size_cd,
+    is_auto_prov_enabled,
+    is_deleted,
+    created_at,
+    created_by
+) values (
+    500,
+    9000,
+    7000,
+    321,
+    654,
+    'Gold',
+    'ذهبي',
+    current_date,
+    current_date + interval '30 days',
+    100.00,
+    0,
+    0,
+    'ACTIVE',
+    'PORTAL',
+    'N',
+    'N',
+    'L',
+    'N',
+    false,
+    now(),
+    'fixture'
+);
+
+insert into subscription.subscription_feature (
+    subscription_feature_id,
+    subscription_id,
+    feature_cd,
+    feature_count
+) values (
+    601,
+    500,
+    'API_CALLS',
+    25
+);
+
+insert into subscription.subscription_additional_service (
+    subscription_additional_service_id,
+    subscription_id,
+    product_additional_service_id,
+    service_cd,
+    service_name_en,
+    service_name_ar,
+    service_desc_en,
+    service_desc_ar,
+    service_price,
+    total_amount,
+    currency,
+    is_countable,
+    requested_count,
+    payment_type_cd
+) values (
+    701,
+    500,
+    9901,
+    'LOGS',
+    'Logs bundle',
+    'حزمة السجلات',
+    null,
+    null,
+    50.00,
+    50.00,
+    'SAR',
+    'Y',
+    5,
+    'ONE_TIME_FEES'
+);


### PR DESCRIPTION
## Summary
- add shared `ResponseAssertions` helpers for validating BaseResponse and ServiceResult payloads in tests
- cover subscription and billing marketplace controllers plus transactional outbox persistence and Kafka consumption with container-backed integration tests
- verify Redis-backed caching and reactive gateway filters using Testcontainers for Redis and Kafka

## Testing
- `mvn -f api-gateway/pom.xml test -Dtest=ReactiveRateLimiterFilterTest,ReactiveRequestContextFilterTest` *(fails: shared-bom 1.0.0 dependency is not published in public Maven repositories)*
- `mvn -f tenant-platform/subscription-service/pom.xml test -Dtest=SubscriptionInboundControllerTest,SubscriptionOutboxPersistenceIT,SubscriptionApprovalConsumerIT` *(fails: shared-bom 1.0.0 dependency is not published in public Maven repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68dba3e0ec58832f9d7be303cda563d9