### PR TITLE
Fix missing JsonAuthEntryPoint import

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
@@ -4,6 +4,7 @@ import com.ejada.common.constants.HeaderNames;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ejada.starter_security.authorization.AuthorizationExpressions;
 import com.ejada.starter_security.web.JsonAccessDeniedHandler;
+import com.ejada.starter_security.web.JsonAuthEntryPoint;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import javax.crypto.SecretKey;


### PR DESCRIPTION
## Summary
- add the missing JsonAuthEntryPoint import to SecurityAutoConfiguration so compilation succeeds

## Testing
- `mvn -pl shared-starters/starter-security -am compile`

------
https://chatgpt.com/codex/tasks/task_e_68dd1bdbd490832faaa7ce96029a66c7