### PR TITLE
Automate tenant and security admin provisioning for new subscriptions

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/config/SubscriptionApprovalConfiguration.java
+++ b/sec-service/src/main/java/com/ejada/sec/config/SubscriptionApprovalConfiguration.java
@@ -1,0 +1,10 @@
+package com.ejada.sec.config;
+
+import com.ejada.common.events.subscription.SubscriptionApprovalProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(SubscriptionApprovalProperties.class)
+public class SubscriptionApprovalConfiguration {
+}

--- a/sec-service/src/main/java/com/ejada/sec/kafka/TenantAdminProvisioningListener.java
+++ b/sec-service/src/main/java/com/ejada/sec/kafka/TenantAdminProvisioningListener.java
@@ -1,0 +1,154 @@
+package com.ejada.sec.kafka;
+
+import com.ejada.common.events.subscription.SubscriptionApprovalAction;
+import com.ejada.common.events.subscription.SubscriptionApprovalMessage;
+import com.ejada.common.tenant.TenantIdentifiers;
+import com.ejada.sec.dto.CreateUserRequest;
+import com.ejada.sec.dto.UserDto;
+import com.ejada.sec.repository.RoleRepository;
+import com.ejada.sec.repository.UserRepository;
+import com.ejada.sec.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TenantAdminProvisioningListener {
+
+    private static final List<String> ADMIN_ROLES = List.of("TENANT_ADMIN");
+    private static final int MAX_USERNAME_LENGTH = 120;
+    private static final int GENERATED_PASSWORD_LENGTH = 16;
+    private static final char[] PASSWORD_ALPHABET =
+            "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789@#%&*!".toCharArray();
+
+    private final ObjectMapper objectMapper;
+    private final UserService userService;
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @KafkaListener(
+            topics = "#{@subscriptionApprovalProperties.topic}",
+            groupId = "#{@subscriptionApprovalProperties.consumerGroup}",
+            containerFactory = "subscriptionApprovalListenerContainerFactory")
+    @Transactional
+    public void onMessage(@Payload final Map<String, Object> payload, final Acknowledgment acknowledgment) {
+        SubscriptionApprovalMessage message = objectMapper.convertValue(payload, SubscriptionApprovalMessage.class);
+
+        if (message.action() != SubscriptionApprovalAction.APPROVED) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (!StringUtils.hasText(message.tenantCode())) {
+            throw new IllegalArgumentException("Missing tenant code in approval message " + message.requestId());
+        }
+
+        if (!StringUtils.hasText(message.adminEmail())) {
+            log.warn(
+                    "Subscription approval {} for tenant {} does not include admin email; skipping auto provisioning",
+                    message.requestId(),
+                    message.tenantCode());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        UUID tenantId = TenantIdentifiers.deriveTenantId(message.tenantCode());
+        ensureTenantAdminRoleExists(tenantId);
+
+        if (userRepository.existsByTenantIdAndEmail(tenantId, message.adminEmail())) {
+            log.info(
+                    "Admin user {} already exists for tenant {}", message.adminEmail(), message.tenantCode());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        String username = generateUsername(tenantId, message);
+        String password = generateTemporaryPassword();
+
+        CreateUserRequest request = CreateUserRequest.builder()
+                .tenantId(tenantId)
+                .username(username)
+                .email(message.adminEmail())
+                .password(password)
+                .roles(ADMIN_ROLES)
+                .build();
+
+        var response = userService.create(request);
+        if (!response.isSuccess() || response.getData() == null) {
+            throw new IllegalStateException(
+                    "Failed to create admin user for tenant %s: %s".formatted(
+                            message.tenantCode(), response.getCode()));
+        }
+
+        UserDto created = response.getData();
+        log.info(
+                "Provisioned tenant admin '{}' ({}) for tenant {}. Temporary credentials issued; enforce password reset.",
+                created.getUsername(),
+                created.getEmail(),
+                message.tenantCode());
+
+        acknowledgment.acknowledge();
+    }
+
+    private void ensureTenantAdminRoleExists(final UUID tenantId) {
+        if (roleRepository.existsByTenantIdAndCode(tenantId, ADMIN_ROLES.getFirst())) {
+            return;
+        }
+
+        var role = new com.ejada.sec.domain.Role();
+        role.setTenantId(tenantId);
+        role.setCode(ADMIN_ROLES.getFirst());
+        role.setName("Tenant Administrator");
+        roleRepository.save(role);
+    }
+
+    private String generateUsername(final UUID tenantId, final SubscriptionApprovalMessage message) {
+        String base = null;
+        if (StringUtils.hasText(message.adminEmail())) {
+            int at = message.adminEmail().indexOf('@');
+            base = at > 0 ? message.adminEmail().substring(0, at) : message.adminEmail();
+        }
+        if (!StringUtils.hasText(base) && StringUtils.hasText(message.tenantCode())) {
+            base = message.tenantCode().toLowerCase(Locale.ROOT) + ".admin";
+        }
+        if (!StringUtils.hasText(base)) {
+            base = "tenant.admin";
+        }
+
+        base = base.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9._-]", "-");
+        base = base.length() > MAX_USERNAME_LENGTH ? base.substring(0, MAX_USERNAME_LENGTH) : base;
+
+        String candidate = base;
+        int suffix = 1;
+        while (userRepository.existsByTenantIdAndUsername(tenantId, candidate)) {
+            String suffixStr = String.valueOf(suffix++);
+            int maxLength = MAX_USERNAME_LENGTH - suffixStr.length();
+            String trimmed = candidate.length() > maxLength ? candidate.substring(0, maxLength) : candidate;
+            candidate = trimmed + suffixStr;
+        }
+        return candidate;
+    }
+
+    private String generateTemporaryPassword() {
+        char[] buffer = new char[GENERATED_PASSWORD_LENGTH];
+        for (int i = 0; i < buffer.length; i++) {
+            buffer[i] = PASSWORD_ALPHABET[secureRandom.nextInt(PASSWORD_ALPHABET.length)];
+        }
+        return new String(buffer);
+    }
+}

--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -158,6 +158,12 @@ shared:
       async: true
     retention:
       enabled: true
+
+app:
+  subscription-approval:
+    topic: tenant.subscription-approvals
+    consumer-group: security-tenant-bootstrap
+    approval-role: ejada-officer
       days: 90
     masking:
       enabled: true

--- a/sec-service/src/main/resources/application-qa.yaml
+++ b/sec-service/src/main/resources/application-qa.yaml
@@ -158,6 +158,12 @@ shared:
       async: true
     retention:
       enabled: true
+
+app:
+  subscription-approval:
+    topic: tenant.subscription-approvals
+    consumer-group: security-tenant-bootstrap
+    approval-role: ejada-officer
       days: 90
     masking:
       enabled: true

--- a/sec-service/src/test/java/com/ejada/sec/kafka/TenantAdminProvisioningListenerTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/kafka/TenantAdminProvisioningListenerTest.java
@@ -1,0 +1,149 @@
+package com.ejada.sec.kafka;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.events.subscription.SubscriptionApprovalAction;
+import com.ejada.common.events.subscription.SubscriptionApprovalMessage;
+import com.ejada.common.tenant.TenantIdentifiers;
+import com.ejada.sec.dto.UserDto;
+import com.ejada.sec.repository.RoleRepository;
+import com.ejada.sec.repository.UserRepository;
+import com.ejada.sec.service.UserService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class TenantAdminProvisioningListenerTest {
+
+    @Mock private UserService userService;
+    @Mock private UserRepository userRepository;
+    @Mock private RoleRepository roleRepository;
+    @Mock private Acknowledgment acknowledgment;
+
+    private final ObjectMapper objectMapper =
+            new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private TenantAdminProvisioningListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new TenantAdminProvisioningListener(
+                objectMapper, userService, userRepository, roleRepository);
+    }
+
+    @Test
+    void ignoresNonApprovedMessages() {
+        SubscriptionApprovalMessage message = baseMessage(SubscriptionApprovalAction.REQUEST);
+
+        listener.onMessage(asPayload(message), acknowledgment);
+
+        verify(acknowledgment).acknowledge();
+        verify(userService, never()).create(any());
+    }
+
+    @Test
+    void skipsWhenAdminEmailMissing() {
+        SubscriptionApprovalMessage message =
+                new SubscriptionApprovalMessage(
+                        SubscriptionApprovalAction.APPROVED,
+                        UUID.randomUUID(),
+                        123L,
+                        456L,
+                        "Customer",
+                        null,
+                        null,
+                        null,
+                        "TEN-1",
+                        "Tenant",
+                        "ops@example.com",
+                        null,
+                        "role",
+                        OffsetDateTime.now(),
+                        null);
+
+        listener.onMessage(asPayload(message), acknowledgment);
+
+        verify(acknowledgment).acknowledge();
+        verify(userService, never()).create(any());
+    }
+
+    @Test
+    void createsAdminUserWhenMissing() {
+        SubscriptionApprovalMessage message = baseMessage(SubscriptionApprovalAction.APPROVED);
+        UUID tenantId = TenantIdentifiers.deriveTenantId(message.tenantCode());
+
+        when(roleRepository.existsByTenantIdAndCode(tenantId, "TENANT_ADMIN")).thenReturn(false);
+        when(userRepository.existsByTenantIdAndEmail(tenantId, message.adminEmail())).thenReturn(false);
+        when(userRepository.existsByTenantIdAndUsername(eq(tenantId), any())).thenReturn(false);
+        when(userService.create(any())).thenReturn(BaseResponse.success(
+                "created",
+                UserDto.builder()
+                        .tenantId(tenantId)
+                        .username("admin")
+                        .email(message.adminEmail())
+                        .build()));
+
+        assertThatCode(() -> listener.onMessage(asPayload(message), acknowledgment)).doesNotThrowAnyException();
+
+        verify(roleRepository).save(any());
+        verify(userService).create(any());
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    void rethrowsWhenUserCreationFails() {
+        SubscriptionApprovalMessage message = baseMessage(SubscriptionApprovalAction.APPROVED);
+        UUID tenantId = TenantIdentifiers.deriveTenantId(message.tenantCode());
+
+        when(roleRepository.existsByTenantIdAndCode(tenantId, "TENANT_ADMIN")).thenReturn(true);
+        when(userRepository.existsByTenantIdAndEmail(tenantId, message.adminEmail())).thenReturn(false);
+        when(userRepository.existsByTenantIdAndUsername(eq(tenantId), any())).thenReturn(false);
+        when(userService.create(any())).thenReturn(BaseResponse.error("ERR", "boom"));
+
+        assertThatThrownBy(() -> listener.onMessage(asPayload(message), acknowledgment))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to create admin user");
+
+        verify(acknowledgment, never()).acknowledge();
+    }
+
+    private SubscriptionApprovalMessage baseMessage(final SubscriptionApprovalAction action) {
+        return new SubscriptionApprovalMessage(
+                action,
+                UUID.randomUUID(),
+                123L,
+                456L,
+                "Customer",
+                null,
+                "admin@example.com",
+                "+966500000000",
+                "TEN-100",
+                "Tenant",
+                "ops@example.com",
+                "+966500000001",
+                "role",
+                OffsetDateTime.now(),
+                null);
+    }
+
+    private Map<String, Object> asPayload(final SubscriptionApprovalMessage message) {
+        return objectMapper.convertValue(message, new TypeReference<Map<String, Object>>() {});
+    }
+}

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/tenant/TenantIdentifiers.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/tenant/TenantIdentifiers.java
@@ -1,0 +1,37 @@
+package com.ejada.common.tenant;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.UUID;
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility helpers for deriving stable identifiers from tenant metadata.
+ */
+public final class TenantIdentifiers {
+
+    private static final String NAMESPACE_PREFIX = "tenant:";
+
+    private TenantIdentifiers() {
+        // utility class
+    }
+
+    /**
+     * Deterministically derives a UUID that can be used as the security tenant identifier
+     * from the supplied tenant code. The same tenant code will always yield the same UUID,
+     * allowing independent services to agree on the identifier without an extra lookup.
+     *
+     * @param tenantCode canonical tenant code (case insensitive)
+     * @return derived UUID
+     * @throws IllegalArgumentException if {@code tenantCode} is blank
+     */
+    public static UUID deriveTenantId(final String tenantCode) {
+        if (!StringUtils.hasText(tenantCode)) {
+            throw new IllegalArgumentException("tenantCode must not be blank");
+        }
+
+        String normalized = tenantCode.trim().toLowerCase(Locale.ROOT);
+        byte[] bytes = (NAMESPACE_PREFIX + normalized).getBytes(StandardCharsets.UTF_8);
+        return UUID.nameUUIDFromBytes(bytes);
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/Subscription.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/Subscription.java
@@ -128,6 +128,12 @@ public class Subscription {
     @Column(name = "prev_subscription_update_action", length = 16)
     private String prevSubscriptionUpdateAction; // UPGRADE | DOWNGRADE | RENEWAL
 
+    @Column(name = "tenant_code", length = 64)
+    private String tenantCode;
+
+    @Column(name = "security_tenant_id")
+    private java.util.UUID securityTenantId;
+
     // housekeeping
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "meta", columnDefinition = "jsonb")

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/tenant/TenantLink.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/tenant/TenantLink.java
@@ -1,0 +1,5 @@
+package com.ejada.subscription.tenant;
+
+import java.util.UUID;
+
+public record TenantLink(String tenantCode, String tenantName, UUID securityTenantId) {}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/tenant/TenantLinkFactory.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/tenant/TenantLinkFactory.java
@@ -1,0 +1,85 @@
+package com.ejada.subscription.tenant;
+
+import com.ejada.common.marketplace.subscription.dto.ReceiveSubscriptionNotificationRq;
+import com.ejada.common.tenant.TenantIdentifiers;
+import com.ejada.subscription.model.Subscription;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Produces normalized tenant metadata derived from incoming marketplace payloads and
+ * stored subscription entities.
+ */
+@Component
+public class TenantLinkFactory {
+
+    private static final int TENANT_CODE_MAX = 64;
+    private static final int TENANT_NAME_MAX = 128;
+
+    public TenantLink resolve(
+            final ReceiveSubscriptionNotificationRq request, final Subscription subscription) {
+
+        String tenantCode = sanitizeCode(subscription != null ? subscription.getTenantCode() : null);
+        if (!StringUtils.hasText(tenantCode) && subscription != null) {
+            tenantCode = deriveDefaultCode(subscription);
+        }
+
+        String tenantName = sanitizeName(resolveTenantName(request, tenantCode));
+        UUID securityTenantId = subscription != null && subscription.getSecurityTenantId() != null
+                ? subscription.getSecurityTenantId()
+                : (StringUtils.hasText(tenantCode) ? TenantIdentifiers.deriveTenantId(tenantCode) : null);
+
+        return new TenantLink(tenantCode, tenantName, securityTenantId);
+    }
+
+    private String deriveDefaultCode(final Subscription subscription) {
+        Long customerId = subscription.getExtCustomerId();
+        String base = customerId != null
+                ? "CUST-" + customerId
+                : "SUB-" + Optional.ofNullable(subscription.getExtSubscriptionId()).orElse(0L);
+        String normalized = base.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9-]", "-");
+        return sanitizeCode(normalized);
+    }
+
+    private String resolveTenantName(
+            final ReceiveSubscriptionNotificationRq request, final String tenantCode) {
+        if (request == null || request.customerInfo() == null) {
+            return tenantCode;
+        }
+        return firstNonBlank(
+                request.customerInfo().customerNameEn(),
+                request.customerInfo().customerNameAr(),
+                tenantCode);
+    }
+
+    private String sanitizeCode(final String code) {
+        return safeTrim(code, TENANT_CODE_MAX);
+    }
+
+    private String sanitizeName(final String name) {
+        return safeTrim(name, TENANT_NAME_MAX);
+    }
+
+    private String safeTrim(final String value, final int maxLength) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.length() <= maxLength ? trimmed : trimmed.substring(0, maxLength);
+    }
+
+    private String firstNonBlank(final String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (StringUtils.hasText(value)) {
+                return value.trim();
+            }
+        }
+        return null;
+    }
+}

--- a/tenant-platform/subscription-service/src/main/resources/db/migration/postgresql/V6__subscription_tenant_link.sql
+++ b/tenant-platform/subscription-service/src/main/resources/db/migration/postgresql/V6__subscription_tenant_link.sql
@@ -1,0 +1,7 @@
+ALTER TABLE subscription
+    ADD COLUMN IF NOT EXISTS tenant_code VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS security_tenant_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_sub_tenant_code
+    ON subscription(tenant_code)
+    WHERE tenant_code IS NOT NULL;

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantCreateReq.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantCreateReq.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import java.util.UUID;
 
 @Schema(name = "TenantCreateReq")
 public record TenantCreateReq(
@@ -34,5 +35,8 @@ public record TenantCreateReq(
         String logoUrl,
 
         @Schema(description = "Active flag; defaults to true if null")
-        Boolean active
+        Boolean active,
+
+        @Schema(description = "Deterministic security tenant identifier")
+        UUID securityTenantId
 ) { }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantRes.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantRes.java
@@ -2,6 +2,7 @@ package com.ejada.tenant.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Schema(name = "TenantRes")
 public record TenantRes(
@@ -13,6 +14,7 @@ public record TenantRes(
         String logoUrl,
         Boolean active,
         Boolean isDeleted,
+        UUID securityTenantId,
         OffsetDateTime createdAt,
         OffsetDateTime updatedAt
 ) { }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/kafka/SubscriptionApprovalListener.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/kafka/SubscriptionApprovalListener.java
@@ -2,6 +2,7 @@ package com.ejada.tenant.kafka;
 
 import com.ejada.common.events.subscription.SubscriptionApprovalAction;
 import com.ejada.common.events.subscription.SubscriptionApprovalMessage;
+import com.ejada.common.tenant.TenantIdentifiers;
 import com.ejada.tenant.dto.TenantCreateReq;
 import com.ejada.tenant.exception.TenantConflictException;
 import com.ejada.tenant.service.TenantService;
@@ -53,7 +54,8 @@ public class SubscriptionApprovalListener {
                 message.contactEmail(),
                 message.contactPhone(),
                 null,
-                Boolean.TRUE);
+                Boolean.TRUE,
+                TenantIdentifiers.deriveTenantId(message.tenantCode()));
 
         try {
             tenantService.create(req);

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/Tenant.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/Tenant.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -61,6 +62,9 @@ public class Tenant {
 
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = Boolean.FALSE;
+
+    @Column(name = "security_tenant_id")
+    private UUID securityTenantId;
 
     // If you mapped created_at/updated_at in DB, keep them here if you want to read them.
     @Column(name = "created_at", updatable = false, insertable = false)

--- a/tenant-platform/tenant-service/src/main/resources/db/migration/postgresql/V7__tenant_security_tenant_id.sql
+++ b/tenant-platform/tenant-service/src/main/resources/db/migration/postgresql/V7__tenant_security_tenant_id.sql
@@ -1,0 +1,6 @@
+ALTER TABLE tenants
+    ADD COLUMN IF NOT EXISTS security_tenant_id UUID;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tenants_security_tenant_id
+    ON tenants (security_tenant_id)
+    WHERE security_tenant_id IS NOT NULL;

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/kafka/SubscriptionApprovalListenerTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/kafka/SubscriptionApprovalListenerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.ejada.common.events.subscription.SubscriptionApprovalAction;
 import com.ejada.common.events.subscription.SubscriptionApprovalMessage;
+import com.ejada.common.tenant.TenantIdentifiers;
 import com.ejada.tenant.dto.TenantCreateReq;
 import com.ejada.tenant.exception.TenantConflictException;
 import com.ejada.tenant.exception.TenantErrorCode;
@@ -131,7 +132,8 @@ class SubscriptionApprovalListenerTest {
                         "ops@example.com",
                         "+966500000001",
                         null,
-                        Boolean.TRUE));
+                        Boolean.TRUE,
+                        TenantIdentifiers.deriveTenantId("TEN-42")));
     }
 
     @Test

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/impl/TenantServiceImplTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/service/impl/TenantServiceImplTest.java
@@ -37,7 +37,7 @@ class TenantServiceImplTest {
 
   @Test
   void createFailsWhenDuplicateCodeExists() {
-    TenantCreateReq req = new TenantCreateReq("CODE", "Tenant", null, null, null, true);
+    TenantCreateReq req = new TenantCreateReq("CODE", "Tenant", null, null, null, true, null);
     when(repository.existsByCodeAndIsDeletedFalse("CODE")).thenReturn(true);
 
     assertThatThrownBy(() -> service.create(req))
@@ -47,7 +47,7 @@ class TenantServiceImplTest {
 
   @Test
   void createFailsWhenDuplicateNameExists() {
-    TenantCreateReq req = new TenantCreateReq("CODE", "Tenant", null, null, null, true);
+    TenantCreateReq req = new TenantCreateReq("CODE", "Tenant", null, null, null, true, null);
     when(repository.existsByCodeAndIsDeletedFalse("CODE")).thenReturn(false);
     when(repository.existsByNameIgnoreCaseAndIsDeletedFalse("Tenant")).thenReturn(true);
 
@@ -58,7 +58,7 @@ class TenantServiceImplTest {
 
   @Test
   void createSucceedsWhenNoActiveDuplicates() {
-    TenantCreateReq req = new TenantCreateReq("CODE", "Tenant", null, null, null, true);
+    TenantCreateReq req = new TenantCreateReq("CODE", "Tenant", null, null, null, true, null);
     when(repository.existsByCodeAndIsDeletedFalse("CODE")).thenReturn(false);
     when(repository.existsByNameIgnoreCaseAndIsDeletedFalse("Tenant")).thenReturn(false);
 
@@ -66,7 +66,7 @@ class TenantServiceImplTest {
     when(mapper.toEntity(req)).thenReturn(entity);
     when(repository.save(entity)).thenReturn(entity);
     TenantRes mapped =
-        new TenantRes(1, "CODE", "Tenant", null, null, null, true, false, null, null);
+        new TenantRes(1, "CODE", "Tenant", null, null, null, true, false, null, null, null);
     when(mapper.toRes(entity)).thenReturn(mapped);
 
     BaseResponse<TenantRes> response = service.create(req);
@@ -113,7 +113,7 @@ class TenantServiceImplTest {
     existing.setName("Name");
     when(repository.findByIdAndIsDeletedFalse(11)).thenReturn(Optional.of(existing));
     when(repository.save(any(Tenant.class))).thenAnswer(invocation -> invocation.getArgument(0));
-    TenantRes mapped = new TenantRes(11, "CODE", "Name", null, null, null, true, false, null, null);
+    TenantRes mapped = new TenantRes(11, "CODE", "Name", null, null, null, true, false, null, null, null);
     when(mapper.toRes(any(Tenant.class))).thenReturn(mapped);
 
     TenantUpdateReq req = new TenantUpdateReq(null, "Updated", null, null, null, null);


### PR DESCRIPTION
## Summary
- derive deterministic tenant links when processing marketplace notifications and store the link on subscriptions
- publish auto-approved subscription messages and expose derived tenant metadata for downstream services
- provision tenants and bootstrap security administrators from subscription approval messages

## Testing
- `mvn -f tenant-platform/pom.xml -pl subscription-service,tenant-service test` *(fails: shared BOM artifacts are not available in this environment)*
- `mvn -pl tenant-platform/subscription-service,tenant-platform/tenant-service,sec-service test` *(fails: shared BOM artifacts are not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de63ec5074832f8ccfadc1475f8ca6