### PR TITLE
Fix TenantControllerSecurityTest constant visibility

### DIFF
--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantControllerSecurityTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantControllerSecurityTest.java
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 class TenantControllerSecurityTest {
 
-    private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
+    static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- make the shared secret constant visible to the annotation processor in TenantControllerSecurityTest

## Testing
- mvn -f tenant-platform/pom.xml -pl tenant-service -am test *(fails: missing shared dependency artifacts in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc55be3590832fb312b24e159491f5