### PR TITLE
Enhance gateway rate limiting key resolution

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRateLimiterConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRateLimiterConfiguration.java
@@ -27,6 +27,7 @@ public class GatewayRateLimiterConfiguration {
   private static final String STRATEGY_TENANT = "tenant";
   private static final String STRATEGY_IP = "ip";
   private static final String STRATEGY_USER = "user";
+  private static final String STRATEGY_TENANT_IP = "tenant_ip";
 
   @Bean
   @Primary
@@ -62,12 +63,19 @@ public class GatewayRateLimiterConfiguration {
     if (!StringUtils.hasText(strategy)) {
       return STRATEGY_TENANT;
     }
-    return strategy.trim().toLowerCase(Locale.ROOT);
+    return strategy.trim().toLowerCase(Locale.ROOT).replace('-', '_').replace('+', '_');
   }
 
   private KeyResolver selectResolver(String strategy, Map<String, KeyResolver> resolvers) {
     if (Objects.equals(strategy, STRATEGY_TENANT)) {
       return resolvers.get("tenantKeyResolver");
+    }
+    if (Objects.equals(strategy, STRATEGY_TENANT_IP)) {
+      KeyResolver composite = resolvers.get("tenantIpKeyResolver");
+      if (composite != null) {
+        return composite;
+      }
+      return resolvers.get("compositeKeyResolver");
     }
     if (Objects.equals(strategy, STRATEGY_IP)) {
       return resolvers.get("ipKeyResolver");

--- a/api-gateway/src/main/java/com/ejada/gateway/config/ReactiveContextConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/ReactiveContextConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -47,11 +48,12 @@ public class ReactiveContextConfiguration {
   public ReactiveRateLimiterFilter reactiveRateLimiterFilter(
       ReactiveStringRedisTemplate redisTemplate,
       RateLimitProps props,
+      KeyResolver keyResolver,
       @Qualifier("jacksonObjectMapper") @Nullable ObjectMapper jacksonObjectMapper,
       ObjectProvider<ObjectMapper> objectMapperProvider) {
     ObjectMapper mapper = (jacksonObjectMapper != null)
         ? jacksonObjectMapper
         : objectMapperProvider.getIfAvailable();
-    return new ReactiveRateLimiterFilter(redisTemplate, props, mapper);
+    return new ReactiveRateLimiterFilter(redisTemplate, props, keyResolver, mapper);
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/ratelimit/TenantIpKeyResolver.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ratelimit/TenantIpKeyResolver.java
@@ -1,0 +1,29 @@
+package com.ejada.gateway.ratelimit;
+
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Combines the tenant and client IP resolvers to provide a more granular
+ * rate-limiting key. The resulting key is in the form
+ * {@code <tenant-id>:<client-ip>}.
+ */
+@Component("tenantIpKeyResolver")
+public class TenantIpKeyResolver implements KeyResolver {
+
+  private final TenantKeyResolver tenantKeyResolver;
+  private final IpKeyResolver ipKeyResolver;
+
+  public TenantIpKeyResolver(TenantKeyResolver tenantKeyResolver, IpKeyResolver ipKeyResolver) {
+    this.tenantKeyResolver = tenantKeyResolver;
+    this.ipKeyResolver = ipKeyResolver;
+  }
+
+  @Override
+  public Mono<String> resolve(ServerWebExchange exchange) {
+    return Mono.zip(tenantKeyResolver.resolve(exchange), ipKeyResolver.resolve(exchange))
+        .map(tuple -> tuple.getT1() + ":" + tuple.getT2());
+  }
+}

--- a/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
@@ -6,6 +6,7 @@ import com.ejada.shared_starter_ratelimit.RateLimitProps;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
@@ -39,7 +40,8 @@ class ReactiveRateLimiterFilterTest {
         props.setCapacity(2);
         props.setRefillPerMinute(2);
         props.setKeyStrategy("tenant");
-        this.filter = new ReactiveRateLimiterFilter(template, props, new ObjectMapper());
+        KeyResolver keyResolver = exchange -> Mono.just("tenant-a");
+        this.filter = new ReactiveRateLimiterFilter(template, props, keyResolver, new ObjectMapper());
         flushRedis();
     }
 


### PR DESCRIPTION
## Summary
- update the tenant key resolver to leverage the reactive context and add a composite tenant+IP resolver
- wire the primary key resolver into the reactive rate limiter filter and configuration to honour strategy selection
- adjust the reactive rate limiter test to provide an explicit key resolver stub

## Testing
- mvn -pl api-gateway -am test *(fails: missing net.bytebuddy-agent artifact while starting Surefire fork)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e868141c832f877af35f3d5b5382