### PR TITLE
Fix Docker Compose backend network label conflict

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -354,8 +354,6 @@ services:
 networks:
   backend:
     driver: bridge
-    labels:
-      com.docker.compose.network: newlms_backend
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- remove the custom label on the shared backend network so Compose can reuse existing networks without errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de4a4e2408832f9803a70a45854475