### PR TITLE
Align platform services behind API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,124 @@
-# Learning Management System (LMS)
+# Learning Management System Platform
 
-This repository houses several components:
+The **newLms** repository hosts the multi-tenant Learning Management System. It is built from
+Spring Boot microservices that share a common set of starters for security, observability,
+resilience, and Redis integration. An API Gateway fronts every service to provide a single edge
+entry point with authentication, tenant enforcement, subscription validation, and rate limiting.
 
-- **shared-lib** – a collection of reusable Spring Boot starter modules and utilities.
-- **lms-setup** – a Spring Boot microservice for reference lookups and tenant/platform configuration.
-- **tenant-persistence** – central JPA entities, repositories, and Flyway migrations for the tenant domain.
-- **api-gateway** – Spring Cloud Gateway instance that fronts the services while reusing shared security and context modules.
+## Repository Layout
+
+| Module | Description |
+| ------ | ----------- |
+| `shared-lib` | Reusable LMS starters (security, core, observability, rate limiting, config) shared by all services. |
+| `tenant-platform` | Aggregator Maven project for the domain services (`tenant`, `catalog`, `subscription`, `billing`, `analytics`). |
+| `setup-service` | Platform bootstrap service for tenant provisioning, catalog metadata, and reference data. |
+| `sec-service` | Security service responsible for IAM, audit, and policy management. |
+| `api-gateway` | Spring Cloud Gateway instance that secures and routes all external traffic to the platform. |
+
+## Runtime Topology
+
+All external traffic flows through the gateway on port **8000**. Downstream services listen on
+private container ports and are no longer exposed outside the Docker network.
+
+| Service | Container Port | Publicly Exposed? |
+| ------- | -------------- | ---------------- |
+| API Gateway | 8000 | ✅ (`localhost:8000`) |
+| Setup Service | 8080 | ❌ |
+| Tenant Service | 8080 | ❌ |
+| Catalog Service | 8080 | ❌ |
+| Subscription Service | 8080 | ❌ |
+| Billing Service | 8080 | ❌ |
+| Analytics Service | 8080 | ❌ |
+| Security Service | 8080 | ❌ |
+
+> **Tip:** Uncomment the commented `ports` entries in `docker-compose.yml` when you need to
+debug a service directly.
 
 ## Getting Started
 
-### Prerequisites
-- Java 21
-- Maven 3.9+
+### 1. Build Shared Libraries
 
-### Build shared libraries
-Install the shared library modules into the local Maven repository:
+Install the shared starters into the local Maven repository:
 
 ```bash
 cd shared-lib
 mvn clean install
 ```
 
-### Build and run the setup service
+### 2. Build the Platform
+
+From the repository root you can build the entire platform, including the gateway, with:
 
 ```bash
-cd ../lms-setup
-mvn spring-boot:run
+mvn clean package
 ```
 
-Set the following variables before running:
-=======
-The service uses environment variables for database and security settings. Defaults are provided for local development:
-- `DB_URL`
-- `DB_USERNAME`
-- `DB_PASSWORD`
-- `JWT_SECRET`
-- `CRYPTO_ACTIVE_KID`
-- `CRYPTO_LOCAL_DEV_KEY`
+### 3. Start the Local Stack
 
-### Running Tests
-
-Run unit tests for both modules:
+The provided `docker-compose.yml` orchestrates PostgreSQL, Redis, Kafka, the microservices, and the
+gateway. Before starting export a shared JWT secret:
 
 ```bash
-cd shared-lib && mvn test
-cd ../lms-setup && mvn test
+export JWT_SECRET=local-dev-secret
+docker compose up --build
 ```
 
-The build pulls dependencies from Maven Central; ensure network access is available.
+Once healthy, invoke the platform via the gateway:
 
-## Contributing
-Contributions are welcome. Please fork the repository and submit pull requests. Ensure tests pass before submitting.
+```bash
+curl http://localhost:8000/actuator/health
+```
 
-## License
-This project is provided under the MIT License.
+### 4. Authentication Flow
 
+1. `POST /api/auth/login` – obtain a JWT from the security service routed via the gateway.
+2. Use the issued token to call downstream APIs, e.g.:
+   ```bash
+   curl -H "Authorization: Bearer $TOKEN" \
+        http://localhost:8000/api/tenant/tenants
+   ```
+
+## Configuration Notes
+
+- The gateway port is configurable with the `SERVER_PORT` environment variable (defaults to `8000`).
+- Each microservice disables its own resource server and trusts authentication performed by the
+  gateway (`shared.security.resource-server.enabled=false`).
+- Redis is required for rate limiting and subscription cache validation. Configure `REDIS_HOST`
+  and `REDIS_PORT` for non-Docker deployments.
+- To roll back quickly, stop the `api-gateway` service and (optionally) re-enable direct ports in
+the compose file.
+
+## Updating Client Integrations
+
+All client SDKs and API documentation should target the unified gateway base URL:
+
+```
+https://api.example.com/api/*
+```
+
+For example, the tenants API changed from `http://localhost:8080/tenant/api/v1/tenants` to
+`http://localhost:8000/api/tenant/tenants`.
+
+## Testing
+
+Run unit tests for the gateway:
+
+```bash
+mvn -pl api-gateway test
+```
+
+Run a full platform build (all modules) with:
+
+```bash
+mvn clean verify
+```
+
+## Operational Checklist
+
+- ✅ JWT validated once at the gateway.
+- ✅ Tenant and subscription context propagated via gateway filters.
+- ✅ Redis-backed rate limiting enabled (tenant and IP resolvers).
+- ✅ Circuit breakers and fallbacks configured per route.
+- ✅ Prometheus metrics exposed at `/actuator/prometheus`.
+
+For in-depth implementation details see `docs/api-gateway-enhancement-plan.md`.

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -21,6 +21,6 @@ RUN set -eux; \
 
 USER appuser
 
-EXPOSE 8080
+EXPOSE 8000
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -1,3 +1,7 @@
+server:
+  port: ${SERVER_PORT:8000}
+  shutdown: graceful
+
 spring:
   application:
     name: api-gateway

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,6 @@ services:
     build:
       context: ./tenant-platform/tenant-service
     restart: unless-stopped
-
     depends_on:
       - postgres
       - otel-collector
@@ -131,8 +130,11 @@ services:
       OTEL_SERVICE_NAME: tenant-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8080:8080"
+    expose:
+      - "8080"
+    # Uncomment the mapping below for troubleshooting individual services outside the gateway.
+    # ports:
+    #   - "8080:8080"
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s
@@ -146,7 +148,6 @@ services:
     build:
       context: ./setup-service
     restart: unless-stopped
-
     depends_on:
       - postgres
       - otel-collector
@@ -162,8 +163,10 @@ services:
       OTEL_SERVICE_NAME: setup-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8081:8080"
+    expose:
+      - "8080"
+    # ports:
+    #   - "8081:8080"
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s
@@ -177,7 +180,6 @@ services:
     build:
       context: ./tenant-platform/billing-service
     restart: unless-stopped
-
     depends_on:
       - postgres
       - otel-collector
@@ -193,8 +195,10 @@ services:
       OTEL_SERVICE_NAME: billing-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8082:8080"
+    expose:
+      - "8080"
+    # ports:
+    #   - "8082:8080"
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s
@@ -208,7 +212,6 @@ services:
     build:
       context: ./tenant-platform/analytics-service
     restart: unless-stopped
-
     depends_on:
       - postgres
       - redis
@@ -225,8 +228,10 @@ services:
       OTEL_SERVICE_NAME: analytics-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8089:8080"
+    expose:
+      - "8080"
+    # ports:
+    #   - "8089:8080"
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/actuator/health || exit 1"]
       interval: 10s
@@ -240,7 +245,6 @@ services:
     build:
       context: ./tenant-platform/catalog-service
     restart: unless-stopped
-
     depends_on:
       - postgres
       - otel-collector
@@ -256,8 +260,10 @@ services:
       OTEL_SERVICE_NAME: catalog-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8083:8080"
+    expose:
+      - "8080"
+    # ports:
+    #   - "8083:8080"
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s
@@ -271,7 +277,6 @@ services:
     build:
       context: ./tenant-platform/subscription-service
     restart: unless-stopped
-
     depends_on:
       - postgres
       - otel-collector
@@ -287,8 +292,10 @@ services:
       OTEL_SERVICE_NAME: subscription-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8084:8080"
+    expose:
+      - "8080"
+    # ports:
+    #   - "8084:8080"
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s
@@ -302,7 +309,6 @@ services:
     build:
       context: ./sec-service
     restart: unless-stopped
-
     depends_on:
       - postgres
       - redis
@@ -324,8 +330,10 @@ services:
       OTEL_SERVICE_NAME: security-service
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Riyadh
-    ports:
-      - "8085:8080"
+    expose:
+      - "8080"
+    # ports:
+    #   - "8085:8080"
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/core/actuator/health || exit 1"]
       interval: 10s
@@ -337,20 +345,33 @@ services:
 
   api-gateway:
     build:
-      context: .
-      dockerfile: ./api-gateway/Dockerfile
-    <<: [*restart_policy]
+      context: ./api-gateway
+    restart: unless-stopped
     depends_on:
-      - setup-service
-      - tenant-service
-      - catalog-service
-      - subscription-service
-      - billing-service
-      - analytics-service
-      - security-service
-      - redis
-      - otel-collector
+      redis:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+      setup-service:
+        condition: service_started
+      tenant-service:
+        condition: service_started
+      catalog-service:
+        condition: service_started
+      subscription-service:
+        condition: service_started
+      billing-service:
+        condition: service_started
+      analytics-service:
+        condition: service_started
+      security-service:
+        condition: service_started
     environment:
+      TZ: Asia/Riyadh
+      SERVER_PORT: 8000
+      JWT_SECRET: ${JWT_SECRET:-local-dev-secret}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
       SPRING_DATA_REDIS_HOST: redis
       SPRING_DATA_REDIS_PORT: 6379
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
@@ -358,7 +379,6 @@ services:
       OTEL_METRICS_EXPORTER: otlp
       OTEL_SERVICE_NAME: api-gateway
       SPRING_PROFILES_ACTIVE: dev
-      TZ: Asia/Riyadh
       SHARED_SECURITY_MODE: hs256
       SHARED_SECURITY_HS256_SECRET: ${JWT_SECRET:-local-dev-secret}
       SHARED_SECURITY_RESOURCE_SERVER_ENABLED: "false"
@@ -368,8 +388,9 @@ services:
       SPRING_CLOUD_DISCOVERY_CLIENT_SIMPLE_INSTANCES_SUBSCRIPTION_SERVICE_0_URI: http://subscription-service:8080
       SPRING_CLOUD_DISCOVERY_CLIENT_SIMPLE_INSTANCES_BILLING_SERVICE_0_URI: http://billing-service:8080
       SPRING_CLOUD_DISCOVERY_CLIENT_SIMPLE_INSTANCES_ANALYTICS_SERVICE_0_URI: http://analytics-service:8080
+      SPRING_CLOUD_DISCOVERY_CLIENT_SIMPLE_INSTANCES_SECURITY_SERVICE_0_URI: http://security-service:8080
     ports:
-      - "8088:8080"
+      - "8000:8000"
     healthcheck:
       test: ["CMD-SHELL", "wget --spider --quiet http://localhost:8080/actuator/health || exit 1"]
       interval: 10s

--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -80,6 +80,8 @@ shared:
         table: audit_outbox
   security:
     enable-role-check: true
+    resource-server:
+      enabled: false
     jwt:
       token-period: 15m
       superadmin-ttl: PT24H

--- a/setup-service/src/main/resources/application.yaml
+++ b/setup-service/src/main/resources/application.yaml
@@ -31,5 +31,7 @@ shared:
     application-name: setup-service
   security:
     enable-role-check: true
+    resource-server:
+      enabled: false
     jwt:
       token-period: 15m

--- a/tenant-platform/analytics-service/src/main/resources/application.yml
+++ b/tenant-platform/analytics-service/src/main/resources/application.yml
@@ -37,3 +37,8 @@ management:
     health:
       probes:
         enabled: true
+
+shared:
+  security:
+    resource-server:
+      enabled: false

--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -32,5 +32,7 @@ shared:
     application-name: billing-service
   security:
     enable-role-check: true
+    resource-server:
+      enabled: false
     jwt:
       token-period: 15m

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -32,5 +32,7 @@ shared:
     application-name: catalog-service
   security:
     enable-role-check: true
+    resource-server:
+      enabled: false
     jwt:
       token-period: 15m

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -32,5 +32,7 @@ shared:
     application-name: subscription-service
   security:
     enable-role-check: true
+    resource-server:
+      enabled: false
     jwt:
       token-period: 15m

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -31,5 +31,7 @@ shared:
     application-name: tenant-service
   security:
     enable-role-check: true
+    resource-server:
+      enabled: false
     jwt:
       token-period: 15m


### PR DESCRIPTION
## Summary
- configure the API Gateway to listen on port 8000 and expose the container appropriately
- update docker-compose to route traffic exclusively through the gateway and keep downstream services internal
- disable per-service resource servers and refresh documentation to reflect the new gateway-first topology

## Testing
- `mvn -pl api-gateway test` *(fails: missing locally installed shared starter artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68e050a8902c832fab63f33d6ea893aa