### PR TITLE
Ensure tenant health metrics provider bean is available

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/config/TenantHealthMetricsConfiguration.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/config/TenantHealthMetricsConfiguration.java
@@ -1,0 +1,17 @@
+package com.ejada.tenant.config;
+
+import com.ejada.tenant.service.health.DefaultTenantHealthMetricsProvider;
+import com.ejada.tenant.service.health.TenantHealthMetricsProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class TenantHealthMetricsConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(TenantHealthMetricsProvider.class)
+    public TenantHealthMetricsProvider tenantHealthMetricsProvider() {
+        return new DefaultTenantHealthMetricsProvider();
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/health/DefaultTenantHealthMetricsProvider.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/health/DefaultTenantHealthMetricsProvider.java
@@ -1,12 +1,8 @@
 package com.ejada.tenant.service.health;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.stereotype.Component;
 
 @Slf4j
-@Component
-@ConditionalOnMissingBean(TenantHealthMetricsProvider.class)
 public class DefaultTenantHealthMetricsProvider implements TenantHealthMetricsProvider {
 
     @Override


### PR DESCRIPTION
## Summary
- create a dedicated configuration class that registers a default TenantHealthMetricsProvider when none is supplied
- simplify DefaultTenantHealthMetricsProvider to be a plain component implementation used by the configuration

## Testing
- `mvn -pl tenant-platform/tenant-service -am test` *(fails: Error opening zip file or JAR manifest missing : /root/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d18f3bb0832f915eb1e0760b7bd5