### PR TITLE
Fix JSONB mapping for inbound notification audit entity

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/InboundNotificationAudit.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/InboundNotificationAudit.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -43,6 +45,7 @@ public class InboundNotificationAudit {
     @Column(name = "endpoint", length = 64, nullable = false)
     private String endpoint; // RECEIVE_NOTIFICATION | RECEIVE_UPDATE
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
     private String payload;
 
@@ -61,6 +64,7 @@ public class InboundNotificationAudit {
     @Column(name = "status_desc", length = 64)
     private String statusDesc;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "status_dtls", columnDefinition = "jsonb")
     private String statusDtls;
 


### PR DESCRIPTION
## Summary
- ensure jsonb columns in inbound notification audit use Hibernate's JSON type mapping to avoid type mismatches

## Testing
- mvn -pl subscription-service test -DskipITs *(fails: Non-resolvable import POM com.ejada:shared-bom:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68de222f9c88832fabc31b0df05fc90e