### PR TITLE
Fix compilation by removing Propagator bean from observability config

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/ObservabilityConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/ObservabilityConfiguration.java
@@ -5,7 +5,6 @@ import io.micrometer.common.KeyValue;
 import io.micrometer.observation.ObservationFilter;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
-import io.micrometer.tracing.propagation.Propagator;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,10 +39,5 @@ public class ObservabilityConfiguration {
     return registry -> registry.observationConfig()
         .observationFilter(tenantObservationFilter)
         .registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
-  }
-
-  @Bean
-  Propagator observationTextMapPropagator() {
-    return Propagator.NOOP;
   }
 }


### PR DESCRIPTION
## Summary
- remove the Micrometer Propagator bean that required an unavailable tracing dependency
- keep the observation registry customization focused on tenant and correlation metadata

## Testing
- mvn compile *(fails: requires internal shared-bom 1.0.0 that is not published to Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68de22d189cc832f8976e865136a7655