### PR TITLE
Allow unauthenticated access to fallback route

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityConfiguration.java
@@ -54,6 +54,7 @@ public class GatewaySecurityConfiguration {
       if (permitAll != null && permitAll.length > 0) {
         spec.pathMatchers(permitAll).permitAll();
       }
+      spec.pathMatchers("/fallback/**").permitAll();
       spec.pathMatchers(HttpMethod.OPTIONS).permitAll();
       spec.anyExchange().authenticated();
     });


### PR DESCRIPTION
## Summary
- permit unauthenticated access to the reactive fallback handler in the gateway security config to ensure it can be invoked during outages

## Testing
- `mvn test` *(fails: Non-resolvable import POM com.ejada:shared-bom and missing dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68dd38b1d728832f9f2bc1767da373c9