### PR TITLE
Fix TenantAccessPolicy role prefix handling

### DIFF
--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantAccessPolicyTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantAccessPolicyTest.java
@@ -2,24 +2,32 @@ package com.ejada.tenant.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.ejada.starter_security.SharedSecurityProps;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 
 class TenantAccessPolicyTest {
 
+    private final SharedSecurityProps props = new SharedSecurityProps();
+
+    private TenantAccessPolicy createPolicy(final String roles) {
+        return new TenantAccessPolicy(roles, props);
+    }
+
     @Test
     void allowsConfiguredRole() {
-        TenantAccessPolicy policy = new TenantAccessPolicy("ROLE_ADMIN, EJADA_OFFICER");
-        TestingAuthenticationToken auth = new TestingAuthenticationToken("user", "pwd", "EJADA_OFFICER");
+        TenantAccessPolicy policy = createPolicy("ROLE_ADMIN, EJADA_OFFICER");
+        TestingAuthenticationToken auth = new TestingAuthenticationToken("user", "pwd", "ROLE_EJADA_OFFICER");
         auth.setAuthenticated(true);
 
+        assertThat(policy.getAllowedRoles()).contains("ROLE_EJADA_OFFICER");
         assertThat(policy.isAllowed(auth)).isTrue();
     }
 
     @Test
     void deniesWhenNotConfigured() {
-        TenantAccessPolicy policy = new TenantAccessPolicy("ROLE_ADMIN");
+        TenantAccessPolicy policy = createPolicy("ROLE_ADMIN");
         TestingAuthenticationToken auth = new TestingAuthenticationToken("user", "pwd", Collections.emptyList());
         auth.setAuthenticated(true);
 
@@ -28,15 +36,15 @@ class TenantAccessPolicyTest {
 
     @Test
     void deniesForAnonymous() {
-        TenantAccessPolicy policy = new TenantAccessPolicy("ROLE_ADMIN");
+        TenantAccessPolicy policy = createPolicy("ROLE_ADMIN");
 
         assertThat(policy.isAllowed(null)).isFalse();
     }
 
     @Test
     void trimsAndIgnoresBlankConfiguration() {
-        TenantAccessPolicy policy = new TenantAccessPolicy("   ");
-        TestingAuthenticationToken auth = new TestingAuthenticationToken("user", "pwd", "EJADA_OFFICER");
+        TenantAccessPolicy policy = createPolicy("   ");
+        TestingAuthenticationToken auth = new TestingAuthenticationToken("user", "pwd", "ROLE_EJADA_OFFICER");
         auth.setAuthenticated(true);
 
         assertThat(policy.getAllowedRoles()).isEmpty();
@@ -45,8 +53,8 @@ class TenantAccessPolicyTest {
 
     @Test
     void nullConfigurationDisablesAccess() {
-        TenantAccessPolicy policy = new TenantAccessPolicy(null);
-        TestingAuthenticationToken auth = new TestingAuthenticationToken("user", "pwd", "EJADA_OFFICER");
+        TenantAccessPolicy policy = createPolicy(null);
+        TestingAuthenticationToken auth = new TestingAuthenticationToken("user", "pwd", "ROLE_EJADA_OFFICER");
         auth.setAuthenticated(true);
 
         assertThat(policy.getAllowedRoles()).isEmpty();


### PR DESCRIPTION
## Summary
- ensure TenantAccessPolicy uses the shared security role prefix and defaults to prefixed roles
- normalize configured roles and extend tests to validate prefixed authorities

## Testing
- mvn -pl tenant-service test -Dtest=TenantAccessPolicyTest *(fails: missing internal shared-bom dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd07a30e3c832f8bf668f854e9f3b1