### PR TITLE
Fix security test context path and JWT role mapping

### DIFF
--- a/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
@@ -56,7 +56,7 @@ class CountryControllerSecurityTest {
 
     @Test
     void protectedEndpointsReturnUnauthorizedWithoutToken() throws Exception {
-        mockMvc.perform(get("/setup/countries").contextPath("/core"))
+        mockMvc.perform(get("/core/setup/countries").contextPath("/core"))
             .andExpect(status().isUnauthorized());
     }
 
@@ -68,7 +68,7 @@ class CountryControllerSecurityTest {
                 .tenant("tenant-1")
                 .build();
 
-        mockMvc.perform(get("/setup/countries").contextPath("/core")
+        mockMvc.perform(get("/core/setup/countries").contextPath("/core")
                         .header(AUTHORIZATION, "Bearer " + token)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -83,7 +83,7 @@ class CountryControllerSecurityTest {
                 .tenant("tenant-1")
                 .build();
 
-        mockMvc.perform(get("/setup/countries").contextPath("/core")
+        mockMvc.perform(get("/core/setup/countries").contextPath("/core")
                         .header(AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value(ErrorCodes.AUTH_FORBIDDEN));
@@ -99,7 +99,7 @@ class CountryControllerSecurityTest {
                 .expiresAt(Instant.now().minusSeconds(3600))
                 .build();
 
-        mockMvc.perform(get("/setup/countries").contextPath("/core")
+        mockMvc.perform(get("/core/setup/countries").contextPath("/core")
                         .header(AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(ErrorCodes.AUTH_UNAUTHORIZED));

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/Role.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/Role.java
@@ -5,8 +5,8 @@ package com.ejada.starter_security;
  */
 public enum Role {
     EJADA_OFFICER("ROLE_EJADA_OFFICER"),
-    TENANT_ADMIN("ROLE_TenantAdmin"),
-    TENANT_OFFICER("ROLE_TenantOfficer");
+    TENANT_ADMIN("ROLE_TENANT_ADMIN"),
+    TENANT_OFFICER("ROLE_TENANT_OFFICER");
 
     private final String authority;
 

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
@@ -204,6 +204,8 @@ public class SecurityAutoConfiguration {
     // Build a final, de-duplicated list of permitAll patterns
     final List<String> permitAllFinal = buildPermitAll(rs);
 
+    var authEntryPoint = new JsonAuthEntryPoint(objectMapper);
+
     http.cors(cors -> cors.configurationSource(corsConfigurationSource))
         .authorizeHttpRequests(auth -> {
           auth.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
@@ -214,9 +216,10 @@ public class SecurityAutoConfiguration {
         })
         .oauth2ResourceServer(oauth -> oauth
             .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthConverter))
+            .authenticationEntryPoint(authEntryPoint)
         )
         .exceptionHandling(eh -> eh
-            .authenticationEntryPoint(new JsonAuthEntryPoint(objectMapper))
+            .authenticationEntryPoint(authEntryPoint)
             .accessDeniedHandler(new JsonAccessDeniedHandler(objectMapper))
         )
         .formLogin(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## Summary
- update the CountryController security tests to hit the /core context path that the application exposes
- correct the Role enum authority strings so TENANT roles align with JWT generated authorities
- reuse the JSON authentication entry point in the resource server configuration so unauthorized responses still emit the standard error payload

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68dc567c0ce0832fb68a3d413d0ad02f