### PR TITLE
Fix backend network label in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -355,7 +355,7 @@ networks:
   backend:
     driver: bridge
     labels:
-      com.docker.compose.network: backend
+      com.docker.compose.network: newlms_backend
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- update the backend network label to match the Compose-generated network name

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68de4837388c832f85fd56bda164b9e1