### PR TITLE
Fix observation registry customization for Micrometer upgrade

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/ObservabilityConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/ObservabilityConfiguration.java
@@ -4,7 +4,6 @@ import com.ejada.common.context.ContextManager;
 import io.micrometer.common.KeyValue;
 import io.micrometer.observation.ObservationFilter;
 import io.micrometer.observation.ObservationRegistry;
-import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,7 +36,6 @@ public class ObservabilityConfiguration {
   ObservationRegistryCustomizer<ObservationRegistry> observationRegistryCustomizer(
       ObservationFilter tenantObservationFilter) {
     return registry -> registry.observationConfig()
-        .observationFilter(tenantObservationFilter)
-        .registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
+        .observationFilter(tenantObservationFilter);
   }
 }


### PR DESCRIPTION
## Summary
- stop invoking the removed `registerThreadLocalAccessor` method when customizing the observation registry
- leave the tenant observation filter in place so emitted metrics retain tenant and correlation metadata

## Testing
- mvn -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68de23edea14832fb169f8c8aeafd4cc