### PR TITLE
Fix analytics trend collector parentheses

### DIFF
--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/service/AnalyticsService.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/service/AnalyticsService.java
@@ -88,18 +88,18 @@ public class AnalyticsService {
             .collect(
                 Collectors.groupingBy(
                     v -> v.getId().getFeatureKey(),
-                    Collectors.mapping(
-                        v ->
-                            new UsageTrendPointDto(
-                                v.getId().getUsageDay(),
-                                safeBigDecimal(v.getTotalUsage()),
-                                Optional.ofNullable(v.getEventCount()).orElse(0L)),
-                        Collectors.collectingAndThen(
-                            Collectors.toList(),
-                            list ->
-                                list.stream()
-                                    .sorted(Comparator.comparing(point -> point.timestamp()))
-                                    .toList())));
+                    Collectors.collectingAndThen(
+                        Collectors.mapping(
+                            v ->
+                                new UsageTrendPointDto(
+                                    v.getId().getUsageDay(),
+                                    safeBigDecimal(v.getTotalUsage()),
+                                    Optional.ofNullable(v.getEventCount()).orElse(0L)),
+                            Collectors.toList()),
+                        list ->
+                            list.stream()
+                                .sorted(Comparator.comparing(UsageTrendPointDto::timestamp))
+                                .toList())));
 
     List<FeatureAdoptionResponse.FeatureTrendDto> features =
         trendByFeature.entrySet().stream()


### PR DESCRIPTION
## Summary
- fix the analytics feature adoption grouping collector to properly nest mapping and sorting calls
- switch to a method reference for sorting usage trend points by timestamp

## Testing
- mvn -pl analytics-service -am clean verify *(fails: missing internal BOM and dependency versions in shared-lib/pom.xml)*

------
https://chatgpt.com/codex/tasks/task_e_68e0496e9158832fa65c774d3f8dce31