### PR TITLE
feat: add tenant dashboard aggregation via gateway BFF

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/bff/TenantDashboardController.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/bff/TenantDashboardController.java
@@ -1,0 +1,54 @@
+package com.ejada.gateway.bff;
+
+import com.ejada.common.dto.BaseResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+/**
+ * Backend for Frontend (BFF) controller exposing aggregated tenant dashboard
+ * endpoints that combine data from multiple downstream services in a single
+ * round-trip for web and mobile clients.
+ */
+@RestController
+@RequestMapping("/api/bff/tenants")
+public class TenantDashboardController {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TenantDashboardController.class);
+
+  private final TenantDashboardService tenantDashboardService;
+
+  public TenantDashboardController(TenantDashboardService tenantDashboardService) {
+    this.tenantDashboardService = tenantDashboardService;
+  }
+
+  @GetMapping("/{tenantId}/dashboard")
+  public Mono<ResponseEntity<BaseResponse<TenantDashboardResponse>>> getDashboard(
+      @PathVariable Integer tenantId,
+      @RequestParam(name = "subscriptionId", required = false) Long subscriptionId,
+      @RequestParam(name = "customerId", required = false) Long customerId,
+      @RequestParam(name = "period", required = false) String period) {
+    return tenantDashboardService.aggregateDashboard(tenantId, subscriptionId, customerId, period)
+        .map(response -> ResponseEntity.ok(BaseResponse.success("Tenant dashboard aggregated", response)))
+        .onErrorResume(ResponseStatusException.class, ex -> Mono.just(ResponseEntity
+            .status(ex.getStatusCode())
+            .body(BaseResponse.error("ERR_TENANT_DASHBOARD", messageOrDefault(ex.getReason())))))
+        .onErrorResume(ex -> {
+          LOGGER.warn("Unexpected failure while building tenant dashboard for {}", tenantId, ex);
+          return Mono.just(ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+              .body(BaseResponse.error("ERR_TENANT_DASHBOARD", "Unable to build tenant dashboard")));
+        });
+  }
+
+  private String messageOrDefault(String value) {
+    return (value == null || value.isBlank()) ? "Unable to build tenant dashboard" : value;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/bff/TenantDashboardResponse.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/bff/TenantDashboardResponse.java
@@ -1,0 +1,23 @@
+package com.ejada.gateway.bff;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+/**
+ * Aggregated payload returned by the tenant dashboard BFF endpoint. The
+ * payload intentionally surfaces downstream JSON nodes so the UI can evolve
+ * without recompiling the gateway while warnings communicate any partial
+ * failures handled gracefully by the aggregator.
+ */
+public record TenantDashboardResponse(
+    JsonNode tenant,
+    JsonNode usageSummary,
+    JsonNode featureAdoption,
+    JsonNode costForecast,
+    JsonNode consumption,
+    List<String> warnings) {
+
+  public TenantDashboardResponse {
+    warnings = (warnings == null) ? List.of() : List.copyOf(warnings);
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/bff/TenantDashboardService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/bff/TenantDashboardService.java
@@ -1,0 +1,212 @@
+package com.ejada.gateway.bff;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.gateway.config.GatewayBffProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.client.circuitbreaker.ReactiveCircuitBreaker;
+import org.springframework.cloud.client.circuitbreaker.ReactiveCircuitBreakerFactory;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+/**
+ * Aggregates data from multiple downstream services (tenant, analytics,
+ * billing) to provide a cohesive tenant dashboard response for UI clients.
+ */
+@Service
+public class TenantDashboardService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TenantDashboardService.class);
+  private static final ParameterizedTypeReference<BaseResponse<JsonNode>> TENANT_RESPONSE_TYPE =
+      new ParameterizedTypeReference<>() {
+      };
+
+  private final WebClient tenantClient;
+  private final WebClient analyticsClient;
+  private final WebClient billingClient;
+  private final GatewayBffProperties.TenantDashboardProperties properties;
+  private final ReactiveCircuitBreakerFactory<?, ?> circuitBreakerFactory;
+
+  public TenantDashboardService(WebClient.Builder webClientBuilder,
+      GatewayBffProperties properties,
+      ObjectProvider<ReactiveCircuitBreakerFactory<?, ?>> circuitBreakerFactoryProvider) {
+    this(webClientBuilder, properties, circuitBreakerFactoryProvider.getIfAvailable());
+  }
+
+  TenantDashboardService(WebClient.Builder webClientBuilder,
+      GatewayBffProperties properties,
+      ReactiveCircuitBreakerFactory<?, ?> circuitBreakerFactory) {
+    Objects.requireNonNull(webClientBuilder, "webClientBuilder");
+    this.properties = Objects.requireNonNull(properties, "properties").getDashboard();
+    this.tenantClient = webClientBuilder.clone().baseUrl(this.properties.getTenantServiceUri()).build();
+    this.analyticsClient = webClientBuilder.clone().baseUrl(this.properties.getAnalyticsServiceUri()).build();
+    this.billingClient = webClientBuilder.clone().baseUrl(this.properties.getBillingServiceUri()).build();
+    this.circuitBreakerFactory = circuitBreakerFactory;
+  }
+
+  /**
+   * Compose a tenant dashboard payload by fan-out/fan-in calls to downstream services.
+   */
+  public Mono<TenantDashboardResponse> aggregateDashboard(Integer tenantId,
+      Long subscriptionId,
+      Long customerId,
+      String requestedPeriod) {
+    Objects.requireNonNull(tenantId, "tenantId");
+
+    String period = sanitisePeriod(requestedPeriod);
+
+    Mono<JsonNode> tenantMono = withCircuitBreaker("bff-tenant-profile", fetchTenantProfile(tenantId));
+
+    Mono<SafeResult<JsonNode>> usageMono = safeFetch("bff-analytics-usage",
+        fetchUsageSummary(tenantId, period),
+        "Usage summary unavailable");
+
+    Mono<SafeResult<JsonNode>> adoptionMono = safeFetch("bff-analytics-adoption",
+        fetchFeatureAdoption(tenantId),
+        "Feature adoption analytics unavailable");
+
+    Mono<SafeResult<JsonNode>> costMono = safeFetch("bff-analytics-cost",
+        fetchCostForecast(tenantId),
+        "Cost forecast analytics unavailable");
+
+    Mono<SafeResult<JsonNode>> consumptionMono;
+    if (subscriptionId != null) {
+      consumptionMono = safeFetch("bff-billing-consumption",
+          fetchConsumptionSnapshot(subscriptionId, customerId),
+          "Billing consumption snapshot unavailable");
+    } else {
+      consumptionMono = Mono.just(SafeResult.success(null));
+    }
+
+    return Mono.zip(tenantMono, usageMono, adoptionMono, costMono, consumptionMono)
+        .map(tuple -> {
+          JsonNode tenant = tuple.getT1();
+          SafeResult<JsonNode> usage = tuple.getT2();
+          SafeResult<JsonNode> adoption = tuple.getT3();
+          SafeResult<JsonNode> cost = tuple.getT4();
+          SafeResult<JsonNode> consumption = tuple.getT5();
+
+          List<String> warnings = Stream.of(usage.warning(), adoption.warning(), cost.warning(), consumption.warning())
+              .filter(StringUtils::hasText)
+              .distinct()
+              .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+
+          return new TenantDashboardResponse(tenant,
+              usage.value(),
+              adoption.value(),
+              cost.value(),
+              consumption.value(),
+              warnings);
+        })
+        .onErrorResume(ResponseStatusException.class, Mono::error)
+        .onErrorResume(ex -> {
+          LOGGER.warn("Failed to aggregate dashboard for tenant {}", tenantId, ex);
+          return Mono.error(new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+              "Unable to aggregate tenant dashboard", ex));
+        });
+  }
+
+  private Mono<JsonNode> fetchTenantProfile(Integer tenantId) {
+    return tenantClient.get()
+        .uri("/api/v1/tenants/{tenantId}", tenantId)
+        .retrieve()
+        .bodyToMono(TENANT_RESPONSE_TYPE)
+        .flatMap(response -> {
+          if (response == null || !response.isSuccess() || response.getData() == null) {
+            LOGGER.warn("Tenant service returned unexpected payload for tenant {}", tenantId);
+            return Mono.error(new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                "Tenant profile unavailable"));
+          }
+          return Mono.just(response.getData());
+        });
+  }
+
+  private Mono<JsonNode> fetchUsageSummary(Integer tenantId, String period) {
+    return analyticsClient.get()
+        .uri(builder -> builder.path("/api/v1/analytics/tenants/{tenantId}/usage-summary")
+            .queryParam("period", period)
+            .build(tenantId))
+        .retrieve()
+        .bodyToMono(JsonNode.class);
+  }
+
+  private Mono<JsonNode> fetchFeatureAdoption(Integer tenantId) {
+    return analyticsClient.get()
+        .uri("/api/v1/analytics/tenants/{tenantId}/feature-adoption", tenantId)
+        .retrieve()
+        .bodyToMono(JsonNode.class);
+  }
+
+  private Mono<JsonNode> fetchCostForecast(Integer tenantId) {
+    return analyticsClient.get()
+        .uri("/api/v1/analytics/tenants/{tenantId}/cost-forecast", tenantId)
+        .retrieve()
+        .bodyToMono(JsonNode.class);
+  }
+
+  private Mono<JsonNode> fetchConsumptionSnapshot(Long subscriptionId, Long customerId) {
+    return billingClient.get()
+        .uri(builder -> {
+          var uriBuilder = builder.path("/billing/subscriptions/{subscriptionId}/consumption");
+          if (customerId != null) {
+            uriBuilder.queryParam("customerId", customerId);
+          }
+          URI uri = uriBuilder.build(subscriptionId);
+          return uri;
+        })
+        .retrieve()
+        .bodyToMono(JsonNode.class);
+  }
+
+  private String sanitisePeriod(String requestedPeriod) {
+    if (StringUtils.hasText(requestedPeriod)) {
+      return requestedPeriod.trim().toUpperCase(Locale.ROOT);
+    }
+    return properties.getDefaultPeriod();
+  }
+
+  private <T> Mono<T> withCircuitBreaker(String name, Mono<T> toRun) {
+    if (circuitBreakerFactory == null) {
+      return toRun;
+    }
+    ReactiveCircuitBreaker breaker = circuitBreakerFactory.create(name);
+    return Mono.defer(() -> breaker.run(toRun, throwable -> Mono.error(throwable)));
+  }
+
+  private <T> Mono<SafeResult<T>> safeFetch(String circuitBreakerName, Mono<T> call, String warning) {
+    return withCircuitBreaker(circuitBreakerName, call)
+        .map(SafeResult::success)
+        .switchIfEmpty(Mono.defer(() -> {
+          LOGGER.debug("{} returned empty payload", circuitBreakerName);
+          return Mono.just(SafeResult.warning(warning));
+        }))
+        .onErrorResume(ex -> {
+          LOGGER.warn("{} failed: {}", circuitBreakerName, ex.getMessage());
+          return Mono.just(SafeResult.warning(warning));
+        });
+  }
+
+  private record SafeResult<T>(T value, String warning) {
+
+    static <T> SafeResult<T> success(T value) {
+      return new SafeResult<>(value, null);
+    }
+
+    static <T> SafeResult<T> warning(String warning) {
+      return new SafeResult<>(null, warning);
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayBffProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayBffProperties.java
@@ -1,0 +1,75 @@
+package com.ejada.gateway.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration properties backing the gateway BFF (Backend for Frontend)
+ * aggregation endpoints. Allows tuning downstream service base URIs without
+ * recompiling the gateway which is useful across environments (local, CI,
+ * production).
+ */
+@ConfigurationProperties(prefix = "gateway.bff")
+public class GatewayBffProperties {
+
+  private final TenantDashboardProperties dashboard = new TenantDashboardProperties();
+
+  public TenantDashboardProperties getDashboard() {
+    return dashboard;
+  }
+
+  public static class TenantDashboardProperties {
+
+    /** Base URI (lb:// or http://) for tenant service lookups. */
+    private String tenantServiceUri = "lb://tenant-service";
+
+    /** Base URI for analytics service aggregations. */
+    private String analyticsServiceUri = "lb://analytics-service";
+
+    /** Base URI for billing consumption lookups. */
+    private String billingServiceUri = "lb://billing-service";
+
+    /** Default analytics period when none supplied by the caller. */
+    private String defaultPeriod = "MONTHLY";
+
+    public String getTenantServiceUri() {
+      return tenantServiceUri;
+    }
+
+    public void setTenantServiceUri(String tenantServiceUri) {
+      if (StringUtils.hasText(tenantServiceUri)) {
+        this.tenantServiceUri = tenantServiceUri.trim();
+      }
+    }
+
+    public String getAnalyticsServiceUri() {
+      return analyticsServiceUri;
+    }
+
+    public void setAnalyticsServiceUri(String analyticsServiceUri) {
+      if (StringUtils.hasText(analyticsServiceUri)) {
+        this.analyticsServiceUri = analyticsServiceUri.trim();
+      }
+    }
+
+    public String getBillingServiceUri() {
+      return billingServiceUri;
+    }
+
+    public void setBillingServiceUri(String billingServiceUri) {
+      if (StringUtils.hasText(billingServiceUri)) {
+        this.billingServiceUri = billingServiceUri.trim();
+      }
+    }
+
+    public String getDefaultPeriod() {
+      return defaultPeriod;
+    }
+
+    public void setDefaultPeriod(String defaultPeriod) {
+      if (StringUtils.hasText(defaultPeriod)) {
+        this.defaultPeriod = defaultPeriod.trim().toUpperCase();
+      }
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySupplementaryConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySupplementaryConfiguration.java
@@ -1,14 +1,13 @@
 package com.ejada.gateway.config;
 
-import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * Enables auxiliary configuration properties for gateway-specific components
  * that are not part of the shared starters.
  */
 @Configuration
-@EnableConfigurationProperties({SubscriptionValidationProperties.class})
+@EnableConfigurationProperties({SubscriptionValidationProperties.class, GatewayBffProperties.class})
 public class GatewaySupplementaryConfiguration {
 }
-

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -181,6 +181,12 @@ resilience4j:
 
 # Declarative downstream routes consumed by GatewayRoutesConfiguration
 gateway:
+  bff:
+    dashboard:
+      tenant-service-uri: lb://tenant-service
+      analytics-service-uri: lb://analytics-service
+      billing-service-uri: lb://billing-service
+      default-period: MONTHLY
   defaults:
     resilience:
       enabled: true

--- a/api-gateway/src/test/java/com/ejada/gateway/bff/TenantDashboardControllerTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/bff/TenantDashboardControllerTest.java
@@ -1,0 +1,71 @@
+package com.ejada.gateway.bff;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+class TenantDashboardControllerTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private TenantDashboardService tenantDashboardService;
+  private WebTestClient webTestClient;
+
+  @BeforeEach
+  void setup() {
+    tenantDashboardService = Mockito.mock(TenantDashboardService.class);
+    TenantDashboardController controller = new TenantDashboardController(tenantDashboardService);
+    webTestClient = WebTestClient.bindToController(controller).build();
+  }
+
+  @Test
+  void returnsAggregatedDashboard() throws Exception {
+    JsonNode tenant = OBJECT_MAPPER.readTree("{\"tenantId\":1}");
+    TenantDashboardResponse dashboard = new TenantDashboardResponse(tenant, null, null, null, null, List.of());
+
+    Mockito.when(tenantDashboardService.aggregateDashboard(1, null, null, null))
+        .thenReturn(Mono.just(dashboard));
+
+    webTestClient.get()
+        .uri("/api/bff/tenants/1/dashboard")
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .jsonPath("$.status").isEqualTo("SUCCESS")
+        .jsonPath("$.data.tenant.tenantId").isEqualTo(1);
+  }
+
+  @Test
+  void propagatesResponseStatusException() {
+    Mockito.when(tenantDashboardService.aggregateDashboard(1, null, null, null))
+        .thenReturn(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Missing")));
+
+    webTestClient.get()
+        .uri("/api/bff/tenants/1/dashboard")
+        .exchange()
+        .expectStatus().isNotFound()
+        .expectBody()
+        .jsonPath("$.status").isEqualTo("ERROR")
+        .jsonPath("$.message").isEqualTo("Missing");
+  }
+
+  @Test
+  void wrapsUnexpectedExceptions() {
+    Mockito.when(tenantDashboardService.aggregateDashboard(1, null, null, null))
+        .thenReturn(Mono.error(new IllegalStateException("boom")));
+
+    webTestClient.get()
+        .uri("/api/bff/tenants/1/dashboard")
+        .exchange()
+        .expectStatus().isEqualTo(HttpStatus.BAD_GATEWAY)
+        .expectBody()
+        .jsonPath("$.code").isEqualTo("ERR_TENANT_DASHBOARD");
+  }
+}

--- a/api-gateway/src/test/java/com/ejada/gateway/bff/TenantDashboardServiceTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/bff/TenantDashboardServiceTest.java
@@ -1,0 +1,125 @@
+package com.ejada.gateway.bff;
+
+import com.ejada.gateway.config.GatewayBffProperties;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.client.circuitbreaker.ReactiveCircuitBreakerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class TenantDashboardServiceTest {
+
+  private Map<String, ClientResponse> responses;
+  private TenantDashboardService service;
+
+  @BeforeEach
+  void setUp() {
+    responses = new HashMap<>();
+    ExchangeFunction exchangeFunction = request -> {
+      ClientResponse response = responses.get(request.url().toString());
+      if (response == null) {
+        return Mono.just(ClientResponse.create(HttpStatus.NOT_FOUND).build());
+      }
+      return Mono.just(response);
+    };
+
+    WebClient.Builder builder = WebClient.builder().exchangeFunction(exchangeFunction);
+    GatewayBffProperties properties = new GatewayBffProperties();
+    properties.getDashboard().setTenantServiceUri("http://tenant");
+    properties.getDashboard().setAnalyticsServiceUri("http://analytics");
+    properties.getDashboard().setBillingServiceUri("http://billing");
+
+    service = new TenantDashboardService(builder, properties, (ReactiveCircuitBreakerFactory<?, ?>) null);
+  }
+
+  @Test
+  void aggregateDashboardReturnsAggregatedPayload() {
+    responses.put("http://tenant/api/v1/tenants/1", jsonResponse("""
+        {"status":"SUCCESS","code":"SUCCESS-200","message":null,
+          "data":{"id":1,"code":"ACME","name":"Acme Corp"}}
+        """));
+
+    responses.put("http://analytics/api/v1/analytics/tenants/1/usage-summary?period=MONTHLY",
+        jsonResponse("""
+            {"tenantId":1,"period":"MONTHLY"}
+            """));
+
+    responses.put("http://analytics/api/v1/analytics/tenants/1/feature-adoption",
+        jsonResponse("""
+            {"tenantId":1,"features":[]}
+            """));
+
+    responses.put("http://analytics/api/v1/analytics/tenants/1/cost-forecast",
+        jsonResponse("""
+            {"tenantId":1,"features":[]}
+            """));
+
+    responses.put("http://billing/billing/subscriptions/42/consumption?customerId=99",
+        jsonResponse("""
+            {"subscriptionId":42,"productConsumptionStts":[]}
+            """));
+
+    StepVerifier.create(service.aggregateDashboard(1, 42L, 99L, "monthly"))
+        .assertNext(response -> {
+          assert response.tenant().get("id").asInt() == 1;
+          assert response.usageSummary().get("period").asText().equals("MONTHLY");
+          assert response.warnings().isEmpty();
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  void aggregateDashboardAddsWarningsWhenDownstreamFails() {
+    responses.put("http://tenant/api/v1/tenants/1", jsonResponse("""
+        {"status":"SUCCESS","code":"SUCCESS-200","message":null,
+          "data":{"id":1,"code":"ACME","name":"Acme Corp"}}
+        """));
+
+    responses.put("http://analytics/api/v1/analytics/tenants/1/usage-summary?period=MONTHLY",
+        ClientResponse.create(HttpStatus.INTERNAL_SERVER_ERROR).build());
+
+    responses.put("http://analytics/api/v1/analytics/tenants/1/feature-adoption",
+        ClientResponse.create(HttpStatus.SERVICE_UNAVAILABLE).build());
+
+    responses.put("http://analytics/api/v1/analytics/tenants/1/cost-forecast",
+        jsonResponse("""
+            {"tenantId":1}
+            """));
+
+    StepVerifier.create(service.aggregateDashboard(1, null, null, null))
+        .assertNext(response -> {
+          assert response.tenant() != null;
+          assert response.warnings().size() == 2;
+          assert response.usageSummary() == null;
+          assert response.featureAdoption() == null;
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  void aggregateDashboardPropagatesTenantFailure() {
+    responses.put("http://tenant/api/v1/tenants/1", ClientResponse.create(HttpStatus.BAD_GATEWAY).build());
+
+    StepVerifier.create(service.aggregateDashboard(1, null, null, null))
+        .expectErrorSatisfies(error -> {
+          assert error instanceof ResponseStatusException;
+          ResponseStatusException ex = (ResponseStatusException) error;
+          assert ex.getStatusCode().equals(HttpStatus.BAD_GATEWAY);
+        })
+        .verify();
+  }
+
+  private ClientResponse jsonResponse(String json) {
+    return ClientResponse.create(HttpStatus.OK)
+        .header("Content-Type", "application/json")
+        .body(json)
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary
- add a tenant dashboard BFF controller and service that aggregate downstream analytics, billing, and tenant data behind the gateway
- expose configurable BFF service endpoints via new `gateway.bff` properties and enable them in the supplementary configuration
- cover the new aggregation flow with unit tests for the service and controller

## Testing
- `mvn -pl api-gateway -am test` *(fails: ReactiveRateLimiterFilterTest requires Docker/Testcontainers which is unavailable in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ceb1ff68832f90326e72e12377ed