### PR TITLE
Fix Kafka Testcontainer compatibility for integration test

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -42,9 +42,12 @@ class SubscriptionApprovalConsumerIT {
     static final PostgreSQLContainer<?> POSTGRES =
             new PostgreSQLContainer<>(DockerImageName.parse("postgres:15-alpine"));
 
+    private static final DockerImageName KAFKA_IMAGE =
+            DockerImageName.parse("confluentinc/cp-kafka:7.5.3")
+                    .asCompatibleSubstituteFor("apache/kafka");
+
     @Container
-    static final KafkaContainer KAFKA =
-            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3"));
+    static final KafkaContainer KAFKA = new KafkaContainer(KAFKA_IMAGE);
 
     @DynamicPropertySource
     static void registerProperties(DynamicPropertyRegistry registry) {


### PR DESCRIPTION
## Summary
- mark the Confluent Kafka Testcontainer image as a compatible substitute for the Apache Kafka image expected by Testcontainers
- reuse the configured Docker image when constructing the KafkaContainer in SubscriptionApprovalConsumerIT

## Testing
- mvn -f tenant-platform/pom.xml -pl subscription-service -am verify *(fails: requires Docker daemon in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd05440874832fad96d0e7872cee8f