### PR TITLE
Fix API gateway Dockerfile module references

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -3,12 +3,11 @@
 FROM maven:3.9.6-eclipse-temurin-21 AS builder
 WORKDIR /workspace
 
-COPY pom.xml ./
 COPY shared-lib ./shared-lib
 COPY api-gateway/pom.xml ./api-gateway/pom.xml
 COPY api-gateway/src ./api-gateway/src
 
-RUN mvn -pl api-gateway -am -B -DskipTests clean package
+RUN mvn -pl api-gateway -am -B -DskipTests -f api-gateway/pom.xml clean package
 
 FROM eclipse-temurin:21-jre-alpine AS runner
 


### PR DESCRIPTION
## Summary
- remove the reference to a non-existent root pom when building the API gateway image
- build the gateway module using its pom so Maven can resolve the shared library modules during the container build

## Testing
- Not run (Docker CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68de27017d60832f86aa3dda5c4f6d31