### PR TITLE
Configure JWT defaults for analytics dev profile

### DIFF
--- a/tenant-platform/analytics-service/src/main/resources/application.yml
+++ b/tenant-platform/analytics-service/src/main/resources/application.yml
@@ -42,3 +42,6 @@ shared:
   security:
     resource-server:
       enabled: false
+    jwt:
+      secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
+      token-period: 15m


### PR DESCRIPTION
## Summary
- add default JWT secret and token period to the analytics service configuration so the dev profile satisfies JwtTokenProperties validation

## Testing
- mvn -pl tenant-platform/analytics-service test *(fails: missing internal com.ejada artifacts in Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e9874a8c832fb3af0a5ccbb98a11