### PR TITLE
Fix subscription approval listener configuration and integration test migrations

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumer.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumer.java
@@ -36,8 +36,8 @@ public class SubscriptionApprovalConsumer {
     private final TenantProvisioningPublisher provisioningPublisher;
 
     @KafkaListener(
-            topics = "#{@subscriptionApprovalProperties.topic}",
-            groupId = "#{@subscriptionApprovalProperties.consumerGroup}"
+            topics = "${app.subscription-approval.topic}",
+            groupId = "${app.subscription-approval.consumer-group}"
     )
     @Transactional(readOnly = true)
     public void onApproval(@Payload final Map<String, Object> payload) {

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
@@ -6,6 +6,7 @@ import com.ejada.subscription.acl.MarketplaceCallbackOrchestrator;
 import com.ejada.subscription.kafka.SubscriptionApprovalPublisher;
 import com.ejada.subscription.repository.OutboxEventRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.flywaydb.core.Flyway;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -47,6 +48,7 @@ class SubscriptionOutboxPersistenceIT {
         registry.add("spring.flyway.locations", () -> "classpath:db/migration/postgresql");
         registry.add("spring.flyway.schemas", () -> "subscription");
         registry.add("spring.flyway.default-schema", () -> "subscription");
+        registry.add("spring.flyway.clean-disabled", () -> "false");
     }
 
     private MarketplaceCallbackOrchestrator orchestrator;
@@ -57,8 +59,13 @@ class SubscriptionOutboxPersistenceIT {
     @Autowired
     private PlatformTransactionManager txManager;
 
+    @Autowired
+    private Flyway flyway;
+
     @BeforeEach
     void setUp() {
+        flyway.clean();
+        flyway.migrate();
         orchestrator = new MarketplaceCallbackOrchestrator(
                 Mockito.mock(com.ejada.subscription.repository.SubscriptionRepository.class),
                 Mockito.mock(com.ejada.subscription.repository.SubscriptionFeatureRepository.class),

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/kafka/SubscriptionApprovalListener.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/kafka/SubscriptionApprovalListener.java
@@ -26,8 +26,8 @@ public class SubscriptionApprovalListener {
     private final ObjectMapper objectMapper;
     private final TenantService tenantService;
     @KafkaListener(
-            topics = "#{@subscriptionApprovalProperties.topic}",
-            groupId = "#{@subscriptionApprovalProperties.consumerGroup}",
+            topics = "${app.subscription-approval.topic}",
+            groupId = "${app.subscription-approval.consumer-group}",
             containerFactory = "subscriptionApprovalListenerContainerFactory"
     )
     public void onMessage(@Payload final Map<String, Object> payload, Acknowledgment acknowledgment) {


### PR DESCRIPTION
## Summary
- replace SpEL bean references in subscription approval Kafka listeners with property placeholders
- reset Flyway schema in the subscription outbox integration test to ensure migrations create the outbox table

## Testing
- `mvn -q verify` *(fails: repository depends on private shared-bom that is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdda8563c832f8adce5867796ec7a