### PR TITLE
Fix analytics service stream sorting lambdas

### DIFF
--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/service/AnalyticsService.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/service/AnalyticsService.java
@@ -98,7 +98,7 @@ public class AnalyticsService {
                             Collectors.toList(),
                             list ->
                                 list.stream()
-                                    .sorted(Comparator.comparing(UsageTrendPointDto::timestamp))
+                                    .sorted(Comparator.comparing(point -> point.timestamp()))
                                     .toList())));
 
     List<FeatureAdoptionResponse.FeatureTrendDto> features =
@@ -155,7 +155,9 @@ public class AnalyticsService {
 
     return new CostForecastResponse(
         tenantId,
-        forecasts.stream().sorted(Comparator.comparing(CostForecastResponse.FeatureForecastDto::featureKey)).toList(),
+        forecasts.stream()
+            .sorted(Comparator.comparing(feature -> feature.featureKey()))
+            .toList(),
         new CostForecastResponse.OffsetDateTimeRange(end, end.plusDays(FORECAST_HORIZON_DAYS)));
   }
 


### PR DESCRIPTION
## Summary
- replace method references in analytics service stream sorting with explicit lambdas to resolve compilation parsing issues

## Testing
- mvn -pl analytics-service -am -DskipTests package *(fails: missing internal Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e0482f46f4832f9de2c04de3e4e25c