### PR TITLE
Implement admin subscription approval endpoint and workflow

### DIFF
--- a/docs/subscription-admin-approval-review.md
+++ b/docs/subscription-admin-approval-review.md
@@ -1,0 +1,33 @@
+# Subscription Admin Approval Endpoint Review
+
+## Requested capability
+
+The platform requirements describe an administrator-triggered approval flow exposed via
+`POST /api/v1/admin/approvals/{approvalRequestId}/approve`. The endpoint should:
+
+1. Validate the administrator's JWT and roles.
+2. Load and transition the `SubscriptionApprovalRequest` entity to **APPROVED**.
+3. Move the associated `Subscription` to an active/approved state.
+4. Persist audit activity, environment identifiers and outbox events.
+5. Call downstream services (tenant provisioning, billing, notifications, onboarding, etc.).
+
+## Repository findings
+
+* The subscription service only exposes `/subscription/receiveSubscriptionNotification`
+  and `/subscription/receiveSubscriptionUpdate` controller methods. No controller handles
+  `/api/v1/admin/approvals/**` routes or any manual approval payloads.
+* `ApprovalWorkflowService` and related repositories only support automatic approval flows
+  triggered when marketplace callbacks arrive. They do not persist administrator metadata
+  or invoke downstream integrations described in the requested sequence.
+* Kafka consumers publish provisioning messages **after** an approval message has already
+  been produced. There is no producer that emits the `SubscriptionApprovalMessage.APPROVED`
+  event from an administrator action.
+* No gateway configuration, DTOs, request validators or tests reference the
+  `approveSubscription` use case.
+
+## Conclusion
+
+The manual administrator approval workflow is **not implemented** in the current codebase.
+Implementing it would require creating a new REST controller and service layer capable of
+executing the end-to-end provisioning steps, coordinating with tenant, billing, policy and
+notification services, and emitting the relevant activity logs and outbox events.

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/MarketplaceCallbackOrchestrator.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/MarketplaceCallbackOrchestrator.java
@@ -126,7 +126,13 @@ public class MarketplaceCallbackOrchestrator {
                         subscriptionRepo.save(sub);
                     }
                     approvalPublisher.publishApprovalDecision(
-                            SubscriptionApprovalAction.APPROVED, rqUid, rq, sub, tenantLink);
+                            SubscriptionApprovalAction.APPROVED,
+                            rqUid,
+                            sub,
+                            rq != null ? rq.customerInfo() : null,
+                            rq != null ? rq.adminUserInfo() : null,
+                            tenantLink,
+                            submissionResult.autoApprovalRule());
                     List<SubscriptionEnvironmentIdentifier> envIds = fetchEnvironmentIdentifiers(sub);
                     ReceiveSubscriptionNotificationRs response =
                             new ReceiveSubscriptionNotificationRs(

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/AdminApprovalController.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/AdminApprovalController.java
@@ -1,0 +1,41 @@
+package com.ejada.subscription.controller;
+
+import com.ejada.common.dto.ServiceResult;
+import com.ejada.common.web.ServiceResultResponses;
+import com.ejada.subscription.dto.admin.AdminApproveSubscriptionRequest;
+import com.ejada.subscription.dto.admin.AdminApproveSubscriptionResponse;
+import com.ejada.subscription.service.approval.AdminApprovalService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller providing administrator actions for subscription approvals.
+ */
+@RestController
+@RequestMapping(value = "/api/v1/admin/approvals", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Validated
+public class AdminApprovalController {
+
+    private final AdminApprovalService approvalService;
+
+    @PostMapping(value = "/{approvalRequestId}/approve", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAuthority('ROLE_EJADA_OFFICER')")
+    public ResponseEntity<ServiceResult<AdminApproveSubscriptionResponse>> approve(
+            @PathVariable final Long approvalRequestId,
+            @Valid @RequestBody final AdminApproveSubscriptionRequest body) {
+
+        ServiceResult<AdminApproveSubscriptionResponse> result =
+                approvalService.approve(approvalRequestId, body);
+        return ServiceResultResponses.respond(result);
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/admin/AdminApproveSubscriptionRequest.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/admin/AdminApproveSubscriptionRequest.java
@@ -1,0 +1,44 @@
+package com.ejada.subscription.dto.admin;
+
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Request payload used by administrators to approve a pending subscription.
+ */
+public record AdminApproveSubscriptionRequest(
+        @Size(max = 1024) String approvalNotes,
+        List<@Size(max = 64) String> additionalChecks,
+        Boolean notifyCustomer) {
+
+    public AdminApproveSubscriptionRequest {
+        approvalNotes = normalizeNotes(approvalNotes);
+        additionalChecks = normalizeChecks(additionalChecks);
+        notifyCustomer = Boolean.TRUE.equals(notifyCustomer);
+    }
+
+    private static String normalizeNotes(final String notes) {
+        if (notes == null) {
+            return null;
+        }
+        String trimmed = notes.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static List<String> normalizeChecks(final List<String> checks) {
+        if (checks == null || checks.isEmpty()) {
+            return List.of();
+        }
+        return List.copyOf(
+                checks.stream()
+                        .filter(Objects::nonNull)
+                        .map(String::trim)
+                        .filter(entry -> !entry.isEmpty())
+                        .toList());
+    }
+
+    public boolean shouldNotifyCustomer() {
+        return Boolean.TRUE.equals(notifyCustomer);
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/admin/AdminApproveSubscriptionResponse.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/admin/AdminApproveSubscriptionResponse.java
@@ -1,0 +1,24 @@
+package com.ejada.subscription.dto.admin;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * Response payload returned after a successful manual approval.
+ */
+public record AdminApproveSubscriptionResponse(
+        Long approvalRequestId,
+        Long subscriptionId,
+        Long extSubscriptionId,
+        Long extCustomerId,
+        String approvalStatus,
+        String subscriptionStatus,
+        OffsetDateTime approvedAt,
+        String approvedBy,
+        String approverEmail,
+        UUID approvalEventId,
+        String tenantCode,
+        String tenantName,
+        String customerNameEn,
+        String customerNameAr,
+        boolean notifyCustomer) {}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/approval/AdminApprovalService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/approval/AdminApprovalService.java
@@ -1,0 +1,199 @@
+package com.ejada.subscription.service.approval;
+
+import com.ejada.common.constants.ErrorCodes;
+import com.ejada.common.dto.ServiceResult;
+import com.ejada.common.events.subscription.SubscriptionApprovalAction;
+import com.ejada.common.events.subscription.SubscriptionApprovalMessage;
+import com.ejada.common.marketplace.subscription.dto.CustomerInfoDto;
+import com.ejada.subscription.dto.admin.AdminApproveSubscriptionRequest;
+import com.ejada.subscription.dto.admin.AdminApproveSubscriptionResponse;
+import com.ejada.subscription.kafka.SubscriptionApprovalPublisher;
+import com.ejada.subscription.model.Subscription;
+import com.ejada.subscription.model.SubscriptionActivityLog;
+import com.ejada.subscription.model.SubscriptionApprovalRequest;
+import com.ejada.subscription.model.SubscriptionApprovalStatus;
+import com.ejada.subscription.repository.SubscriptionActivityLogRepository;
+import com.ejada.subscription.repository.SubscriptionApprovalRequestRepository;
+import com.ejada.subscription.repository.SubscriptionRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * Handles administrator driven approvals of subscription requests.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminApprovalService {
+
+    private final SubscriptionApprovalRequestRepository approvalRequestRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionActivityLogRepository activityLogRepository;
+    private final SubscriptionApprovalPublisher approvalPublisher;
+    private final ApprovalActorProvider actorProvider;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public ServiceResult<AdminApproveSubscriptionResponse> approve(
+            final Long approvalRequestId, final AdminApproveSubscriptionRequest command) {
+
+        SubscriptionApprovalRequest approvalRequest =
+                approvalRequestRepository.findById(approvalRequestId).orElse(null);
+        if (approvalRequest == null) {
+            return ServiceResult.error(
+                    null,
+                    ErrorCodes.NOT_FOUND,
+                    "Approval request not found",
+                    List.of("approvalRequestId=" + approvalRequestId));
+        }
+        if (!"PENDING".equalsIgnoreCase(approvalRequest.getStatus())) {
+            return ServiceResult.error(
+                    null,
+                    ErrorCodes.BUSINESS_RULE_VIOLATION,
+                    "Approval request cannot be processed",
+                    List.of("status=" + approvalRequest.getStatus()));
+        }
+
+        Subscription subscription = approvalRequest.getSubscription();
+        if (subscription == null) {
+            return ServiceResult.error(
+                    null,
+                    ErrorCodes.INTERNAL_ERROR,
+                    "Approval request is missing subscription reference",
+                    List.of("approvalRequestId=" + approvalRequestId));
+        }
+
+        ApprovalActorProvider.ApprovalActor actor = actorProvider.currentActor();
+        OffsetDateTime now = OffsetDateTime.now();
+
+        transitionApprovalRequest(approvalRequest, command, actor, now);
+        transitionSubscription(subscription, actor, now);
+
+        approvalRequestRepository.save(approvalRequest);
+        subscriptionRepository.save(subscription);
+        recordActivity(approvalRequest, subscription, command, actor);
+
+        CustomerInfoDto customerInfo = parseCustomerInfo(approvalRequest.getTenantInfoJson());
+        SubscriptionApprovalMessage message = approvalPublisher.publishApprovalDecision(
+                SubscriptionApprovalAction.APPROVED,
+                UUID.randomUUID(),
+                subscription,
+                customerInfo,
+                null,
+                null,
+                command.approvalNotes());
+
+        AdminApproveSubscriptionResponse response = new AdminApproveSubscriptionResponse(
+                approvalRequest.getApprovalRequestId(),
+                subscription.getSubscriptionId(),
+                subscription.getExtSubscriptionId(),
+                subscription.getExtCustomerId(),
+                subscription.getApprovalStatus(),
+                subscription.getSubscriptionSttsCd(),
+                subscription.getApprovedAt(),
+                subscription.getApprovedBy(),
+                approvalRequest.getApproverEmail(),
+                message.requestId(),
+                message.tenantCode(),
+                message.tenantName(),
+                message.customerNameEn(),
+                message.customerNameAr(),
+                command.shouldNotifyCustomer());
+
+        String requestId = message.requestId() != null ? message.requestId().toString() : null;
+        return ServiceResult.ok(requestId, response, "Subscription approved successfully");
+    }
+
+    private void transitionApprovalRequest(
+            final SubscriptionApprovalRequest approvalRequest,
+            final AdminApproveSubscriptionRequest command,
+            final ApprovalActorProvider.ApprovalActor actor,
+            final OffsetDateTime now) {
+
+        approvalRequest.setStatus("APPROVED");
+        approvalRequest.setApprovedAt(now);
+        approvalRequest.setApprovedBy(actor.username());
+        approvalRequest.setApproverEmail(actor.email());
+        approvalRequest.setApprovalNotes(command.approvalNotes());
+        approvalRequest.setProcessedAt(now);
+        approvalRequest.setRejectionNotes(null);
+        approvalRequest.setRejectionReason(null);
+        approvalRequest.setRejectedAt(null);
+        approvalRequest.setRejectedBy(null);
+    }
+
+    private void transitionSubscription(
+            final Subscription subscription,
+            final ApprovalActorProvider.ApprovalActor actor,
+            final OffsetDateTime now) {
+        subscription.setApprovalStatus(SubscriptionApprovalStatus.APPROVED.name());
+        subscription.setApprovalRequired(Boolean.FALSE);
+        subscription.setApprovedAt(now);
+        subscription.setApprovedBy(actor.username());
+        subscription.setRejectedAt(null);
+        subscription.setRejectedBy(null);
+        subscription.setSubscriptionSttsCd("ACTIVE");
+        subscription.setUpdatedAt(now);
+        subscription.setUpdatedBy(actor.username());
+    }
+
+    private void recordActivity(
+            final SubscriptionApprovalRequest approvalRequest,
+            final Subscription subscription,
+            final AdminApproveSubscriptionRequest command,
+            final ApprovalActorProvider.ApprovalActor actor) {
+        SubscriptionActivityLog activity = new SubscriptionActivityLog();
+        activity.setSubscription(subscription);
+        activity.setActivityType("APPROVED");
+        activity.setDescription(
+                StringUtils.hasText(command.approvalNotes())
+                        ? command.approvalNotes()
+                        : "Subscription approved by " + actor.displayName());
+        activity.setPerformedBy(actor.username());
+        activity.setMetadata(buildMetadata(approvalRequest, subscription, command, actor));
+        activityLogRepository.save(activity);
+    }
+
+    private String buildMetadata(
+            final SubscriptionApprovalRequest approvalRequest,
+            final Subscription subscription,
+            final AdminApproveSubscriptionRequest command,
+            final ApprovalActorProvider.ApprovalActor actor) {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("approvalRequestId", approvalRequest.getApprovalRequestId());
+        metadata.put("subscriptionId", subscription.getSubscriptionId());
+        metadata.put("approvalNotes", command.approvalNotes());
+        metadata.put("additionalChecks", command.additionalChecks());
+        metadata.put("notifyCustomer", command.shouldNotifyCustomer());
+        metadata.put("approvedBy", actor.username());
+        metadata.put("approverEmail", actor.email());
+        try {
+            return objectMapper.writeValueAsString(metadata);
+        } catch (JsonProcessingException ex) {
+            log.warn("Failed to serialize approval metadata", ex);
+            return null;
+        }
+    }
+
+    private CustomerInfoDto parseCustomerInfo(final String json) {
+        if (!StringUtils.hasText(json)) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(json, CustomerInfoDto.class);
+        } catch (Exception ex) {
+            log.warn("Unable to deserialize customer info for approval request", ex);
+            return null;
+        }
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/approval/ApprovalActorProvider.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/approval/ApprovalActorProvider.java
@@ -1,0 +1,87 @@
+package com.ejada.subscription.service.approval;
+
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Resolves information about the authenticated administrator performing an approval action.
+ */
+@Component
+public class ApprovalActorProvider {
+
+    private static final String DEFAULT_USERNAME = "SYSTEM";
+
+    public ApprovalActor currentActor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof JwtAuthenticationToken jwtAuth) {
+            Jwt jwt = jwtAuth.getToken();
+            String username = firstNonBlank(
+                    claim(jwt, "preferred_username"),
+                    claim(jwt, "upn"),
+                    claim(jwt, "uid"),
+                    jwt.getSubject(),
+                    authentication.getName());
+            String email = firstNonBlank(claim(jwt, "email"), claim(jwt, "mail"));
+            String displayName = firstNonBlank(claim(jwt, "name"), username);
+            return new ApprovalActor(defaultString(username), defaultString(displayName), email);
+        }
+
+        if (authentication != null && StringUtils.hasText(authentication.getName())) {
+            String username = authentication.getName();
+            return new ApprovalActor(username, username, null);
+        }
+
+        return new ApprovalActor(DEFAULT_USERNAME, DEFAULT_USERNAME, null);
+    }
+
+    private String claim(final Jwt jwt, final String name) {
+        if (jwt == null || !StringUtils.hasText(name)) {
+            return null;
+        }
+        Object value = jwt.getClaim(name);
+        if (value instanceof String str) {
+            return str;
+        }
+        if (value instanceof Iterable<?> iterable) {
+            return StreamSupport.stream(iterable.spliterator(), false)
+                    .map(this::asString)
+                    .filter(StringUtils::hasText)
+                    .findFirst()
+                    .orElse(null);
+        }
+        return asString(value);
+    }
+
+    private String asString(final Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String str) {
+            return str;
+        }
+        return value.toString();
+    }
+
+    private String firstNonBlank(final String... values) {
+        if (values == null) {
+            return null;
+        }
+        return Stream.of(values)
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String defaultString(final String value) {
+        return StringUtils.hasText(value) ? value : DEFAULT_USERNAME;
+    }
+
+    public record ApprovalActor(String username, String displayName, String email) {}
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/tenant/TenantLinkFactory.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/tenant/TenantLinkFactory.java
@@ -1,5 +1,6 @@
 package com.ejada.subscription.tenant;
 
+import com.ejada.common.marketplace.subscription.dto.CustomerInfoDto;
 import com.ejada.common.marketplace.subscription.dto.ReceiveSubscriptionNotificationRq;
 import com.ejada.common.tenant.TenantIdentifiers;
 import com.ejada.subscription.model.Subscription;
@@ -21,13 +22,18 @@ public class TenantLinkFactory {
 
     public TenantLink resolve(
             final ReceiveSubscriptionNotificationRq request, final Subscription subscription) {
+        CustomerInfoDto customerInfo = request != null ? request.customerInfo() : null;
+        return resolve(customerInfo, subscription);
+    }
+
+    public TenantLink resolve(final CustomerInfoDto customerInfo, final Subscription subscription) {
 
         String tenantCode = sanitizeCode(subscription != null ? subscription.getTenantCode() : null);
         if (!StringUtils.hasText(tenantCode) && subscription != null) {
             tenantCode = deriveDefaultCode(subscription);
         }
 
-        String tenantName = sanitizeName(resolveTenantName(request, tenantCode));
+        String tenantName = sanitizeName(resolveTenantName(customerInfo, tenantCode));
         UUID securityTenantId = subscription != null && subscription.getSecurityTenantId() != null
                 ? subscription.getSecurityTenantId()
                 : (StringUtils.hasText(tenantCode) ? TenantIdentifiers.deriveTenantId(tenantCode) : null);
@@ -44,14 +50,13 @@ public class TenantLinkFactory {
         return sanitizeCode(normalized);
     }
 
-    private String resolveTenantName(
-            final ReceiveSubscriptionNotificationRq request, final String tenantCode) {
-        if (request == null || request.customerInfo() == null) {
+    private String resolveTenantName(final CustomerInfoDto customerInfo, final String tenantCode) {
+        if (customerInfo == null) {
             return tenantCode;
         }
         return firstNonBlank(
-                request.customerInfo().customerNameEn(),
-                request.customerInfo().customerNameAr(),
+                customerInfo.customerNameEn(),
+                customerInfo.customerNameAr(),
                 tenantCode);
     }
 

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/approval/AdminApprovalServiceTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/approval/AdminApprovalServiceTest.java
@@ -1,0 +1,176 @@
+package com.ejada.subscription.service.approval;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ejada.common.dto.ServiceResult;
+import com.ejada.common.events.subscription.SubscriptionApprovalAction;
+import com.ejada.common.events.subscription.SubscriptionApprovalMessage;
+import com.ejada.common.marketplace.subscription.dto.CustomerInfoDto;
+import com.ejada.subscription.dto.admin.AdminApproveSubscriptionRequest;
+import com.ejada.subscription.dto.admin.AdminApproveSubscriptionResponse;
+import com.ejada.subscription.kafka.SubscriptionApprovalPublisher;
+import com.ejada.subscription.model.Subscription;
+import com.ejada.subscription.model.SubscriptionActivityLog;
+import com.ejada.subscription.model.SubscriptionApprovalRequest;
+import com.ejada.subscription.model.SubscriptionApprovalStatus;
+import com.ejada.subscription.repository.SubscriptionActivityLogRepository;
+import com.ejada.subscription.repository.SubscriptionApprovalRequestRepository;
+import com.ejada.subscription.repository.SubscriptionRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminApprovalServiceTest {
+
+    @Mock private SubscriptionApprovalRequestRepository approvalRequestRepository;
+    @Mock private SubscriptionRepository subscriptionRepository;
+    @Mock private SubscriptionActivityLogRepository activityLogRepository;
+    @Mock private SubscriptionApprovalPublisher approvalPublisher;
+    @Mock private ApprovalActorProvider actorProvider;
+
+    private AdminApprovalService service;
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminApprovalService(
+                approvalRequestRepository,
+                subscriptionRepository,
+                activityLogRepository,
+                approvalPublisher,
+                actorProvider,
+                objectMapper);
+    }
+
+    @Test
+    void approveTransitionsEntitiesAndPublishesEvent() throws Exception {
+        Subscription subscription = new Subscription();
+        subscription.setSubscriptionId(10L);
+        subscription.setExtSubscriptionId(123L);
+        subscription.setExtCustomerId(456L);
+        subscription.setApprovalStatus(SubscriptionApprovalStatus.PENDING_APPROVAL.name());
+        subscription.setSubscriptionSttsCd("PENDING_APPROVAL");
+
+        CustomerInfoDto customerInfo = new CustomerInfoDto(
+                "Customer EN",
+                "Customer AR",
+                "TYPE",
+                "1234",
+                "SA",
+                "RUH",
+                "Address",
+                "Address",
+                "ops@example.com",
+                "+971500000000");
+
+        SubscriptionApprovalRequest approvalRequest = new SubscriptionApprovalRequest();
+        approvalRequest.setApprovalRequestId(5L);
+        approvalRequest.setStatus("PENDING");
+        approvalRequest.setSubscription(subscription);
+        approvalRequest.setTenantInfoJson(objectMapper.writeValueAsString(customerInfo));
+
+        when(approvalRequestRepository.findById(5L)).thenReturn(Optional.of(approvalRequest));
+        when(actorProvider.currentActor())
+                .thenReturn(new ApprovalActorProvider.ApprovalActor("approver", "Approver", "approver@example.com"));
+        when(subscriptionRepository.save(any(Subscription.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(approvalRequestRepository.save(any(SubscriptionApprovalRequest.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        SubscriptionApprovalMessage message = new SubscriptionApprovalMessage(
+                SubscriptionApprovalAction.APPROVED,
+                UUID.randomUUID(),
+                subscription.getExtSubscriptionId(),
+                subscription.getExtCustomerId(),
+                customerInfo.customerNameEn(),
+                customerInfo.customerNameAr(),
+                customerInfo.email(),
+                customerInfo.mobileNo(),
+                "TEN-123",
+                "Tenant",
+                customerInfo.email(),
+                customerInfo.mobileNo(),
+                "role",
+                OffsetDateTime.now(),
+                "notes");
+        when(approvalPublisher.publishApprovalDecision(
+                        any(), any(), any(Subscription.class), any(), any(), any(), any()))
+                .thenReturn(message);
+
+        AdminApproveSubscriptionRequest request =
+                new AdminApproveSubscriptionRequest("All good", List.of("PAYMENT_VERIFIED"), true);
+
+        ServiceResult<AdminApproveSubscriptionResponse> result = service.approve(5L, request);
+
+        assertThat(result).isNotNull();
+        assertThat(result.success()).isTrue();
+        assertThat(result.payload()).isNotNull();
+        assertThat(result.payload().approvalRequestId()).isEqualTo(5L);
+        assertThat(subscription.getApprovalStatus()).isEqualTo(SubscriptionApprovalStatus.APPROVED.name());
+        assertThat(subscription.getSubscriptionSttsCd()).isEqualTo("ACTIVE");
+        assertThat(approvalRequest.getStatus()).isEqualTo("APPROVED");
+        assertThat(approvalRequest.getApprovedBy()).isEqualTo("approver");
+
+        ArgumentCaptor<SubscriptionActivityLog> logCaptor = ArgumentCaptor.forClass(SubscriptionActivityLog.class);
+        verify(activityLogRepository).save(logCaptor.capture());
+        SubscriptionActivityLog logEntry = logCaptor.getValue();
+        assertThat(logEntry.getSubscription()).isEqualTo(subscription);
+        assertThat(logEntry.getActivityType()).isEqualTo("APPROVED");
+        assertThat(logEntry.getPerformedBy()).isEqualTo("approver");
+        assertThat(logEntry.getMetadata()).contains("PAYMENT_VERIFIED");
+
+        verify(approvalPublisher)
+                .publishApprovalDecision(
+                        SubscriptionApprovalAction.APPROVED,
+                        any(UUID.class),
+                        any(Subscription.class),
+                        any(CustomerInfoDto.class),
+                        any(),
+                        any(),
+                        any());
+    }
+
+    @Test
+    void approveReturnsErrorWhenRequestMissing() {
+        when(approvalRequestRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        ServiceResult<AdminApproveSubscriptionResponse> result =
+                service.approve(999L, new AdminApproveSubscriptionRequest(null, List.of(), false));
+
+        assertThat(result.success()).isFalse();
+        verify(subscriptionRepository, never()).save(any());
+        verify(approvalPublisher, never())
+                .publishApprovalDecision(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void approveReturnsErrorWhenAlreadyProcessed() {
+        SubscriptionApprovalRequest approvalRequest = new SubscriptionApprovalRequest();
+        approvalRequest.setApprovalRequestId(7L);
+        approvalRequest.setStatus("APPROVED");
+        when(approvalRequestRepository.findById(7L)).thenReturn(Optional.of(approvalRequest));
+
+        ServiceResult<AdminApproveSubscriptionResponse> result =
+                service.approve(7L, new AdminApproveSubscriptionRequest(null, List.of(), false));
+
+        assertThat(result.success()).isFalse();
+        verify(subscriptionRepository, never()).save(any());
+        verify(approvalPublisher, never())
+                .publishApprovalDecision(any(), any(), any(), any(), any(), any(), any());
+    }
+}


### PR DESCRIPTION
## Summary
- add an administrator-facing approval controller, request/response DTOs, and service logic to transition approval requests and subscriptions while logging activity
- capture the acting approver from the security context and emit approval events via an extended publisher that supports manual decisions
- adjust tenant link resolution and the auto-approval path to use the new publisher contract and cover the workflow with unit tests

## Testing
- mvn -pl subscription-service test *(fails: missing shared-bom import and dependency versions in tenant-platform build)*

------
https://chatgpt.com/codex/tasks/task_e_68e048d02f88832f9921119dd3961294