### PR TITLE
Fix api-gateway Docker build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,7 +276,9 @@ services:
       backend:
 
   api-gateway:
-    build: ./api-gateway
+    build:
+      context: .
+      dockerfile: api-gateway/Dockerfile
     <<: [*restart_policy]
     depends_on:
       setup-service: { condition: service_started }


### PR DESCRIPTION
## Summary
- point the api-gateway image build to the repository root so the Dockerfile can copy shared modules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de25ad2880832fa69ae3169e85effa