### PR TITLE
Fix SpotBugs findings in tenant service

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/kafka/SubscriptionApprovalListener.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/kafka/SubscriptionApprovalListener.java
@@ -8,7 +8,6 @@ import com.ejada.tenant.exception.TenantConflictException;
 import com.ejada.tenant.service.TenantService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
@@ -20,12 +19,16 @@ import org.springframework.util.StringUtils;
  * Consumes subscription approval decisions and provisions tenants for approved subscriptions.
  */
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class SubscriptionApprovalListener {
 
     private final ObjectMapper objectMapper;
     private final TenantService tenantService;
+
+    public SubscriptionApprovalListener(final ObjectMapper objectMapper, final TenantService tenantService) {
+        this.objectMapper = objectMapper.copy();
+        this.tenantService = tenantService;
+    }
     @KafkaListener(
             topics = "${app.subscription-approval.topic}",
             groupId = "${app.subscription-approval.consumer-group}",

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantHealthScore.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/TenantHealthScore.java
@@ -15,7 +15,6 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -33,8 +32,6 @@ import org.hibernate.annotations.DynamicUpdate;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class TenantHealthScore {
 
@@ -81,6 +78,51 @@ public class TenantHealthScore {
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
+
+    @Builder(toBuilder = true)
+    public TenantHealthScore(
+            final Long id,
+            final Tenant tenant,
+            final Integer score,
+            final TenantHealthRiskCategory riskCategory,
+            final BigDecimal featureAdoptionRate,
+            final BigDecimal loginFrequencyScore,
+            final BigDecimal userEngagementScore,
+            final BigDecimal usageTrendPercent,
+            final BigDecimal supportTicketScore,
+            final BigDecimal paymentHistoryScore,
+            final BigDecimal apiHealthScore,
+            final OffsetDateTime evaluatedAt,
+            final OffsetDateTime createdAt) {
+        this.id = id;
+        this.tenant = tenant == null ? null : Tenant.ref(tenant.getId());
+        this.score = score;
+        this.riskCategory = riskCategory;
+        this.featureAdoptionRate = featureAdoptionRate;
+        this.loginFrequencyScore = loginFrequencyScore;
+        this.userEngagementScore = userEngagementScore;
+        this.usageTrendPercent = usageTrendPercent;
+        this.supportTicketScore = supportTicketScore;
+        this.paymentHistoryScore = paymentHistoryScore;
+        this.apiHealthScore = apiHealthScore;
+        this.evaluatedAt = evaluatedAt;
+        this.createdAt = createdAt;
+    }
+
+    public Tenant getTenant() {
+        return tenant == null ? null : Tenant.ref(tenant.getId());
+    }
+
+    public void setTenant(final Tenant tenant) {
+        this.tenant = tenant == null ? null : Tenant.ref(tenant.getId());
+    }
+
+    public static class TenantHealthScoreBuilder {
+        public TenantHealthScoreBuilder tenant(final Tenant tenant) {
+            this.tenant = tenant == null ? null : Tenant.ref(tenant.getId());
+            return this;
+        }
+    }
 
     @PrePersist
     void prePersist() {

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/security/TenantAccessPolicy.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/security/TenantAccessPolicy.java
@@ -24,8 +24,10 @@ public class TenantAccessPolicy {
                 .map(SharedSecurityProps::getRolePrefix)
                 .orElse("ROLE_");
 
-        String[] tokens = StringUtils.tokenizeToStringArray(allowedRoles, ",");
-        if (tokens == null || tokens.length == 0) {
+        String[] tokens = StringUtils.hasText(allowedRoles)
+                ? StringUtils.tokenizeToStringArray(allowedRoles, ",")
+                : new String[0];
+        if (tokens.length == 0) {
             this.allowedRoles = Collections.emptySet();
         } else {
             this.allowedRoles = Arrays.stream(tokens)

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantHealthServiceImpl.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantHealthServiceImpl.java
@@ -21,14 +21,12 @@ import java.math.RoundingMode;
 import java.time.OffsetDateTime;
 import java.util.EnumMap;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 @Transactional
 public class TenantHealthServiceImpl implements TenantHealthService {
 
@@ -41,6 +39,19 @@ public class TenantHealthServiceImpl implements TenantHealthService {
     private final TenantHealthMetricsProvider metricsProvider;
     private final OutboxEventRepository outboxEventRepository;
     private final ObjectMapper objectMapper;
+
+    public TenantHealthServiceImpl(
+            final TenantRepository tenantRepository,
+            final TenantHealthScoreRepository tenantHealthScoreRepository,
+            final TenantHealthMetricsProvider metricsProvider,
+            final OutboxEventRepository outboxEventRepository,
+            final ObjectMapper objectMapper) {
+        this.tenantRepository = tenantRepository;
+        this.tenantHealthScoreRepository = tenantHealthScoreRepository;
+        this.metricsProvider = metricsProvider;
+        this.outboxEventRepository = outboxEventRepository;
+        this.objectMapper = objectMapper.copy();
+    }
 
     @Override
     public BaseResponse<TenantHealthScoreRes> getHealthScore(final Integer tenantId) {


### PR DESCRIPTION
## Summary
- create defensive copies of injected `ObjectMapper` instances in the Kafka listener and tenant health service to avoid SpotBugs exposure warnings
- defensively copy the tenant association throughout `TenantHealthScore` so the entity does not leak internal state via its constructor, setter, getter, or builder
- normalize allowed role tokenization in `TenantAccessPolicy` without a redundant null check flagged by SpotBugs

## Testing
- mvn -pl tenant-service spotbugs:check *(fails: missing com.ejada:shared-bom:1.0.0 in Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e114698c90832f912fc7835c3826f1