### PR TITLE
Allow admin login without CSRF token in dev profile

### DIFF
--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -215,7 +215,10 @@ shared:
       enabled: true
       permit-all:
         - "/actuator/health"
+        - "/api/v1/auth/**"
       disable-csrf: false
+      csrf-ignore:
+        - "/api/v1/auth/**"
     stateless: true
     roles-claim: roles
     tenant-claim: tenant


### PR DESCRIPTION
## Summary
- allow the dev profile to skip CSRF protection for /api/v1/auth/** requests
- keep the super-admin login endpoint accessible without a pre-fetched CSRF token

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddb584e958832f8652a1aa12a60cea