### PR TITLE
Use prebuilt service jars in Docker images

### DIFF
--- a/Dockerfile.spring-service
+++ b/Dockerfile.spring-service
@@ -1,20 +1,5 @@
 # syntax=docker/dockerfile:1.7
 
-ARG MAVEN_IMAGE=maven:3.9.6-eclipse-temurin-21
-FROM ${MAVEN_IMAGE} AS builder
-
-WORKDIR /workspace
-
-ARG MODULE_ROOT
-ARG MODULE_PATH
-ARG ARTIFACT_NAME
-
-COPY shared-lib ./shared-lib
-COPY ${MODULE_ROOT} ./${MODULE_ROOT}
-
-RUN mvn -f shared-lib/pom.xml -B -DskipTests install \
-    && mvn -f ${MODULE_PATH}/pom.xml -B -DskipTests clean package
-
 FROM eclipse-temurin:21-jre-alpine AS runner
 
 ARG APP_GROUP=appgroup
@@ -33,7 +18,7 @@ RUN addgroup -g 1001 -S ${APP_GROUP} \
 
 WORKDIR /app
 
-COPY --from=builder /workspace/${MODULE_PATH}/target/*.jar ./
+COPY ${MODULE_PATH}/target/*.jar ./
 
 RUN set -eux; \
     BOOT_JAR=$(find . -maxdepth 1 -name "${ARTIFACT_NAME}-*.jar" ! -name "*-plain.jar" | head -n 1); \

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,14 +1,5 @@
 # syntax=docker/dockerfile:1.7
 
-FROM maven:3.9.6-eclipse-temurin-21 AS builder
-WORKDIR /workspace
-
-COPY shared-lib ./shared-lib
-COPY api-gateway ./api-gateway
-
-RUN mvn -f shared-lib/pom.xml -B -DskipTests install \
-    && mvn -f api-gateway/pom.xml -B -DskipTests clean package
-
 FROM eclipse-temurin:21-jre-alpine AS runner
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
@@ -19,7 +10,7 @@ RUN addgroup -g 1001 -S appgroup \
 
 WORKDIR /app
 
-COPY --from=builder /workspace/api-gateway/target/*.jar ./
+COPY api-gateway/target/*.jar ./
 
 RUN set -eux; \
     BOOT_JAR=$(find . -maxdepth 1 -name 'api-gateway-*.jar' ! -name '*-plain.jar' | head -n 1); \

--- a/sec-service/Dockerfile
+++ b/sec-service/Dockerfile
@@ -1,14 +1,5 @@
 # syntax=docker/dockerfile:1.7
 
-FROM maven:3.9.6-eclipse-temurin-21 AS builder
-WORKDIR /workspace
-
-COPY shared-lib ./shared-lib
-COPY sec-service ./sec-service
-
-RUN mvn -f shared-lib/pom.xml -B -DskipTests install \
-    && mvn -f sec-service/pom.xml -B -DskipTests clean package
-
 FROM eclipse-temurin:21-jre-alpine AS runner
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
@@ -18,7 +9,7 @@ RUN addgroup -g 1001 -S appgroup \
 
 WORKDIR /app
 
-COPY --from=builder /workspace/sec-service/target/*.jar ./
+COPY sec-service/target/*.jar ./
 
 RUN set -eux; \
     BOOT_JAR=$(find . -maxdepth 1 -name 'sec-service-*.jar' ! -name '*-plain.jar' | head -n 1); \

--- a/setup-service/Dockerfile
+++ b/setup-service/Dockerfile
@@ -1,14 +1,5 @@
 # syntax=docker/dockerfile:1.7
 
-FROM maven:3.9.6-eclipse-temurin-21 AS builder
-WORKDIR /workspace
-
-COPY shared-lib ./shared-lib
-COPY setup-service ./setup-service
-
-RUN mvn -f shared-lib/pom.xml -B -DskipTests install \
-    && mvn -f setup-service/pom.xml -B -DskipTests clean package
-
 FROM eclipse-temurin:21-jre-alpine AS runner
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
@@ -18,7 +9,7 @@ RUN addgroup -g 1001 -S appgroup \
 
 WORKDIR /app
 
-COPY --from=builder /workspace/setup-service/target/*.jar ./
+COPY setup-service/target/*.jar ./
 
 RUN set -eux; \
     BOOT_JAR=$(find . -maxdepth 1 -name 'setup-service-*.jar' ! -name '*-plain.jar' | head -n 1); \

--- a/tenant-platform/billing-service/Dockerfile
+++ b/tenant-platform/billing-service/Dockerfile
@@ -1,14 +1,5 @@
 # syntax=docker/dockerfile:1.7
 
-FROM maven:3.9.6-eclipse-temurin-21 AS builder
-WORKDIR /workspace
-
-COPY shared-lib ./shared-lib
-COPY tenant-platform ./tenant-platform
-
-RUN mvn -f shared-lib/pom.xml -B -DskipTests install \
-    && mvn -f tenant-platform/pom.xml -pl billing-service -am -B -DskipTests clean package
-
 FROM eclipse-temurin:21-jre-alpine AS runner
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
@@ -18,7 +9,7 @@ RUN addgroup -g 1001 -S appgroup \
 
 WORKDIR /app
 
-COPY --from=builder /workspace/tenant-platform/billing-service/target/*.jar ./
+COPY tenant-platform/billing-service/target/*.jar ./
 
 RUN set -eux; \
     BOOT_JAR=$(find . -maxdepth 1 -name 'billing-service-*.jar' ! -name '*-plain.jar' | head -n 1); \

--- a/tenant-platform/catalog-service/Dockerfile
+++ b/tenant-platform/catalog-service/Dockerfile
@@ -1,14 +1,5 @@
 # syntax=docker/dockerfile:1.7
 
-FROM maven:3.9.6-eclipse-temurin-21 AS builder
-WORKDIR /workspace
-
-COPY shared-lib ./shared-lib
-COPY tenant-platform ./tenant-platform
-
-RUN mvn -f shared-lib/pom.xml -B -DskipTests install \
-    && mvn -f tenant-platform/pom.xml -pl catalog-service -am -B -DskipTests clean package
-
 FROM eclipse-temurin:21-jre-alpine AS runner
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
@@ -18,7 +9,7 @@ RUN addgroup -g 1001 -S appgroup \
 
 WORKDIR /app
 
-COPY --from=builder /workspace/tenant-platform/catalog-service/target/*.jar ./
+COPY tenant-platform/catalog-service/target/*.jar ./
 
 RUN set -eux; \
     BOOT_JAR=$(find . -maxdepth 1 -name 'catalog-service-*.jar' ! -name '*-plain.jar' | head -n 1); \

--- a/tenant-platform/subscription-service/Dockerfile
+++ b/tenant-platform/subscription-service/Dockerfile
@@ -1,14 +1,5 @@
 # syntax=docker/dockerfile:1.7
 
-FROM maven:3.9.6-eclipse-temurin-21 AS builder
-WORKDIR /workspace
-
-COPY shared-lib ./shared-lib
-COPY tenant-platform ./tenant-platform
-
-RUN mvn -f shared-lib/pom.xml -B -DskipTests install \
-    && mvn -f tenant-platform/pom.xml -pl subscription-service -am -B -DskipTests clean package
-
 FROM eclipse-temurin:21-jre-alpine AS runner
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
@@ -18,7 +9,7 @@ RUN addgroup -g 1001 -S appgroup \
 
 WORKDIR /app
 
-COPY --from=builder /workspace/tenant-platform/subscription-service/target/*.jar ./
+COPY tenant-platform/subscription-service/target/*.jar ./
 
 RUN set -eux; \
     BOOT_JAR=$(find . -maxdepth 1 -name 'subscription-service-*.jar' ! -name '*-plain.jar' | head -n 1); \

--- a/tenant-platform/tenant-service/Dockerfile
+++ b/tenant-platform/tenant-service/Dockerfile
@@ -1,14 +1,5 @@
 # syntax=docker/dockerfile:1.7
 
-FROM maven:3.9.6-eclipse-temurin-21 AS builder
-WORKDIR /workspace
-
-COPY shared-lib ./shared-lib
-COPY tenant-platform ./tenant-platform
-
-RUN mvn -f shared-lib/pom.xml -B -DskipTests install \
-    && mvn -f tenant-platform/pom.xml -pl tenant-service -am -B -DskipTests clean package
-
 FROM eclipse-temurin:21-jre-alpine AS runner
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication"
@@ -18,7 +9,7 @@ RUN addgroup -g 1001 -S appgroup \
 
 WORKDIR /app
 
-COPY --from=builder /workspace/tenant-platform/tenant-service/target/*.jar ./
+COPY tenant-platform/tenant-service/target/*.jar ./
 
 RUN set -eux; \
     BOOT_JAR=$(find . -maxdepth 1 -name 'tenant-service-*.jar' ! -name '*-plain.jar' | head -n 1); \


### PR DESCRIPTION
## Summary
- remove the Maven builder stages from the Spring service Dockerfiles
- copy the pre-built module jars directly from each module's target directory when building the images

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de413ea570832f84a805e92b97b7b0