### PR TITLE
Add version-aware routing and admin aggregation endpoints

### DIFF
--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -9,6 +9,7 @@ Enterprise-ready Spring Cloud Gateway that fronts the LMS microservices. It reus
 - **Performance** – Reactive rate limiting, tuned Netty client, weighted load balancing.
 - **Observability** – OpenTelemetry traces, Prometheus metrics, structured JSON logs.
 - **Operations** – Dynamic route reloads, blue/green routing flags, Helm deployment assets.
+- **Routing Intelligence** – API version normalisation, weighted canary traffic, session affinity cookies, and operator-facing admin aggregates.
 - **Tenant & Subscription Enforcement** – Dedicated filters for correlation id propagation, tenant extraction, and subscription validation with Redis caching.
 - **Flexible Rate Limiting** – Built-in tenant and IP-based key resolvers that plug directly into Spring Cloud Gateway's `RequestRateLimiter` filter.
 - **Downstream Client Configuration** – Centralised, load-balanced `WebClient` builder with context propagation and timeout tuning.

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationController.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationController.java
@@ -1,0 +1,37 @@
+package com.ejada.gateway.admin;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.gateway.admin.model.AdminOverview;
+import com.ejada.gateway.admin.model.AdminRouteView;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST entrypoint that exposes aggregated operational views across downstream services and
+ * configured gateway routes.
+ */
+@RestController
+@RequestMapping("/api/v1/admin")
+public class AdminAggregationController {
+
+  private final AdminAggregationService aggregationService;
+
+  public AdminAggregationController(AdminAggregationService aggregationService) {
+    this.aggregationService = aggregationService;
+  }
+
+  @GetMapping("/overview")
+  public Mono<BaseResponse<AdminOverview>> overview() {
+    return aggregationService.fetchOverview()
+        .map(data -> BaseResponse.success("Aggregated gateway overview", data));
+  }
+
+  @GetMapping("/routes")
+  public Mono<BaseResponse<List<AdminRouteView>>> routes() {
+    return Mono.fromSupplier(aggregationService::describeRoutes)
+        .map(data -> BaseResponse.success("Gateway route catalogue", data));
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationService.java
@@ -1,0 +1,108 @@
+package com.ejada.gateway.admin;
+
+import com.ejada.gateway.admin.model.AdminOverview;
+import com.ejada.gateway.admin.model.AdminRouteView;
+import com.ejada.gateway.admin.model.AdminServiceSnapshot;
+import com.ejada.gateway.config.AdminAggregationProperties;
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Aggregates status information across downstream services so platform operators can inspect the
+ * health of the estate via the admin API hosted by the gateway.
+ */
+@Service
+public class AdminAggregationService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AdminAggregationService.class);
+
+  private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE =
+      new ParameterizedTypeReference<>() {};
+
+  private final WebClient.Builder webClientBuilder;
+  private final AdminAggregationProperties adminProperties;
+  private final GatewayRoutesProperties routesProperties;
+
+  public AdminAggregationService(WebClient.Builder webClientBuilder,
+      AdminAggregationProperties adminProperties,
+      GatewayRoutesProperties routesProperties) {
+    this.webClientBuilder = webClientBuilder;
+    this.adminProperties = adminProperties;
+    this.routesProperties = routesProperties;
+  }
+
+  public Mono<AdminOverview> fetchOverview() {
+    List<AdminAggregationProperties.Service> services = adminProperties.getAggregation().getServices();
+    if (services.isEmpty()) {
+      return Mono.just(AdminOverview.empty());
+    }
+
+    IntStream.range(0, services.size()).forEach(index -> {
+      AdminAggregationProperties.Service service = services.get(index);
+      String key = service.getId() != null ? service.getId() : String.valueOf(index);
+      service.validate(key);
+    });
+
+    Duration timeout = adminProperties.getAggregation().getTimeout();
+
+    return Flux.fromIterable(services)
+        .flatMap(service -> fetchSnapshot(service, timeout))
+        .sort(Comparator.comparing(AdminServiceSnapshot::serviceId))
+        .collectList()
+        .map(AdminOverview::fromSnapshots);
+  }
+
+  public List<AdminRouteView> describeRoutes() {
+    return routesProperties.getRoutes().values().stream()
+        .sorted(Comparator.comparing(route -> {
+          String id = route.getId();
+          return id == null ? "" : id;
+        }))
+        .map(AdminRouteView::fromRoute)
+        .toList();
+  }
+
+  private Mono<AdminServiceSnapshot> fetchSnapshot(AdminAggregationProperties.Service service,
+      Duration defaultTimeout) {
+    WebClient client = webClientBuilder.clone()
+        .baseUrl(service.getUri().toString())
+        .build();
+    Duration timeout = service.resolveTimeout(defaultTimeout);
+
+    return client.get()
+        .uri(service.getHealthPath())
+        .headers(httpHeaders -> service.getHeaders().forEach(httpHeaders::add))
+        .retrieve()
+        .bodyToMono(MAP_TYPE)
+        .timeout(timeout)
+        .elapsed()
+        .map(tuple -> AdminServiceSnapshot.success(
+            service.getId(),
+            service.getDeployment(),
+            service.isRequired(),
+            tuple.getT2(),
+            tuple.getT1(),
+            Instant.now()))
+        .onErrorResume(ex -> {
+          LOGGER.warn("Admin aggregation failed for {}", service.getId(), ex);
+          return Mono.just(AdminServiceSnapshot.failure(
+              service.getId(),
+              service.getDeployment(),
+              service.isRequired(),
+              ex,
+              Instant.now()));
+        });
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/model/AdminOverview.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/model/AdminOverview.java
@@ -1,0 +1,39 @@
+package com.ejada.gateway.admin.model;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Aggregated view returned from {@code /api/v1/admin/overview}.
+ */
+public record AdminOverview(
+    Instant generatedAt,
+    int totalServices,
+    long upServices,
+    long downServices,
+    long degradedServices,
+    List<AdminServiceSnapshot> services) {
+
+  public static AdminOverview fromSnapshots(List<AdminServiceSnapshot> snapshots) {
+    if (snapshots == null || snapshots.isEmpty()) {
+      return empty();
+    }
+    long up = snapshots.stream().filter(snapshot -> snapshot.state() == AdminServiceState.UP).count();
+    long down = snapshots.stream().filter(snapshot -> snapshot.state() == AdminServiceState.DOWN).count();
+    long degraded = snapshots.stream()
+        .filter(snapshot -> snapshot.state() == AdminServiceState.DEGRADED)
+        .count();
+    return new AdminOverview(
+        Instant.now(),
+        snapshots.size(),
+        up,
+        down,
+        degraded,
+        List.copyOf(snapshots));
+  }
+
+  public static AdminOverview empty() {
+    return new AdminOverview(Instant.now(), 0, 0, 0, 0, Collections.emptyList());
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/model/AdminRouteView.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/model/AdminRouteView.java
@@ -1,0 +1,61 @@
+package com.ejada.gateway.admin.model;
+
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Lightweight DTO describing a configured route. Exposed via {@code /api/v1/admin/routes} so
+ * operators can inspect gateway routing behaviour without logging into the cluster.
+ */
+public record AdminRouteView(
+    String id,
+    String targetUri,
+    List<String> paths,
+    List<String> methods,
+    int stripPrefix,
+    String prefixPath,
+    boolean versioningEnabled,
+    String defaultVersion,
+    List<String> supportedVersions,
+    boolean sessionAffinityEnabled,
+    String sessionAffinityCookie,
+    String sessionAffinityHeader,
+    boolean weightEnabled,
+    String weightGroup,
+    int weightValue,
+    Map<String, String> requestHeaders,
+    boolean resilienceEnabled,
+    String fallbackUri,
+    String circuitBreakerName) {
+
+  public static AdminRouteView fromRoute(GatewayRoutesProperties.ServiceRoute route) {
+    GatewayRoutesProperties.ServiceRoute.Versioning versioning = route.getVersioning();
+    GatewayRoutesProperties.ServiceRoute.SessionAffinity affinity = route.getSessionAffinity();
+    GatewayRoutesProperties.ServiceRoute.Weight weight = route.getWeight();
+    GatewayRoutesProperties.ServiceRoute.Resilience resilience = route.getResilience();
+    URI uri = route.getUri();
+
+    return new AdminRouteView(
+        route.getId(),
+        uri != null ? uri.toString() : "",
+        List.copyOf(route.getPaths()),
+        List.copyOf(route.getMethods()),
+        route.getStripPrefix(),
+        route.getPrefixPath(),
+        versioning.isEnabled(),
+        versioning.isEnabled() ? versioning.getDefaultVersion() : null,
+        versioning.isEnabled() ? List.copyOf(versioning.getSupportedVersions()) : List.of(),
+        affinity.isEnabled(),
+        affinity.isEnabled() ? affinity.getCookieName() : null,
+        affinity.isEnabled() ? affinity.getHeaderName() : null,
+        weight.isEnabled(),
+        weight.isEnabled() ? weight.getGroup() : null,
+        weight.isEnabled() ? weight.getValue() : 0,
+        Map.copyOf(route.getRequestHeaders()),
+        resilience.isEnabled(),
+        resilience.isEnabled() ? resilience.resolvedFallbackUri(route.getId()) : null,
+        resilience.isEnabled() ? resilience.resolvedCircuitBreakerName(route.getId()) : null);
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/model/AdminServiceSnapshot.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/model/AdminServiceSnapshot.java
@@ -1,0 +1,83 @@
+package com.ejada.gateway.admin.model;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Captures the outcome of aggregating a single downstream service's status.
+ */
+public record AdminServiceSnapshot(
+    String serviceId,
+    String deployment,
+    boolean required,
+    AdminServiceState state,
+    String status,
+    long latencyMs,
+    Instant checkedAt,
+    Map<String, Object> details) {
+
+  public static AdminServiceSnapshot success(String serviceId,
+      String deployment,
+      boolean required,
+      Map<String, Object> payload,
+      long latencyMs,
+      Instant timestamp) {
+    String status = extractStatus(payload);
+    AdminServiceState state = mapState(status);
+    Map<String, Object> details = extractDetails(payload);
+    return new AdminServiceSnapshot(serviceId, deployment, required, state, status, latencyMs, timestamp, details);
+  }
+
+  public static AdminServiceSnapshot failure(String serviceId,
+      String deployment,
+      boolean required,
+      Throwable failure,
+      Instant timestamp) {
+    Map<String, Object> details = new LinkedHashMap<>();
+    details.put("error", failure.getClass().getSimpleName());
+    details.put("message", Optional.ofNullable(failure.getMessage()).orElse("Unavailable"));
+    return new AdminServiceSnapshot(serviceId, deployment, required, AdminServiceState.DOWN,
+        "UNAVAILABLE", -1, timestamp, Collections.unmodifiableMap(details));
+  }
+
+  private static String extractStatus(Map<String, Object> payload) {
+    if (payload == null) {
+      return "UNKNOWN";
+    }
+    Object candidate = payload.get("status");
+    return Objects.toString(candidate, "UNKNOWN").toUpperCase();
+  }
+
+  private static Map<String, Object> extractDetails(Map<String, Object> payload) {
+    if (payload == null) {
+      return Collections.emptyMap();
+    }
+    Object details = payload.get("details");
+    if (details instanceof Map<?, ?> map) {
+      Map<String, Object> sanitized = new LinkedHashMap<>();
+      map.forEach((key, value) -> sanitized.put(Objects.toString(key, ""), value));
+      return Collections.unmodifiableMap(sanitized);
+    }
+    Map<String, Object> single = new LinkedHashMap<>();
+    if (details != null) {
+      single.put("details", details);
+    }
+    return Collections.unmodifiableMap(single);
+  }
+
+  private static AdminServiceState mapState(String status) {
+    if (!String.valueOf(status).isEmpty()) {
+      return switch (status.toUpperCase()) {
+        case "UP" -> AdminServiceState.UP;
+        case "OUT_OF_SERVICE", "DOWN" -> AdminServiceState.DOWN;
+        case "DEGRADED" -> AdminServiceState.DEGRADED;
+        default -> AdminServiceState.UNKNOWN;
+      };
+    }
+    return AdminServiceState.UNKNOWN;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/model/AdminServiceState.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/model/AdminServiceState.java
@@ -1,0 +1,11 @@
+package com.ejada.gateway.admin.model;
+
+/**
+ * High-level status classification returned from aggregated service health checks.
+ */
+public enum AdminServiceState {
+  UP,
+  DOWN,
+  DEGRADED,
+  UNKNOWN
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/AdminAggregationProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/AdminAggregationProperties.java
@@ -1,0 +1,166 @@
+package com.ejada.gateway.config;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration backing the aggregated admin endpoints exposed by the gateway. Operators can
+ * describe which downstream services should be queried for health/status information and how long
+ * the gateway should wait for those calls before falling back to graceful degradation.
+ */
+@ConfigurationProperties(prefix = "gateway.admin")
+public class AdminAggregationProperties {
+
+  private Aggregation aggregation = new Aggregation();
+
+  public Aggregation getAggregation() {
+    return aggregation;
+  }
+
+  public void setAggregation(Aggregation aggregation) {
+    this.aggregation = (aggregation == null) ? new Aggregation() : aggregation;
+  }
+
+  public static class Aggregation {
+
+    private Duration timeout = Duration.ofSeconds(3);
+
+    private List<Service> services = new ArrayList<>();
+
+    public Duration getTimeout() {
+      return timeout;
+    }
+
+    public void setTimeout(Duration timeout) {
+      this.timeout = timeout;
+    }
+
+    public List<Service> getServices() {
+      return services;
+    }
+
+    public void setServices(List<Service> services) {
+      this.services = (services == null) ? new ArrayList<>() : new ArrayList<>(services);
+    }
+  }
+
+  public static class Service {
+
+    private String id;
+    private URI uri;
+    private String healthPath = "/actuator/health";
+    private Duration timeout;
+    private Map<String, String> headers = new LinkedHashMap<>();
+    private boolean required = true;
+    private String deployment = "primary";
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public URI getUri() {
+      return uri;
+    }
+
+    public void setUri(URI uri) {
+      this.uri = uri;
+    }
+
+    public void setUri(String value) {
+      if (StringUtils.hasText(value)) {
+        this.uri = URI.create(value.trim());
+      } else {
+        this.uri = null;
+      }
+    }
+
+    public String getHealthPath() {
+      return healthPath;
+    }
+
+    public void setHealthPath(String healthPath) {
+      if (!StringUtils.hasText(healthPath)) {
+        this.healthPath = "/actuator/health";
+      } else {
+        String trimmed = healthPath.trim();
+        this.healthPath = trimmed.startsWith("/") ? trimmed : '/' + trimmed;
+      }
+    }
+
+    public Duration getTimeout() {
+      return timeout;
+    }
+
+    public void setTimeout(Duration timeout) {
+      this.timeout = timeout;
+    }
+
+    public Map<String, String> getHeaders() {
+      return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+      if (headers == null) {
+        this.headers = new LinkedHashMap<>();
+        return;
+      }
+      Map<String, String> sanitized = new LinkedHashMap<>();
+      headers.forEach((key, value) -> {
+        if (!StringUtils.hasText(key)) {
+          return;
+        }
+        String headerValue = Objects.toString(value, null);
+        if (!StringUtils.hasText(headerValue)) {
+          return;
+        }
+        sanitized.put(key.trim(), headerValue.trim());
+      });
+      this.headers = sanitized;
+    }
+
+    public boolean isRequired() {
+      return required;
+    }
+
+    public void setRequired(boolean required) {
+      this.required = required;
+    }
+
+    public String getDeployment() {
+      return deployment;
+    }
+
+    public void setDeployment(String deployment) {
+      this.deployment = StringUtils.hasText(deployment) ? deployment.trim() : "primary";
+    }
+
+    public Duration resolveTimeout(Duration defaultTimeout) {
+      if (timeout != null && !timeout.isNegative() && !timeout.isZero()) {
+        return timeout;
+      }
+      return (defaultTimeout == null || defaultTimeout.isNegative() || defaultTimeout.isZero())
+          ? Duration.ofSeconds(3)
+          : defaultTimeout;
+    }
+
+    public void validate(String key) {
+      if (!StringUtils.hasText(id)) {
+        throw new IllegalStateException("gateway.admin.aggregation.services[" + key + "].id must not be blank");
+      }
+      if (uri == null) {
+        throw new IllegalStateException("gateway.admin.aggregation.services[" + key + "].uri must be provided");
+      }
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySupplementaryConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySupplementaryConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
  * that are not part of the shared starters.
  */
 @Configuration
-@EnableConfigurationProperties({SubscriptionValidationProperties.class})
+@EnableConfigurationProperties({SubscriptionValidationProperties.class, AdminAggregationProperties.class})
 public class GatewaySupplementaryConfiguration {
 }
 

--- a/api-gateway/src/main/java/com/ejada/gateway/config/WebClientConfig.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/WebClientConfig.java
@@ -83,6 +83,7 @@ public class WebClientConfig {
       propagate(contextView, builder, GatewayRequestAttributes.CORRELATION_ID, HeaderNames.CORRELATION_ID);
       propagate(contextView, builder, GatewayRequestAttributes.TENANT_ID, HeaderNames.X_TENANT_ID);
       propagate(contextView, builder, HeaderNames.USER_ID, HeaderNames.USER_ID);
+      propagate(contextView, builder, GatewayRequestAttributes.API_VERSION, HeaderNames.API_VERSION);
       return next.exchange(builder.build());
     });
   }

--- a/api-gateway/src/main/java/com/ejada/gateway/context/GatewayRequestAttributes.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/GatewayRequestAttributes.java
@@ -17,6 +17,9 @@ public final class GatewayRequestAttributes {
   /** Attribute storing the cached subscription status for the current tenant. */
   public static final String SUBSCRIPTION = GatewayRequestAttributes.class.getName() + ".subscription";
 
+  /** Attribute storing the resolved API version for versioned routes. */
+  public static final String API_VERSION = GatewayRequestAttributes.class.getName() + ".apiVersion";
+
   private GatewayRequestAttributes() {
     // utility class
   }

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/ApiVersioningGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/ApiVersioningGatewayFilter.java
@@ -1,0 +1,141 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+/**
+ * Normalises versioned API requests so downstream services do not have to parse
+ * URI prefixes such as {@code /v1/...}. The filter optionally strips the
+ * version segment from the request path, falls back to a default version when a
+ * request omits the version, and propagates the resolved version through a
+ * canonical header.
+ */
+public class ApiVersioningGatewayFilter implements GatewayFilter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ApiVersioningGatewayFilter.class);
+
+  private static final Pattern VERSION_PATTERN = Pattern.compile("^v(\\d+)$", Pattern.CASE_INSENSITIVE);
+
+  private final GatewayRoutesProperties.ServiceRoute.Versioning versioning;
+
+  public ApiVersioningGatewayFilter(GatewayRoutesProperties.ServiceRoute.Versioning versioning) {
+    this.versioning = Objects.requireNonNull(versioning, "versioning");
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+    if (!versioning.isEnabled()) {
+      return chain.filter(exchange);
+    }
+
+    ServerHttpRequest request = exchange.getRequest();
+    URI originalUri = request.getURI();
+    String rawPath = originalUri.getRawPath();
+
+    List<String> segments = tokenise(rawPath);
+    boolean hadVersionSegment = false;
+    String requestedVersion = null;
+
+    if (!segments.isEmpty()) {
+      String candidate = segments.get(0);
+      if (isVersionSegment(candidate)) {
+        hadVersionSegment = true;
+        requestedVersion = normalise(candidate);
+        segments.remove(0);
+      }
+    }
+
+    String effectiveVersion = versioning.getDefaultVersion();
+    if (hadVersionSegment && requestedVersion != null) {
+      if (versioning.hasSupportedVersions() && !versioning.getSupportedVersions().contains(requestedVersion)) {
+        if (!versioning.isFallbackToDefault()) {
+          LOGGER.debug("Rejecting unsupported API version '{}' for route {}", requestedVersion, versioning);
+          exchange.getResponse().setStatusCode(HttpStatus.NOT_FOUND);
+          return exchange.getResponse().setComplete();
+        }
+        LOGGER.debug("Falling back to default version {} for unsupported request version {}", effectiveVersion,
+            requestedVersion);
+      } else {
+        effectiveVersion = requestedVersion;
+      }
+    }
+
+    if (!hadVersionSegment && StringUtils.hasText(versioning.getDefaultVersion())) {
+      effectiveVersion = versioning.getDefaultVersion();
+    }
+
+    String normalisedPath = rebuildPath(rawPath, segments);
+    ServerHttpRequest.Builder requestBuilder = request.mutate();
+    if (!normalisedPath.equals(rawPath)) {
+      URI newUri = UriComponentsBuilder.fromUri(originalUri)
+          .replacePath(normalisedPath)
+          .build(true)
+          .toUri();
+      requestBuilder.uri(newUri);
+    }
+
+    if (versioning.isPropagateHeader()) {
+      final String headerValue = effectiveVersion;
+      requestBuilder.headers(httpHeaders -> httpHeaders.set(HeaderNames.API_VERSION, headerValue));
+    }
+
+    ServerHttpRequest mutatedRequest = requestBuilder.build();
+    ServerWebExchange mutatedExchange = exchange.mutate()
+        .request(mutatedRequest)
+        .build();
+    mutatedExchange.getAttributes().put(GatewayRequestAttributes.API_VERSION, effectiveVersion);
+    return chain.filter(mutatedExchange);
+  }
+
+  private static List<String> tokenise(String path) {
+    if (!StringUtils.hasText(path)) {
+      return new ArrayList<>();
+    }
+    String[] rawSegments = path.split("/");
+    List<String> result = new ArrayList<>(rawSegments.length);
+    for (String segment : rawSegments) {
+      if (!StringUtils.hasText(segment)) {
+        continue;
+      }
+      result.add(segment);
+    }
+    return result;
+  }
+
+  private static boolean isVersionSegment(String value) {
+    return StringUtils.hasText(value) && VERSION_PATTERN.matcher(value.trim()).matches();
+  }
+
+  private static String normalise(String value) {
+    return value == null ? null : value.trim().toLowerCase(Locale.ROOT);
+  }
+
+  private static String rebuildPath(String originalPath, List<String> segments) {
+    if (segments.isEmpty()) {
+      return originalPath.startsWith("/") ? "/" : "";
+    }
+    String joined = String.join("/", segments);
+    String rebuilt = '/' + joined;
+    if (originalPath.endsWith("/") && !rebuilt.endsWith("/")) {
+      rebuilt = rebuilt + '/';
+    }
+    return rebuilt;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/SessionAffinityGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/SessionAffinityGatewayFilter.java
@@ -1,0 +1,82 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import java.util.Objects;
+import java.util.UUID;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Lightweight session affinity helper that ensures a stable affinity identifier is propagated for
+ * routes that require sticky sessions. The gateway emits/echoes a cookie and mirrors it to a
+ * configurable header so downstream services or load balancers can honour the affinity.
+ */
+public class SessionAffinityGatewayFilter implements GatewayFilter {
+
+  private final GatewayRoutesProperties.ServiceRoute.SessionAffinity affinity;
+
+  public SessionAffinityGatewayFilter(GatewayRoutesProperties.ServiceRoute.SessionAffinity affinity) {
+    this.affinity = Objects.requireNonNull(affinity, "affinity");
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+    if (!affinity.isEnabled()) {
+      return chain.filter(exchange);
+    }
+
+    String affinityId = resolveAffinityId(exchange);
+    boolean generated = false;
+    if (!StringUtils.hasText(affinityId)) {
+      affinityId = UUID.randomUUID().toString();
+      generated = true;
+    }
+
+    ServerHttpRequest.Builder requestBuilder = exchange.getRequest().mutate();
+    String headerName = affinity.getHeaderName();
+    if (StringUtils.hasText(headerName)) {
+      final String headerValue = affinityId;
+      requestBuilder.headers(httpHeaders -> {
+        if (!httpHeaders.containsKey(headerName)) {
+          httpHeaders.add(headerName, headerValue);
+        }
+      });
+    }
+
+    ServerWebExchange mutated = exchange.mutate()
+        .request(requestBuilder.build())
+        .build();
+
+    if (generated || !hasAffinityCookie(exchange)) {
+      ResponseCookie cookie = ResponseCookie.from(affinity.getCookieName(), affinityId)
+          .path("/")
+          .httpOnly(false)
+          .secure(false)
+          .sameSite("Lax")
+          .build();
+      mutated.getResponse().addCookie(cookie);
+    }
+
+    return chain.filter(mutated);
+  }
+
+  private String resolveAffinityId(ServerWebExchange exchange) {
+    var request = exchange.getRequest();
+    var cookie = request.getCookies().getFirst(affinity.getCookieName());
+    if (cookie != null && StringUtils.hasText(cookie.getValue())) {
+      return cookie.getValue();
+    }
+    String header = request.getHeaders().getFirst(affinity.getHeaderName());
+    return StringUtils.hasText(header) ? header : null;
+  }
+
+  private boolean hasAffinityCookie(ServerWebExchange exchange) {
+    var cookie = exchange.getRequest().getCookies().getFirst(affinity.getCookieName());
+    return cookie != null && StringUtils.hasText(cookie.getValue());
+  }
+}

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -57,6 +57,10 @@ spring:
     loadbalancer:
       retry:
         enabled: true
+      sticky-session:
+        enabled: true
+        add-service-instance-cookie: true
+        cookie-name: LMS-AFFINITY
     kubernetes:
       reload:
         enabled: true
@@ -157,6 +161,10 @@ resilience4j:
         base-config: default
       setup-service:
         base-config: default
+      policy-service:
+        base-config: default
+      tenant-service-canary:
+        base-config: default
   retry:
     configs:
       default:
@@ -170,6 +178,10 @@ resilience4j:
     instances:
       catalog-service:
         base-config: default
+      policy-service:
+        base-config: default
+      tenant-service:
+        base-config: default
   bulkhead:
     configs:
       default:
@@ -177,6 +189,8 @@ resilience4j:
         max-wait-duration: 1s
     instances:
       tenant-service:
+        base-config: default
+      policy-service:
         base-config: default
 
 # Declarative downstream routes consumed by GatewayRoutesConfiguration
@@ -213,6 +227,7 @@ gateway:
       catalog-service: catalog.read
       billing-service: billing.manage
       subscription-service: subscription.manage
+      policy-service: policy.manage
   webclient:
     connect-timeout: 3s
     response-timeout: 15s
@@ -235,18 +250,70 @@ gateway:
       id: tenant-service
       uri: lb://tenant-service
       paths:
+        - /api/v1/tenants/**
+        - /api/tenants/**
         - /api/tenant/**
       strip-prefix: 1
+      versioning:
+        enabled: true
+        default-version: v1
+        supported-versions:
+          - v1
+        fallback-to-default: true
+        propagate-header: true
+      session-affinity:
+        enabled: true
+        cookie-name: LMS-TENANT-AFFINITY
+        header-name: X-Tenant-Affinity
+      weight:
+        enabled: true
+        group: tenant-service
+        value: 90
+      request-headers:
+        X-Gateway-Track: primary
       resilience:
         enabled: true
         circuit-breaker-name: tenant-service
+        fallback-uri: forward:/fallback/tenant-service
+    tenant-canary:
+      id: tenant-service-canary
+      uri: lb://tenant-service
+      paths:
+        - /api/v1/tenants/**
+        - /api/tenants/**
+        - /api/tenant/**
+      strip-prefix: 1
+      versioning:
+        enabled: true
+        default-version: v1
+        supported-versions:
+          - v1
+      session-affinity:
+        enabled: true
+        cookie-name: LMS-TENANT-AFFINITY
+        header-name: X-Tenant-Affinity
+      weight:
+        enabled: true
+        group: tenant-service
+        value: 10
+      request-headers:
+        X-Gateway-Track: canary
+      resilience:
+        enabled: true
+        circuit-breaker-name: tenant-service-canary
         fallback-uri: forward:/fallback/tenant-service
     catalog:
       id: catalog-service
       uri: lb://catalog-service
       paths:
+        - /api/v1/catalog/**
         - /api/catalog/**
       strip-prefix: 1
+      versioning:
+        enabled: true
+        default-version: v1
+        supported-versions:
+          - v1
       resilience:
         enabled: true
         circuit-breaker-name: catalog-service
@@ -272,9 +339,15 @@ gateway:
       id: subscription-service
       uri: lb://subscription-service
       paths:
+        - /api/v1/subscriptions/**
+        - /api/subscriptions/**
         - /api/subscription/**
       strip-prefix: 1
-      prefix-path: /subscription
+      versioning:
+        enabled: true
+        default-version: v1
+        supported-versions:
+          - v1
       resilience:
         enabled: true
         circuit-breaker-name: subscription-service
@@ -283,12 +356,70 @@ gateway:
       id: billing-service
       uri: lb://billing-service
       paths:
+        - /api/v1/billing/**
         - /api/billing/**
       strip-prefix: 1
+      versioning:
+        enabled: true
+        default-version: v1
+        supported-versions:
+          - v1
       resilience:
         enabled: true
         circuit-breaker-name: billing-service
         fallback-uri: forward:/fallback/billing-service
+    policy:
+      id: policy-service
+      uri: lb://policy-service
+      paths:
+        - /api/v1/policies/**
+        - /api/policies/**
+      strip-prefix: 1
+      versioning:
+        enabled: true
+        default-version: v1
+        supported-versions:
+          - v1
+      resilience:
+        enabled: true
+        circuit-breaker-name: policy-service
+        fallback-uri: forward:/fallback/default
+  admin:
+    aggregation:
+      timeout: 3s
+      services:
+        - id: tenant-service
+          uri: lb://tenant-service
+          health-path: /actuator/health
+          required: true
+          deployment: primary
+        - id: tenant-service-canary
+          uri: lb://tenant-service
+          health-path: /actuator/health
+          required: false
+          deployment: canary
+          headers:
+            X-Gateway-Track: canary
+        - id: catalog-service
+          uri: lb://catalog-service
+          health-path: /actuator/health
+          required: true
+          deployment: primary
+        - id: subscription-service
+          uri: lb://subscription-service
+          health-path: /actuator/health
+          required: true
+          deployment: primary
+        - id: billing-service
+          uri: lb://billing-service
+          health-path: /actuator/health
+          required: true
+          deployment: primary
+        - id: policy-service
+          uri: lb://policy-service
+          health-path: /actuator/health
+          required: true
+          deployment: primary
 
 logging:
   level:

--- a/api-gateway/src/test/java/com/ejada/gateway/filter/ApiVersioningGatewayFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/filter/ApiVersioningGatewayFilterTest.java
@@ -1,0 +1,116 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.mock.web.server.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ApiVersioningGatewayFilterTest {
+
+  @Test
+  void stripsVersionPrefixAndPropagatesHeader() {
+    GatewayRoutesProperties.ServiceRoute route = buildRoute(List.of("/demo/**"));
+    GatewayRoutesProperties.ServiceRoute.Versioning versioning = route.getVersioning();
+    versioning.setEnabled(true);
+    versioning.setDefaultVersion("v1");
+    versioning.setSupportedVersions(List.of("v1", "v2"));
+    route.validate("demo");
+
+    ApiVersioningGatewayFilter filter = new ApiVersioningGatewayFilter(versioning);
+
+    MockServerWebExchange exchange = MockServerWebExchange.from(
+        MockServerHttpRequest.get("/v2/demo/items").build());
+
+    AtomicReference<String> path = new AtomicReference<>();
+    AtomicReference<String> header = new AtomicReference<>();
+    AtomicReference<String> attribute = new AtomicReference<>();
+
+    GatewayFilterChain chain = webExchange -> {
+      path.set(webExchange.getRequest().getURI().getRawPath());
+      header.set(webExchange.getRequest().getHeaders().getFirst(HeaderNames.API_VERSION));
+      attribute.set((String) webExchange.getAttribute(GatewayRequestAttributes.API_VERSION));
+      return Mono.empty();
+    };
+
+    filter.filter(exchange, chain).block();
+
+    assertEquals("/demo/items", path.get());
+    assertEquals("v2", header.get());
+    assertEquals("v2", attribute.get());
+  }
+
+  @Test
+  void assignsDefaultVersionWhenMissing() {
+    GatewayRoutesProperties.ServiceRoute route = buildRoute(List.of("/demo/**"));
+    GatewayRoutesProperties.ServiceRoute.Versioning versioning = route.getVersioning();
+    versioning.setEnabled(true);
+    versioning.setDefaultVersion("v3");
+    route.validate("demo");
+
+    ApiVersioningGatewayFilter filter = new ApiVersioningGatewayFilter(versioning);
+
+    MockServerWebExchange exchange = MockServerWebExchange.from(
+        MockServerHttpRequest.get("/demo/items").build());
+
+    AtomicReference<String> header = new AtomicReference<>();
+    AtomicReference<String> attribute = new AtomicReference<>();
+
+    GatewayFilterChain chain = webExchange -> {
+      header.set(webExchange.getRequest().getHeaders().getFirst(HeaderNames.API_VERSION));
+      attribute.set((String) webExchange.getAttribute(GatewayRequestAttributes.API_VERSION));
+      return Mono.empty();
+    };
+
+    filter.filter(exchange, chain).block();
+
+    assertEquals("/demo/items", exchange.getRequest().getURI().getRawPath());
+    assertEquals("v3", header.get());
+    assertEquals("v3", attribute.get());
+  }
+
+  @Test
+  void rejectsUnsupportedVersionWhenFallbackDisabled() {
+    GatewayRoutesProperties.ServiceRoute route = buildRoute(List.of("/demo/**"));
+    GatewayRoutesProperties.ServiceRoute.Versioning versioning = route.getVersioning();
+    versioning.setEnabled(true);
+    versioning.setDefaultVersion("v1");
+    versioning.setSupportedVersions(List.of("v1"));
+    versioning.setFallbackToDefault(false);
+    route.validate("demo");
+
+    ApiVersioningGatewayFilter filter = new ApiVersioningGatewayFilter(versioning);
+
+    MockServerWebExchange exchange = MockServerWebExchange.from(
+        MockServerHttpRequest.get("/v9/demo/items").build());
+
+    AtomicBoolean invoked = new AtomicBoolean(false);
+    GatewayFilterChain chain = webExchange -> {
+      invoked.set(true);
+      return Mono.empty();
+    };
+
+    filter.filter(exchange, chain).block();
+
+    assertFalse(invoked.get());
+    assertEquals(404, exchange.getResponse().getStatusCode().value());
+  }
+
+  private GatewayRoutesProperties.ServiceRoute buildRoute(List<String> paths) {
+    GatewayRoutesProperties.ServiceRoute route = new GatewayRoutesProperties.ServiceRoute();
+    route.setId("demo");
+    route.setUri(URI.create("http://example.com"));
+    route.setPaths(paths);
+    return route;
+  }
+}

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
@@ -39,6 +39,14 @@ public final class HeaderNames {
     public static final String PLATFORM = "X-Platform"; // e.g. iOS, Android, Web
     public static final String USER_ID = "X-USER_ID"; // e.g. iOS, Android, Web
 
+    // 📦 API Governance
+    /**
+     * Canonical API version header propagated by the API gateway whenever a
+     * request targets a versioned endpoint. Downstream services can rely on
+     * this header instead of parsing the URI.
+     */
+    public static final String API_VERSION = "X-Api-Version";
+
     // 📜 Content / Localization
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String ACCEPT = "Accept";


### PR DESCRIPTION
## Summary
- add API versioning and session-affinity filters so routes rewrite version prefixes, emit the X-Api-Version header, and maintain sticky sessions when configured
- configure v1 tenant, catalog, subscription, billing, and policy routes with weighted canary support plus expose gateway health aggregation properties and admin endpoints
- document the routing intelligence upgrades and provide a focused unit test for the API versioning filter

## Testing
- mvn -pl api-gateway test *(fails: repository is missing internal com.ejada artifacts so dependencies cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68e0cfaf8ed0832f8e1cd9af2fc358e8