### PR TITLE
Fix tenant access policy prefix and Kafka listener resilience

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
@@ -2,12 +2,11 @@ package com.ejada.tenant.repository;
 
 
 import com.ejada.tenant.model.Tenant;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface TenantRepository extends JpaRepository<Tenant, Integer> {
@@ -21,14 +20,6 @@ public interface TenantRepository extends JpaRepository<Tenant, Integer> {
     Page<Tenant> findByNameContainingIgnoreCaseAndIsDeletedFalse(String name, Pageable pageable);
 
     Page<Tenant> findByNameContainingIgnoreCaseAndActiveAndIsDeletedFalse(String name, boolean active, Pageable pageable);
-
-    boolean existsByCode(String code);
-
-    boolean existsByCodeAndIdNot(String code, Integer id);
-
-    boolean existsByNameIgnoreCase(String name);
-
-    boolean existsByNameIgnoreCaseAndIdNot(String name, Integer id);
 
     boolean existsByCodeAndIsDeletedFalse(String code);
 

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/impl/TenantServiceImplTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/impl/TenantServiceImplTest.java
@@ -57,6 +57,25 @@ class TenantServiceImplTest {
   }
 
   @Test
+  void createSucceedsWhenNoActiveDuplicates() {
+    TenantCreateReq req = new TenantCreateReq("CODE", "Tenant", null, null, null, true);
+    when(repository.existsByCodeAndIsDeletedFalse("CODE")).thenReturn(false);
+    when(repository.existsByNameIgnoreCaseAndIsDeletedFalse("Tenant")).thenReturn(false);
+
+    Tenant entity = new Tenant();
+    when(mapper.toEntity(req)).thenReturn(entity);
+    when(repository.save(entity)).thenReturn(entity);
+    TenantRes mapped =
+        new TenantRes(1, "CODE", "Tenant", null, null, null, true, false, null, null);
+    when(mapper.toRes(entity)).thenReturn(mapped);
+
+    BaseResponse<TenantRes> response = service.create(req);
+
+    assertThat(response.isSuccess()).isTrue();
+    assertThat(response.getData()).isEqualTo(mapped);
+  }
+
+  @Test
   void updateRejectsDuplicateCodeForDifferentTenant() {
     Tenant existing = new Tenant();
     existing.setId(5);


### PR DESCRIPTION
## Summary
- normalize allowed tenant roles using the configured prefix (including empty prefixes) and cover real JWT authorities in tests
- rely on the configured Kafka error handler for retry/dead-letter handling and exercise the listener for unexpected failures
- streamline tenant repository uniqueness helpers and add a regression test ensuring soft-delete aware creation succeeds

## Testing
- mvn test *(fails: project depends on internal shared-bom and explicit dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0d8cde9c832fbd333f09bed562b5