### PR TITLE
Enhance YAML profiles and Kubernetes manifests

### DIFF
--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: security-service
   profiles:
-    active: dev
+    active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0

--- a/setup-service/k8s/deployment.yaml
+++ b/setup-service/k8s/deployment.yaml
@@ -4,22 +4,38 @@ metadata:
   name: ejada-setup
   labels:
     app: ejada-setup
-    version: 1.0.0
+    app.kubernetes.io/name: setup-service
+    app.kubernetes.io/instance: ejada-setup
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: ejada-lms
 spec:
   replicas: 2
-  selector: 
-    matchLabels: 
+  selector:
+    matchLabels:
       app: ejada-setup
+      app.kubernetes.io/name: setup-service
   template:
-    metadata: 
-      labels: 
+    metadata:
+      labels:
         app: ejada-setup
-        version: 1.0.0
+        app.kubernetes.io/name: setup-service
+        app.kubernetes.io/instance: ejada-setup
+        app.kubernetes.io/version: "1.0.0"
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: ejada-lms
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: /core/actuator/prometheus
     spec:
       containers:
         - name: app
           image: your.registry/ejada-setup:1.0.0
-          ports: [{ containerPort: 8080 }]
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
           env:
             - name: SPRING_DATASOURCE_URL
               value: jdbc:postgresql://postgres:5432/ejada?currentSchema=setup

--- a/setup-service/k8s/service.yaml
+++ b/setup-service/k8s/service.yaml
@@ -4,10 +4,15 @@ metadata:
   name: ejada-setup
   labels:
     app: ejada-setup
-    version: 1.0.0
+    app.kubernetes.io/name: setup-service
+    app.kubernetes.io/instance: ejada-setup
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: ejada-lms
 spec:
   selector:
     app: ejada-setup
+    app.kubernetes.io/name: setup-service
   ports:
     - protocol: TCP
       port: 80

--- a/setup-service/src/main/resources/application.yaml
+++ b/setup-service/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: setup-service
   profiles:
-    active: dev
+    active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0

--- a/tenant-platform/billing-service/k8s/deployment.yaml
+++ b/tenant-platform/billing-service/k8s/deployment.yaml
@@ -1,28 +1,44 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ejada-catalog
+  name: ejada-billing
   labels:
-    app: ejada-catalog
-    version: 1.0.0
+    app: ejada-billing
+    app.kubernetes.io/name: billing-service
+    app.kubernetes.io/instance: ejada-billing
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: ejada-lms
 spec:
   replicas: 2
-  selector: 
-    matchLabels: 
-      app: ejada-catalog
+  selector:
+    matchLabels:
+      app: ejada-billing
+      app.kubernetes.io/name: billing-service
   template:
-    metadata: 
-      labels: 
-        app: ejada-catalog
-        version: 1.0.0
+    metadata:
+      labels:
+        app: ejada-billing
+        app.kubernetes.io/name: billing-service
+        app.kubernetes.io/instance: ejada-billing
+        app.kubernetes.io/version: "1.0.0"
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: ejada-lms
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: /billing/actuator/prometheus
     spec:
       containers:
         - name: app
-          image: your.registry/ejada-catalog:1.0.0
-          ports: [{ containerPort: 8080 }]
+          image: your.registry/ejada-billing:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
           env:
             - name: SPRING_DATASOURCE_URL
-              value: jdbc:postgresql://postgres:5432/ejada?currentSchema=catalog
+              value: jdbc:postgresql://postgres:5432/ejada?currentSchema=billing
             - name: SPRING_DATASOURCE_USERNAME
               value: ejada
             - name: SPRING_DATASOURCE_PASSWORD
@@ -42,13 +58,13 @@ spec:
               cpu: "500m"
           livenessProbe:
             httpGet:
-              path: /core/actuator/health
+              path: /billing/actuator/health
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /core/actuator/health
+              path: /billing/actuator/health
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/tenant-platform/billing-service/k8s/service.yaml
+++ b/tenant-platform/billing-service/k8s/service.yaml
@@ -1,13 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ejada-catalog
+  name: ejada-billing
   labels:
-    app: ejada-catalog
-    version: 1.0.0
+    app: ejada-billing
+    app.kubernetes.io/name: billing-service
+    app.kubernetes.io/instance: ejada-billing
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: ejada-lms
 spec:
   selector:
-    app: ejada-catalog
+    app: ejada-billing
+    app.kubernetes.io/name: billing-service
   ports:
     - protocol: TCP
       port: 80

--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: billing-service
   profiles:
-    active: dev
+    active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0

--- a/tenant-platform/catalog-service/k8s/deployment.yaml
+++ b/tenant-platform/catalog-service/k8s/deployment.yaml
@@ -4,22 +4,38 @@ metadata:
   name: ejada-catalog
   labels:
     app: ejada-catalog
-    version: 1.0.0
+    app.kubernetes.io/name: catalog-service
+    app.kubernetes.io/instance: ejada-catalog
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: ejada-lms
 spec:
   replicas: 2
-  selector: 
-    matchLabels: 
+  selector:
+    matchLabels:
       app: ejada-catalog
+      app.kubernetes.io/name: catalog-service
   template:
-    metadata: 
-      labels: 
+    metadata:
+      labels:
         app: ejada-catalog
-        version: 1.0.0
+        app.kubernetes.io/name: catalog-service
+        app.kubernetes.io/instance: ejada-catalog
+        app.kubernetes.io/version: "1.0.0"
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: ejada-lms
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: /catalog/actuator/prometheus
     spec:
       containers:
         - name: app
           image: your.registry/ejada-catalog:1.0.0
-          ports: [{ containerPort: 8080 }]
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
           env:
             - name: SPRING_DATASOURCE_URL
               value: jdbc:postgresql://postgres:5432/ejada?currentSchema=catalog
@@ -42,13 +58,13 @@ spec:
               cpu: "500m"
           livenessProbe:
             httpGet:
-              path: /core/actuator/health
+              path: /catalog/actuator/health
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /core/actuator/health
+              path: /catalog/actuator/health
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/tenant-platform/catalog-service/k8s/service.yaml
+++ b/tenant-platform/catalog-service/k8s/service.yaml
@@ -4,10 +4,15 @@ metadata:
   name: ejada-catalog
   labels:
     app: ejada-catalog
-    version: 1.0.0
+    app.kubernetes.io/name: catalog-service
+    app.kubernetes.io/instance: ejada-catalog
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: ejada-lms
 spec:
   selector:
     app: ejada-catalog
+    app.kubernetes.io/name: catalog-service
   ports:
     - protocol: TCP
       port: 80

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: catalog-service
   profiles:
-    active: dev
+    active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0

--- a/tenant-platform/subscription-service/k8s/deployment.yaml
+++ b/tenant-platform/subscription-service/k8s/deployment.yaml
@@ -1,28 +1,44 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ejada-catalog
+  name: ejada-subscription
   labels:
-    app: ejada-catalog
-    version: 1.0.0
+    app: ejada-subscription
+    app.kubernetes.io/name: subscription-service
+    app.kubernetes.io/instance: ejada-subscription
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: ejada-lms
 spec:
   replicas: 2
-  selector: 
-    matchLabels: 
-      app: ejada-catalog
+  selector:
+    matchLabels:
+      app: ejada-subscription
+      app.kubernetes.io/name: subscription-service
   template:
-    metadata: 
-      labels: 
-        app: ejada-catalog
-        version: 1.0.0
+    metadata:
+      labels:
+        app: ejada-subscription
+        app.kubernetes.io/name: subscription-service
+        app.kubernetes.io/instance: ejada-subscription
+        app.kubernetes.io/version: "1.0.0"
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: ejada-lms
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: /subscription/actuator/prometheus
     spec:
       containers:
         - name: app
-          image: your.registry/ejada-catalog:1.0.0
-          ports: [{ containerPort: 8080 }]
+          image: your.registry/ejada-subscription:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
           env:
             - name: SPRING_DATASOURCE_URL
-              value: jdbc:postgresql://postgres:5432/ejada?currentSchema=catalog
+              value: jdbc:postgresql://postgres:5432/ejada?currentSchema=subscription
             - name: SPRING_DATASOURCE_USERNAME
               value: ejada
             - name: SPRING_DATASOURCE_PASSWORD
@@ -42,13 +58,13 @@ spec:
               cpu: "500m"
           livenessProbe:
             httpGet:
-              path: /core/actuator/health
+              path: /subscription/actuator/health
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /core/actuator/health
+              path: /subscription/actuator/health
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/tenant-platform/subscription-service/k8s/service.yaml
+++ b/tenant-platform/subscription-service/k8s/service.yaml
@@ -1,13 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ejada-catalog
+  name: ejada-subscription
   labels:
-    app: ejada-catalog
-    version: 1.0.0
+    app: ejada-subscription
+    app.kubernetes.io/name: subscription-service
+    app.kubernetes.io/instance: ejada-subscription
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: ejada-lms
 spec:
   selector:
-    app: ejada-catalog
+    app: ejada-subscription
+    app.kubernetes.io/name: subscription-service
   ports:
     - protocol: TCP
       port: 80

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: subscription-service
   profiles:
-    active: dev
+    active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0

--- a/tenant-platform/tenant-service/k8s/deployment.yaml
+++ b/tenant-platform/tenant-service/k8s/deployment.yaml
@@ -1,28 +1,44 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ejada-catalog
+  name: ejada-tenant
   labels:
-    app: ejada-catalog
-    version: 1.0.0
+    app: ejada-tenant
+    app.kubernetes.io/name: tenant-service
+    app.kubernetes.io/instance: ejada-tenant
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: ejada-lms
 spec:
   replicas: 2
-  selector: 
-    matchLabels: 
-      app: ejada-catalog
+  selector:
+    matchLabels:
+      app: ejada-tenant
+      app.kubernetes.io/name: tenant-service
   template:
-    metadata: 
-      labels: 
-        app: ejada-catalog
-        version: 1.0.0
+    metadata:
+      labels:
+        app: ejada-tenant
+        app.kubernetes.io/name: tenant-service
+        app.kubernetes.io/instance: ejada-tenant
+        app.kubernetes.io/version: "1.0.0"
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: ejada-lms
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: /tenant/actuator/prometheus
     spec:
       containers:
         - name: app
-          image: your.registry/ejada-catalog:1.0.0
-          ports: [{ containerPort: 8080 }]
+          image: your.registry/ejada-tenant:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
           env:
             - name: SPRING_DATASOURCE_URL
-              value: jdbc:postgresql://postgres:5432/ejada?currentSchema=catalog
+              value: jdbc:postgresql://postgres:5432/ejada?currentSchema=tenant
             - name: SPRING_DATASOURCE_USERNAME
               value: ejada
             - name: SPRING_DATASOURCE_PASSWORD
@@ -42,13 +58,13 @@ spec:
               cpu: "500m"
           livenessProbe:
             httpGet:
-              path: /core/actuator/health
+              path: /tenant/actuator/health
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /core/actuator/health
+              path: /tenant/actuator/health
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/tenant-platform/tenant-service/k8s/service.yaml
+++ b/tenant-platform/tenant-service/k8s/service.yaml
@@ -1,13 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ejada-catalog
+  name: ejada-tenant
   labels:
-    app: ejada-catalog
-    version: 1.0.0
+    app: ejada-tenant
+    app.kubernetes.io/name: tenant-service
+    app.kubernetes.io/instance: ejada-tenant
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: ejada-lms
 spec:
   selector:
-    app: ejada-catalog
+    app: ejada-tenant
+    app.kubernetes.io/name: tenant-service
   ports:
     - protocol: TCP
       port: 80

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: tenant-service
   profiles:
-    active: dev
+    active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0


### PR DESCRIPTION
## Summary
- allow overriding the active Spring profile via environment variables across the setup, security, and tenant platform services
- fix each service deployment/service manifest with accurate naming, labels, probes, and Prometheus annotations while standardising container settings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dda1b2e7d8832fbdf66781d2b3e59d