### PR TITLE
Fix test secrets accessibility

### DIFF
--- a/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
@@ -39,7 +39,7 @@ import org.springframework.test.web.servlet.MockMvc;
 })
 class CountryControllerSecurityTest {
 
-    private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
+    static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
     static final String ISSUER = "test-issuer";
 
     @Autowired

--- a/setup-service/src/test/java/com/ejada/setup/security/SystemParameterControllerSecurityTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/security/SystemParameterControllerSecurityTest.java
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 class SystemParameterControllerSecurityTest {
 
-    private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
+    static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- make the HS256 secret constants package-visible so they can be referenced from test property sources

## Testing
- `mvn -DskipITs test` *(fails: missing internal BOM dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dc53ffc5a0832f965a456282f7c4c8