### PR TITLE
Fix Podman compose Dockerfile path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -278,7 +278,7 @@ services:
   api-gateway:
     build:
       context: .
-      dockerfile: api-gateway/Dockerfile
+      dockerfile: ./api-gateway/Dockerfile
     <<: [*restart_policy]
     depends_on:
       setup-service: { condition: service_started }


### PR DESCRIPTION
## Summary
- ensure the api-gateway build step in docker-compose references the Dockerfile with an explicit relative path that Podman accepts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de2c0dffa8832f96f59130a51c31bb