### PR TITLE
Populate subscription metadata in mapper

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionMapper.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionMapper.java
@@ -1,6 +1,10 @@
 package com.ejada.subscription.mapper;
 
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
 import org.mapstruct.BeanMapping;
+import org.mapstruct.InheritConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -9,6 +13,7 @@ import org.mapstruct.ReportingPolicy;
 
 import com.ejada.common.marketplace.subscription.dto.SubscriptionInfoDto;
 import com.ejada.subscription.model.Subscription;
+import com.ejada.subscription.model.SubscriptionApprovalStatus;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface SubscriptionMapper {
@@ -39,18 +44,31 @@ public interface SubscriptionMapper {
     @Mapping(target = "isAutoProvEnabled",  source = "isAutoProvEnabled", defaultValue = "false")
     @Mapping(target = "prevSubscriptionId", source = "prevSubscriptionId")
     @Mapping(target = "prevSubscriptionUpdateAction", source = "prevSubscriptionUpdateAction")
-    @Mapping(target = "meta", ignore = true)
+    @Mapping(target = "approvalStatus", expression = "java(defaultApprovalStatus())")
+    @Mapping(target = "approvalRequired", expression = "java(defaultApprovalRequired())")
+    @Mapping(target = "submittedAt", expression = "java(nullOffsetDateTime())")
+    @Mapping(target = "submittedBy", expression = "java(nullString())")
+    @Mapping(target = "approvedAt", expression = "java(nullOffsetDateTime())")
+    @Mapping(target = "approvedBy", expression = "java(nullString())")
+    @Mapping(target = "rejectedAt", expression = "java(nullOffsetDateTime())")
+    @Mapping(target = "rejectedBy", expression = "java(nullString())")
+    @Mapping(target = "tenantId", expression = "java(nullLong())")
+    @Mapping(target = "adminUserId", expression = "java(nullLong())")
+    @Mapping(target = "tenantCode", expression = "java(nullString())")
+    @Mapping(target = "securityTenantId", expression = "java(nullUuid())")
+    @Mapping(target = "meta", expression = "java(nullString())")
     @Mapping(target = "isDeleted", constant = "false")
-    @Mapping(target = "createdAt", ignore = true)
-    @Mapping(target = "createdBy", ignore = true)
-    @Mapping(target = "updatedAt", ignore = true)
-    @Mapping(target = "updatedBy", ignore = true)
+    @Mapping(target = "createdAt", expression = "java(currentTimestamp())")
+    @Mapping(target = "createdBy", expression = "java(nullString())")
+    @Mapping(target = "updatedAt", expression = "java(nullOffsetDateTime())")
+    @Mapping(target = "updatedBy", expression = "java(nullString())")
     Subscription toEntity(SubscriptionInfoDto dto);
 
     @BeanMapping(
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
         ignoreByDefault = true
     )
+    @InheritConfiguration(name = "toEntity")
     @Mapping(target = "extSubscriptionId", source = "subscriptionId")
     @Mapping(target = "extCustomerId",    source = "customerId")
     @Mapping(target = "extProductId",     source = "productId")
@@ -76,5 +94,51 @@ public interface SubscriptionMapper {
     @Mapping(target = "isAutoProvEnabled",  source = "isAutoProvEnabled")
     @Mapping(target = "prevSubscriptionId", source = "prevSubscriptionId")
     @Mapping(target = "prevSubscriptionUpdateAction", source = "prevSubscriptionUpdateAction")
+    @Mapping(target = "approvalStatus", expression = "java(entity.getApprovalStatus())")
+    @Mapping(target = "approvalRequired", expression = "java(entity.getApprovalRequired())")
+    @Mapping(target = "submittedAt", expression = "java(entity.getSubmittedAt())")
+    @Mapping(target = "submittedBy", expression = "java(entity.getSubmittedBy())")
+    @Mapping(target = "approvedAt", expression = "java(entity.getApprovedAt())")
+    @Mapping(target = "approvedBy", expression = "java(entity.getApprovedBy())")
+    @Mapping(target = "rejectedAt", expression = "java(entity.getRejectedAt())")
+    @Mapping(target = "rejectedBy", expression = "java(entity.getRejectedBy())")
+    @Mapping(target = "tenantId", expression = "java(entity.getTenantId())")
+    @Mapping(target = "adminUserId", expression = "java(entity.getAdminUserId())")
+    @Mapping(target = "tenantCode", expression = "java(entity.getTenantCode())")
+    @Mapping(target = "securityTenantId", expression = "java(entity.getSecurityTenantId())")
+    @Mapping(target = "meta", expression = "java(entity.getMeta())")
+    @Mapping(target = "isDeleted", expression = "java(entity.getIsDeleted())")
+    @Mapping(target = "createdAt", expression = "java(entity.getCreatedAt())")
+    @Mapping(target = "createdBy", expression = "java(entity.getCreatedBy())")
+    @Mapping(target = "updatedAt", expression = "java(entity.getUpdatedAt())")
+    @Mapping(target = "updatedBy", expression = "java(entity.getUpdatedBy())")
     void update(@MappingTarget Subscription entity, SubscriptionInfoDto dto);
+
+    default String defaultApprovalStatus() {
+        return SubscriptionApprovalStatus.PENDING_APPROVAL.name();
+    }
+
+    default Boolean defaultApprovalRequired() {
+        return Boolean.TRUE;
+    }
+
+    default OffsetDateTime currentTimestamp() {
+        return OffsetDateTime.now();
+    }
+
+    default OffsetDateTime nullOffsetDateTime() {
+        return null;
+    }
+
+    default String nullString() {
+        return null;
+    }
+
+    default Long nullLong() {
+        return null;
+    }
+
+    default UUID nullUuid() {
+        return null;
+    }
 }


### PR DESCRIPTION
## Summary
- map approval workflow and tenant linkage fields to explicit defaults when creating subscriptions from marketplace data
- reuse the same mapping configuration for updates while preserving existing metadata so MapStruct compilation remains strict and meaningful

## Testing
- mvn -f tenant-platform/pom.xml -pl subscription-service -am compile *(fails: missing internal BOM dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e04491cb90832f80563cca93ff8e8d