### PR TITLE
Add default JWT secret for security service configuration

### DIFF
--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -83,6 +83,7 @@ shared:
     resource-server:
       enabled: false
     jwt:
+      secret: ${SHARED_SECURITY_JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
       token-period: 15m
       superadmin-ttl: PT24H
     superadmin:


### PR DESCRIPTION
## Summary
- define a default value for `shared.security.jwt.secret` in the security service configuration so the application starts without a blank secret

## Testing
- `mvn -pl sec-service test` *(fails: missing private com.ejada starter dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e0df63f710832fa13e35c82f6a1a07