### PR TITLE
Fix Micrometer observation API usage

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/ObservabilityConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/ObservabilityConfiguration.java
@@ -4,9 +4,9 @@ import com.ejada.common.context.ContextManager;
 import io.micrometer.common.KeyValue;
 import io.micrometer.observation.ObservationFilter;
 import io.micrometer.observation.ObservationRegistry;
-import io.micrometer.observation.ObservationTextMapPropagator;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
-import io.micrometer.observation.ObservationRegistryCustomizer;
+import io.micrometer.tracing.propagation.Propagator;
+import org.springframework.boot.actuate.autoconfigure.observation.ObservationRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
@@ -43,7 +43,7 @@ public class ObservabilityConfiguration {
   }
 
   @Bean
-  ObservationTextMapPropagator observationTextMapPropagator() {
-    return ObservationTextMapPropagator.noop();
+  Propagator observationTextMapPropagator() {
+    return Propagator.NOOP;
   }
 }


### PR DESCRIPTION
## Summary
- update the gateway observability configuration to use Spring Boot's ObservationRegistryCustomizer now that Micrometer removed the old type
- switch the propagation bean to Micrometer Tracing's Propagator.NOOP in place of the removed ObservationTextMapPropagator

## Testing
- mvn -f api-gateway/pom.xml -DskipTests compile *(fails: required internal shared artifacts such as com.ejada:shared-bom are not yet installed in the local Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_68de20340c60832f9b99596cd79ddaf8