### PR TITLE
Avoid security auto-configuration in SystemParameterControllerIntegrationTest

### DIFF
--- a/setup-service/src/test/java/com/ejada/setup/controller/SystemParameterControllerIntegrationTest.java
+++ b/setup-service/src/test/java/com/ejada/setup/controller/SystemParameterControllerIntegrationTest.java
@@ -85,12 +85,19 @@ class SystemParameterControllerIntegrationTest {
     }
 
     @EnableCaching(proxyTargetClass = true)
+    // Exclude security auto-configuration to avoid loading the full resource server stack
+    // when only verifying controller/caching behaviour.
     @EnableAutoConfiguration(exclude = {
         DataSourceAutoConfiguration.class,
         HibernateJpaAutoConfiguration.class,
         JpaRepositoriesAutoConfiguration.class,
         LiquibaseAutoConfiguration.class,
-        FlywayAutoConfiguration.class
+        FlywayAutoConfiguration.class,
+        com.ejada.starter_security.SecurityAutoConfiguration.class,
+        org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class,
+        org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration.class,
+        org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration.class,
+        org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration.class
     })
     @Import(SystemParameterController.class)
     static class TestApp {


### PR DESCRIPTION
## Summary
- exclude Spring Security auto-configuration classes from the SystemParameterControllerIntegrationTest test slice
- keep the integration test focused on controller and cache behaviour without loading the resource server stack

## Testing
- mvn -pl setup-service -Dtest=SystemParameterControllerIntegrationTest test *(fails: requires proprietary com.ejada:shared-bom dependency not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd28367394832f821b8748821e4ccf