### PR TITLE
Fix lambda capture in gateway retry configuration

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
@@ -504,12 +504,13 @@ public class GatewayRoutesProperties {
           if (classLoader == null) {
             classLoader = Retry.class.getClassLoader();
           }
+          final ClassLoader classLoaderToUse = classLoader;
           java.util.List<Class<? extends Throwable>> resolved = exceptions.stream()
               .filter(StringUtils::hasText)
               .map(String::trim)
               .map(name -> {
                 try {
-                  return (Class<? extends Throwable>) ClassUtils.resolveClassName(name, classLoader);
+                  return (Class<? extends Throwable>) ClassUtils.resolveClassName(name, classLoaderToUse);
                 } catch (IllegalArgumentException ex) {
                   throw new IllegalStateException("Unable to resolve exception class '" + name + "'", ex);
                 }


### PR DESCRIPTION
## Summary
- ensure the retry exception resolution lambda uses an effectively final class loader reference to satisfy the compiler

## Testing
- `mvn -q -DskipTests compile` *(fails: missing internal BOM and dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68dd05761a20832f81b3fde1d2b30874