### PR TITLE
Fix country controller test expectations

### DIFF
--- a/setup-service/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/controller/CountryControllerTest.java
@@ -177,7 +177,7 @@ class CountryControllerTest {
 
         mockMvc.perform(get(BASE_URL + "/999")
                         .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
+                .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value("ERROR"))
                 .andExpect(jsonPath("$.code").value("ERR_COUNTRY_NOT_FOUND"));
 

--- a/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
@@ -56,7 +56,7 @@ class CountryControllerSecurityTest {
 
     @Test
     void protectedEndpointsReturnUnauthorizedWithoutToken() throws Exception {
-        mockMvc.perform(get("/core/setup/countries"))
+        mockMvc.perform(get("/setup/countries").contextPath("/core"))
             .andExpect(status().isUnauthorized());
     }
 
@@ -68,7 +68,7 @@ class CountryControllerSecurityTest {
                 .tenant("tenant-1")
                 .build();
 
-        mockMvc.perform(get("/core/setup/countries")
+        mockMvc.perform(get("/setup/countries").contextPath("/core")
                         .header(AUTHORIZATION, "Bearer " + token)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -83,7 +83,7 @@ class CountryControllerSecurityTest {
                 .tenant("tenant-1")
                 .build();
 
-        mockMvc.perform(get("/core/setup/countries")
+        mockMvc.perform(get("/setup/countries").contextPath("/core")
                         .header(AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value(ErrorCodes.AUTH_FORBIDDEN));
@@ -99,7 +99,7 @@ class CountryControllerSecurityTest {
                 .expiresAt(Instant.now().minusSeconds(3600))
                 .build();
 
-        mockMvc.perform(get("/core/setup/countries")
+        mockMvc.perform(get("/setup/countries").contextPath("/core")
                         .header(AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(ErrorCodes.AUTH_UNAUTHORIZED));


### PR DESCRIPTION
## Summary
- update the country controller not-found test to expect the mapped HTTP 404 status
- adjust country controller security tests to apply the configured servlet context path when building requests

## Testing
- `mvn -pl setup-service test -Dtest=CountryControllerTest#get_shouldReturn404_whenCountryNotFound` *(fails: Non-resolvable import POM com.ejada:shared-bom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dc54ffb980832fbf38a111abc1991b