### PR TITLE
Align gateway routing and marketplace error handling

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.util.StringUtils;
 
 /**
@@ -35,10 +36,12 @@ public class GatewayRoutesConfiguration {
             .map(String::trim)
             .toArray(String[]::new);
 
-        String[] methods = route.getMethods().stream()
+        HttpMethod[] methods = route.getMethods().stream()
             .filter(StringUtils::hasText)
             .map(String::trim)
-            .toArray(String[]::new);
+            .map(String::toUpperCase)
+            .map(HttpMethod::valueOf)
+            .toArray(HttpMethod[]::new);
 
         var methodPredicate = predicate.path(paths);
         if (methods.length > 0) {

--- a/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
@@ -89,16 +89,10 @@ public class ReactiveRateLimiterFilter implements WebFilter {
 
   private Duration resolveWindow() {
     Duration configured = props.getWindow();
-    if (configured != null && !configured.isZero() && !configured.isNegative()) {
-      return configured;
+    if (configured == null || configured.isZero() || configured.isNegative()) {
+      return Duration.ofMinutes(1);
     }
-    int capacity = Math.max(1, props.getCapacity());
-    int refillPerMinute = Math.max(1, props.getRefillPerMinute());
-    long seconds = (long) Math.ceil(capacity * 60.0 / refillPerMinute);
-    if (seconds <= 0L) {
-      seconds = 1L;
-    }
-    return Duration.ofSeconds(seconds);
+    return configured;
   }
 
   private String keyFor(ServerWebExchange exchange) {

--- a/api-gateway/src/test/java/com/ejada/gateway/config/GatewayRoutesPropertiesTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/config/GatewayRoutesPropertiesTest.java
@@ -1,0 +1,32 @@
+package com.ejada.gateway.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GatewayRoutesPropertiesTest {
+
+  @Test
+  void setMethodsNormalisesAndDeduplicatesValues() {
+    GatewayRoutesProperties.ServiceRoute route = new GatewayRoutesProperties.ServiceRoute();
+    route.setMethods(List.of(" get ", "POST", "get", ""));
+
+    assertThat(route.getMethods()).containsExactly("GET", "POST");
+  }
+
+  @Test
+  void validateThrowsWhenMethodInvalid() {
+    GatewayRoutesProperties.ServiceRoute route = new GatewayRoutesProperties.ServiceRoute();
+    route.setId("test");
+    route.setUri(URI.create("http://example.com"));
+    route.setPaths(List.of("/foo"));
+    route.setMethods(List.of("GET", "INVALID"));
+
+    assertThatThrownBy(() -> route.validate("sample"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("INVALID");
+  }
+}

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/web/ServiceResultResponses.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/web/ServiceResultResponses.java
@@ -1,8 +1,10 @@
 package com.ejada.common.web;
 
 import com.ejada.common.dto.ServiceResult;
+import com.ejada.common.http.ApiStatusMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 
 /** Utility methods for converting {@link ServiceResult} objects to {@link ResponseEntity} instances. */
 public final class ServiceResultResponses {
@@ -24,9 +26,12 @@ public final class ServiceResultResponses {
             return HttpStatus.OK;
         }
         String statusCode = result.statusCode();
-        if (statusCode == null || statusCode.startsWith("EINT")) {
+        if (!StringUtils.hasText(statusCode)) {
+            return HttpStatus.BAD_REQUEST;
+        }
+        if (statusCode.startsWith("EINT")) {
             return HttpStatus.INTERNAL_SERVER_ERROR;
         }
-        return HttpStatus.BAD_REQUEST;
+        return ApiStatusMapper.fromErrorCode(statusCode, HttpStatus.BAD_REQUEST);
     }
 }

--- a/shared-lib/shared-common/src/test/java/com/ejada/common/web/ServiceResultResponsesTest.java
+++ b/shared-lib/shared-common/src/test/java/com/ejada/common/web/ServiceResultResponsesTest.java
@@ -1,0 +1,39 @@
+package com.ejada.common.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.ejada.common.dto.ServiceResult;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class ServiceResultResponsesTest {
+
+    @Test
+    void resolveHttpStatusReturnsUnauthorizedForAuthError() {
+        ServiceResult<Void> result = ServiceResult.error(null, "ERR-AUTH-INVALID", "Invalid", List.of());
+
+        assertEquals(HttpStatus.UNAUTHORIZED, ServiceResultResponses.resolveHttpStatus(result));
+    }
+
+    @Test
+    void resolveHttpStatusReturnsInternalServerErrorForInternalFailures() {
+        ServiceResult<Void> result = ServiceResult.error(null, "EINT000", "boom", List.of());
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ServiceResultResponses.resolveHttpStatus(result));
+    }
+
+    @Test
+    void resolveHttpStatusReturnsBadRequestWhenCodeMissing() {
+        ServiceResult<Void> result = new ServiceResult<>(null, "", "desc", List.of(), null, null);
+
+        assertEquals(HttpStatus.BAD_REQUEST, ServiceResultResponses.resolveHttpStatus(result));
+    }
+
+    @Test
+    void resolveHttpStatusReturnsBadRequestForValidationCodesByDefault() {
+        ServiceResult<Void> result = ServiceResult.error(null, "EVAL100", "fail", List.of("missing"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, ServiceResultResponses.resolveHttpStatus(result));
+    }
+}


### PR DESCRIPTION
## Summary
- normalise configured HTTP methods, validate them, and apply HttpMethod-aware predicates when registering gateway routes
- reuse shared ApiStatusMapper for marketplace ServiceResult HTTP status resolution and extend coverage with new tests
- align the reactive rate limiter window with the shared configuration defaults and add configuration unit tests

## Testing
- mvn -pl shared-common -am test

------
https://chatgpt.com/codex/tasks/task_e_68dba83901e4832f953cdc16ebf94b25