### PR TITLE
Move service healthchecks to compose for podman builds

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -15,7 +15,4 @@ EXPOSE 8080
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1
-
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,6 +170,9 @@ services:
       OTEL_SERVICE_NAME: tenant-service
     ports:
       - "8080:8080"
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
     networks:
       backend:
 
@@ -185,6 +188,9 @@ services:
       OTEL_SERVICE_NAME: setup-service
     ports:
       - "8081:8080"
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
     networks:
       backend:
 
@@ -200,6 +206,9 @@ services:
       OTEL_SERVICE_NAME: billing-service
     ports:
       - "8082:8080"
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
     networks:
       backend:
 
@@ -215,6 +224,9 @@ services:
       OTEL_SERVICE_NAME: catalog-service
     ports:
       - "8083:8080"
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
     networks:
       backend:
 
@@ -230,6 +242,9 @@ services:
       OTEL_SERVICE_NAME: subscription-service
     ports:
       - "8084:8080"
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
     networks:
       backend:
 
@@ -254,6 +269,9 @@ services:
       OTEL_SERVICE_NAME: security-service
     ports:
       - "8085:8080"
+    healthcheck:
+      <<: *health_defaults
+      test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
     networks:
       backend:
 

--- a/sec-service/Dockerfile
+++ b/sec-service/Dockerfile
@@ -22,9 +22,5 @@ EXPOSE 8080
 # Add JVM optimizations
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/core/actuator/health || exit 1
-
 # Run the application
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]

--- a/setup-service/Dockerfile
+++ b/setup-service/Dockerfile
@@ -22,9 +22,5 @@ EXPOSE 8080
 # Add JVM optimizations
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/core/actuator/health || exit 1
-
 # Run the application
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]

--- a/tenant-platform/billing-service/Dockerfile
+++ b/tenant-platform/billing-service/Dockerfile
@@ -22,9 +22,5 @@ EXPOSE 8080
 # Add JVM optimizations
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/core/actuator/health || exit 1
-
 # Run the application
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]

--- a/tenant-platform/catalog-service/Dockerfile
+++ b/tenant-platform/catalog-service/Dockerfile
@@ -28,9 +28,5 @@ EXPOSE 8080
 # Add JVM optimizations
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/core/actuator/health || exit 1
-
 # Run the application
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]

--- a/tenant-platform/subscription-service/Dockerfile
+++ b/tenant-platform/subscription-service/Dockerfile
@@ -22,9 +22,5 @@ EXPOSE 8080
 # Add JVM optimizations
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/core/actuator/health || exit 1
-
 # Run the application
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]

--- a/tenant-platform/tenant-service/Dockerfile
+++ b/tenant-platform/tenant-service/Dockerfile
@@ -22,9 +22,5 @@ EXPOSE 8080
 # Add JVM optimizations
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/core/actuator/health || exit 1
-
 # Run the application
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]


### PR DESCRIPTION
## Summary
- remove image-level healthchecks from Spring Boot service Dockerfiles
- add equivalent service healthchecks in docker-compose.yml to keep runtime checks
- ensure podman builds do not emit unsupported OCI healthcheck warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddb08b9648832f9f481721353018b2