### PR TITLE
Skip Kafka integration test unless enabled

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -16,14 +16,15 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -32,6 +33,7 @@ import org.testcontainers.kafka.KafkaContainer;
 
 @SpringBootTest(classes = SubscriptionApplication.class)
 @Testcontainers
+@EnabledIfEnvironmentVariable(named = "RUN_KAFKA_IT", matches = "true")
 @ActiveProfiles("test")
 class SubscriptionApprovalConsumerIT {
 


### PR DESCRIPTION
## Summary
- gate the Kafka Testcontainers-based integration test behind the RUN_KAFKA_IT environment variable so it is skipped by default

## Testing
- mvn -f tenant-platform/pom.xml -pl subscription-service -am verify *(fails: repository com.ejada:shared-bom unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd07ae4e80832f97c88febd595cdf9