### PR TITLE
Fix setup service Hibernate default schema configuration

### DIFF
--- a/setup-service/src/main/resources/application-dev.yaml
+++ b/setup-service/src/main/resources/application-dev.yaml
@@ -35,13 +35,11 @@ spring:
       ddl-auto: none
     properties:
       hibernate:
-        ddl-auto: none
-      properties:
-        hibernate:
-          default_schema: setup
-          hbm2ddl.create_namespaces: true
-          format_sql: true
-        jdbc.time_zone: UTC
+        default_schema: setup
+        hbm2ddl.create_namespaces: true
+        format_sql: true
+      jdbc:
+        time_zone: UTC
   flyway:
     enabled: true
     baseline-on-migrate: true

--- a/setup-service/src/main/resources/application-local.yaml
+++ b/setup-service/src/main/resources/application-local.yaml
@@ -18,13 +18,11 @@ spring:
       ddl-auto: none
     properties:
       hibernate:
-        ddl-auto: none
-      properties:
-        hibernate:
-          default_schema: setup
-          hbm2ddl.create_namespaces: true
-          format_sql: true
-        jdbc.time_zone: UTC
+        default_schema: setup
+        hbm2ddl.create_namespaces: true
+        format_sql: true
+      jdbc:
+        time_zone: UTC
   flyway:
     enabled: true
     baseline-on-migrate: true

--- a/setup-service/src/main/resources/application-qa.yaml
+++ b/setup-service/src/main/resources/application-qa.yaml
@@ -23,7 +23,8 @@ spring:
         default_schema: setup
         hbm2ddl.create_namespaces: true
         format_sql: true
-        jdbc.time_zone: UTC
+      jdbc:
+        time_zone: UTC
   flyway:
     enabled: true
     baseline-on-migrate: true


### PR DESCRIPTION
## Summary
- correct the Spring JPA property structure so Hibernate reads the `setup` default schema in all profiles
- move the JDBC time zone setting out of the Hibernate block to ensure it is applied consistently

## Testing
- mvn -pl setup-service -am test *(fails: module is not part of the root reactor layout in this environment)*
- mvn -f setup-service/pom.xml test *(fails: project depends on parent-managed dependency versions that are not available standalone in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de1fefeb90832f82ccfc59fa051b87