### PR TITLE
Update Mockito bean usage and clean up tests

### DIFF
--- a/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
@@ -73,6 +73,8 @@ class ReactiveRateLimiterFilterTest {
     }
 
     private void flushRedis() {
-        connectionFactory.getReactiveConnection().serverCommands().flushAll().block();
+        try (var connection = connectionFactory.getReactiveConnection()) {
+            connection.serverCommands().flushAll().block();
+        }
     }
 }

--- a/sec-service/src/test/java/com/ejada/sec/controller/AuthControllerTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/controller/AuthControllerTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -34,10 +34,10 @@ class AuthControllerTest {
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
 
-    @MockBean AuthService authService;
-    @MockBean SuperadminService superadminService;
-    @MockBean PasswordResetService passwordResetService;
-    @MockBean JpaMetamodelMappingContext jpaMappingContext;
+    @MockitoBean AuthService authService;
+    @MockitoBean SuperadminService superadminService;
+    @MockitoBean PasswordResetService passwordResetService;
+    @MockitoBean JpaMetamodelMappingContext jpaMappingContext;
 
     @BeforeEach
     void resetMocks() {

--- a/sec-service/src/test/java/com/ejada/sec/security/RoleControllerSecurityTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/security/RoleControllerSecurityTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
@@ -47,10 +47,10 @@ class RoleControllerSecurityTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private RoleService roleService;
 
-    @MockBean
+    @MockitoBean
     private JpaMetamodelMappingContext jpaMappingContext;
 
     @BeforeEach

--- a/sec-service/src/test/java/com/ejada/sec/security/SuperadminControllerSecurityTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/security/SuperadminControllerSecurityTest.java
@@ -6,7 +6,7 @@ import com.ejada.starter_security.SecurityAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.context.TestPropertySource;
@@ -27,16 +27,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "shared.security.resource-server.permit-all[0]=/actuator/health"
 })
 class SuperadminControllerSecurityTest {
-
-    private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
-
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private SuperadminService superadminService;
 
-    @MockBean
+    @MockitoBean
     private JpaMetamodelMappingContext jpaMappingContext;
 
     @Test

--- a/sec-service/src/test/java/com/ejada/sec/security/UserControllerSecurityTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/security/UserControllerSecurityTest.java
@@ -6,7 +6,7 @@ import com.ejada.starter_security.SecurityAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.context.TestPropertySource;
@@ -27,16 +27,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "shared.security.resource-server.permit-all[0]=/actuator/health"
 })
 class UserControllerSecurityTest {
-
-    private static final String SECRET = "0123456789ABCDEF0123456789ABCDEF";
-
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private UserService userService;
 
-    @MockBean
+    @MockitoBean
     private JpaMetamodelMappingContext jpaMappingContext;
 
     @Test

--- a/setup-service/src/main/java/com/ejada/setup/controller/SystemParameterController.java
+++ b/setup-service/src/main/java/com/ejada/setup/controller/SystemParameterController.java
@@ -6,7 +6,6 @@ import com.ejada.common.dto.BaseResponse;
 import com.ejada.setup.dto.SystemParameterRequest;
 import com.ejada.setup.dto.SystemParameterResponse;
 
-import com.ejada.setup.model.SystemParameter;
 import com.ejada.setup.security.SetupAuthorized;
 import com.ejada.setup.service.SystemParameterService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/security/CountryControllerSecurityTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
@@ -45,7 +45,7 @@ class CountryControllerSecurityTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private CountryService countryService;
 
     @BeforeEach

--- a/setup-service/src/test/java/com/ejada/setup/security/SystemParameterControllerSecurityTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/security/SystemParameterControllerSecurityTest.java
@@ -6,7 +6,7 @@ import com.ejada.starter_security.SecurityAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -33,7 +33,7 @@ class SystemParameterControllerSecurityTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private SystemParameterService systemParameterService;
 
     @Test

--- a/setup-service/src/test/java/com/ejada/setup/service/LookupServiceCachingIT.java
+++ b/setup-service/src/test/java/com/ejada/setup/service/LookupServiceCachingIT.java
@@ -12,7 +12,6 @@ import com.ejada.common.dto.BaseResponse;
 import com.ejada.setup.dto.LookupResponse;
 import com.ejada.setup.model.Lookup;
 import com.ejada.setup.repository.LookupRepository;
-import com.ejada.setup.service.LookupService;
 import com.ejada.setup.service.impl.LookupServiceImpl;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -19,16 +19,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.kafka.KafkaContainer;
 
 @SpringBootTest(classes = SubscriptionApplication.class)
 @Testcontainers
@@ -84,7 +84,7 @@ class SubscriptionApprovalConsumerIT {
     @Autowired
     private KafkaTemplate<String, Object> kafkaTemplate;
 
-    @MockBean
+    @MockitoBean
     private TenantProvisioningPublisher provisioningPublisher;
 
     @Test

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/kafka/SubscriptionApprovalListenerTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/kafka/SubscriptionApprovalListenerTest.java
@@ -15,6 +15,7 @@ import com.ejada.tenant.dto.TenantCreateReq;
 import com.ejada.tenant.exception.TenantConflictException;
 import com.ejada.tenant.exception.TenantErrorCode;
 import com.ejada.tenant.service.TenantService;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -163,6 +164,6 @@ class SubscriptionApprovalListenerTest {
     }
 
     private Map<String, Object> toPayload(final SubscriptionApprovalMessage message) {
-        return objectMapper.convertValue(message, Map.class);
+        return objectMapper.convertValue(message, new TypeReference<Map<String, Object>>() {});
     }
 }

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantControllerSecurityTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantControllerSecurityTest.java
@@ -6,7 +6,7 @@ import com.ejada.tenant.service.TenantService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -33,7 +33,7 @@ class TenantControllerSecurityTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private TenantService tenantService;
 
     @Test


### PR DESCRIPTION
## Summary
- replace deprecated `@MockBean` usage with Spring's new `@MockitoBean` across controller security tests and Kafka integration test
- update Kafka Testcontainers usage and fix miscellaneous warnings (resource leak, unchecked map conversion, unused imports/constants)
- close Redis test connection to avoid resource leak warnings in the rate limiter test

## Testing
- `mvn -f api-gateway/pom.xml test -DskipITs` *(fails: Testcontainers requires Docker in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf9282820832fb6da58ce34694eb8