### PR TITLE
Add Testcontainers dependency for api-gateway tests

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -116,6 +116,11 @@
       <artifactId>spring-boot-testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/api-gateway/src/test/java/com/ejada/gateway/ApiGatewayApplicationTests.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/ApiGatewayApplicationTests.java
@@ -21,7 +21,7 @@ import org.springframework.test.context.TestPropertySource;
 })
 class ApiGatewayApplicationTests {
 
-  private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
+  static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
 
   @Autowired
   private RouteLocator routeLocator;


### PR DESCRIPTION
## Summary
- add the missing Testcontainers JUnit Jupiter dependency so the Redis-backed rate limiter test compiles
- relax the visibility of the secret constant so it can be referenced in @TestPropertySource configuration

## Testing
- mvn test *(fails: repository is missing private com.ejada:shared-bom artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68dc577cc234832f8180ee956bd65f94