### PR TITLE
Propagate tenant context into Reactor and add coverage

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/context/TenantExtractionGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/TenantExtractionGatewayFilter.java
@@ -97,10 +97,14 @@ public class TenantExtractionGatewayFilter implements WebFilter {
       mutated.getAttributes().putIfAbsent(HeaderNames.X_TENANT_ID, sanitized);
       return chain.filter(mutated)
           .contextWrite(context -> {
-            Context updated = context.put(GatewayRequestAttributes.TENANT_ID, sanitized);
+            Context updated = context
+                .put(GatewayRequestAttributes.TENANT_ID, sanitized)
+                .put(HeaderNames.X_TENANT_ID, sanitized);
             String correlationId = mutated.getAttribute(GatewayRequestAttributes.CORRELATION_ID);
             if (StringUtils.hasText(correlationId)) {
-              updated = updated.put(GatewayRequestAttributes.CORRELATION_ID, correlationId);
+              updated = updated
+                  .put(GatewayRequestAttributes.CORRELATION_ID, correlationId)
+                  .put(HeaderNames.CORRELATION_ID, correlationId);
             }
             return updated;
           });

--- a/api-gateway/src/test/java/com/ejada/gateway/context/TenantExtractionGatewayFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/context/TenantExtractionGatewayFilterTest.java
@@ -1,0 +1,46 @@
+package com.ejada.gateway.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.ejada.starter_core.config.CoreAutoConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.util.context.ContextView;
+
+class TenantExtractionGatewayFilterTest {
+
+  private TenantExtractionGatewayFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    CoreAutoConfiguration.CoreProps props = new CoreAutoConfiguration.CoreProps();
+    props.getTenant().setSkipPatterns(new String[0]);
+    filter = new TenantExtractionGatewayFilter(props, new ObjectMapper());
+  }
+
+  @Test
+  void populatesReactorContextWithResolvedTenant() {
+    MockServerHttpRequest request = MockServerHttpRequest.get("/api/v1/data?tenantId=acme")
+        .build();
+    MockServerWebExchange exchange = MockServerWebExchange.from(request);
+    exchange.getAttributes().put(GatewayRequestAttributes.CORRELATION_ID, "corr-123");
+
+    WebFilterChain chain = serverExchange -> Mono.deferContextual((ContextView ctx) -> {
+      assertThat((String) ctx.get(GatewayRequestAttributes.TENANT_ID)).isEqualTo("acme");
+      assertThat((String) ctx.get(HeaderNames.X_TENANT_ID)).isEqualTo("acme");
+      assertThat((String) ctx.get(GatewayRequestAttributes.CORRELATION_ID)).isEqualTo("corr-123");
+      assertThat((String) ctx.get(HeaderNames.CORRELATION_ID)).isEqualTo("corr-123");
+      return Mono.empty();
+    });
+
+    StepVerifier.create(filter.filter(exchange, chain)).verifyComplete();
+  }
+}

--- a/api-gateway/src/test/java/com/ejada/gateway/filter/ApiVersioningGatewayFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/filter/ApiVersioningGatewayFilterTest.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
-import org.springframework.mock.web.server.MockServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import reactor.core.publisher.Mono;
 


### PR DESCRIPTION
## Summary
- populate the Reactor context with both tenant and correlation identifiers (including header aliases) in TenantExtractionGatewayFilter
- add a unit test that verifies the resolved tenant is available in the Reactor context during filter execution
- adjust ApiVersioningGatewayFilterTest to use the reactive MockServerHttpRequest helper

## Testing
- mvn -pl api-gateway test -Dtest=TenantExtractionGatewayFilterTest

------
https://chatgpt.com/codex/tasks/task_e_68e0de7c8dbc832fbe209e91f43ede80