### PR TITLE
Ensure tenant provisioning properties bean is available

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/config/TenantProvisioningConfiguration.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/config/TenantProvisioningConfiguration.java
@@ -1,10 +1,16 @@
 package com.ejada.catalog.config;
 
 import com.ejada.common.events.provisioning.TenantProvisioningProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(TenantProvisioningProperties.class)
 public class TenantProvisioningConfiguration {
+
+    @Bean
+    @ConfigurationProperties(prefix = "app.tenant-provisioning")
+    public TenantProvisioningProperties tenantProvisioningProperties() {
+        return new TenantProvisioningProperties();
+    }
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/TenantProvisioningConfiguration.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/TenantProvisioningConfiguration.java
@@ -1,10 +1,16 @@
 package com.ejada.subscription.config;
 
 import com.ejada.common.events.provisioning.TenantProvisioningProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(TenantProvisioningProperties.class)
 public class TenantProvisioningConfiguration {
+
+    @Bean
+    @ConfigurationProperties(prefix = "app.tenant-provisioning")
+    public TenantProvisioningProperties tenantProvisioningProperties() {
+        return new TenantProvisioningProperties();
+    }
 }


### PR DESCRIPTION
## Summary
- register the tenant provisioning configuration properties bean in the catalog service
- register the tenant provisioning configuration properties bean in the subscription service

## Testing
- `mvn -pl catalog-service -am test` *(fails: requires internal shared-bom and dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68dda5aa39b4832f95e4f39444f85bac