### PR TITLE
Fix gateway weight filter compilation error

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.gateway.filter.factory.WeightGatewayFilterFactory;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
@@ -35,8 +34,7 @@ public class GatewayRoutesConfiguration {
   @Bean
   RouteLocator gatewayRoutes(RouteLocatorBuilder builder,
       GatewayRoutesProperties properties,
-      ObjectProvider<GatewayRouteDefinitionProvider> dynamicProviders,
-      WeightGatewayFilterFactory weightGatewayFilterFactory) {
+      ObjectProvider<GatewayRouteDefinitionProvider> dynamicProviders) {
     RouteLocatorBuilder.Builder routes = builder.routes();
 
     Map<String, GatewayRoutesProperties.ServiceRoute> aggregated = new LinkedHashMap<>();
@@ -113,10 +111,7 @@ public class GatewayRoutesConfiguration {
               }
               route.getRequestHeaders().forEach(filters::addRequestHeader);
               if (route.getWeight().isEnabled()) {
-                WeightGatewayFilterFactory.Config weightConfig = new WeightGatewayFilterFactory.Config();
-                weightConfig.setGroup(route.getWeight().getGroup());
-                weightConfig.setWeight(route.getWeight().getValue());
-                filters.filter(weightGatewayFilterFactory.apply(weightConfig));
+                filters.weight(route.getWeight().getGroup(), route.getWeight().getValue());
               }
               if (route.getSessionAffinity().isEnabled()) {
                 filters.filter(new SessionAffinityGatewayFilter(route.getSessionAffinity()));


### PR DESCRIPTION
## Summary
- remove the direct WeightGatewayFilterFactory dependency from the gateway route configuration
- use the fluent builder's weight filter helper to keep weighted routing support without referencing the removed class

## Testing
- `mvn -pl api-gateway clean compile` *(fails: missing internal com.ejada starter artifacts in the local repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e0da785194832f95fdfd16f2b7eab9