### PR TITLE
Improve API versioning validation and normalization

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
@@ -2,6 +2,7 @@ package com.ejada.gateway.config;
 
 import java.net.URI;
 import java.time.Duration;
+import com.ejada.gateway.versioning.VersionNumber;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -427,15 +428,13 @@ public class GatewayRoutesProperties {
           throw new IllegalStateException(
               "gateway.routes." + key + ".versioning." + property + " must not be blank when versioning is enabled");
         }
-        String candidate = value.trim().toLowerCase(Locale.ROOT);
-        if (candidate.startsWith("v")) {
-          candidate = candidate.substring(1);
-        }
-        if (!candidate.chars().allMatch(Character::isDigit)) {
+        try {
+          return VersionNumber.canonicalise(value);
+        } catch (IllegalArgumentException ex) {
           throw new IllegalStateException(
-              "gateway.routes." + key + ".versioning." + property + " must be a numeric version (e.g. v1, 2)");
+              "gateway.routes." + key + ".versioning." + property + " must be a numeric version (e.g. v1, 2.0)",
+              ex);
         }
-        return "v" + candidate;
       }
 
       @Override

--- a/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionNumber.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionNumber.java
@@ -1,0 +1,86 @@
+package com.ejada.gateway.versioning;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility methods for dealing with API version tokens. Versions are parsed as
+ * dot separated positive integers (e.g. {@code v1}, {@code 2.0},
+ * {@code V2.1.3}). The canonical representation always uses a {@code v}
+ * prefix, removes redundant leading zeroes and trims trailing zero components
+ * (so {@code v1.0.0} normalises to {@code v1}).
+ */
+public final class VersionNumber {
+
+  private static final Pattern NUMERIC_PATTERN = Pattern.compile("^(\\d+)(?:\\.\\d+)*$");
+
+  private VersionNumber() {
+  }
+
+  /**
+   * Returns the canonical representation of the supplied version token.
+   *
+   * @param value raw version token (may optionally start with {@code v})
+   * @return canonical version token with a {@code v} prefix
+   * @throws IllegalArgumentException if the supplied value is blank or does not
+   *                                  follow the numeric version format
+   */
+  public static String canonicalise(String value) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException("Version token must not be blank");
+    }
+
+    String candidate = value.trim().toLowerCase(Locale.ROOT);
+    if (candidate.startsWith("v")) {
+      candidate = candidate.substring(1);
+    }
+
+    if (!NUMERIC_PATTERN.matcher(candidate).matches()) {
+      throw new IllegalArgumentException("Version token must be numeric (e.g. v1, 2.0)");
+    }
+
+    String[] components = candidate.split("\\.");
+    List<String> normalised = new ArrayList<>(components.length);
+    for (String component : components) {
+      normalised.add(normaliseComponent(component));
+    }
+
+    int lastNonZero = normalised.size() - 1;
+    while (lastNonZero > 0 && "0".equals(normalised.get(lastNonZero))) {
+      lastNonZero--;
+    }
+
+    StringBuilder builder = new StringBuilder("v");
+    for (int i = 0; i <= lastNonZero; i++) {
+      builder.append(normalised.get(i));
+      if (i < lastNonZero) {
+        builder.append('.');
+      }
+    }
+    return builder.toString();
+  }
+
+  private static String normaliseComponent(String component) {
+    BigInteger numeric = new BigInteger(component);
+    return numeric.toString();
+  }
+
+  /**
+   * Attempts to canonicalise the supplied value. Returns {@code null} when the
+   * value is blank or not a valid version.
+   */
+  public static String canonicaliseOrNull(String value) {
+    if (!StringUtils.hasText(value)) {
+      return null;
+    }
+    try {
+      return canonicalise(value);
+    } catch (IllegalArgumentException ex) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a shared `VersionNumber` utility to canonicalise API version tokens
- update the gateway versioning filter to normalise version segments, reject unsupported values, and consistently strip the version from the path
- extend configuration validation and unit tests to cover the expanded version formats and behaviour

## Testing
- `mvn -pl api-gateway test` *(fails: missing internal com.ejada starter dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e48dd994832fb0ee4e8a9b65cbfe