### PR TITLE
Ensure subscription-service jar is executable

### DIFF
--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -154,6 +154,13 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
## Summary
- run the Spring Boot repackage goal as part of the subscription-service build so the jar has a Main-Class manifest entry

## Testing
- mvn -pl subscription-service -am package -DskipTests *(fails: repository lacks internal artifacts such as com.ejada:shared-bom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9fc9abd8832fbefebfe966947569