### PR TITLE
Add compose label for backend network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -354,6 +354,8 @@ services:
 networks:
   backend:
     driver: bridge
+    labels:
+      com.docker.compose.network: backend
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- add the expected Docker Compose network label to the backend network definition

## Testing
- docker compose config --quiet *(fails: command not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de45b4b3b4832fb1a4530485d5b027