### PR TITLE
Fix LookupServiceCachingIT configuration

### DIFF
--- a/setup-service/src/test/java/com/ejada/setup/service/LookupServiceCachingIT.java
+++ b/setup-service/src/test/java/com/ejada/setup/service/LookupServiceCachingIT.java
@@ -13,6 +13,7 @@ import com.ejada.setup.dto.LookupResponse;
 import com.ejada.setup.model.Lookup;
 import com.ejada.setup.repository.LookupRepository;
 import com.ejada.setup.service.LookupService;
+import com.ejada.setup.service.impl.LookupServiceImpl;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- add the missing LookupServiceImpl import to the caching integration test configuration so the bean definition compiles

## Testing
- mvn -q -DskipTests package *(fails: unresolved parent/shared-bom and missing dependency versions in shared-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68dc63ddbdfc832f80001400e542b8ce