### PR TITLE
feat: enforce tenant context and subscription validation in API gateway

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySupplementaryConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySupplementaryConfiguration.java
@@ -1,0 +1,14 @@
+package com.ejada.gateway.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+/**
+ * Enables auxiliary configuration properties for gateway-specific components
+ * that are not part of the shared starters.
+ */
+@Configuration
+@EnableConfigurationProperties({SubscriptionValidationProperties.class})
+public class GatewaySupplementaryConfiguration {
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayWebClientProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayWebClientProperties.java
@@ -1,0 +1,76 @@
+package com.ejada.gateway.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Tunable properties for the gateway {@link org.springframework.web.reactive.function.client.WebClient}.
+ */
+@ConfigurationProperties(prefix = "gateway.webclient")
+public class GatewayWebClientProperties {
+
+  private Duration connectTimeout = Duration.ofSeconds(3);
+  private Duration responseTimeout = Duration.ofSeconds(15);
+  private Duration readTimeout = Duration.ofSeconds(10);
+  private Duration writeTimeout = Duration.ofSeconds(10);
+  private boolean wiretap = false;
+  private boolean compress = true;
+  private int maxInMemorySize = 4 * 1024 * 1024; // 4MB
+
+  public Duration getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  public void setConnectTimeout(Duration connectTimeout) {
+    this.connectTimeout = connectTimeout;
+  }
+
+  public Duration getResponseTimeout() {
+    return responseTimeout;
+  }
+
+  public void setResponseTimeout(Duration responseTimeout) {
+    this.responseTimeout = responseTimeout;
+  }
+
+  public Duration getReadTimeout() {
+    return readTimeout;
+  }
+
+  public void setReadTimeout(Duration readTimeout) {
+    this.readTimeout = readTimeout;
+  }
+
+  public Duration getWriteTimeout() {
+    return writeTimeout;
+  }
+
+  public void setWriteTimeout(Duration writeTimeout) {
+    this.writeTimeout = writeTimeout;
+  }
+
+  public boolean isWiretap() {
+    return wiretap;
+  }
+
+  public void setWiretap(boolean wiretap) {
+    this.wiretap = wiretap;
+  }
+
+  public boolean isCompress() {
+    return compress;
+  }
+
+  public void setCompress(boolean compress) {
+    this.compress = compress;
+  }
+
+  public int getMaxInMemorySize() {
+    return maxInMemorySize;
+  }
+
+  public void setMaxInMemorySize(int maxInMemorySize) {
+    this.maxInMemorySize = maxInMemorySize;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/SubscriptionValidationProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/SubscriptionValidationProperties.java
@@ -1,0 +1,116 @@
+package com.ejada.gateway.config;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration properties controlling the subscription validation filter.
+ */
+@ConfigurationProperties(prefix = "gateway.subscription")
+public class SubscriptionValidationProperties {
+
+  /** Enable or disable subscription validation. */
+  private boolean enabled = true;
+
+  /** URI template for subscription validation endpoint (supports {tenantId}). */
+  private String validationUri = "lb://subscription-service/internal/subscriptions/{tenantId}";
+
+  /** Cache time-to-live for subscription lookups. */
+  private Duration cacheTtl = Duration.ofMinutes(5);
+
+  /** Cache key prefix. */
+  private String cachePrefix = "gateway:subscription:";
+
+  /** Whether to allow traffic to continue when validation fails. */
+  private boolean failOpen = true;
+
+  /** Apply validation to all routes (otherwise only those listed in requiredFeatures). */
+  private boolean validateAllRoutes = true;
+
+  /** Ant-style patterns to skip subscription validation (e.g. /actuator/**). */
+  private String[] skipPatterns = new String[] {"/actuator/**", "/fallback/**"};
+
+  /** Optional mapping of routeId to required feature identifier. */
+  private Map<String, String> requiredFeatures = new LinkedHashMap<>();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getValidationUri() {
+    return validationUri;
+  }
+
+  public void setValidationUri(String validationUri) {
+    this.validationUri = validationUri;
+  }
+
+  public Duration getCacheTtl() {
+    return cacheTtl;
+  }
+
+  public void setCacheTtl(Duration cacheTtl) {
+    this.cacheTtl = cacheTtl;
+  }
+
+  public String getCachePrefix() {
+    return cachePrefix;
+  }
+
+  public void setCachePrefix(String cachePrefix) {
+    this.cachePrefix = cachePrefix;
+  }
+
+  public boolean isFailOpen() {
+    return failOpen;
+  }
+
+  public void setFailOpen(boolean failOpen) {
+    this.failOpen = failOpen;
+  }
+
+  public boolean isValidateAllRoutes() {
+    return validateAllRoutes;
+  }
+
+  public void setValidateAllRoutes(boolean validateAllRoutes) {
+    this.validateAllRoutes = validateAllRoutes;
+  }
+
+  public String[] getSkipPatterns() {
+    return skipPatterns;
+  }
+
+  public void setSkipPatterns(String[] skipPatterns) {
+    this.skipPatterns = (skipPatterns != null) ? skipPatterns : new String[0];
+  }
+
+  public Map<String, String> getRequiredFeatures() {
+    return requiredFeatures;
+  }
+
+  public void setRequiredFeatures(Map<String, String> requiredFeatures) {
+    this.requiredFeatures = (requiredFeatures != null)
+        ? new LinkedHashMap<>(requiredFeatures)
+        : new LinkedHashMap<>();
+  }
+
+  public boolean requiresValidation(String routeId) {
+    if (validateAllRoutes) {
+      return true;
+    }
+    return StringUtils.hasText(routeId) && requiredFeatures.containsKey(routeId);
+  }
+
+  public String cacheKey(String tenantId) {
+    return cachePrefix + tenantId;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/WebClientConfig.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/WebClientConfig.java
@@ -1,0 +1,110 @@
+package com.ejada.gateway.config;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.transport.logging.AdvancedByteBufFormat;
+
+/**
+ * Central {@link WebClient} configuration with sensible defaults for
+ * downstream service calls. The builder is load-balanced so URIs with the
+ * {@code lb://} scheme resolve via Spring Cloud LoadBalancer/Eureka.
+ */
+@Configuration
+@EnableConfigurationProperties(GatewayWebClientProperties.class)
+public class WebClientConfig {
+
+  @Bean
+  public ClientHttpConnector gatewayClientHttpConnector(GatewayWebClientProperties properties) {
+    HttpClient httpClient = HttpClient.create();
+    Duration connectTimeout = properties.getConnectTimeout();
+    if (connectTimeout != null) {
+      httpClient = httpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) connectTimeout.toMillis());
+    }
+    Duration responseTimeout = properties.getResponseTimeout();
+    if (responseTimeout != null) {
+      httpClient = httpClient.responseTimeout(responseTimeout);
+    }
+    Duration readTimeout = properties.getReadTimeout();
+    Duration writeTimeout = properties.getWriteTimeout();
+    httpClient = httpClient.doOnConnected(connection -> {
+      if (readTimeout != null && !readTimeout.isZero() && !readTimeout.isNegative()) {
+        connection.addHandlerLast(new ReadTimeoutHandler(readTimeout.toMillis(), TimeUnit.MILLISECONDS));
+      }
+      if (writeTimeout != null && !writeTimeout.isZero() && !writeTimeout.isNegative()) {
+        connection.addHandlerLast(new WriteTimeoutHandler(writeTimeout.toMillis(), TimeUnit.MILLISECONDS));
+      }
+    });
+
+    if (properties.isCompress()) {
+      httpClient = httpClient.compress(true);
+    }
+    if (properties.isWiretap()) {
+      httpClient = httpClient.wiretap("gateway-webclient", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL);
+    }
+    return new ReactorClientHttpConnector(httpClient);
+  }
+
+  @Bean
+  @LoadBalanced
+  public WebClient.Builder loadBalancedWebClientBuilder(ClientHttpConnector gatewayClientHttpConnector,
+      GatewayWebClientProperties properties,
+      ObjectProvider<ExchangeFilterFunction> customFilters) {
+    WebClient.Builder builder = WebClient.builder()
+        .clientConnector(gatewayClientHttpConnector)
+        .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(properties.getMaxInMemorySize()))
+        .filter(contextPropagationFilter());
+
+    customFilters.orderedStream().forEach(builder::filter);
+    return builder;
+  }
+
+  private ExchangeFilterFunction contextPropagationFilter() {
+    return (request, next) -> Mono.deferContextual(contextView -> {
+      ClientRequest.Builder builder = ClientRequest.from(request);
+      propagate(contextView, builder, GatewayRequestAttributes.CORRELATION_ID, HeaderNames.CORRELATION_ID);
+      propagate(contextView, builder, GatewayRequestAttributes.TENANT_ID, HeaderNames.X_TENANT_ID);
+      propagate(contextView, builder, HeaderNames.USER_ID, HeaderNames.USER_ID);
+      return next.exchange(builder.build());
+    });
+  }
+
+  private void propagate(reactor.util.context.ContextView contextView, ClientRequest.Builder builder,
+      String contextKey, String headerName) {
+    if (!contextView.hasKey(contextKey)) {
+      return;
+    }
+    Object value = contextView.get(contextKey);
+    if (value == null) {
+      return;
+    }
+    String text = Objects.toString(value, null);
+    if (text == null || text.isBlank()) {
+      return;
+    }
+    builder.headers(httpHeaders -> {
+      if (!httpHeaders.containsKey(headerName)) {
+        httpHeaders.add(headerName, text);
+      }
+    });
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/context/CorrelationIdGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/CorrelationIdGatewayFilter.java
@@ -1,0 +1,86 @@
+package com.ejada.gateway.context;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.starter_core.config.CoreAutoConfiguration;
+import com.ejada.starter_core.web.FilterSkipUtils;
+import java.util.Objects;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Ensures every request flowing through the gateway has a correlation id.
+ *
+ * <p>The filter simply mirrors the servlet starter's behaviour: if the client
+ * provides a correlation id header it is reused, otherwise a new identifier is
+ * generated (when configured). The value is exposed via the exchange
+ * attributes so downstream components (rate-limiters, WebClient) can reuse it
+ * without re-parsing headers.</p>
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CorrelationIdGatewayFilter implements WebFilter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CorrelationIdGatewayFilter.class);
+
+  private final CoreAutoConfiguration.CoreProps props;
+
+  public CorrelationIdGatewayFilter(CoreAutoConfiguration.CoreProps props) {
+    this.props = Objects.requireNonNull(props, "props");
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    var correlationProps = props.getCorrelation();
+    if (!correlationProps.isEnabled()) {
+      return chain.filter(exchange);
+    }
+
+    String path = exchange.getRequest().getPath().pathWithinApplication().value();
+    if (FilterSkipUtils.shouldSkip(path, correlationProps.getSkipPatterns())) {
+      return chain.filter(exchange);
+    }
+
+    String headerName = correlationProps.getHeaderName();
+    String correlationId = trimToNull(exchange.getRequest().getHeaders().getFirst(headerName));
+    if (!StringUtils.hasText(correlationId) && correlationProps.isGenerateIfMissing()) {
+      correlationId = UUID.randomUUID().toString();
+      LOGGER.trace("Generated correlation id {} for request {}", correlationId, path);
+    }
+
+    if (!StringUtils.hasText(correlationId)) {
+      return chain.filter(exchange);
+    }
+
+    ServerWebExchange mutatedExchange = exchange;
+    if (!StringUtils.hasText(exchange.getRequest().getHeaders().getFirst(headerName))) {
+      ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+          .header(headerName, correlationId)
+          .build();
+      mutatedExchange = exchange.mutate().request(mutatedRequest).build();
+    }
+
+    mutatedExchange.getAttributes().put(GatewayRequestAttributes.CORRELATION_ID, correlationId);
+    mutatedExchange.getAttributes().putIfAbsent(HeaderNames.CORRELATION_ID, correlationId);
+
+    return chain.filter(mutatedExchange);
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/context/GatewayRequestAttributes.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/GatewayRequestAttributes.java
@@ -1,0 +1,24 @@
+package com.ejada.gateway.context;
+
+/**
+ * Keys for {@link org.springframework.web.server.ServerWebExchange#getAttributes()}
+ * used across gateway filters. Centralising the constants avoids string typos
+ * when different components need to share contextual information such as the
+ * resolved tenant identifier or correlation id.
+ */
+public final class GatewayRequestAttributes {
+
+  /** Attribute storing the resolved tenant identifier. */
+  public static final String TENANT_ID = GatewayRequestAttributes.class.getName() + ".tenantId";
+
+  /** Attribute storing the correlation identifier for the current request. */
+  public static final String CORRELATION_ID = GatewayRequestAttributes.class.getName() + ".correlationId";
+
+  /** Attribute storing the cached subscription status for the current tenant. */
+  public static final String SUBSCRIPTION = GatewayRequestAttributes.class.getName() + ".subscription";
+
+  private GatewayRequestAttributes() {
+    // utility class
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/context/TenantExtractionGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/TenantExtractionGatewayFilter.java
@@ -1,0 +1,195 @@
+package com.ejada.gateway.context;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.starter_core.config.CoreAutoConfiguration;
+import com.ejada.starter_core.web.FilterSkipUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.lang.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Resolves the tenant identifier early in the gateway pipeline so other
+ * filters (rate limiting, subscription validation) can rely on a canonical
+ * value. The logic mirrors the servlet {@code ContextFilter} semantics by
+ * checking header, query parameter, JWT claims, and finally the request host
+ * (subdomain pattern).
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 5)
+public class TenantExtractionGatewayFilter implements WebFilter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TenantExtractionGatewayFilter.class);
+
+  private static final Set<String> IGNORED_SUBDOMAINS = Set.of("www", "api", "edge");
+
+  private final CoreAutoConfiguration.CoreProps props;
+  private final ObjectMapper objectMapper;
+
+  public TenantExtractionGatewayFilter(CoreAutoConfiguration.CoreProps props, ObjectMapper objectMapper) {
+    this.props = Objects.requireNonNull(props, "props");
+    this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    var tenantProps = props.getTenant();
+    if (!tenantProps.isEnabled()) {
+      return chain.filter(exchange);
+    }
+
+    String path = exchange.getRequest().getPath().pathWithinApplication().value();
+    if (FilterSkipUtils.shouldSkip(path, tenantProps.getSkipPatterns())) {
+      return chain.filter(exchange);
+    }
+
+    Mono<Optional<Authentication>> authentication = exchange.getPrincipal()
+        .filter(Authentication.class::isInstance)
+        .cast(Authentication.class)
+        .map(Optional::of)
+        .defaultIfEmpty(Optional.empty())
+        .cache(Duration.ofSeconds(1));
+
+    return authentication.flatMap(optionalAuth -> {
+      String fromHeader = trimToNull(exchange.getRequest().getHeaders().getFirst(tenantProps.getHeaderName()));
+      String fromQuery = trimToNull(exchange.getRequest().getQueryParams().getFirst(tenantProps.getQueryParam()));
+      String fromJwt = optionalAuth.map(auth -> extractFromJwt(auth, tenantProps.getJwtClaimNames())).orElse(null);
+      String fromHost = extractFromHost(exchange.getRequest());
+
+      String candidate = tenantProps.isPreferHeaderOverJwt()
+          ? firstNonNull(fromHeader, fromQuery, fromJwt, fromHost)
+          : firstNonNull(fromJwt, fromHeader, fromQuery, fromHost);
+
+      if (!StringUtils.hasText(candidate)) {
+        return chain.filter(exchange);
+      }
+
+      String sanitized = sanitize(candidate);
+      if (sanitized == null) {
+        return reject(exchange, candidate);
+      }
+
+      ServerWebExchange mutated = mutateRequest(exchange, tenantProps.getHeaderName(), sanitized, fromHeader);
+      mutated.getAttributes().put(GatewayRequestAttributes.TENANT_ID, sanitized);
+      mutated.getAttributes().putIfAbsent(HeaderNames.X_TENANT_ID, sanitized);
+      return chain.filter(mutated);
+    });
+  }
+
+  private ServerWebExchange mutateRequest(ServerWebExchange exchange, String headerName, String tenant, @Nullable String originalHeader) {
+    if (StringUtils.hasText(originalHeader)) {
+      return exchange;
+    }
+    ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+        .header(headerName, tenant)
+        .build();
+    return exchange.mutate().request(mutatedRequest).build();
+  }
+
+  @Nullable
+  private String extractFromJwt(Authentication authentication, String[] claimNames) {
+    if (!(authentication instanceof JwtAuthenticationToken jwtAuthenticationToken)) {
+      return null;
+    }
+    for (String claim : claimNames) {
+      Object value = jwtAuthenticationToken.getToken().getClaims().get(claim);
+      if (value != null) {
+        String tenant = trimToNull(Objects.toString(value, null));
+        if (StringUtils.hasText(tenant)) {
+          return tenant;
+        }
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private String extractFromHost(ServerHttpRequest request) {
+    String hostHeader = request.getHeaders().getFirst("Host");
+    if (!StringUtils.hasText(hostHeader)) {
+      hostHeader = request.getURI().getHost();
+    }
+    if (!StringUtils.hasText(hostHeader)) {
+      return null;
+    }
+    String host = hostHeader.toLowerCase(Locale.ROOT);
+    if (host.chars().allMatch(Character::isDigit)) {
+      return null;
+    }
+    String[] parts = host.split("\\.");
+    if (parts.length < 2) {
+      return null;
+    }
+    String first = parts[0];
+    if (!StringUtils.hasText(first) || IGNORED_SUBDOMAINS.contains(first)) {
+      return null;
+    }
+    return first;
+  }
+
+  @Nullable
+  private String sanitize(String candidate) {
+    if (!StringUtils.hasText(candidate)) {
+      return null;
+    }
+    String trimmed = candidate.trim();
+    if (!trimmed.matches("[A-Za-z0-9_-]{1,36}")) {
+      return null;
+    }
+    return trimmed;
+  }
+
+  private Mono<Void> reject(ServerWebExchange exchange, String rawValue) {
+    LOGGER.warn("Rejecting request due to invalid tenant identifier: {}", rawValue);
+    var response = exchange.getResponse();
+    response.setStatusCode(HttpStatus.BAD_REQUEST);
+    response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+    BaseResponse<Void> body = BaseResponse.error("ERR_INVALID_TENANT", "Invalid " + HeaderNames.X_TENANT_ID);
+    byte[] payload;
+    try {
+      payload = objectMapper.writeValueAsBytes(body);
+    } catch (JsonProcessingException e) {
+      payload = body.toString().getBytes(StandardCharsets.UTF_8);
+    }
+    return response.writeWith(Mono.just(response.bufferFactory().wrap(payload)));
+  }
+
+  private static String firstNonNull(String... values) {
+    return Arrays.stream(values)
+        .filter(StringUtils::hasText)
+        .map(String::trim)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/SubscriptionValidationGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/SubscriptionValidationGatewayFilter.java
@@ -1,0 +1,262 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.gateway.config.SubscriptionValidationProperties;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.lang.Nullable;
+import reactor.core.publisher.Mono;
+
+/**
+ * Validates tenant subscriptions before forwarding traffic to downstream
+ * services. Results are cached in Redis to avoid overwhelming the
+ * subscription-service and to minimise latency.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 40)
+public class SubscriptionValidationGatewayFilter implements GlobalFilter, Ordered {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionValidationGatewayFilter.class);
+
+  private static final AntPathMatcher ANT_PATH_MATCHER = new AntPathMatcher();
+  private static final ParameterizedTypeReference<BaseResponse<SubscriptionPayload>> RESPONSE_TYPE =
+      new ParameterizedTypeReference<>() {
+      };
+
+  private final SubscriptionValidationProperties properties;
+  private final ReactiveStringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
+  private final WebClient webClient;
+
+  public SubscriptionValidationGatewayFilter(
+      SubscriptionValidationProperties properties,
+      ReactiveStringRedisTemplate redisTemplate,
+      @Qualifier("jacksonObjectMapper") ObjectProvider<ObjectMapper> primaryObjectMapper,
+      ObjectProvider<ObjectMapper> fallbackObjectMapper,
+      WebClient.Builder webClientBuilder) {
+    this.properties = Objects.requireNonNull(properties, "properties");
+    this.redisTemplate = Objects.requireNonNull(redisTemplate, "redisTemplate");
+    ObjectMapper mapper = (primaryObjectMapper != null) ? primaryObjectMapper.getIfAvailable() : null;
+    if (mapper == null) {
+      mapper = (fallbackObjectMapper != null) ? fallbackObjectMapper.getIfAvailable() : null;
+    }
+    this.objectMapper = Objects.requireNonNull(mapper, "objectMapper");
+
+    this.webClient = webClientBuilder.clone().build();
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+    if (!properties.isEnabled()) {
+      return chain.filter(exchange);
+    }
+
+    String path = exchange.getRequest().getPath().value();
+    if (shouldSkip(path)) {
+      return chain.filter(exchange);
+    }
+
+    String tenantId = exchange.getAttribute(GatewayRequestAttributes.TENANT_ID);
+    if (!StringUtils.hasText(tenantId)) {
+      return chain.filter(exchange);
+    }
+
+    String routeId = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ID_ATTR);
+    if (!properties.requiresValidation(routeId)) {
+      return chain.filter(exchange);
+    }
+
+    String requiredFeature = properties.getRequiredFeatures().get(routeId);
+
+    return ensureSubscription(tenantId, requiredFeature)
+        .flatMap(decision -> {
+          if (decision.allowed()) {
+            exchange.getAttributes().put(GatewayRequestAttributes.SUBSCRIPTION, decision.record());
+            return chain.filter(exchange);
+          }
+          return reject(exchange, decision.status(), decision.code(), decision.message());
+        });
+  }
+
+  private boolean shouldSkip(String path) {
+    for (String pattern : properties.getSkipPatterns()) {
+      if (StringUtils.hasText(pattern) && ANT_PATH_MATCHER.match(pattern, path)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Mono<SubscriptionDecision> ensureSubscription(String tenantId, @Nullable String requiredFeature) {
+    String cacheKey = properties.cacheKey(tenantId);
+    return redisTemplate.opsForValue().get(cacheKey)
+        .flatMap(json -> decode(json).map(Mono::just).orElseGet(Mono::empty))
+        .switchIfEmpty(Mono.defer(() -> fetchSubscription(tenantId)
+            .flatMap(record -> cache(cacheKey, record).thenReturn(record))))
+        .map(record -> evaluate(record, requiredFeature))
+        .onErrorResume(ex -> {
+          LOGGER.warn("Subscription validation failed for tenant {}", tenantId, ex);
+          if (properties.isFailOpen()) {
+            return Mono.just(SubscriptionDecision.allow(null));
+          }
+          return Mono.just(SubscriptionDecision.deny(HttpStatus.SERVICE_UNAVAILABLE,
+              "ERR_SUBSCRIPTION_UNAVAILABLE",
+              "Unable to validate subscription status"));
+        });
+  }
+
+  private Mono<Void> cache(String cacheKey, SubscriptionRecord record) {
+    try {
+      String value = objectMapper.writeValueAsString(record);
+      Duration ttl = Optional.ofNullable(properties.getCacheTtl()).filter(d -> !d.isZero() && !d.isNegative())
+          .orElse(Duration.ofMinutes(5));
+      return redisTemplate.opsForValue().set(cacheKey, value, ttl);
+    } catch (JsonProcessingException e) {
+      LOGGER.debug("Failed to serialise subscription record for cache", e);
+      return Mono.empty();
+    }
+  }
+
+  private Optional<SubscriptionRecord> decode(String json) {
+    try {
+      return Optional.ofNullable(objectMapper.readValue(json, SubscriptionRecord.class));
+    } catch (Exception ex) {
+      LOGGER.debug("Failed to decode cached subscription payload", ex);
+      return Optional.empty();
+    }
+  }
+
+  private Mono<SubscriptionRecord> fetchSubscription(String tenantId) {
+    return webClient.get()
+        .uri(properties.getValidationUri(), tenantId)
+        .accept(MediaType.APPLICATION_JSON)
+        .retrieve()
+        .bodyToMono(RESPONSE_TYPE)
+        .map(this::extractPayload)
+        .doOnNext(record -> LOGGER.debug("Fetched subscription for tenant {} -> {}", tenantId, record.status))
+        .switchIfEmpty(Mono.just(SubscriptionRecord.inactive()));
+  }
+
+  private SubscriptionRecord extractPayload(BaseResponse<SubscriptionPayload> response) {
+    if (response == null) {
+      return SubscriptionRecord.inactive();
+    }
+    SubscriptionPayload payload = response.getData();
+    if (payload == null) {
+      return SubscriptionRecord.inactive();
+    }
+    boolean active = payload.active != null ? payload.active : "ACTIVE".equalsIgnoreCase(payload.status);
+    Set<String> features = (payload.features != null)
+        ? new HashSet<>(payload.features)
+        : Collections.emptySet();
+    return SubscriptionRecord.of(active, features, payload.expiresAt);
+  }
+
+  private SubscriptionDecision evaluate(SubscriptionRecord record, @Nullable String requiredFeature) {
+    if (!record.isActive()) {
+      return SubscriptionDecision.deny(HttpStatus.PAYMENT_REQUIRED,
+          "ERR_SUBSCRIPTION_INACTIVE",
+          "Subscription is inactive or expired");
+    }
+    if (StringUtils.hasText(requiredFeature) && !record.hasFeature(requiredFeature)) {
+      return SubscriptionDecision.deny(HttpStatus.FORBIDDEN,
+          "ERR_SUBSCRIPTION_FEATURE", "Subscription does not include required feature");
+    }
+    return SubscriptionDecision.allow(record);
+  }
+
+  private Mono<Void> reject(ServerWebExchange exchange, HttpStatus status, String code, String message) {
+    exchange.getResponse().setStatusCode(status);
+    exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+    BaseResponse<Void> body = BaseResponse.error(code, message);
+    byte[] payload;
+    try {
+      payload = objectMapper.writeValueAsBytes(body);
+    } catch (JsonProcessingException e) {
+      payload = body.toString().getBytes(StandardCharsets.UTF_8);
+    }
+    return exchange.getResponse().writeWith(Mono.just(exchange.getResponse().bufferFactory().wrap(payload)));
+  }
+
+  private record SubscriptionDecision(boolean allowed, SubscriptionRecord record, HttpStatus status, String code, String message) {
+
+    static SubscriptionDecision allow(SubscriptionRecord record) {
+      return new SubscriptionDecision(true, record, HttpStatus.OK, null, null);
+    }
+
+    static SubscriptionDecision deny(HttpStatus status, String code, String message) {
+      return new SubscriptionDecision(false, null, status, code, message);
+    }
+  }
+
+  private record SubscriptionRecord(boolean active, Set<String> features, Instant expiresAt, String status) {
+
+    SubscriptionRecord {
+      features = (features == null) ? Set.of() : Set.copyOf(features);
+      status = StringUtils.hasText(status) ? status : (active ? "ACTIVE" : "INACTIVE");
+    }
+
+    static SubscriptionRecord of(boolean active, Set<String> features, Instant expiresAt) {
+      return new SubscriptionRecord(active, features, expiresAt, active ? "ACTIVE" : "INACTIVE");
+    }
+
+    static SubscriptionRecord inactive() {
+      return new SubscriptionRecord(false, Set.of(), null, "INACTIVE");
+    }
+
+    boolean isActive() {
+      if (!active) {
+        return false;
+      }
+      if (expiresAt == null) {
+        return true;
+      }
+      return expiresAt.isAfter(Instant.now());
+    }
+
+    boolean hasFeature(String feature) {
+      if (!StringUtils.hasText(feature)) {
+        return true;
+      }
+      return features.stream().anyMatch(value -> value.equalsIgnoreCase(feature));
+    }
+  }
+
+  private static final class SubscriptionPayload {
+    private Boolean active;
+    private String status;
+    private java.util.List<String> features;
+    private Instant expiresAt;
+
+    SubscriptionPayload() {
+    }
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/ratelimit/IpKeyResolver.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ratelimit/IpKeyResolver.java
@@ -1,0 +1,52 @@
+package com.ejada.gateway.ratelimit;
+
+import com.ejada.common.constants.HeaderNames;
+import java.net.InetSocketAddress;
+import java.util.List;
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Key resolver that uses the originating client IP address. The resolver
+ * honours common proxy headers (e.g. {@code X-Forwarded-For}) before falling
+ * back to the TCP remote address exposed by Reactor Netty.
+ */
+@Component("ipKeyResolver")
+public class IpKeyResolver implements KeyResolver {
+
+  private static final List<String> FORWARDED_HEADERS = List.of(
+      HeaderNames.CLIENT_IP,
+      "X-Forwarded-For",
+      "X-Real-IP"
+  );
+
+  @Override
+  public Mono<String> resolve(ServerWebExchange exchange) {
+    for (String header : FORWARDED_HEADERS) {
+      String value = exchange.getRequest().getHeaders().getFirst(header);
+      if (StringUtils.hasText(value)) {
+        String candidate = extractFirst(value);
+        if (StringUtils.hasText(candidate)) {
+          return Mono.just(candidate);
+        }
+      }
+    }
+
+    InetSocketAddress remote = exchange.getRequest().getRemoteAddress();
+    String fallback = (remote != null) ? remote.getAddress().getHostAddress() : "unknown";
+    return Mono.just(fallback);
+  }
+
+  private String extractFirst(String headerValue) {
+    String[] parts = headerValue.split(",");
+    if (parts.length == 0) {
+      return null;
+    }
+    String first = parts[0].trim();
+    return first.isEmpty() ? null : first;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/ratelimit/TenantKeyResolver.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ratelimit/TenantKeyResolver.java
@@ -1,0 +1,37 @@
+package com.ejada.gateway.ratelimit;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Resolves rate-limiter keys based on the current tenant. The resolver first
+ * checks the exchange attributes (populated by {@code TenantExtractionGatewayFilter})
+ * and then falls back to the {@link ContextManager} thread-local to support
+ * non-reactive integrations.
+ */
+@Component("tenantKeyResolver")
+public class TenantKeyResolver implements KeyResolver {
+
+  @Override
+  public Mono<String> resolve(ServerWebExchange exchange) {
+    String tenant = exchange.getAttribute(GatewayRequestAttributes.TENANT_ID);
+    if (!StringUtils.hasText(tenant)) {
+      tenant = ContextManager.Tenant.get();
+    }
+    if (!StringUtils.hasText(tenant)) {
+      tenant = exchange.getRequest().getHeaders().getFirst(HeaderNames.X_TENANT_ID);
+    }
+    if (!StringUtils.hasText(tenant)) {
+      tenant = "public";
+    }
+    String key = tenant.trim().toLowerCase();
+    return Mono.just(key);
+  }
+}
+

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -196,6 +196,25 @@ gateway:
           max-backoff: 2s
           factor: 2
           based-on-previous-value: true
+  subscription:
+    enabled: true
+    validation-uri: lb://subscription-service/internal/subscriptions/{tenantId}
+    cache-ttl: 5m
+    fail-open: true
+    validate-all-routes: true
+    skip-patterns:
+      - /actuator/**
+      - /fallback/**
+    required-features:
+      catalog-service: catalog.read
+      billing-service: billing.manage
+      subscription-service: subscription.manage
+  webclient:
+    connect-timeout: 3s
+    response-timeout: 15s
+    read-timeout: 10s
+    write-timeout: 10s
+    max-in-memory-size: 5242880
   routes:
     setup:
       id: setup-service


### PR DESCRIPTION
## Summary
- add correlation id and tenant extraction filters plus reusable request attribute constants
- introduce Redis-backed subscription validation filter with configuration properties and tenant/IP rate-limit key resolvers
- configure a load-balanced WebClient builder and document gateway configuration updates, including new subscription settings

## Testing
- mvn test *(fails: shared BOM dependencies are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e04bc8fb88832fbdbc410be9626101