### PR TITLE
Add feature-aware cache keys for subscription validation

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/SubscriptionValidationProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/SubscriptionValidationProperties.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
@@ -109,7 +110,10 @@ public class SubscriptionValidationProperties {
     return StringUtils.hasText(routeId) && requiredFeatures.containsKey(routeId);
   }
 
-  public String cacheKey(String tenantId) {
+  public String cacheKey(String tenantId, @Nullable String feature) {
+    if (StringUtils.hasText(feature)) {
+      return cachePrefix + tenantId + ":" + feature;
+    }
     return cachePrefix + tenantId;
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/SubscriptionValidationGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/SubscriptionValidationGatewayFilter.java
@@ -122,7 +122,7 @@ public class SubscriptionValidationGatewayFilter implements GlobalFilter, Ordere
   }
 
   private Mono<SubscriptionDecision> ensureSubscription(String tenantId, @Nullable String requiredFeature) {
-    String cacheKey = properties.cacheKey(tenantId);
+    String cacheKey = properties.cacheKey(tenantId, requiredFeature);
     return redisTemplate.opsForValue().get(cacheKey)
         .flatMap(json -> decode(json).map(Mono::just).orElseGet(Mono::empty))
         .switchIfEmpty(Mono.defer(() -> fetchSubscription(tenantId)


### PR DESCRIPTION
## Summary
- allow subscription cache keys to include an optional feature suffix
- use the feature-aware cache key when validating subscriptions in the gateway filter

## Testing
- mvn -pl api-gateway test *(fails: missing internal com.ejada starter dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e372eb50832fbaccd9e0198fd7d0