### PR TITLE
Add explicit JDBC JSON type mappings for jsonb columns

### DIFF
--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/model/OutboxEvent.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/model/OutboxEvent.java
@@ -14,6 +14,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 
@@ -44,6 +46,7 @@ public class OutboxEvent {
   @Column(name = "event_type", length = EVENT_TYPE_LENGTH, nullable = false)
   private String eventType;
 
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
   private String payload;
 

--- a/tenant-platform/billing-service/src/main/java/com/ejada/billing/model/UsageEvent.java
+++ b/tenant-platform/billing-service/src/main/java/com/ejada/billing/model/UsageEvent.java
@@ -14,6 +14,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -44,6 +46,7 @@ public class UsageEvent {
   private String tokenHash;
 
   /** Raw request payload for audit (JSON string stored in jsonb). */
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
   private String payload;
 
@@ -63,6 +66,7 @@ public class UsageEvent {
   private String statusDesc;
 
   /** Optional details (errors etc.) as JSON. */
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "status_dtls", columnDefinition = "jsonb")
   private String statusDtls;
 

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/AddonFeature.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/AddonFeature.java
@@ -2,6 +2,8 @@ package com.ejada.catalog.model;
 
 import jakarta.persistence.*;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import lombok.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -74,6 +76,7 @@ public class AddonFeature {
     @Column(name = "overage_currency", length = 3)
     private String overageCurrency = "SAR";
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "meta", columnDefinition = "jsonb")
     private String meta;
 

--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierFeature.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/model/TierFeature.java
@@ -2,6 +2,8 @@ package com.ejada.catalog.model;
 
 import jakarta.persistence.*;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -82,6 +84,7 @@ public class TierFeature {
     private String overageCurrency = "SAR";
 
     // Meta / soft-delete
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "meta", columnDefinition = "jsonb")
     private String meta;
 

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/EntitlementCache.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/EntitlementCache.java
@@ -17,6 +17,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -84,6 +86,7 @@ public class EntitlementCache {
     @Column(name = "effective_to")
     private OffsetDateTime effectiveTo;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "source_meta", columnDefinition = "jsonb")
     private String sourceMeta;
 

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/Subscription.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/Subscription.java
@@ -14,6 +14,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -127,6 +129,7 @@ public class Subscription {
     private String prevSubscriptionUpdateAction; // UPGRADE | DOWNGRADE | RENEWAL
 
     // housekeeping
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "meta", columnDefinition = "jsonb")
     private String meta;
 

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantIntegrationKey.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantIntegrationKey.java
@@ -18,6 +18,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 // Uncomment if using hibernate-types library:
 // import com.vladmihalcea.hibernate.type.array.StringArrayType;
@@ -107,6 +109,7 @@ public class TenantIntegrationKey {
     // private Map<String, Object> meta;
 
     // Option B: store raw JSON string
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "meta", columnDefinition = "jsonb")
     private String meta;
 


### PR DESCRIPTION
## Summary
- ensure all jsonb-backed entity fields declare `@JdbcTypeCode(SqlTypes.JSON)` so Hibernate binds parameters correctly
- cover subscription, catalog, billing, and tenant service entities that persist JSON metadata

## Testing
- mvn -pl subscription-service,catalog-service,tenant-service,billing-service -am -DskipTests compile *(fails: missing internal parent/shared BOM artifacts in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de57a20880832f81bb28903558a152