### PR TITLE
Fix security service Dockerfile jar copy path

### DIFF
--- a/sec-service/Dockerfile
+++ b/sec-service/Dockerfile
@@ -9,7 +9,7 @@ RUN addgroup -g 1001 -S appgroup \
 
 WORKDIR /app
 
-COPY sec-service/target/*.jar ./
+COPY target/*.jar ./
 
 RUN set -eux; \
     BOOT_JAR=$(find . -maxdepth 1 -name 'sec-service-*.jar' ! -name '*-plain.jar' | head -n 1); \


### PR DESCRIPTION
## Summary
- update the security service Dockerfile to copy the packaged jar from the correct target directory so image builds succeed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de4fbc5ce4832fadea49cb7b1414d1