### PR TITLE
Ensure rate limiter key resolver is always primary

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRateLimiterConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRateLimiterConfiguration.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,7 +20,7 @@ import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
  * configured rate limiting strategy.
  */
 @Configuration
-@ConditionalOnBean({RateLimitProps.class, KeyResolver.class})
+@ConditionalOnBean(KeyResolver.class)
 public class GatewayRateLimiterConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GatewayRateLimiterConfiguration.class);
@@ -30,7 +31,9 @@ public class GatewayRateLimiterConfiguration {
 
   @Bean
   @Primary
-  public KeyResolver rateLimiterKeyResolver(RateLimitProps props, Map<String, KeyResolver> resolvers) {
+  public KeyResolver rateLimiterKeyResolver(ObjectProvider<RateLimitProps> propsProvider,
+      Map<String, KeyResolver> resolvers) {
+    RateLimitProps props = propsProvider.getIfAvailable(RateLimitProps::new);
     String strategy = normalizeStrategy(props.getKeyStrategy());
 
     KeyResolver resolver = selectResolver(strategy, resolvers);


### PR DESCRIPTION
## Summary
- allow GatewayRateLimiterConfiguration to create the primary KeyResolver even when RateLimitProps has not been bound yet by using an ObjectProvider fallback
- relax the conditional so the configuration only requires existing KeyResolver beans, preventing startup failures when multiple resolvers are present

## Testing
- mvn -pl api-gateway -am test *(fails: Error opening zip file or JAR manifest missing : /root/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e9538818832fa05a39565d651fcd