### PR TITLE
Fix invalid auth path pattern for security configuration

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SharedSecurityProps.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SharedSecurityProps.java
@@ -92,7 +92,7 @@ public class SharedSecurityProps implements BaseStarterProperties {
         "/v3/api-docs/**",
         "/swagger-ui/**",
         // common public endpoints (with and without /api version prefix):
-        "/auth/**", "/api/**/auth/**",
+        "/auth/**", "/api/*/auth/**",
         "/login", "/register",
         "/config/**"
     };
@@ -102,7 +102,7 @@ public class SharedSecurityProps implements BaseStarterProperties {
 
     /** Patterns that should bypass CSRF checks when CSRF is enabled. */
     private String[] csrfIgnore = new String[]{
-        "/auth/**", "/api/**/auth/**",
+        "/auth/**", "/api/*/auth/**",
         "/login", "/register"
     };
 


### PR DESCRIPTION
## Summary
- replace the invalid `/api/**/auth/**` pattern with a single-segment wildcard so it works with Spring's PathPattern parser

## Testing
- mvn test *(fails: requires internal shared-bom and dependency versions unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddaf673510832fbb58937aca57a077