### PR TITLE
Fix subscription service test config and JSON mapping

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/OutboxEvent.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/OutboxEvent.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 
@@ -42,9 +44,11 @@ public class OutboxEvent {
     @Column(name = "event_type", length = 64, nullable = false)
     private String eventType;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
     private String payload;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "headers", columnDefinition = "jsonb")
     private String headers;
 

--- a/tenant-platform/subscription-service/src/test/resources/application-test.yml
+++ b/tenant-platform/subscription-service/src/test/resources/application-test.yml
@@ -51,6 +51,6 @@ logging:
 shared:
   security:
     enable-role-check: false
-    mode: hs256
-    hs256:
+    jwt:
       secret: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMQ==
+      token-period: 5m


### PR DESCRIPTION
## Summary
- map the subscription outbox event JSON columns with `SqlTypes.JSON` so Postgres jsonb inserts succeed
- align the subscription service test profile with the new `shared.security.jwt` structure and provide a token period

## Testing
- mvn -f tenant-platform/pom.xml -pl subscription-service -am verify -Pskip-its

------
https://chatgpt.com/codex/tasks/task_e_68dcf0540664832fa61de2e6aacff34c