### PR TITLE
Fix resource server entry point configuration

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
@@ -216,7 +216,6 @@ public class SecurityAutoConfiguration {
         .oauth2ResourceServer(oauth -> oauth
             .authenticationEntryPoint(jsonEntryPoint)
             .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthConverter))
-            .authenticationEntryPoint(authEntryPoint)
         )
         .exceptionHandling(eh -> eh
             .authenticationEntryPoint(jsonEntryPoint)


### PR DESCRIPTION
## Summary
- remove the reference to the undefined `authEntryPoint` bean in the resource server configuration to restore compilation

## Testing
- `mvn -q -DskipTests compile` *(fails: missing internal dependencies `com.ejada:shared-bom:1.0.0` and related version-managed artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5b231188832fb322d5e29414d52f