### PR TITLE
Fix kafka listener config and silence mapstruct warnings

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/kafka/SubscriptionApprovalKafkaConfiguration.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/kafka/SubscriptionApprovalKafkaConfiguration.java
@@ -56,7 +56,6 @@ public class SubscriptionApprovalKafkaConfiguration {
         factory.setConsumerFactory(consumerFactory);
         factory.setConcurrency(kafkaProperties.getConcurrency());
         factory.setCommonErrorHandler(subscriptionApprovalErrorHandler);
-        factory.getContainerProperties().setAckOnError(false);
         factory.getContainerProperties().setAckMode(
                 org.springframework.kafka.listener.ContainerProperties.AckMode.MANUAL);
         return factory;

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantIntegrationKeyMapper.java
@@ -26,7 +26,7 @@ import java.time.OffsetDateTime;
 public interface TenantIntegrationKeyMapper {
 
     // ---------- Create ----------
-    @BeanMapping(ignoreUnmappedSourceProperties = "tenantId")
+    @BeanMapping(ignoreUnmappedSourceProperties = {"tenantId", "plainSecret"})
     @Mapping(target = "tikId", ignore = true)
     @Mapping(target = "tenant", expression = "java(Tenant.ref(req.tenantId()))")
     @Mapping(target = "keyId", source = "keyId")
@@ -67,7 +67,9 @@ public interface TenantIntegrationKeyMapper {
     }
 
     // ---------- Update (PATCH/PUT with IGNORE nulls) ----------
-    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @BeanMapping(
+            nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+            ignoreUnmappedSourceProperties = {"newPlainSecret", "rotatedBy"})
     @Mapping(target = "tikId", ignore = true)
     @Mapping(target = "tenant", ignore = true)
     @Mapping(target = "keyId", ignore = true)
@@ -85,7 +87,7 @@ public interface TenantIntegrationKeyMapper {
     void update(@MappingTarget @NonNull TenantIntegrationKey entity, @NonNull TenantIntegrationKeyUpdateReq req);
 
     // ---------- Response ----------
-    @BeanMapping(ignoreUnmappedSourceProperties = {"keySecret", "active", "expired"})
+    @BeanMapping(ignoreUnmappedSourceProperties = {"keySecret", "active", "expired", "deleted"})
     @Mapping(target = "tenantId", source = "tenant.id")
     @Mapping(target = "scopes", source = "scopes", qualifiedByName = "toList")
     @Mapping(target = "status", source = "status", qualifiedByName = "toDtoStatus")

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
@@ -45,6 +45,7 @@ public interface TenantMapper {
     void update(@MappingTarget @NonNull Tenant entity, @NonNull TenantUpdateReq req);
 
     // ---------- Response ----------
+    @BeanMapping(ignoreUnmappedSourceProperties = "deleted")
     @Mapping(target = "isDeleted", source = "isDeleted")
     TenantRes toRes(@NonNull Tenant entity);
 


### PR DESCRIPTION
## Summary
- stop calling the removed `ContainerProperties#setAckOnError` API when wiring the subscription approval listener
- update the tenant integration key mapper to ignore DTO-only fields that are handled in the service layer
- ignore the derived `deleted` accessor when mapping tenants to DTOs to silence MapStruct warnings

## Testing
- `mvn -pl tenant-service -am compile -f tenant-platform/pom.xml` *(fails: requires private parent BOM/commercial artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68dc54ad8314832f92b030fcb277d971