### PR TITLE
Fix subscription integration test configuration

### DIFF
--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -131,6 +131,11 @@
       <artifactId>spring-boot-testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -51,6 +51,7 @@ class SubscriptionApprovalConsumerIT {
         registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
         registry.add("spring.datasource.username", POSTGRES::getUsername);
         registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
         registry.add("spring.jpa.properties.hibernate.default_schema", () -> "subscription");
         registry.add("spring.flyway.enabled", () -> "true");

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -49,10 +50,15 @@ class SubscriptionOutboxPersistenceIT {
     }
 
     private MarketplaceCallbackOrchestrator orchestrator;
+
+    @Autowired
     private OutboxEventRepository outboxRepo;
 
+    @Autowired
+    private PlatformTransactionManager txManager;
+
     @BeforeEach
-    void setUp(OutboxEventRepository outboxRepo, PlatformTransactionManager txManager) {
+    void setUp() {
         orchestrator = new MarketplaceCallbackOrchestrator(
                 Mockito.mock(com.ejada.subscription.repository.SubscriptionRepository.class),
                 Mockito.mock(com.ejada.subscription.repository.SubscriptionFeatureRepository.class),
@@ -72,7 +78,6 @@ class SubscriptionOutboxPersistenceIT {
                 new ObjectMapper(),
                 txManager,
                 Mockito.mock(SubscriptionApprovalPublisher.class));
-        this.outboxRepo = outboxRepo;
         outboxRepo.deleteAll();
     }
 


### PR DESCRIPTION
## Summary
- add the H2 driver as a test dependency so the test profile can initialize its in-memory database
- ensure the Kafka integration test explicitly selects the PostgreSQL driver provided by Testcontainers
- autowire the repository and transaction manager in the outbox integration test to allow Spring to inject them properly

## Testing
- mvn -pl subscription-service -Dtest=SubscriptionOutboxPersistenceIT test *(fails: build cannot resolve internal BOM dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc63aaa230832fb141d14d384d950f