### PR TITLE
Ensure API gateway routes align with downstream services

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
@@ -54,6 +54,9 @@ public class GatewayRoutesConfiguration {
               if (route.getStripPrefix() > 0) {
                 filters.stripPrefix(route.getStripPrefix());
               }
+              if (StringUtils.hasText(route.getPrefixPath())) {
+                filters.prefixPath(route.getPrefixPath());
+              }
               if (resilience.isEnabled()) {
                 filters.circuitBreaker(config -> {
                   config.setName(resilience.resolvedCircuitBreakerName(route.getId()));
@@ -102,20 +105,23 @@ public class GatewayRoutesConfiguration {
 
       if (LOGGER.isInfoEnabled()) {
         String resilienceSummary = resilience.isEnabled() ? resilience.toString() : "Resilience{enabled=false}";
+        String prefixSummary = StringUtils.hasText(route.getPrefixPath()) ? route.getPrefixPath() : "/";
         if (route.getMethods().isEmpty()) {
           LOGGER.info(
-              "Registered route {} -> {} ({}) resilience={}",
+              "Registered route {} -> {} ({} prefix={}) resilience={}",
               route.getId(),
               route.getUri(),
               route.getPaths(),
+              prefixSummary,
               resilienceSummary);
         } else {
           LOGGER.info(
-              "Registered route {} -> {} ({}, methods={}) resilience={}",
+              "Registered route {} -> {} ({}, methods={}, prefix={}) resilience={}",
               route.getId(),
               route.getUri(),
               route.getPaths(),
               route.getMethods(),
+              prefixSummary,
               resilienceSummary);
         }
       }

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -13,6 +13,20 @@ spring:
       httpclient:
         connect-timeout: 5000
         response-timeout: 10s
+    discovery:
+      client:
+        simple:
+          instances:
+            setup-service:
+              - uri: http://setup-service:8080
+            tenant-service:
+              - uri: http://tenant-service:8080
+            catalog-service:
+              - uri: http://catalog-service:8080
+            subscription-service:
+              - uri: http://subscription-service:8080
+            billing-service:
+              - uri: http://billing-service:8080
 management:
   endpoints:
     web:
@@ -55,6 +69,7 @@ gateway:
       paths:
         - /api/setup/**
       strip-prefix: 1
+      prefix-path: /core
       resilience:
         enabled: true
         fallback-uri: forward:/fallback/setup-service
@@ -99,6 +114,7 @@ gateway:
       paths:
         - /api/subscription/**
       strip-prefix: 1
+      prefix-path: /subscription
       resilience:
         enabled: true
         fallback-uri: forward:/fallback/subscription-service


### PR DESCRIPTION
## Summary
- add optional prefixPath support to gateway route properties and apply it when registering filters so downstream context paths are honoured
- configure a static discovery client map and per-route prefixes to align gateway forwarding with service container addresses

## Testing
- `mvn test` *(fails: missing shared-bom and managed dependency versions in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcfb2f9a98832f962b26c262a61e14