### PR TITLE
Add API gateway health check to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -278,5 +278,8 @@ services:
       SHARED_SECURITY_RESOURCE_SERVER_ENABLED: "false"
     ports:
       - "8088:8080"
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/actuator/health || exit 1"]
     networks:
       backend:


### PR DESCRIPTION
## Summary
- add an application health check to the api-gateway service so docker-compose can monitor it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf0a7d678832f913471c4203aac8f