### PR TITLE
Fix TestingAuthenticationToken initialization in TenantAccessPolicyTest

### DIFF
--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantAccessPolicyTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/security/TenantAccessPolicyTest.java
@@ -29,7 +29,8 @@ class TenantAccessPolicyTest {
                 new TestingAuthenticationToken(
                         "user",
                         "pwd",
-                        new SimpleGrantedAuthority("ROLE_EJADA_OFFICER"));
+                        Collections.singletonList(
+                                new SimpleGrantedAuthority("ROLE_EJADA_OFFICER")));
         auth.setAuthenticated(true);
 
         assertThat(policy.getAllowedRoles()).contains("ROLE_EJADA_OFFICER");
@@ -60,7 +61,8 @@ class TenantAccessPolicyTest {
                 new TestingAuthenticationToken(
                         "user",
                         "pwd",
-                        new SimpleGrantedAuthority("ROLE_EJADA_OFFICER"));
+                        Collections.singletonList(
+                                new SimpleGrantedAuthority("ROLE_EJADA_OFFICER")));
         auth.setAuthenticated(true);
 
         assertThat(policy.getAllowedRoles()).isEmpty();
@@ -74,7 +76,8 @@ class TenantAccessPolicyTest {
                 new TestingAuthenticationToken(
                         "user",
                         "pwd",
-                        new SimpleGrantedAuthority("ROLE_EJADA_OFFICER"));
+                        Collections.singletonList(
+                                new SimpleGrantedAuthority("ROLE_EJADA_OFFICER")));
         auth.setAuthenticated(true);
 
         assertThat(policy.getAllowedRoles()).isEmpty();
@@ -90,7 +93,8 @@ class TenantAccessPolicyTest {
                 new TestingAuthenticationToken(
                         "user",
                         "pwd",
-                        new SimpleGrantedAuthority("EJADA_OFFICER"));
+                        Collections.singletonList(
+                                new SimpleGrantedAuthority("EJADA_OFFICER")));
         auth.setAuthenticated(true);
 
         assertThat(policy.getAllowedRoles()).containsExactly("EJADA_OFFICER");
@@ -106,7 +110,8 @@ class TenantAccessPolicyTest {
                 new TestingAuthenticationToken(
                         "user",
                         "pwd",
-                        new SimpleGrantedAuthority("AUTH_EJADA_OFFICER"));
+                        Collections.singletonList(
+                                new SimpleGrantedAuthority("AUTH_EJADA_OFFICER")));
         auth.setAuthenticated(true);
 
         assertThat(policy.getAllowedRoles()).containsExactly("AUTH_EJADA_OFFICER");
@@ -122,7 +127,8 @@ class TenantAccessPolicyTest {
                 new TestingAuthenticationToken(
                         "user",
                         "pwd",
-                        new SimpleGrantedAuthority("EJADA_OFFICER"));
+                        Collections.singletonList(
+                                new SimpleGrantedAuthority("EJADA_OFFICER")));
         auth.setAuthenticated(true);
 
         assertThat(policy.getAllowedRoles()).containsExactly("EJADA_OFFICER");


### PR DESCRIPTION
## Summary
- ensure TenantAccessPolicyTest supplies a collection of authorities when constructing TestingAuthenticationToken instances to match the current Spring Security API

## Testing
- mvn -pl tenant-service test *(fails: build cannot resolve com.ejada:shared-bom:1.0.0 import POM)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3515774c832f9c5c7251a0d27413