### PR TITLE
Fix shared-test-support module dependency on shared-common

### DIFF
--- a/shared-lib/shared-test-support/pom.xml
+++ b/shared-lib/shared-test-support/pom.xml
@@ -17,6 +17,12 @@
   <description>Shared test utilities and base classes for Shared modules</description>
 
   <dependencies>
+    <!-- Shared common DTOs and utilities -->
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>shared-common</artifactId>
+    </dependency>
+
     <!-- Spring Boot test stack -->
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- add the shared-common module as a dependency of shared-test-support so assertion helpers can compile

## Testing
- ⚠️ `mvn -pl shared-test-support -am test` *(fails because the environment cannot load byte-buddy-agent from the local Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4eeb77a4832f81cce308a76220f7