### PR TITLE
Adjust CSRF defaults for versioned auth endpoints

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SharedSecurityProps.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SharedSecurityProps.java
@@ -91,15 +91,20 @@ public class SharedSecurityProps implements BaseStarterProperties {
         "/actuator/health",
         "/v3/api-docs/**",
         "/swagger-ui/**",
-        // common public endpoints:
-        "/auth/**", "/login", "/register","/config/**"
+        // common public endpoints (with and without /api version prefix):
+        "/auth/**", "/api/**/auth/**",
+        "/login", "/register",
+        "/config/**"
     };
 
     /** Disable CSRF for stateless REST APIs. */
     private boolean disableCsrf = true;
 
     /** Patterns that should bypass CSRF checks when CSRF is enabled. */
-    private String[] csrfIgnore = new String[0];
+    private String[] csrfIgnore = new String[]{
+        "/auth/**", "/api/**/auth/**",
+        "/login", "/register"
+    };
 
     /** Force stateless sessions for APIs. */
     private boolean stateless = true;


### PR DESCRIPTION
## Summary
- include versioned /api/**/auth/** routes in the default permit-all list
- configure CSRF ignores to cover common authentication endpoints so login flows succeed when CSRF is enabled

## Testing
- `mvn -pl shared-lib/shared-starters/starter-security test` *(fails: module not found in reactor)*

------
https://chatgpt.com/codex/tasks/task_e_68ddab5089ec832f83d0d104bff97552