### PR TITLE
Add lenient UUID converter for subscription inbound headers

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/web/LenientUuidConverter.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/web/LenientUuidConverter.java
@@ -1,0 +1,28 @@
+package com.ejada.subscription.web;
+
+import java.util.UUID;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Converter that tolerates UUID header values wrapped in curly braces.
+ */
+@Component
+public class LenientUuidConverter implements Converter<String, UUID> {
+
+    @Override
+    public UUID convert(@Nullable final String source) {
+        if (!StringUtils.hasText(source)) {
+            return null;
+        }
+
+        String normalized = source.trim();
+        if (normalized.startsWith("{") && normalized.endsWith("}")) {
+            normalized = normalized.substring(1, normalized.length() - 1);
+        }
+
+        return UUID.fromString(normalized);
+    }
+}

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/web/LenientUuidConverterTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/web/LenientUuidConverterTest.java
@@ -1,0 +1,32 @@
+package com.ejada.subscription.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class LenientUuidConverterTest {
+
+    private final LenientUuidConverter converter = new LenientUuidConverter();
+
+    @Test
+    void convertReturnsNullWhenSourceIsBlank() {
+        assertThat(converter.convert(null)).isNull();
+        assertThat(converter.convert(" ")).isNull();
+    }
+
+    @Test
+    void convertStripsCurlyBracesBeforeParsing() {
+        UUID expected = UUID.randomUUID();
+        String wrapped = "{" + expected + "}";
+
+        assertThat(converter.convert(wrapped)).isEqualTo(expected);
+    }
+
+    @Test
+    void convertDelegatesToUuidParsingForInvalidValues() {
+        assertThatThrownBy(() -> converter.convert("not-a-uuid"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Spring converter that trims curly braces from rqUID header values before converting to UUID
- cover the new converter with unit tests to ensure blank and wrapped values are handled

## Testing
- mvn -pl subscription-service test *(fails: missing internal BOM and dependency versions in the provided workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68de5b6d62cc832f9ea34d813652c906