### PR TITLE
Add RedisCacheHelper bean to Redis auto-configuration

### DIFF
--- a/shared-lib/shared-starters/starter-redis/src/main/java/com/ejada/redis/starter/config/RedisAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-redis/src/main/java/com/ejada/redis/starter/config/RedisAutoConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.CacheManager;
+import com.ejada.redis.starter.support.RedisCacheHelper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
@@ -83,6 +84,13 @@ public class RedisAutoConfiguration {
     if (props.getClientName() != null && !props.getClientName().isBlank()) client.clientName(props.getClientName());
 
     return new LettuceConnectionFactory(standalone, client.build());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public RedisCacheHelper redisCacheHelper(
+      RedisTemplate<String, Object> redisTemplate, KeyPrefixStrategy keyPrefixStrategy) {
+    return new RedisCacheHelper(redisTemplate, keyPrefixStrategy);
   }
 
   // Serializers


### PR DESCRIPTION
## Summary
- register `RedisCacheHelper` as a conditional bean inside the Redis starter auto-configuration so downstream services can inject it without component scanning

## Testing
- mvn -pl starter-redis -am -DskipTests package *(fails: repository modules such as `shared-bom` are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd939a1cac832fbb706f7a5f9bd12e