### PR TITLE
Handle null conversions in tenant provisioning listener

### DIFF
--- a/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/kafka/TenantProvisioningListener.java
+++ b/tenant-platform/catalog-service/src/main/java/com/ejada/catalog/kafka/TenantProvisioningListener.java
@@ -4,26 +4,37 @@ import com.ejada.catalog.service.TenantProvisioningService;
 import com.ejada.common.events.provisioning.TenantProvisioningMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
+import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class TenantProvisioningListener {
 
-    private final ObjectMapper objectMapper;
+    private final Function<Map<String, Object>, TenantProvisioningMessage> messageConverter;
     private final TenantProvisioningService provisioningService;
+
+    public TenantProvisioningListener(final ObjectMapper objectMapper,
+                                      final TenantProvisioningService provisioningService) {
+        ObjectMapper mapper = objectMapper != null ? objectMapper.copy() : new ObjectMapper();
+        this.messageConverter = payload -> mapper.convertValue(payload, TenantProvisioningMessage.class);
+        this.provisioningService = provisioningService;
+    }
 
     @KafkaListener(
             topics = "#{@tenantProvisioningProperties.topic}",
             groupId = "#{@tenantProvisioningProperties.consumerGroup}"
     )
     public void onMessage(@Payload final Map<String, Object> payload) {
-        TenantProvisioningMessage message = objectMapper.convertValue(payload, TenantProvisioningMessage.class);
+        TenantProvisioningMessage message = messageConverter.apply(payload);
+        if (message == null) {
+            log.warn("Ignoring provisioning payload that could not be converted into a provisioning message");
+            return;
+        }
+
         log.info("Applying provisioning update for tenant {}", message.tenantCode());
         provisioningService.applyProvisioning(message);
     }


### PR DESCRIPTION
## Summary
- defensively copy the injected ObjectMapper before using it for Kafka payload conversion
- convert inbound payloads via a stored converter function and guard against null results
- log and skip messages that fail conversion before invoking the provisioning service

## Testing
- `mvn -pl tenant-platform/catalog-service spotbugs:check -DskipTests -Dcheckstyle.skip=true -Dpmd.skip=true`


------
https://chatgpt.com/codex/tasks/task_e_68e0dd46aa70832fb71d542ba31e1d1c