### PR TITLE
Enable subscription integration tests by default

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -16,7 +16,6 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,7 +32,6 @@ import org.testcontainers.kafka.KafkaContainer;
 
 @SpringBootTest(classes = SubscriptionApplication.class)
 @Testcontainers
-@EnabledIfEnvironmentVariable(named = "RUN_KAFKA_IT", matches = "true")
 @ActiveProfiles("test")
 class SubscriptionApprovalConsumerIT {
 

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -29,7 +28,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
-@EnabledIfEnvironmentVariable(named = "RUN_PG_IT", matches = "true")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ImportAutoConfiguration(FlywayAutoConfiguration.class)


### PR DESCRIPTION
## Summary
- remove the RUN_KAFKA_IT and RUN_PG_IT environment guards so the subscription service integration tests run when Docker is available

## Testing
- mvn -f tenant-platform/pom.xml -pl subscription-service test *(fails: requires lengthy internal build chain to resolve shared dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddaef13a3c832f9c1a43f008007b14