### PR TITLE
Fix ambiguous AssertJ assertion in ReactiveRequestContextFilterTest

### DIFF
--- a/api-gateway/src/test/java/com/ejada/gateway/context/ReactiveRequestContextFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/context/ReactiveRequestContextFilterTest.java
@@ -77,7 +77,7 @@ class ReactiveRequestContextFilterTest {
 
         StepVerifier.create(filter.filter(exchange, chain)).verifyComplete();
 
-        assertThat(invoked).isFalse();
+        assertThat(invoked.get()).isFalse();
         assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         String body = exchange.getResponse().getBodyAsString().block(Duration.ofSeconds(3));
         assertThat(body).contains("ERR_INVALID_TENANT");


### PR DESCRIPTION
## Summary
- read the AtomicBoolean value in ReactiveRequestContextFilterTest before asserting to avoid the ambiguous AssertJ overload

## Testing
- `mvn test -DskipITs` *(fails: Non-resolvable import POM com.ejada:shared-bom:1.0.0 in central)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5885cb8c832f8d29451a7fe6a55e