### PR TITLE
Fix ambiguous AssertJ assertions in reactive context test

### DIFF
--- a/api-gateway/src/test/java/com/ejada/gateway/context/ReactiveRequestContextFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/context/ReactiveRequestContextFilterTest.java
@@ -57,8 +57,8 @@ class ReactiveRequestContextFilterTest {
 
         assertThat(exchange.getResponse().getHeaders().getFirst(HeaderNames.CORRELATION_ID)).isEqualTo("corr-123");
         assertThat(contextRef.get()).isNotNull();
-        assertThat(contextRef.get().get(HeaderNames.CORRELATION_ID)).isEqualTo("corr-123");
-        assertThat(contextRef.get().get(HeaderNames.X_TENANT_ID)).isEqualTo("tenant-1");
+        assertThat((String) contextRef.get().get(HeaderNames.CORRELATION_ID)).isEqualTo("corr-123");
+        assertThat((String) contextRef.get().get(HeaderNames.X_TENANT_ID)).isEqualTo("tenant-1");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- cast context lookups in `ReactiveRequestContextFilterTest` to String to disambiguate AssertJ overloads

## Testing
- mvn -pl . -am test *(fails: missing shared BOM and dependency versions in Maven configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5933bc90832fa77d6674e22d9e87