### PR TITLE
Add migration to ensure subscription outbox uses schema

### DIFF
--- a/tenant-platform/subscription-service/src/main/resources/db/migration/postgresql/V5__subscription_outbox_schema.sql
+++ b/tenant-platform/subscription-service/src/main/resources/db/migration/postgresql/V5__subscription_outbox_schema.sql
@@ -1,0 +1,28 @@
+create schema if not exists subscription;
+
+do $$
+begin
+    if exists (
+        select 1
+        from information_schema.tables
+        where table_schema = 'public'
+          and table_name = 'outbox_event'
+    ) then
+        execute 'alter table public.outbox_event set schema subscription';
+    end if;
+end $$;
+
+create table if not exists subscription.outbox_event (
+  id             bigserial primary key,
+  aggregate_type varchar(64) not null,
+  aggregate_id   varchar(128) not null,
+  event_type     varchar(64) not null,
+  payload        jsonb       not null,
+  headers        jsonb,
+  created_at     timestamptz not null default now(),
+  processed_at   timestamptz
+);
+
+create index if not exists idx_outbox_unprocessed
+  on subscription.outbox_event(aggregate_type, aggregate_id)
+  where processed_at is null;


### PR DESCRIPTION
## Summary
- add a Flyway migration that creates the subscription schema when missing
- move any existing public.outbox_event table into the subscription schema and ensure the table and index exist there

## Testing
- `mvn -P integration-tests verify -DskipITs=false` *(fails: requires internal com.ejada:shared-bom artifact that is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc656ccce4832f81a640a00f9ad164