### PR TITLE
Use 256-bit secrets in security tests

### DIFF
--- a/api-gateway/src/test/java/com/ejada/gateway/ApiGatewayApplicationTests.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/ApiGatewayApplicationTests.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest
 @TestPropertySource(properties = {
     "shared.security.mode=hs256",
-    "shared.security.hs256.secret=unit-test-secret",
+    "shared.security.hs256.secret=" + ApiGatewayApplicationTests.SECRET,
     "shared.security.resource-server.enabled=false",
     "gateway.routes.test.id=test-route",
     "gateway.routes.test.uri=http://example.org",
@@ -20,6 +20,8 @@ import org.springframework.test.context.TestPropertySource;
     "spring.autoconfigure.exclude=com.ejada.shared_starter_ratelimit.RateLimitAutoConfiguration"
 })
 class ApiGatewayApplicationTests {
+
+  private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
 
   @Autowired
   private RouteLocator routeLocator;

--- a/sec-service/src/test/java/com/ejada/sec/security/RoleControllerSecurityTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/security/RoleControllerSecurityTest.java
@@ -29,8 +29,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @TestPropertySource(properties = {
     "spring.main.allow-bean-definition-overriding=true",
     "shared.security.mode=hs256",
-    "shared.security.hs256.secret=test-secret",
-    "shared.security.jwt.secret=test-secret",
+    "shared.security.hs256.secret=" + RoleControllerSecurityTest.SECRET,
+    "shared.security.jwt.secret=" + RoleControllerSecurityTest.SECRET,
     "shared.security.issuer=" + RoleControllerSecurityTest.ISSUER,
     "shared.security.resource-server.enabled=true",
     "shared.security.resource-server.disable-csrf=true",

--- a/sec-service/src/test/java/com/ejada/sec/security/SuperadminControllerSecurityTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/security/SuperadminControllerSecurityTest.java
@@ -19,14 +19,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
     "spring.main.allow-bean-definition-overriding=true",
     "shared.security.mode=hs256",
-    "shared.security.hs256.secret=test-secret",
-    "shared.security.jwt.secret=test-secret",
+    "shared.security.hs256.secret=" + SuperadminControllerSecurityTest.SECRET,
+    "shared.security.jwt.secret=" + SuperadminControllerSecurityTest.SECRET,
     "shared.security.resource-server.enabled=true",
     "shared.security.resource-server.disable-csrf=true",
     "shared.security.resource-server.permit-all[0]=/actuator/health",
     "server.servlet.context-path=/sec"
 })
 class SuperadminControllerSecurityTest {
+
+    private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
 
     @Autowired
     private MockMvc mockMvc;

--- a/sec-service/src/test/java/com/ejada/sec/security/UserControllerSecurityTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/security/UserControllerSecurityTest.java
@@ -19,14 +19,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
     "spring.main.allow-bean-definition-overriding=true",
     "shared.security.mode=hs256",
-    "shared.security.hs256.secret=test-secret",
-    "shared.security.jwt.secret=test-secret",
+    "shared.security.hs256.secret=" + UserControllerSecurityTest.SECRET,
+    "shared.security.jwt.secret=" + UserControllerSecurityTest.SECRET,
     "shared.security.resource-server.enabled=true",
     "shared.security.resource-server.disable-csrf=true",
     "shared.security.resource-server.permit-all[0]=/actuator/health",
     "server.servlet.context-path=/sec"
 })
 class UserControllerSecurityTest {
+
+    private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
 
     @Autowired
     private MockMvc mockMvc;

--- a/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
@@ -29,8 +29,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @TestPropertySource(properties = {
     "spring.main.allow-bean-definition-overriding=true",
     "shared.security.mode=hs256",
-    "shared.security.hs256.secret=test-secret",
-    "shared.security.jwt.secret=test-secret",
+    "shared.security.hs256.secret=" + CountryControllerSecurityTest.SECRET,
+    "shared.security.jwt.secret=" + CountryControllerSecurityTest.SECRET,
     "shared.security.issuer=" + CountryControllerSecurityTest.ISSUER,
     "shared.security.resource-server.enabled=true",
     "shared.security.resource-server.disable-csrf=true",

--- a/setup-service/src/test/java/com/ejada/setup/security/SystemParameterControllerSecurityTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/security/SystemParameterControllerSecurityTest.java
@@ -19,14 +19,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
     "spring.main.allow-bean-definition-overriding=true",
     "shared.security.mode=hs256",
-    "shared.security.hs256.secret=test-secret",
-    "shared.security.jwt.secret=test-secret",
+    "shared.security.hs256.secret=" + SystemParameterControllerSecurityTest.SECRET,
+    "shared.security.jwt.secret=" + SystemParameterControllerSecurityTest.SECRET,
     "shared.security.resource-server.enabled=true",
     "shared.security.resource-server.disable-csrf=true",
     "shared.security.resource-server.permit-all[0]=/actuator/health",
     "server.servlet.context-path=/core"
 })
 class SystemParameterControllerSecurityTest {
+
+    private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
 
     @Autowired
     private MockMvc mockMvc;

--- a/setup-service/src/test/resources/application-test.yml
+++ b/setup-service/src/test/resources/application-test.yml
@@ -52,5 +52,5 @@ shared:
   security:
     enable-role-check: false
     jwt:
-      secret: test-secret
+      secret: 0123456789ABCDEF0123456789ABCDEF
       token-period: 5m

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/RoleCheckerAutoConfigurationTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/RoleCheckerAutoConfigurationTest.java
@@ -12,7 +12,7 @@ class RoleCheckerAutoConfigurationTest {
   private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
       .withConfiguration(AutoConfigurations.of(SecurityAutoConfiguration.class))
       .withPropertyValues(
-          "shared.security.hs256.secret=secret",
+          "shared.security.hs256.secret=0123456789ABCDEF0123456789ABCDEF",
           "shared.security.resource-server.enabled=false");
 
   @Test

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/SharedSecurityPropsTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/SharedSecurityPropsTest.java
@@ -14,10 +14,10 @@ class SharedSecurityPropsTest {
   @Test
   void bindsHs256Secret() {
     MapConfigurationPropertySource source = new MapConfigurationPropertySource(
-        Map.of("shared.security.hs256.secret", "s3cr3t"));
+        Map.of("shared.security.hs256.secret", "0123456789ABCDEF0123456789ABCDEF"));
     SharedSecurityProps props = new Binder(source)
         .bind("shared.security", SharedSecurityProps.class).get();
-    assertEquals("s3cr3t", props.getHs256().getSecret());
+    assertEquals("0123456789ABCDEF0123456789ABCDEF", props.getHs256().getSecret());
   }
 
   @Test

--- a/tenant-platform/billing-service/src/test/resources/application-test.yml
+++ b/tenant-platform/billing-service/src/test/resources/application-test.yml
@@ -52,5 +52,5 @@ shared:
   security:
     enable-role-check: false
     jwt:
-      secret: test-secret
+      secret: 0123456789ABCDEF0123456789ABCDEF
       token-period: 5m

--- a/tenant-platform/catalog-service/src/test/resources/application-test.yml
+++ b/tenant-platform/catalog-service/src/test/resources/application-test.yml
@@ -52,5 +52,5 @@ shared:
   security:
     enable-role-check: false
     jwt:
-      secret: test-secret
+      secret: 0123456789ABCDEF0123456789ABCDEF
       token-period: 5m

--- a/tenant-platform/subscription-service/src/test/resources/application-test.yml
+++ b/tenant-platform/subscription-service/src/test/resources/application-test.yml
@@ -52,5 +52,5 @@ shared:
   security:
     enable-role-check: false
     jwt:
-      secret: test-secret
+      secret: 0123456789ABCDEF0123456789ABCDEF
       token-period: 5m

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantControllerSecurityTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantControllerSecurityTest.java
@@ -19,14 +19,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
     "spring.main.allow-bean-definition-overriding=true",
     "shared.security.mode=hs256",
-    "shared.security.hs256.secret=test-secret",
-    "shared.security.jwt.secret=test-secret",
+    "shared.security.hs256.secret=" + TenantControllerSecurityTest.SECRET,
+    "shared.security.jwt.secret=" + TenantControllerSecurityTest.SECRET,
     "shared.security.resource-server.enabled=true",
     "shared.security.resource-server.disable-csrf=true",
     "shared.security.resource-server.permit-all[0]=/actuator/health",
     "server.servlet.context-path=/tenant"
 })
 class TenantControllerSecurityTest {
+
+    private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
 
     @Autowired
     private MockMvc mockMvc;

--- a/tenant-platform/tenant-service/src/test/resources/application-test.yml
+++ b/tenant-platform/tenant-service/src/test/resources/application-test.yml
@@ -52,5 +52,5 @@ shared:
   security:
     enable-role-check: false
     jwt:
-      secret: test-secret
+      secret: 0123456789ABCDEF0123456789ABCDEF
       token-period: 5m


### PR DESCRIPTION
## Summary
- replace short HS256 secrets in security-related tests with a shared 256-bit-friendly value to satisfy decoder requirements
- align test application YAML configuration secrets across services with the strengthened secret

## Testing
- mvn -Dtest=CountryControllerSecurityTest test *(fails: missing dependency versions in module POM)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5290c1ac832f98b83f0a077bd76b