### PR TITLE
Fix tenant update uniqueness checks to ignore soft-deleted tenants

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
@@ -29,8 +29,12 @@ public interface TenantRepository extends JpaRepository<Tenant, Integer> {
     boolean existsByNameIgnoreCase(String name);
 
     boolean existsByNameIgnoreCaseAndIdNot(String name, Integer id);
-    
+
     boolean existsByCodeAndIsDeletedFalse(String code);
 
     boolean existsByNameIgnoreCaseAndIsDeletedFalse(String name);
+
+    boolean existsByCodeAndIsDeletedFalseAndIdNot(String code, Integer id);
+
+    boolean existsByNameIgnoreCaseAndIsDeletedFalseAndIdNot(String name, Integer id);
 }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantServiceImpl.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantServiceImpl.java
@@ -49,11 +49,11 @@ public class TenantServiceImpl implements TenantService {
                 .orElseThrow(() -> new EntityNotFoundException("Tenant " + id));
 
         if (req.code() != null && !req.code().equals(e.getCode())
-                && repo.existsByCodeAndIdNot(req.code(), id)) {
+                && repo.existsByCodeAndIsDeletedFalseAndIdNot(req.code(), id)) {
             throw new TenantConflictException(TenantErrorCode.CODE_EXISTS, "tenant code exists: " + req.code());
         }
         if (req.name() != null && !req.name().equalsIgnoreCase(e.getName())
-                && repo.existsByNameIgnoreCaseAndIdNot(req.name(), id)) {
+                && repo.existsByNameIgnoreCaseAndIsDeletedFalseAndIdNot(req.name(), id)) {
             throw new TenantConflictException(TenantErrorCode.NAME_EXISTS, "tenant name exists: " + req.name());
         }
 

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/impl/TenantServiceImplTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/impl/TenantServiceImplTest.java
@@ -62,7 +62,7 @@ class TenantServiceImplTest {
     existing.setId(5);
     existing.setCode("OLD");
     when(repository.findByIdAndIsDeletedFalse(5)).thenReturn(Optional.of(existing));
-    when(repository.existsByCodeAndIdNot("NEW", 5)).thenReturn(true);
+    when(repository.existsByCodeAndIsDeletedFalseAndIdNot("NEW", 5)).thenReturn(true);
 
     TenantUpdateReq req = new TenantUpdateReq("NEW", null, null, null, null, null);
 
@@ -77,7 +77,7 @@ class TenantServiceImplTest {
     existing.setId(7);
     existing.setName("Current");
     when(repository.findByIdAndIsDeletedFalse(7)).thenReturn(Optional.of(existing));
-    when(repository.existsByNameIgnoreCaseAndIdNot("NewName", 7)).thenReturn(true);
+    when(repository.existsByNameIgnoreCaseAndIsDeletedFalseAndIdNot("NewName", 7)).thenReturn(true);
 
     TenantUpdateReq req = new TenantUpdateReq(null, "NewName", null, null, null, null);
 


### PR DESCRIPTION
## Summary
- ensure tenant update uniqueness checks only consider active tenants
- add repository methods that exclude soft-deleted tenants during uniqueness checks
- update service tests to reflect the new repository methods

## Testing
- mvn -f tenant-platform/tenant-service/pom.xml test *(fails: missing internal BOM artifact and dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68dd089e761c832f843e55c8dc364186