### PR TITLE
Consolidate security expressions and add integration coverage

### DIFF
--- a/api-gateway/src/test/java/com/ejada/gateway/config/GatewayRoutesIntegrationTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/config/GatewayRoutesIntegrationTest.java
@@ -1,0 +1,74 @@
+package com.ejada.gateway.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "shared.ratelimit.enabled=false"
+    }
+)
+@TestPropertySource(properties = {
+    "gateway.routes.test.id=test-service",
+    "gateway.routes.test.uri=http://localhost:65535",
+    "gateway.routes.test.paths[0]=/api/test/**",
+    "gateway.routes.test.resilience.enabled=true",
+    "gateway.routes.test.resilience.fallback-status=BAD_GATEWAY",
+    "gateway.routes.test.resilience.fallback-message=Custom outage message"
+})
+class GatewayRoutesIntegrationTest {
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @Autowired
+  private RouteLocator routeLocator;
+
+  @Test
+  void fallbackEndpointHonoursConfiguredStatusAndMessage() {
+    webTestClient
+        .post()
+        .uri("/fallback/test-service")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.BAD_GATEWAY)
+        .expectBody()
+        .jsonPath("$.routeId")
+        .isEqualTo("test-service")
+        .jsonPath("$.message")
+        .isEqualTo("Custom outage message");
+  }
+
+  @Test
+  void routeLocatorRegistersConfiguredRoute() {
+    assertThat(routeLocator.getRoutes().collectList().block(Duration.ofSeconds(5)))
+        .anySatisfy(route -> {
+          assertThat(route.getId()).isEqualTo("test-service");
+          assertThat(route.getUri().toString()).isEqualTo("http://localhost:65535");
+        });
+  }
+
+  @TestConfiguration
+  static class AllowAllSecurityConfig {
+
+    @Bean
+    SecurityWebFilterChain testSecurityWebFilterChain(ServerHttpSecurity http) {
+      return http.authorizeExchange(exchanges -> exchanges.anyExchange().permitAll())
+          .csrf(ServerHttpSecurity.CsrfSpec::disable)
+          .build();
+    }
+  }
+}

--- a/setup-service/src/main/resources/application-dev.yaml
+++ b/setup-service/src/main/resources/application-dev.yaml
@@ -1,6 +1,21 @@
 spring:
   config:
-    import: optional:classpath:application-shared-platform-dev.yaml
+    import:
+      - optional:classpath:application-shared-platform-dev.yaml
+      - optional:vault://secret/data/setup-service
+      - optional:aws-secretsmanager:setup-service/config
+  cloud:
+    vault:
+      enabled: ${VAULT_ENABLED:false}
+      uri: ${VAULT_URI:}
+      authentication: ${VAULT_AUTH_METHOD:token}
+      token: ${VAULT_TOKEN:}
+      kv:
+        enabled: true
+        application-name: setup-service
+    aws:
+      secretsmanager:
+        enabled: ${AWS_SECRETS_MANAGER_ENABLED:false}
   datasource:
     url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:lms}?currentSchema=setup}"
     username: ${DB_USERNAME:postgres}
@@ -173,10 +188,18 @@ shared:
     reactive: false
   crypto:
     algorithm: AES_GCM
+    key-provider: ${CRYPTO_KEY_PROVIDER:in-memory}
     in-memory:
       activeKid: ${CRYPTO_ACTIVE_KID:local-dev-key}
       keys:
-        local-dev-key: ${CRYPTO_LOCAL_DEV_KEY:4J8bfqUaEqzJCQakoJPM3w==}
+        ${CRYPTO_ACTIVE_KID:local-dev-key}: ${CRYPTO_LOCAL_DEV_KEY:?set CRYPTO_LOCAL_DEV_KEY via Vault or Secrets Manager}
+    vault:
+      endpoint: ${VAULT_URI:}
+      transitPath: ${VAULT_TRANSIT_PATH:transit}
+      keyName: ${VAULT_CRYPTO_KEY_NAME:}
+    aws-kms:
+      region: ${AWS_KMS_REGION:}
+      key-id: ${AWS_KMS_KEY_ID:}
 
 logging:
   level:

--- a/setup-service/src/test/java/com/ejada/setup/controller/SystemParameterControllerIntegrationTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/controller/SystemParameterControllerIntegrationTest.java
@@ -1,0 +1,161 @@
+package com.ejada.setup.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ejada.common.constants.ErrorCodes;
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.setup.dto.SystemParameterRequest;
+import com.ejada.setup.dto.SystemParameterResponse;
+import com.ejada.setup.service.SystemParameterService;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.JpaRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(classes = SystemParameterControllerIntegrationTest.TestApp.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SystemParameterControllerIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    TestSystemParameterService testSystemParameterService;
+
+    @Autowired
+    CacheManager cacheManager;
+
+    @BeforeEach
+    void clearCache() {
+        cacheManager.getCacheNames().forEach(name -> {
+            Cache cache = cacheManager.getCache(name);
+            if (cache != null) {
+                cache.clear();
+            }
+        });
+        testSystemParameterService.reset();
+    }
+
+    @Test
+    void getByKeysCachesResponses() throws Exception {
+        mockMvc.perform(post("/setup/systemParameters/by-keys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("[\"alpha\"]"))
+            .andExpect(status().isOk());
+
+        mockMvc.perform(post("/setup/systemParameters/by-keys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("[\"alpha\"]"))
+            .andExpect(status().isOk());
+
+        assertThat(testSystemParameterService.getByKeysInvocationCount()).isEqualTo(1);
+        Cache cache = cacheManager.getCache("sysparams:byKeys");
+        assertThat(cache).isNotNull();
+        assertThat(cache.get(List.of("alpha"))).isNotNull();
+    }
+
+    @Test
+    void getByKeysMapsErrorStatusFromResponse() throws Exception {
+        mockMvc.perform(post("/setup/systemParameters/by-keys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("[\"missing\"]"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value(ErrorCodes.DATA_NOT_FOUND));
+    }
+
+    @EnableCaching(proxyTargetClass = true)
+    @EnableAutoConfiguration(exclude = {
+        DataSourceAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class,
+        JpaRepositoriesAutoConfiguration.class,
+        LiquibaseAutoConfiguration.class,
+        FlywayAutoConfiguration.class
+    })
+    @Import(SystemParameterController.class)
+    static class TestApp {
+
+        @Bean
+        CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager("sysparams:byKeys");
+        }
+
+        @Bean
+        TestSystemParameterService systemParameterService() {
+            return new TestSystemParameterService();
+        }
+    }
+
+    static class TestSystemParameterService implements SystemParameterService {
+
+        private final AtomicInteger byKeysInvocationCount = new AtomicInteger();
+
+        @Override
+        public BaseResponse<SystemParameterResponse> add(SystemParameterRequest request) {
+            throw new UnsupportedOperationException("Not needed for test");
+        }
+
+        @Override
+        public BaseResponse<SystemParameterResponse> update(Integer paramId, SystemParameterRequest request) {
+            throw new UnsupportedOperationException("Not needed for test");
+        }
+
+        @Override
+        public BaseResponse<SystemParameterResponse> get(Integer paramId) {
+            throw new UnsupportedOperationException("Not needed for test");
+        }
+
+        @Override
+        public BaseResponse<org.springframework.data.domain.Page<SystemParameterResponse>> list(
+            org.springframework.data.domain.Pageable pageable, String group, Boolean onlyActive) {
+            throw new UnsupportedOperationException("Not needed for test");
+        }
+
+        @Override
+        @Cacheable(cacheNames = "sysparams:byKeys", key = "#keys")
+        public BaseResponse<List<SystemParameterResponse>> getByKeys(List<String> keys) {
+            byKeysInvocationCount.incrementAndGet();
+            if (keys.contains("missing")) {
+                return BaseResponse.error(ErrorCodes.DATA_NOT_FOUND, "Parameter not found");
+            }
+            SystemParameterResponse response = new SystemParameterResponse();
+            response.setParamKey("alpha");
+            response.setParamValue("42");
+            response.setIsActive(Boolean.TRUE);
+            return BaseResponse.success("Parameters", List.of(response));
+        }
+
+        @Override
+        public BaseResponse<SystemParameterResponse> getByKey(String paramKey) {
+            throw new UnsupportedOperationException("Not needed for test");
+        }
+
+        int getByKeysInvocationCount() {
+            return byKeysInvocationCount.get();
+        }
+
+        void reset() {
+            byKeysInvocationCount.set(0);
+        }
+    }
+}

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
@@ -2,8 +2,8 @@ package com.ejada.starter_security;
 
 import com.ejada.common.constants.HeaderNames;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ejada.starter_security.authorization.AuthorizationExpressions;
 import com.ejada.starter_security.web.JsonAccessDeniedHandler;
-import com.ejada.starter_security.web.JsonAuthEntryPoint;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import javax.crypto.SecretKey;
@@ -76,6 +76,15 @@ public class SecurityAutoConfiguration {
   @ConditionalOnMissingBean(RoleChecker.class)
   public RoleChecker roleChecker(SharedSecurityProps props) {
     return new RoleChecker(props);
+  }
+
+  /* ---------------------------------------------------
+   * AuthorizationExpressions : reusable SpEL helpers
+   * --------------------------------------------------- */
+  @Bean
+  @ConditionalOnMissingBean(AuthorizationExpressions.class)
+  public AuthorizationExpressions authorizationExpressions(RoleChecker roleChecker) {
+    return new AuthorizationExpressions(roleChecker);
   }
 
   /* ---------------------------------------------------

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/authorization/AuthorizationExpressions.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/authorization/AuthorizationExpressions.java
@@ -1,0 +1,50 @@
+package com.ejada.starter_security.authorization;
+
+import com.ejada.starter_security.Role;
+import com.ejada.starter_security.RoleChecker;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.Assert;
+
+/**
+ * Reusable security expressions that can be referenced from Spring Expression Language (SpEL)
+ * {@code @PreAuthorize} declarations. Centralising these helpers keeps the
+ * composed annotations concise while providing an easy extension point for
+ * service applications that need to evaluate role combinations in tests.
+ */
+public class AuthorizationExpressions {
+
+    private final RoleChecker roleChecker;
+
+    public AuthorizationExpressions(RoleChecker roleChecker) {
+        Assert.notNull(roleChecker, "roleChecker must not be null");
+        this.roleChecker = roleChecker;
+    }
+
+    /**
+     * Evaluates whether the authenticated principal has at least one of the supplied roles.
+     *
+     * @param authentication current authentication
+     * @param roles roles that grant access
+     * @return {@code true} when access should be granted
+     */
+    public boolean hasAnyRole(Authentication authentication, Role... roles) {
+        return roleChecker.hasRole(authentication, roles);
+    }
+
+    /**
+     * @return {@code true} when the current user is registered as an EJADA officer.
+     */
+    public boolean isEjadaOfficer(Authentication authentication) {
+        return hasAnyRole(authentication, Role.EJADA_OFFICER);
+    }
+
+    /**
+     * @return {@code true} when the current user belongs to the EJADA platform staff cohort.
+     */
+    public boolean isPlatformStaff(Authentication authentication) {
+        return hasAnyRole(authentication,
+                Role.EJADA_OFFICER,
+                Role.TENANT_ADMIN,
+                Role.TENANT_OFFICER);
+    }
+}

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/authorization/EjadaOfficerAuthorized.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/authorization/EjadaOfficerAuthorized.java
@@ -13,6 +13,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@PreAuthorize("@roleChecker.hasRole(authentication, T(com.ejada.starter_security.Role).EJADA_OFFICER)")
+@PreAuthorize("@authorizationExpressions.isEjadaOfficer(authentication)")
 public @interface EjadaOfficerAuthorized {
 }

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/authorization/PlatformStaffAuthorized.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/authorization/PlatformStaffAuthorized.java
@@ -13,9 +13,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@PreAuthorize("@roleChecker.hasRole(authentication, "
-        + "T(com.ejada.starter_security.Role).EJADA_OFFICER, "
-        + "T(com.ejada.starter_security.Role).TENANT_ADMIN, "
-        + "T(com.ejada.starter_security.Role).TENANT_OFFICER)")
+@PreAuthorize("@authorizationExpressions.isPlatformStaff(authentication)")
 public @interface PlatformStaffAuthorized {
 }

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/RoleCheckerAutoConfigurationTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/RoleCheckerAutoConfigurationTest.java
@@ -22,4 +22,12 @@ class RoleCheckerAutoConfigurationTest {
       assertNotNull(context.getBean(RoleChecker.class));
     });
   }
+
+  @Test
+  void providesAuthorizationExpressionsBean() {
+    contextRunner.run(context -> {
+      assertTrue(context.containsBean("authorizationExpressions"));
+      assertNotNull(context.getBean(com.ejada.starter_security.authorization.AuthorizationExpressions.class));
+    });
+  }
 }

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/authorization/AuthorizationExpressionsTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/authorization/AuthorizationExpressionsTest.java
@@ -1,0 +1,57 @@
+package com.ejada.starter_security.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ejada.starter_security.Role;
+import com.ejada.starter_security.RoleChecker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+
+class AuthorizationExpressionsTest {
+
+    @Mock
+    private RoleChecker roleChecker;
+
+    @Mock
+    private Authentication authentication;
+
+    private AuthorizationExpressions expressions;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        expressions = new AuthorizationExpressions(roleChecker);
+    }
+
+    @Test
+    void hasAnyRoleDelegatesToRoleChecker() {
+        when(roleChecker.hasRole(authentication, Role.EJADA_OFFICER)).thenReturn(true);
+
+        boolean result = expressions.hasAnyRole(authentication, Role.EJADA_OFFICER);
+
+        assertThat(result).isTrue();
+        verify(roleChecker).hasRole(authentication, Role.EJADA_OFFICER);
+    }
+
+    @Test
+    void isEjadaOfficerUsesHelper() {
+        expressions.isEjadaOfficer(authentication);
+
+        verify(roleChecker).hasRole(authentication, Role.EJADA_OFFICER);
+    }
+
+    @Test
+    void isPlatformStaffCoversAllPlatformRoles() {
+        expressions.isPlatformStaff(authentication);
+
+        verify(roleChecker).hasRole(authentication,
+                Role.EJADA_OFFICER,
+                Role.TENANT_ADMIN,
+                Role.TENANT_OFFICER);
+    }
+}


### PR DESCRIPTION
## Summary
- centralize the starter-security SpEL helpers in a reusable `AuthorizationExpressions` bean and update the composed annotations to reference it
- add integration coverage for the gateway fallback route registration/status mapping and setup-service controller caching behaviour
- externalize crypto secrets for setup-service by importing Vault/AWS sources and removing the in-repo default key material

## Testing
- `mvn -pl shared-lib/shared-starters/starter-security,api-gateway,setup-service test -am` *(fails: could not find the selected project in the reactor)*


------
https://chatgpt.com/codex/tasks/task_e_68dd0da9cf7c832f8b01fc281d8f1340