### PR TITLE
Fix TenantDashboardService constructor injection

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/bff/TenantDashboardService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/bff/TenantDashboardService.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.circuitbreaker.ReactiveCircuitBreaker;
 import org.springframework.cloud.client.circuitbreaker.ReactiveCircuitBreakerFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -40,6 +41,7 @@ public class TenantDashboardService {
   private final GatewayBffProperties.TenantDashboardProperties properties;
   private final ReactiveCircuitBreakerFactory<?, ?> circuitBreakerFactory;
 
+  @Autowired
   public TenantDashboardService(WebClient.Builder webClientBuilder,
       GatewayBffProperties properties,
       ObjectProvider<ReactiveCircuitBreakerFactory<?, ?>> circuitBreakerFactoryProvider) {


### PR DESCRIPTION
## Summary
- annotate TenantDashboardService's primary constructor for dependency injection
- ensure Spring can instantiate the BFF dashboard service at runtime

## Testing
- mvn -pl api-gateway test *(fails: missing internal dependencies com.ejada:starter-*)*

------
https://chatgpt.com/codex/tasks/task_e_68e0df765358832fa6c455847aa996bb