### PR TITLE
Fix lookup caching bypassing when called via service API

### DIFF
--- a/setup-service/src/test/java/com/ejada/setup/service/impl/LookupServiceImplTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/service/impl/LookupServiceImplTest.java
@@ -45,12 +45,17 @@ class LookupServiceImplTest {
   }
 
   @Test
-  void getAllRawCachesRepositoryResults() {
+  void getAllCachesRepositoryResults() {
     Lookup lookup = new Lookup();
+    lookup.setLookupItemId(1);
+    lookup.setLookupItemCd("CODE");
+    lookup.setLookupGroupCode("GROUP");
     when(lookupRepository.findAll()).thenReturn(List.of(lookup));
 
-    assertThat(service.getAllRaw()).containsExactly(lookup);
-    assertThat(service.getAllRaw()).containsExactly(lookup);
+    LookupResponse expected = new LookupResponse(1, "CODE", null, null, "GROUP", null, null, null, null);
+
+    assertThat(service.getAll().getData()).containsExactly(expected);
+    assertThat(service.getAll().getData()).containsExactly(expected);
 
     verify(lookupRepository, times(1)).findAll();
   }
@@ -68,11 +73,18 @@ class LookupServiceImplTest {
   @Test
   void getByGroupUsesCacheAndHandlesRepositoryExceptions() {
     Lookup lookup = new Lookup();
+    lookup.setLookupItemId(1);
+    lookup.setLookupItemCd("CODE");
+    lookup.setLookupGroupCode("GROUP");
     when(lookupRepository.findByLookupGroupCodeAndIsActiveTrueOrderByLookupItemEnNmAsc("GROUP"))
         .thenReturn(List.of(lookup));
 
-    assertThat(service.getByGroupRaw("GROUP")).containsExactly(lookup);
-    assertThat(service.getByGroupRaw("GROUP")).containsExactly(lookup);
+    LookupResponse expected = new LookupResponse(1, "CODE", null, null, "GROUP", null, null, null, null);
+
+    BaseResponse<List<LookupResponse>> first = service.getByGroup("GROUP");
+    BaseResponse<List<LookupResponse>> second = service.getByGroup("GROUP");
+    assertThat(first.getData()).containsExactly(expected);
+    assertThat(second.getData()).containsExactly(expected);
     verify(lookupRepository, times(1))
         .findByLookupGroupCodeAndIsActiveTrueOrderByLookupItemEnNmAsc("GROUP");
 


### PR DESCRIPTION
## Summary
- fetch lookup data through the cache manager so API calls reuse cached results
- guard cache fallback and reuse shared constants for cache names/keys
- extend lookup service tests to assert caching is effective through the public API

## Testing
- mvn -f setup-service/pom.xml test

------
https://chatgpt.com/codex/tasks/task_e_68dc5ccc0404832fa14210a9a9923d53