### PR TITLE
Fix Flyway plugin version resolution in QA profile

### DIFF
--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -50,6 +50,7 @@
     <jacoco.coverage.minimum>0.00</jacoco.coverage.minimum>
                 <!-- if any module uses Boot plugin -->
     <spring.boot.version>3.5.5</spring.boot.version>
+    <flyway.version>11.8.2</flyway.version>
     <mockito.inline.version>5.2.0</mockito.inline.version>
     <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
   </properties>


### PR DESCRIPTION
## Summary
- define the Flyway Maven plugin version in the shared parent POM so QA migrations can resolve the property

## Testing
- mvn -Pqa -DskipTests help:evaluate -Dexpression=flyway.version -DforceStdout *(fails: internal shared-bom artifact is not published to Maven Central in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcff0ddc3c832fa364f07f36f7189f