### PR TITLE
Fix generic response handling in country endpoints

### DIFF
--- a/setup-service/src/main/java/com/ejada/setup/controller/CountryController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/CountryController.java
@@ -107,14 +107,14 @@ public class CountryController {
         @ApiResponse(responseCode = "200", description = "Countries retrieved successfully"),
         @ApiResponse(responseCode = "403", description = "Access denied")
     })
-    public ResponseEntity<BaseResponse<?>> list(
+    public ResponseEntity<BaseResponse<Object>> list(
             @PageableDefault(size = ValidationConstants.PAGE_SIZE_DEFAULT) final Pageable pageable,
             @Parameter(description = "Search query for country names")
             @RequestParam(required = false) final String q,
             @Parameter(description = "Whether to retrieve all countries (ignores pagination)")
             @RequestParam(name = "unpaged", defaultValue = "false") final boolean unpaged) {
         Pageable effectivePageable = unpaged ? Pageable.unpaged() : pageable;
-        BaseResponse<?> response = countryService.list(effectivePageable, q, unpaged);
+        BaseResponse<Object> response = countryService.list(effectivePageable, q, unpaged);
         return build(response);
     }
 

--- a/setup-service/src/main/java/com/ejada/setup/service/CountryService.java
+++ b/setup-service/src/main/java/com/ejada/setup/service/CountryService.java
@@ -14,7 +14,7 @@ public interface CountryService {
 
     BaseResponse<CountryDto> get(Integer countryId);
 
-    BaseResponse<?> list(Pageable pageable, String q, boolean unpaged);
+    BaseResponse<Object> list(Pageable pageable, String q, boolean unpaged);
 
     BaseResponse<List<CountryDto>> listActive();
 }

--- a/setup-service/src/main/java/com/ejada/setup/service/impl/CountryServiceImpl.java
+++ b/setup-service/src/main/java/com/ejada/setup/service/impl/CountryServiceImpl.java
@@ -126,7 +126,7 @@ public class CountryServiceImpl
     @Override
     @Transactional(Transactional.TxType.SUPPORTS)
     @Audited(action = AuditAction.READ, entity = "Country", dataClass = DataClass.HEALTH, message = "List countries")
-    public BaseResponse<?> list(final Pageable pageable, final String q, final boolean unpaged) {
+    public BaseResponse<Object> list(final Pageable pageable, final String q, final boolean unpaged) {
         Sort sort = SortUtils.sanitize(pageable != null ? pageable.getSort() : Sort.unsorted(),
                 "countryEnNm", "countryArNm", "countryCd");
         Pageable pg = (pageable == null || !pageable.isPaged()
@@ -141,7 +141,7 @@ public class CountryServiceImpl
                 list = countryRepository
                         .findByCountryEnNmContainingIgnoreCaseOrCountryArNmContainingIgnoreCase(q, q, sort);
             }
-            return BaseResponse.success("Countries list", mapper.toDtoList(list));
+            return BaseResponse.<Object>success("Countries list", mapper.toDtoList(list));
         }
 
         Page<Country> page;
@@ -151,7 +151,7 @@ public class CountryServiceImpl
             page = countryRepository
                     .findByCountryEnNmContainingIgnoreCaseOrCountryArNmContainingIgnoreCase(q, q, pg);
         }
-        return BaseResponse.success("Countries page", mapper.toDtoPage(page));
+        return BaseResponse.<Object>success("Countries page", mapper.toDtoPage(page));
     }
 
     // cache only the RAW list to avoid BaseResponse <-> LinkedHashMap casts in Redis

--- a/setup-service/src/main/java/com/ejada/setup/service/impl/SystemParameterServiceImpl.java
+++ b/setup-service/src/main/java/com/ejada/setup/service/impl/SystemParameterServiceImpl.java
@@ -83,7 +83,7 @@ public class SystemParameterServiceImpl
     }
 
     @Override
-    protected String duplicateResourceMessage(final SystemParameter dto) {
+    protected String duplicateResourceMessage(final SystemParameterRequest dto) {
         return "Parameter key already exists";
     }
 


### PR DESCRIPTION
## Summary
- align the country list endpoint/controller with a concrete `BaseResponse<Object>` signature so the response factory infers the proper generic type
- update the country service implementation to build success responses with explicit generics for list and page results
- correct the system parameter duplicate resource message override to use the request DTO type expected by `BaseCrudService`

## Testing
- `mvn -f setup-service/pom.xml clean compile` *(fails: missing internal BOM and dependency versions such as `com.ejada:shared-bom:1.0.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5131192c832fbfa2df8824c29905