### PR TITLE
Register JavaTimeModule in SubscriptionApprovalConsumerTest

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerTest.java
@@ -18,6 +18,7 @@ import com.ejada.subscription.repository.SubscriptionAdditionalServiceRepository
 import com.ejada.subscription.repository.SubscriptionFeatureRepository;
 import com.ejada.subscription.repository.SubscriptionRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -39,7 +40,7 @@ class SubscriptionApprovalConsumerTest {
     @Mock private TenantProvisioningPublisher provisioningPublisher;
 
     private SubscriptionApprovalConsumer consumer;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## Summary
- register the Jackson JavaTimeModule in SubscriptionApprovalConsumerTest so OffsetDateTime values can be serialized during test setup

## Testing
- `mvn -pl subscription-service test` *(fails: missing internal BOM dependencies available in upstream environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc60466468832f9bdd1d1bfbc7606d