### PR TITLE
Fix integration test import for Spring Boot 3

### DIFF
--- a/setup-service/src/test/java/com/ejada/setup/controller/SystemParameterControllerIntegrationTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/controller/SystemParameterControllerIntegrationTest.java
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
-import org.springframework.boot.autoconfigure.orm.jpa.JpaRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;


### PR DESCRIPTION
## Summary
- update the SystemParameterControllerIntegrationTest to import JpaRepositoriesAutoConfiguration from the Spring Boot 3 package

## Testing
- mvn test *(fails: missing internal BOM and dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68dd228a3184832fa6860b50069e4b84