### PR TITLE
Fix consumption controller test import

### DIFF
--- a/tenant-platform/billing-service/src/test/java/com/ejada/billing/controller/ConsumptionControllerTest.java
+++ b/tenant-platform/billing-service/src/test/java/com/ejada/billing/controller/ConsumptionControllerTest.java
@@ -12,7 +12,7 @@ import com.ejada.billing.dto.ProductConsumption;
 import com.ejada.billing.dto.ProductSubscription;
 import com.ejada.billing.dto.TrackProductConsumptionRq;
 import com.ejada.billing.dto.TrackProductConsumptionRs;
-import com.ejada.billing.exception.ServiceResultException;
+import com.ejada.common.exception.ServiceResultException;
 import com.ejada.billing.service.ConsumptionService;
 import com.ejada.common.dto.ServiceResult;
 import java.util.List;


### PR DESCRIPTION
## Summary
- update the consumption controller unit test to import the shared ServiceResultException

## Testing
- mvn -q -DskipTests compile *(fails: missing internal BOM artifacts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf7ad3dc0832f88fd56cbd78f146d