### PR TITLE
Fix SubscriptionApprovalListener tests failing on OffsetDateTime serialization

### DIFF
--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/kafka/SubscriptionApprovalListenerTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/kafka/SubscriptionApprovalListenerTest.java
@@ -16,6 +16,8 @@ import com.ejada.tenant.exception.TenantConflictException;
 import com.ejada.tenant.exception.TenantErrorCode;
 import com.ejada.tenant.service.TenantService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.UUID;
@@ -33,7 +35,10 @@ class SubscriptionApprovalListenerTest {
     @Mock private TenantService tenantService;
     @Mock private Acknowledgment acknowledgment;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper =
+            new ObjectMapper()
+                    .registerModule(new JavaTimeModule())
+                    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     private SubscriptionApprovalListener listener;
 
     @BeforeEach


### PR DESCRIPTION
## Summary
- configure the test ObjectMapper used in SubscriptionApprovalListenerTest with the Java time module
- disable timestamp serialization to align with the application's ObjectMapper configuration

## Testing
- mvn -f tenant-platform/pom.xml -pl tenant-service test

------
https://chatgpt.com/codex/tasks/task_e_68dc5855ab04832f88b3a71d56bba8f9