### PR TITLE
Provide HS256 secret for subscription tests

### DIFF
--- a/tenant-platform/subscription-service/src/test/resources/application-test.yml
+++ b/tenant-platform/subscription-service/src/test/resources/application-test.yml
@@ -51,6 +51,8 @@ logging:
 shared:
   security:
     enable-role-check: false
+    hs256:
+      secret: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMQ==
     jwt:
       secret: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMQ==
       token-period: 5m


### PR DESCRIPTION
## Summary
- add the shared.security.hs256.secret configuration to the subscription service test profile so JwtDecoderAutoConfiguration can create a decoder during integration tests

## Testing
- not run (building the full shared-lib aggregator locally is required before module tests can execute)


------
https://chatgpt.com/codex/tasks/task_e_68dcf311820c832fb063416701fa9465