### PR TITLE
Fix subscription service tests for tenant link publisher changes

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionOutboxPersistenceIT.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.ejada.subscription.acl.MarketplaceCallbackOrchestrator;
 import com.ejada.subscription.kafka.SubscriptionApprovalPublisher;
 import com.ejada.subscription.repository.OutboxEventRepository;
+import com.ejada.subscription.tenant.TenantLinkFactory;
+import com.ejada.subscription.service.approval.ApprovalWorkflowService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.flywaydb.core.Flyway;
 import java.util.List;
@@ -84,7 +86,9 @@ class SubscriptionOutboxPersistenceIT {
                 Mockito.mock(com.ejada.subscription.mapper.SubscriptionUpdateEventMapper.class),
                 new ObjectMapper(),
                 txManager,
-                Mockito.mock(SubscriptionApprovalPublisher.class));
+                Mockito.mock(SubscriptionApprovalPublisher.class),
+                new TenantLinkFactory(),
+                Mockito.mock(ApprovalWorkflowService.class));
         outboxRepo.deleteAll();
     }
 


### PR DESCRIPTION
## Summary
- update MarketplaceCallbackOrchestratorTest to account for the new publishApprovalDecision signature and tenant link resolution
- inject TenantLinkFactory and an ApprovalWorkflowService mock into SubscriptionOutboxPersistenceIT so the orchestrator can be constructed

## Testing
- mvn -pl tenant-platform/subscription-service test *(fails: missing com.ejada starter dependencies in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d2c1c9ec832f8e919926a674247f