### PR TITLE
Add HS256 secret for gateway integration tests

### DIFF
--- a/api-gateway/src/test/java/com/ejada/gateway/config/GatewayRoutesIntegrationTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/config/GatewayRoutesIntegrationTest.java
@@ -18,7 +18,9 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {
-        "shared.ratelimit.enabled=false"
+        "shared.ratelimit.enabled=false",
+        "shared.security.mode=hs256",
+        "shared.security.hs256.secret=" + GatewayRoutesIntegrationTest.SECRET
     }
 )
 @TestPropertySource(properties = {
@@ -30,6 +32,9 @@ import org.springframework.test.web.reactive.server.WebTestClient;
     "gateway.routes.test.resilience.fallback-message=Custom outage message"
 })
 class GatewayRoutesIntegrationTest {
+
+  static final String SECRET =
+      "0123456789ABCDEF0123456789ABCDEF-SECURE-0123456789ABCDEF";
 
   @Autowired
   private WebTestClient webTestClient;


### PR DESCRIPTION
## Summary
- configure GatewayRoutesIntegrationTest with explicit HS256 mode and shared secret so the JWT decoder can initialize during context startup

## Testing
- mvn -q test *(fails: Non-resolvable import POM com.ejada:shared-bom:pom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dd378db040832fb626fdb9dca63d46