### PR TITLE
Configure Kafka serializers for approval consumer IT

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -62,6 +62,21 @@ class SubscriptionApprovalConsumerIT {
         registry.add("spring.flyway.default-schema", () -> "subscription");
         registry.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
         registry.add("spring.kafka.consumer.auto-offset-reset", () -> "earliest");
+        registry.add(
+                "spring.kafka.producer.value-serializer",
+                () -> "org.springframework.kafka.support.serializer.JsonSerializer");
+        registry.add(
+                "spring.kafka.producer.properties.spring.json.add.type.headers",
+                () -> "false");
+        registry.add(
+                "spring.kafka.consumer.value-deserializer",
+                () -> "org.springframework.kafka.support.serializer.JsonDeserializer");
+        registry.add(
+                "spring.kafka.consumer.properties.spring.json.trusted.packages",
+                () -> "*");
+        registry.add(
+                "spring.kafka.consumer.properties.spring.json.value.default.type",
+                () -> "java.util.LinkedHashMap");
         registry.add("app.subscription-approval.topic", () -> APPROVAL_TOPIC);
         registry.add("app.subscription-approval.consumer-group", () -> CONSUMER_GROUP);
     }


### PR DESCRIPTION
## Summary
- configure the SubscriptionApprovalConsumerIT dynamic properties to use JSON serializers for both the Kafka producer and consumer
- prevent ClassCastException when sending SubscriptionApprovalMessage payloads during the approval provisioning integration test

## Testing
- mvn -pl subscription-service -am -DskipITs test *(fails: missing private dependencies such as com.ejada:shared-bom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf579a9fc832f864eabcdf1289c30