### PR TITLE
feat: introduce tenant health scoring pipeline

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/TenantApplication.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/TenantApplication.java
@@ -1,13 +1,15 @@
 package com.ejada.tenant;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableCaching
+@EnableScheduling
 @OpenAPIDefinition(info = @Info(title = "Ejada Tenant Service", version = "1.0"))
 public class TenantApplication {
   private TenantApplication() { }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/controller/TenantHealthController.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/controller/TenantHealthController.java
@@ -1,0 +1,39 @@
+package com.ejada.tenant.controller;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.http.BaseResponseController;
+import com.ejada.tenant.dto.TenantHealthScoreRes;
+import com.ejada.tenant.security.TenantAuthorized;
+import com.ejada.tenant.service.TenantHealthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tenants")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Tenant Health", description = "APIs for tenant health scoring")
+public class TenantHealthController extends BaseResponseController {
+
+    private final TenantHealthService tenantHealthService;
+
+    @GetMapping("/{id}/health-score")
+    @TenantAuthorized
+    @Operation(summary = "Get tenant health score", description = "Retrieves the latest health score for a tenant")
+    @ApiResponse(responseCode = "200", description = "Tenant health score retrieved",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    public ResponseEntity<BaseResponse<TenantHealthScoreRes>> getHealthScore(@PathVariable("id") @Min(1) final Integer tenantId) {
+        return respond(() -> tenantHealthService.getHealthScore(tenantId));
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantHealthScoreRes.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantHealthScoreRes.java
@@ -1,0 +1,21 @@
+package com.ejada.tenant.dto;
+
+import com.ejada.tenant.model.TenantHealthRiskCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Schema(name = "TenantHealthScoreRes")
+public record TenantHealthScoreRes(
+        Integer tenantId,
+        Integer score,
+        TenantHealthRiskCategory riskCategory,
+        BigDecimal featureAdoptionRate,
+        BigDecimal loginFrequencyScore,
+        BigDecimal userEngagementScore,
+        BigDecimal usageTrendPercent,
+        BigDecimal supportTicketScore,
+        BigDecimal paymentHistoryScore,
+        BigDecimal apiHealthScore,
+        OffsetDateTime evaluatedAt
+) { }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/event/TenantHealthScoreCalculatedEvent.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/event/TenantHealthScoreCalculatedEvent.java
@@ -1,0 +1,20 @@
+package com.ejada.tenant.dto.event;
+
+import com.ejada.tenant.model.TenantHealthRiskCategory;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+public record TenantHealthScoreCalculatedEvent(
+        Integer tenantId,
+        Integer score,
+        TenantHealthRiskCategory riskCategory,
+        BigDecimal featureAdoptionRate,
+        BigDecimal loginFrequencyScore,
+        BigDecimal userEngagementScore,
+        BigDecimal usageTrendPercent,
+        BigDecimal supportTicketScore,
+        BigDecimal paymentHistoryScore,
+        BigDecimal apiHealthScore,
+        OffsetDateTime evaluatedAt
+) {
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/OutboxEvent.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/OutboxEvent.java
@@ -1,0 +1,74 @@
+package com.ejada.tenant.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "outbox_event",
+        indexes = {
+                @Index(name = "idx_outbox_unpublished_tenant", columnList = "published, created_at")
+        })
+@DynamicUpdate
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OutboxEvent {
+
+    private static final int AGGREGATE_TYPE_LENGTH = 64;
+    private static final int AGGREGATE_ID_LENGTH = 128;
+    private static final int EVENT_TYPE_LENGTH = 64;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "outbox_event_id", updatable = false, nullable = false)
+    private Long outboxEventId;
+
+    @Column(name = "aggregate_type", length = AGGREGATE_TYPE_LENGTH, nullable = false)
+    private String aggregateType;
+
+    @Column(name = "aggregate_id", length = AGGREGATE_ID_LENGTH, nullable = false)
+    private String aggregateId;
+
+    @Column(name = "event_type", length = EVENT_TYPE_LENGTH, nullable = false)
+    private String eventType;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
+    private String payload;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "published", nullable = false)
+    private Boolean published;
+
+    @Column(name = "published_at")
+    private OffsetDateTime publishedAt;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now();
+        }
+        if (published == null) {
+            published = Boolean.FALSE;
+        }
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantHealthRiskCategory.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantHealthRiskCategory.java
@@ -1,0 +1,8 @@
+package com.ejada.tenant.model;
+
+public enum TenantHealthRiskCategory {
+    AT_RISK,
+    NEEDS_ATTENTION,
+    HEALTHY,
+    CHAMPION
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantHealthScore.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantHealthScore.java
@@ -1,0 +1,94 @@
+package com.ejada.tenant.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Table(name = "tenant_health_score",
+        indexes = {
+                @Index(name = "idx_tenant_health_score_tenant", columnList = "tenant_id, evaluated_at"),
+                @Index(name = "idx_tenant_health_score_created", columnList = "created_at")
+        })
+@DynamicUpdate
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class TenantHealthScore {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    @Column(name = "tenant_health_score_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "tenant_id", nullable = false)
+    private Tenant tenant;
+
+    @Column(name = "score", nullable = false)
+    private Integer score;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "risk_category", length = 32, nullable = false)
+    private TenantHealthRiskCategory riskCategory;
+
+    @Column(name = "feature_adoption_rate", precision = 5, scale = 2, nullable = false)
+    private BigDecimal featureAdoptionRate;
+
+    @Column(name = "login_frequency_score", precision = 5, scale = 2, nullable = false)
+    private BigDecimal loginFrequencyScore;
+
+    @Column(name = "user_engagement_score", precision = 5, scale = 2, nullable = false)
+    private BigDecimal userEngagementScore;
+
+    @Column(name = "usage_trend_percent", precision = 6, scale = 2, nullable = false)
+    private BigDecimal usageTrendPercent;
+
+    @Column(name = "support_ticket_score", precision = 5, scale = 2, nullable = false)
+    private BigDecimal supportTicketScore;
+
+    @Column(name = "payment_history_score", precision = 5, scale = 2, nullable = false)
+    private BigDecimal paymentHistoryScore;
+
+    @Column(name = "api_health_score", precision = 5, scale = 2, nullable = false)
+    private BigDecimal apiHealthScore;
+
+    @Column(name = "evaluated_at", nullable = false)
+    private OffsetDateTime evaluatedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void prePersist() {
+        if (evaluatedAt == null) {
+            evaluatedAt = OffsetDateTime.now();
+        }
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now();
+        }
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/OutboxEventRepository.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/OutboxEventRepository.java
@@ -1,0 +1,7 @@
+package com.ejada.tenant.repository;
+
+import com.ejada.tenant.model.OutboxEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantHealthScoreRepository.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantHealthScoreRepository.java
@@ -1,0 +1,10 @@
+package com.ejada.tenant.repository;
+
+import com.ejada.tenant.model.TenantHealthScore;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TenantHealthScoreRepository extends JpaRepository<TenantHealthScore, Long> {
+
+    Optional<TenantHealthScore> findFirstByTenant_IdOrderByEvaluatedAtDesc(Integer tenantId);
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
@@ -2,6 +2,7 @@ package com.ejada.tenant.repository;
 
 
 import com.ejada.tenant.model.Tenant;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +21,8 @@ public interface TenantRepository extends JpaRepository<Tenant, Integer> {
     Page<Tenant> findByNameContainingIgnoreCaseAndIsDeletedFalse(String name, Pageable pageable);
 
     Page<Tenant> findByNameContainingIgnoreCaseAndActiveAndIsDeletedFalse(String name, boolean active, Pageable pageable);
+
+    List<Tenant> findByIsDeletedFalse();
 
     boolean existsByCodeAndIsDeletedFalse(String code);
 

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/scheduler/TenantHealthScoreScheduler.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/scheduler/TenantHealthScoreScheduler.java
@@ -1,0 +1,31 @@
+package com.ejada.tenant.scheduler;
+
+import com.ejada.tenant.model.Tenant;
+import com.ejada.tenant.repository.TenantRepository;
+import com.ejada.tenant.service.TenantHealthService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TenantHealthScoreScheduler {
+
+    private final TenantRepository tenantRepository;
+    private final TenantHealthService tenantHealthService;
+
+    @Scheduled(cron = "0 0 2 * * ?")
+    public void recalculateDailyScores() {
+        List<Tenant> tenants = tenantRepository.findByIsDeletedFalse();
+        for (Tenant tenant : tenants) {
+            try {
+                tenantHealthService.calculateAndStoreHealthScore(tenant.getId());
+            } catch (Exception ex) {
+                log.error("Failed to calculate health score for tenant {}", tenant.getId(), ex);
+            }
+        }
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/TenantHealthService.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/TenantHealthService.java
@@ -1,0 +1,11 @@
+package com.ejada.tenant.service;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.tenant.dto.TenantHealthScoreRes;
+
+public interface TenantHealthService {
+
+    BaseResponse<TenantHealthScoreRes> getHealthScore(Integer tenantId);
+
+    TenantHealthScoreRes calculateAndStoreHealthScore(Integer tenantId);
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/health/DefaultTenantHealthMetricsProvider.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/health/DefaultTenantHealthMetricsProvider.java
@@ -1,0 +1,17 @@
+package com.ejada.tenant.service.health;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnMissingBean(TenantHealthMetricsProvider.class)
+public class DefaultTenantHealthMetricsProvider implements TenantHealthMetricsProvider {
+
+    @Override
+    public TenantHealthMetrics collect(final Integer tenantId) {
+        log.debug("Using default tenant health metrics provider for tenant {}", tenantId);
+        return TenantHealthMetrics.empty();
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/health/TenantHealthMetrics.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/health/TenantHealthMetrics.java
@@ -1,0 +1,16 @@
+package com.ejada.tenant.service.health;
+
+public record TenantHealthMetrics(
+        double featureAdoptionRate,
+        double loginFrequencyScore,
+        double userEngagementScore,
+        double usageTrendScore,
+        double supportTicketScore,
+        double paymentHistoryScore,
+        double apiHealthScore
+) {
+
+    public static TenantHealthMetrics empty() {
+        return new TenantHealthMetrics(0, 0, 0, 0, 0, 0, 0);
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/health/TenantHealthMetricsProvider.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/health/TenantHealthMetricsProvider.java
@@ -1,0 +1,6 @@
+package com.ejada.tenant.service.health;
+
+public interface TenantHealthMetricsProvider {
+
+    TenantHealthMetrics collect(Integer tenantId);
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantHealthServiceImpl.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantHealthServiceImpl.java
@@ -1,0 +1,215 @@
+package com.ejada.tenant.service.impl;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.tenant.dto.TenantHealthScoreRes;
+import com.ejada.tenant.dto.event.TenantHealthScoreCalculatedEvent;
+import com.ejada.tenant.model.OutboxEvent;
+import com.ejada.tenant.model.Tenant;
+import com.ejada.tenant.model.TenantHealthRiskCategory;
+import com.ejada.tenant.model.TenantHealthScore;
+import com.ejada.tenant.repository.OutboxEventRepository;
+import com.ejada.tenant.repository.TenantHealthScoreRepository;
+import com.ejada.tenant.repository.TenantRepository;
+import com.ejada.tenant.service.TenantHealthService;
+import com.ejada.tenant.service.health.TenantHealthMetrics;
+import com.ejada.tenant.service.health.TenantHealthMetricsProvider;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+import java.util.EnumMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TenantHealthServiceImpl implements TenantHealthService {
+
+    private static final String AGGREGATE_TYPE = "TENANT";
+    private static final String EVENT_TYPE = "TenantHealthScoreCalculated";
+    private static final Map<MetricKey, Double> WEIGHTS = createWeights();
+
+    private final TenantRepository tenantRepository;
+    private final TenantHealthScoreRepository tenantHealthScoreRepository;
+    private final TenantHealthMetricsProvider metricsProvider;
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public BaseResponse<TenantHealthScoreRes> getHealthScore(final Integer tenantId) {
+        Tenant tenant = tenantRepository.findByIdAndIsDeletedFalse(tenantId)
+                .orElseThrow(() -> new EntityNotFoundException("Tenant " + tenantId));
+
+        TenantHealthScore latest = tenantHealthScoreRepository
+                .findFirstByTenant_IdOrderByEvaluatedAtDesc(tenant.getId())
+                .orElseGet(() -> persistHealthScore(tenant));
+
+        return BaseResponse.success("Tenant health score fetched", mapToResponse(latest));
+    }
+
+    @Override
+    public TenantHealthScoreRes calculateAndStoreHealthScore(final Integer tenantId) {
+        Tenant tenant = tenantRepository.findByIdAndIsDeletedFalse(tenantId)
+                .orElseThrow(() -> new EntityNotFoundException("Tenant " + tenantId));
+        TenantHealthScore score = persistHealthScore(tenant);
+        return mapToResponse(score);
+    }
+
+    private TenantHealthScore persistHealthScore(final Tenant tenant) {
+        TenantHealthMetrics metrics = metricsOrDefault(metricsProvider.collect(tenant.getId()));
+        int score = calculateScore(metrics);
+        TenantHealthRiskCategory riskCategory = determineRiskCategory(score);
+        TenantHealthScore entity = TenantHealthScore.builder()
+                .tenant(Tenant.ref(tenant.getId()))
+                .score(score)
+                .riskCategory(riskCategory)
+                .featureAdoptionRate(toPercentage(metrics.featureAdoptionRate()))
+                .loginFrequencyScore(toPercentage(metrics.loginFrequencyScore()))
+                .userEngagementScore(toPercentage(metrics.userEngagementScore()))
+                .usageTrendPercent(toTrendPercentage(metrics.usageTrendScore()))
+                .supportTicketScore(toPercentage(metrics.supportTicketScore()))
+                .paymentHistoryScore(toPercentage(metrics.paymentHistoryScore()))
+                .apiHealthScore(toPercentage(metrics.apiHealthScore()))
+                .evaluatedAt(OffsetDateTime.now())
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        TenantHealthScore saved = tenantHealthScoreRepository.save(entity);
+        publishOutboxEvent(saved);
+        return saved;
+    }
+
+    private int calculateScore(final TenantHealthMetrics metrics) {
+        double adoption = clamp(metrics.featureAdoptionRate());
+        double login = clamp(metrics.loginFrequencyScore());
+        double engagement = clamp(metrics.userEngagementScore());
+        double usage = clamp((metrics.usageTrendScore() + 1.0) / 2.0);
+        double support = clamp(metrics.supportTicketScore());
+        double payment = clamp(metrics.paymentHistoryScore());
+        double api = clamp(metrics.apiHealthScore());
+
+        double weighted = adoption * weight(MetricKey.ADOPTION)
+                + login * weight(MetricKey.LOGIN)
+                + engagement * weight(MetricKey.ENGAGEMENT)
+                + usage * weight(MetricKey.USAGE)
+                + support * weight(MetricKey.SUPPORT)
+                + payment * weight(MetricKey.PAYMENT)
+                + api * weight(MetricKey.API);
+
+        return (int) Math.round(weighted * 100);
+    }
+
+    private TenantHealthMetrics metricsOrDefault(final TenantHealthMetrics metrics) {
+        return metrics == null ? TenantHealthMetrics.empty() : metrics;
+    }
+
+    private TenantHealthRiskCategory determineRiskCategory(final int score) {
+        if (score < 40) {
+            return TenantHealthRiskCategory.AT_RISK;
+        } else if (score < 65) {
+            return TenantHealthRiskCategory.NEEDS_ATTENTION;
+        } else if (score < 85) {
+            return TenantHealthRiskCategory.HEALTHY;
+        }
+        return TenantHealthRiskCategory.CHAMPION;
+    }
+
+    private BigDecimal toPercentage(final double value) {
+        double clamped = clamp(value);
+        return BigDecimal.valueOf(clamped * 100).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal toTrendPercentage(final double value) {
+        double clamped = Math.max(-1.0, Math.min(1.0, value));
+        return BigDecimal.valueOf(clamped * 100).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private double clamp(final double value) {
+        if (Double.isNaN(value)) {
+            return 0;
+        }
+        return Math.max(0, Math.min(1, value));
+    }
+
+    private double weight(final MetricKey key) {
+        return WEIGHTS.getOrDefault(key, 0d);
+    }
+
+    private TenantHealthScoreRes mapToResponse(final TenantHealthScore score) {
+        Integer tenantId = score.getTenant() != null ? score.getTenant().getId() : null;
+        return new TenantHealthScoreRes(
+                tenantId,
+                score.getScore(),
+                score.getRiskCategory(),
+                score.getFeatureAdoptionRate(),
+                score.getLoginFrequencyScore(),
+                score.getUserEngagementScore(),
+                score.getUsageTrendPercent(),
+                score.getSupportTicketScore(),
+                score.getPaymentHistoryScore(),
+                score.getApiHealthScore(),
+                score.getEvaluatedAt()
+        );
+    }
+
+    private void publishOutboxEvent(final TenantHealthScore saved) {
+        TenantHealthScoreCalculatedEvent event = new TenantHealthScoreCalculatedEvent(
+                saved.getTenant().getId(),
+                saved.getScore(),
+                saved.getRiskCategory(),
+                saved.getFeatureAdoptionRate(),
+                saved.getLoginFrequencyScore(),
+                saved.getUserEngagementScore(),
+                saved.getUsageTrendPercent(),
+                saved.getSupportTicketScore(),
+                saved.getPaymentHistoryScore(),
+                saved.getApiHealthScore(),
+                saved.getEvaluatedAt()
+        );
+
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            OutboxEvent outboxEvent = OutboxEvent.builder()
+                    .aggregateType(AGGREGATE_TYPE)
+                    .aggregateId(String.valueOf(saved.getTenant().getId()))
+                    .eventType(EVENT_TYPE)
+                    .payload(payload)
+                    .createdAt(OffsetDateTime.now())
+                    .published(Boolean.FALSE)
+                    .build();
+            outboxEventRepository.save(outboxEvent);
+        } catch (JsonProcessingException ex) {
+            log.error("Failed to serialize tenant health score event for tenant {}", saved.getTenant().getId(), ex);
+            throw new IllegalStateException("Failed to serialize tenant health score event", ex);
+        }
+    }
+
+    private static Map<MetricKey, Double> createWeights() {
+        Map<MetricKey, Double> map = new EnumMap<>(MetricKey.class);
+        map.put(MetricKey.ADOPTION, 0.25);
+        map.put(MetricKey.LOGIN, 0.15);
+        map.put(MetricKey.ENGAGEMENT, 0.15);
+        map.put(MetricKey.USAGE, 0.15);
+        map.put(MetricKey.SUPPORT, 0.1);
+        map.put(MetricKey.PAYMENT, 0.1);
+        map.put(MetricKey.API, 0.1);
+        return Map.copyOf(map);
+    }
+
+    private enum MetricKey {
+        ADOPTION,
+        LOGIN,
+        ENGAGEMENT,
+        USAGE,
+        SUPPORT,
+        PAYMENT,
+        API
+    }
+}

--- a/tenant-platform/tenant-service/src/main/resources/db/migration/common/V8__tenant_health_score.sql
+++ b/tenant-platform/tenant-service/src/main/resources/db/migration/common/V8__tenant_health_score.sql
@@ -1,0 +1,38 @@
+-- Tenant health scoring infrastructure
+
+CREATE TABLE IF NOT EXISTS tenant_health_score (
+    tenant_health_score_id BIGSERIAL PRIMARY KEY,
+    tenant_id              INTEGER      NOT NULL,
+    score                  INTEGER      NOT NULL CHECK (score BETWEEN 0 AND 100),
+    risk_category          VARCHAR(32)  NOT NULL,
+    feature_adoption_rate  NUMERIC(5,2) NOT NULL,
+    login_frequency_score  NUMERIC(5,2) NOT NULL,
+    user_engagement_score  NUMERIC(5,2) NOT NULL,
+    usage_trend_percent    NUMERIC(6,2) NOT NULL,
+    support_ticket_score   NUMERIC(5,2) NOT NULL,
+    payment_history_score  NUMERIC(5,2) NOT NULL,
+    api_health_score       NUMERIC(5,2) NOT NULL,
+    evaluated_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    created_at             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_ths_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_health_score_tenant ON tenant_health_score (tenant_id, evaluated_at);
+CREATE INDEX IF NOT EXISTS idx_tenant_health_score_created ON tenant_health_score (created_at);
+
+CREATE TABLE IF NOT EXISTS outbox_event (
+    outbox_event_id BIGSERIAL PRIMARY KEY,
+    aggregate_type  VARCHAR(64)  NOT NULL,
+    aggregate_id    VARCHAR(128) NOT NULL,
+    event_type      VARCHAR(64)  NOT NULL,
+    payload         JSONB        NOT NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    published       BOOLEAN      NOT NULL DEFAULT FALSE,
+    published_at    TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_tenant ON outbox_event (published, created_at);
+
+COMMENT ON TABLE tenant_health_score IS 'Historical tenant health scores with metric breakdowns';
+COMMENT ON TABLE outbox_event IS 'Transactional outbox for tenant events';


### PR DESCRIPTION
## Summary
- add tenant health score domain model, repository, and migration including transactional outbox support
- implement a health scoring service with weighted metrics, risk categorization, event publication, and scheduled recalculation
- expose a secured GET /api/v1/tenants/{id}/health-score endpoint returning the latest score

## Testing
- mvn -f tenant-platform/pom.xml -pl tenant-service -am test *(fails: missing shared-bom and dependency versions in aggregator POM)*

------
https://chatgpt.com/codex/tasks/task_e_68de70de821c832fa31a8304afa58921