### PR TITLE
Ensure subscription approval properties bean is available

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/config/SubscriptionApprovalConfiguration.java
+++ b/sec-service/src/main/java/com/ejada/sec/config/SubscriptionApprovalConfiguration.java
@@ -1,10 +1,16 @@
 package com.ejada.sec.config;
 
 import com.ejada.common.events.subscription.SubscriptionApprovalProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(SubscriptionApprovalProperties.class)
 public class SubscriptionApprovalConfiguration {
+
+    @Bean(name = "subscriptionApprovalProperties")
+    @ConfigurationProperties(prefix = "app.subscription-approval")
+    public SubscriptionApprovalProperties subscriptionApprovalProperties() {
+        return new SubscriptionApprovalProperties();
+    }
 }


### PR DESCRIPTION
## Summary
- register `SubscriptionApprovalProperties` via a named `@Bean` so the listener can resolve it by bean name

## Testing
- mvn -pl sec-service -am -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68e0e99976dc832fb40181084e05736e