### PR TITLE
Add H2 test dependency to setup service

### DIFF
--- a/setup-service/pom.xml
+++ b/setup-service/pom.xml
@@ -141,6 +141,11 @@
       <artifactId>shared-test-support</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Summary
- add the H2 database dependency in test scope for the setup-service module so Spring Boot can load the test ApplicationContext

## Testing
- mvn -f setup-service/pom.xml verify *(fails: cannot resolve private com.ejada artifacts in the public Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5cf3d4f0832fb3389eaf9403b311