### PR TITLE
Fix weight filter invocation for Spring Cloud Gateway

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
@@ -111,7 +111,7 @@ public class GatewayRoutesConfiguration {
               }
               route.getRequestHeaders().forEach(filters::addRequestHeader);
               if (route.getWeight().isEnabled()) {
-                filters.weight(route.getWeight().getGroup(), route.getWeight().getValue());
+                filters.weight(route.getWeight().getGroup(), (double) route.getWeight().getValue());
               }
               if (route.getSessionAffinity().isEnabled()) {
                 filters.filter(new SessionAffinityGatewayFilter(route.getSessionAffinity()));


### PR DESCRIPTION
## Summary
- update the GatewayRoutesConfiguration to call the `weight` filter with a double value expected by the newer GatewayFilterSpec implementation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0db3fd0ac832fa3a5ddaafb9d0c6a