### PR TITLE
Enable privileged Ryuk for shared test containers

### DIFF
--- a/shared-lib/shared-test-support/README.md
+++ b/shared-lib/shared-test-support/README.md
@@ -2,6 +2,12 @@
 
 Utilities for integration tests using Testcontainers.
 
+> **Note**
+> The library bundles a [`testcontainers.properties`](src/main/resources/testcontainers.properties)
+> file that enables privileged mode for Ryuk. This avoids connection errors on
+> Windows environments that expose Docker via named pipes (e.g. when the log
+> contains `Found Docker environment with local Npipe socket`).
+
 ## Features
 - `PostgresTestExtension`, `RedisTestExtension`, and `SetupSchemaExtension` for opt-in container and schema support.
 - Helpers for generating JWTs in tests.

--- a/shared-lib/shared-test-support/src/main/resources/testcontainers.properties
+++ b/shared-lib/shared-test-support/src/main/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+ryuk.container.privileged=true


### PR DESCRIPTION
## Summary
- add a shared testcontainers.properties that enables privileged Ryuk mode to avoid connection issues on Windows Docker setups
- document the bundled configuration in the shared-test-support README

## Testing
- mvn -f shared-lib/pom.xml -pl shared-test-support -am test

------
https://chatgpt.com/codex/tasks/task_e_68dc5bfeb5ac832fa16c6c9e0588e790