### PR TITLE
Fix retention days indentation in sec-service

### DIFF
--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -158,13 +158,13 @@ shared:
       async: true
     retention:
       enabled: true
+      days: 90
 
 app:
   subscription-approval:
     topic: tenant.subscription-approvals
     consumer-group: security-tenant-bootstrap
     approval-role: ejada-officer
-      days: 90
     masking:
       enabled: true
       fields-by-key:

--- a/sec-service/src/main/resources/application-qa.yaml
+++ b/sec-service/src/main/resources/application-qa.yaml
@@ -158,13 +158,13 @@ shared:
       async: true
     retention:
       enabled: true
+      days: 90
 
 app:
   subscription-approval:
     topic: tenant.subscription-approvals
     consumer-group: security-tenant-bootstrap
     approval-role: ejada-officer
-      days: 90
     masking:
       enabled: true
       fields-by-key:


### PR DESCRIPTION
## Summary
- fix the audit retention configuration in the sec-service dev and QA profiles by properly nesting the days value under the retention block

## Testing
- ⚠️ `mvn -pl sec-service -am -DskipTests package` *(terminated after dependency downloads to save time)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d10308e8832fbcbab12aa144cbfc