### PR TITLE
Fix audit tenant column mapping

### DIFF
--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/core/dispatch/sinks/DatabaseSink.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/core/dispatch/sinks/DatabaseSink.java
@@ -24,7 +24,7 @@ public class DatabaseSink implements Sink {
     this.table = (schema == null || schema.isBlank() ? "public" : schema) + "." + table;
     this.insertSql =
         "INSERT INTO " + this.table + " (" +
-        " id, ts_utc, " + HeaderNames.X_TENANT_ID + ", actor_id, actor_username, action, entity_type, entity_id, outcome," +
+        " id, ts_utc, x_tenant_id, actor_id, actor_username, action, entity_type, entity_id, outcome," +
         " data_class, sensitivity, resource_path, resource_method, correlation_id, span_id, message, payload) " +
         "VALUES (? , ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, cast(? as jsonb))";
   }

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/persistence/entity/AuditEventEntity.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/persistence/entity/AuditEventEntity.java
@@ -1,6 +1,5 @@
 package com.ejada.audit.starter.persistence.entity;
 
-import com.ejada.common.constants.HeaderNames;
 import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.UUID;
@@ -11,7 +10,7 @@ public class AuditEventEntity {
   @Id
   private UUID id;
   @Column(name="ts_utc") private Instant tsUtc;
-  @Column(name = HeaderNames.X_TENANT_ID) private String xTenantId;
+  @Column(name="x_tenant_id") private String xTenantId;
   @Column(name="actor_id") private String actorId;
   @Column(name="actor_username") private String actorUsername;
   @Column(name="action") private String action;


### PR DESCRIPTION
## Summary
- align the audit JDBC insert SQL with the x_tenant_id column defined in the schema
- update the JPA audit event entity to map its tenant field to the same column

## Testing
- mvn -pl shared-lib/shared-starters/starter-audit -am -DskipTests compile *(fails: module path not found in reactor)*

------
https://chatgpt.com/codex/tasks/task_e_68de52e7aa34832fb859e737277233e0