### PR TITLE
Restrict local microservices behind the API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,30 +21,22 @@ cd shared-lib
 mvn clean install
 ```
 
-### Build and run the setup service
+### Run the platform with Docker Compose
+
+From the repository root run:
 
 ```bash
-cd ../lms-setup
-mvn spring-boot:run
+docker-compose up --build
 ```
 
-Set the following variables before running:
-=======
-The service uses environment variables for database and security settings. Defaults are provided for local development:
-- `DB_URL`
-- `DB_USERNAME`
-- `DB_PASSWORD`
-- `JWT_SECRET`
-- `CRYPTO_ACTIVE_KID`
-- `CRYPTO_LOCAL_DEV_KEY`
+The compose file provisions infrastructure dependencies (PostgreSQL, Redis, Kafka, OTEL collector) alongside the domain services and the API Gateway. Only the gateway is exposed on the host via `http://localhost:8088`; all downstream services remain on the internal Docker network to prevent direct access.
 
 ### Running Tests
 
-Run unit tests for both modules:
+Run unit tests for the shared libraries:
 
 ```bash
 cd shared-lib && mvn test
-cd ../lms-setup && mvn test
 ```
 
 The build pulls dependencies from Maven Central; ensure network access is available.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,8 +131,7 @@ services:
       OTEL_SERVICE_NAME: tenant-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8080:8080"
+    # Internal-only; traffic should originate from the api-gateway container.
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s
@@ -162,8 +161,7 @@ services:
       OTEL_SERVICE_NAME: setup-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8081:8080"
+    # Internal-only; traffic should originate from the api-gateway container.
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s
@@ -193,8 +191,7 @@ services:
       OTEL_SERVICE_NAME: billing-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8082:8080"
+    # Internal-only; traffic should originate from the api-gateway container.
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s
@@ -225,8 +222,7 @@ services:
       OTEL_SERVICE_NAME: analytics-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8089:8080"
+    # Internal-only; traffic should originate from the api-gateway container.
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/actuator/health || exit 1"]
       interval: 10s
@@ -256,8 +252,7 @@ services:
       OTEL_SERVICE_NAME: catalog-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8083:8080"
+    # Internal-only; traffic should originate from the api-gateway container.
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s
@@ -287,8 +282,7 @@ services:
       OTEL_SERVICE_NAME: subscription-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8084:8080"
+    # Internal-only; traffic should originate from the api-gateway container.
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s
@@ -324,8 +318,7 @@ services:
       OTEL_SERVICE_NAME: security-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8085:8080"
+    # Internal-only; traffic should originate from the api-gateway container.
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s

--- a/tenant-platform/README.md
+++ b/tenant-platform/README.md
@@ -28,4 +28,4 @@ From the project root, run:
 ```bash
 docker-compose up --build
 ```
-Services listen on `localhost:8081`..`8084`.
+All business services run on the internal Docker network; the only public entry point is the [API Gateway](../api-gateway) on `http://localhost:8088`.


### PR DESCRIPTION
## Summary
- remove host port mappings for the tenant platform services so they are only reachable via the API Gateway
- document that docker-compose now exposes only http://localhost:8088 as the public entry point

## Testing
- not run (docker-compose is unavailable in the CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68e04fded454832fa2a66bae5e846b9b