### PR TITLE
Fix subscription IT JWT secret length

### DIFF
--- a/tenant-platform/subscription-service/src/test/resources/application-test.yml
+++ b/tenant-platform/subscription-service/src/test/resources/application-test.yml
@@ -52,5 +52,5 @@ shared:
   security:
     enable-role-check: false
     jwt:
-      secret: 0123456789ABCDEF0123456789ABCDEF
+      secret: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMQ==
       token-period: 5m


### PR DESCRIPTION
## Summary
- update the subscription-service test profile to use a base64-encoded JWT secret that meets JwtTokenService requirements

## Testing
- `mvn -pl subscription-service failsafe:integration-test -DskipUTs` *(fails: missing internal com.ejada artifacts in the local Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dce2b2fd64832f8085f92e02278f5f