### PR TITLE
Remove deprecated circuit breaker status setter

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
@@ -58,10 +58,6 @@ public class GatewayRoutesConfiguration {
                 filters.circuitBreaker(config -> {
                   config.setName(resilience.resolvedCircuitBreakerName(route.getId()));
                   config.setFallbackUri(resilience.resolvedFallbackUri(route.getId()));
-                  HttpStatus fallbackStatus = resilience.getFallbackStatus();
-                  if (fallbackStatus != null) {
-                    config.setStatusCode(fallbackStatus);
-                  }
                 });
 
                 GatewayRoutesProperties.ServiceRoute.Resilience.Retry retry = resilience.getRetry();


### PR DESCRIPTION
## Summary
- drop usage of Spring Cloud Gateway circuit breaker `setStatusCode` API removed in 2024.0.x
- rely on existing fallback handling without setting the deprecated status property

## Testing
- `mvn clean compile` *(fails: missing internal dependencies such as com.ejada:shared-bom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dcfa1f13b4832fa6fa8eb81bac8df7