### PR TITLE
Fix subscription-service tests by aligning security and Flyway config

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -30,7 +30,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(FlywayAutoConfiguration.class)
+@ImportAutoConfiguration(FlywayAutoConfiguration.class)
 class SubscriptionOutboxPersistenceIT {
 
     @Container

--- a/tenant-platform/subscription-service/src/test/resources/application-test.yml
+++ b/tenant-platform/subscription-service/src/test/resources/application-test.yml
@@ -51,6 +51,6 @@ logging:
 shared:
   security:
     enable-role-check: false
-    jwt:
+    mode: hs256
+    hs256:
       secret: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMQ==
-      token-period: 5m


### PR DESCRIPTION
## Summary
- update the test Spring profile to provide the hs256 shared security secret required by the starter security auto-configuration
- ensure the outbox persistence slice test imports Flyway via ImportAutoConfiguration so the Flyway bean is created during the test

## Testing
- mvn -P integration-tests verify *(fails: missing private dependencies from shared BOM in Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dce4302b9c832fb0d72e341c9b0321