### PR TITLE
Fix MapStruct mapping for tenant security identifier

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
@@ -19,6 +19,7 @@ public interface TenantMapper {
     // ---------- Create ----------
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "active", source = "active")
+    @Mapping(target = "securityTenantId", source = "securityTenantId")
     @Mapping(target = "isDeleted", constant = "false")
     // DB-managed timestamps
     @Mapping(target = "createdAt", ignore = true)
@@ -40,6 +41,7 @@ public interface TenantMapper {
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "isDeleted", ignore = true)
+    @Mapping(target = "securityTenantId", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     void update(@MappingTarget @NonNull Tenant entity, @NonNull TenantUpdateReq req);


### PR DESCRIPTION
## Summary
- map the security tenant identifier when creating a tenant entity
- keep the security tenant identifier unchanged during partial updates

## Testing
- `mvn -pl tenant-service -am compile` *(fails: missing internal shared-bom and dependency versions from private repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e04320d394832f88c488206539ade4