### PR TITLE
Fix shared quality resource paths

### DIFF
--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -225,13 +225,13 @@
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${plugin.checkstyle.version}</version>
           <configuration>
-            <configLocation>${maven.multiModuleProjectDirectory}/shared-quality/checkstyle.xml</configLocation>
-            <suppressionsLocation>${maven.multiModuleProjectDirectory}/shared-quality/suppressions.xml</suppressionsLocation>
+            <configLocation>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/checkstyle.xml</configLocation>
+            <suppressionsLocation>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/suppressions.xml</suppressionsLocation>
             <encoding>${project.build.sourceEncoding}</encoding>
             <consoleOutput>true</consoleOutput>
             <failOnViolation>${maven.build.isCI}</failOnViolation>
             <properties>
-              <checkstyle.suppressions.file>${maven.multiModuleProjectDirectory}/shared-quality/suppressions.xml</checkstyle.suppressions.file>
+              <checkstyle.suppressions.file>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/suppressions.xml</checkstyle.suppressions.file>
             </properties>
           </configuration>
         </plugin>
@@ -242,7 +242,7 @@
           <configuration>
             <effort>Max</effort>
             <threshold>Low</threshold>
-            <excludeFilterFile>${maven.multiModuleProjectDirectory}/shared-quality/spotbugs-exclude.xml</excludeFilterFile>
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/spotbugs-exclude.xml</excludeFilterFile>
           </configuration>
           <dependencies>
             <dependency>
@@ -258,7 +258,7 @@
           <version>${plugin.pmd.version}</version>
           <configuration>
             <rulesets>
-              <ruleset>${maven.multiModuleProjectDirectory}/shared-quality/pmd.xml</ruleset>
+              <ruleset>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/pmd.xml</ruleset>
             </rulesets>
           </configuration>
         </plugin>

--- a/shared-lib/shared-quality/README.md
+++ b/shared-lib/shared-quality/README.md
@@ -15,8 +15,8 @@ Reference the configuration in your Maven build:
   <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-checkstyle-plugin</artifactId>
   <configuration>
-    <configLocation>shared-quality/checkstyle.xml</configLocation>
-    <suppressionsLocation>shared-quality/suppressions.xml</suppressionsLocation>
+    <configLocation>shared-lib/shared-quality/checkstyle.xml</configLocation>
+    <suppressionsLocation>shared-lib/shared-quality/suppressions.xml</suppressionsLocation>
   </configuration>
 </plugin>
 ```

--- a/shared-lib/shared-quality/pom.xml
+++ b/shared-lib/shared-quality/pom.xml
@@ -22,13 +22,13 @@
             <artifactId>maven-checkstyle-plugin</artifactId>
             <version>${plugin.checkstyle.version}</version>
             <configuration>
-            <configLocation>${maven.multiModuleProjectDirectory}/shared-quality/checkstyle.xml</configLocation>
-            <suppressionsLocation>${maven.multiModuleProjectDirectory}/shared-quality/suppressions.xml</suppressionsLocation>
+            <configLocation>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/checkstyle.xml</configLocation>
+            <suppressionsLocation>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/suppressions.xml</suppressionsLocation>
               <consoleOutput>true</consoleOutput>
               <encoding>${project.build.sourceEncoding}</encoding>
               <failOnViolation>${maven.build.isCI}</failOnViolation>
               <properties>
-                <checkstyle.suppressions.file>${maven.multiModuleProjectDirectory}/shared-quality/suppressions.xml</checkstyle.suppressions.file>
+                <checkstyle.suppressions.file>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/suppressions.xml</checkstyle.suppressions.file>
               </properties>
             </configuration>
           </plugin>
@@ -39,7 +39,7 @@
             <configuration>
               <effort>Max</effort>
               <threshold>Low</threshold>
-              <excludeFilterFile>${maven.multiModuleProjectDirectory}/shared-quality/spotbugs-exclude.xml</excludeFilterFile>
+              <excludeFilterFile>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/spotbugs-exclude.xml</excludeFilterFile>
             </configuration>
             <dependencies>
               <dependency>
@@ -55,7 +55,7 @@
             <version>${plugin.pmd.version}</version>
             <configuration>
               <rulesets>
-                <ruleset>${maven.multiModuleProjectDirectory}/shared-quality/pmd.xml</ruleset>
+                <ruleset>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/pmd.xml</ruleset>
               </rulesets>
             </configuration>
           </plugin>


### PR DESCRIPTION
## Summary
- update static analysis plugin configurations to reference the actual shared quality directory
- refresh the shared-quality documentation snippet to use the corrected paths

## Testing
- mvn -pl setup-service -am checkstyle:check -DskipTests

------
https://chatgpt.com/codex/tasks/task_e_68e0d5f2ac28832f89edbb2c4e96ced6