### PR TITLE
Annotate Kafka producer/consumer configs for auto-registration

### DIFF
--- a/shared-lib/shared-starters/starter-kafka/src/main/java/com/ejada/kafka_starter/config/KafkaConsumerConfig.java
+++ b/shared-lib/shared-starters/starter-kafka/src/main/java/com/ejada/kafka_starter/config/KafkaConsumerConfig.java
@@ -8,6 +8,7 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
@@ -23,6 +24,7 @@ import org.springframework.kafka.support.serializer.JsonDeserializer;
 import java.util.HashMap;
 import java.util.Map;
 
+@AutoConfiguration
 public class KafkaConsumerConfig {
 
     @Bean

--- a/shared-lib/shared-starters/starter-kafka/src/main/java/com/ejada/kafka_starter/config/KafkaProducerConfig.java
+++ b/shared-lib/shared-starters/starter-kafka/src/main/java/com/ejada/kafka_starter/config/KafkaProducerConfig.java
@@ -6,6 +6,7 @@ import com.ejada.common.context.ContextManager;
 import com.ejada.kafka_starter.props.KafkaProperties;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.core.*;
@@ -29,6 +30,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
+@AutoConfiguration
 public class KafkaProducerConfig {
 
   @Bean

--- a/shared-lib/shared-starters/starter-kafka/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/shared-lib/shared-starters/starter-kafka/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,4 @@
 com.ejada.kafka_starter.config.KafkaAutoConfiguration
+com.ejada.kafka_starter.config.KafkaConsumerConfig
+com.ejada.kafka_starter.config.KafkaProducerConfig
 com.ejada.kafka_starter.config.TenantProvisioningAutoConfiguration


### PR DESCRIPTION
## Summary
- annotate Kafka producer and consumer configuration classes with `@AutoConfiguration`
- register both configurations in the starter auto-configuration imports so their beans are discovered

## Testing
- `mvn -pl starter-kafka clean package` *(fails: missing private dependency com.ejada:shared-bom:1.0.0 in Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68de5e20f790832fa4aafbe7a2666652