### PR TITLE
Add gateway observability instrumentation and health aggregation

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationController.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationController.java
@@ -3,6 +3,7 @@ package com.ejada.gateway.admin;
 import com.ejada.common.dto.BaseResponse;
 import com.ejada.gateway.admin.model.AdminOverview;
 import com.ejada.gateway.admin.model.AdminRouteView;
+import com.ejada.gateway.admin.model.DetailedHealthResponse;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,5 +34,11 @@ public class AdminAggregationController {
   public Mono<BaseResponse<List<AdminRouteView>>> routes() {
     return Mono.fromSupplier(aggregationService::describeRoutes)
         .map(data -> BaseResponse.success("Gateway route catalogue", data));
+  }
+
+  @GetMapping("/health/detailed")
+  public Mono<BaseResponse<DetailedHealthResponse>> detailedHealth() {
+    return aggregationService.fetchDetailedHealth()
+        .map(data -> BaseResponse.success("Aggregated dependency health", data));
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationService.java
@@ -3,8 +3,11 @@ package com.ejada.gateway.admin;
 import com.ejada.gateway.admin.model.AdminOverview;
 import com.ejada.gateway.admin.model.AdminRouteView;
 import com.ejada.gateway.admin.model.AdminServiceSnapshot;
+import com.ejada.gateway.admin.model.DetailedHealthResponse;
 import com.ejada.gateway.config.AdminAggregationProperties;
 import com.ejada.gateway.config.GatewayRoutesProperties;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.annotation.Timed;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
@@ -14,6 +17,9 @@ import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
@@ -34,26 +40,27 @@ public class AdminAggregationService {
   private final WebClient.Builder webClientBuilder;
   private final AdminAggregationProperties adminProperties;
   private final GatewayRoutesProperties routesProperties;
+  private final ReactiveStringRedisTemplate redisTemplate;
+  private final CircuitBreakerRegistry circuitBreakerRegistry;
 
   public AdminAggregationService(WebClient.Builder webClientBuilder,
       AdminAggregationProperties adminProperties,
-      GatewayRoutesProperties routesProperties) {
+      GatewayRoutesProperties routesProperties,
+      @Nullable ReactiveStringRedisTemplate redisTemplate,
+      @Nullable CircuitBreakerRegistry circuitBreakerRegistry) {
     this.webClientBuilder = webClientBuilder;
     this.adminProperties = adminProperties;
     this.routesProperties = routesProperties;
+    this.redisTemplate = redisTemplate;
+    this.circuitBreakerRegistry = circuitBreakerRegistry;
   }
 
+  @Timed(value = "gateway.admin.fetchOverview", description = "Aggregated admin overview retrieval")
   public Mono<AdminOverview> fetchOverview() {
-    List<AdminAggregationProperties.Service> services = adminProperties.getAggregation().getServices();
+    List<AdminAggregationProperties.Service> services = configuredServices();
     if (services.isEmpty()) {
       return Mono.just(AdminOverview.empty());
     }
-
-    IntStream.range(0, services.size()).forEach(index -> {
-      AdminAggregationProperties.Service service = services.get(index);
-      String key = service.getId() != null ? service.getId() : String.valueOf(index);
-      service.validate(key);
-    });
 
     Duration timeout = adminProperties.getAggregation().getTimeout();
 
@@ -62,6 +69,23 @@ public class AdminAggregationService {
         .sort(Comparator.comparing(AdminServiceSnapshot::serviceId))
         .collectList()
         .map(AdminOverview::fromSnapshots);
+  }
+
+  @Timed(value = "gateway.admin.detailedHealth", description = "Detailed dependency health aggregation")
+  public Mono<DetailedHealthResponse> fetchDetailedHealth() {
+    List<AdminAggregationProperties.Service> services = configuredServices();
+    Duration timeout = adminProperties.getAggregation().getTimeout();
+
+    Mono<DetailedHealthResponse.ComponentHealth> redisHealth = checkRedisConnectivity();
+    Mono<List<DetailedHealthResponse.ComponentHealth>> downstreamHealth = Flux.fromIterable(services)
+        .flatMap(service -> fetchSnapshot(service, timeout)
+            .map(DetailedHealthResponse.ComponentHealth::fromSnapshot)
+            .defaultIfEmpty(DetailedHealthResponse.ComponentHealth.unreachable(service)))
+        .collectList();
+    Mono<List<DetailedHealthResponse.CircuitBreakerHealth>> circuitBreakers = collectCircuitBreakerStates();
+
+    return Mono.zip(redisHealth, downstreamHealth, circuitBreakers)
+        .map(tuple -> DetailedHealthResponse.compose(tuple.getT1(), tuple.getT2(), tuple.getT3()));
   }
 
   public List<AdminRouteView> describeRoutes() {
@@ -104,5 +128,51 @@ public class AdminAggregationService {
               ex,
               Instant.now()));
         });
+  }
+
+  private Mono<DetailedHealthResponse.ComponentHealth> checkRedisConnectivity() {
+    if (redisTemplate == null || redisTemplate.getConnectionFactory() == null) {
+      return Mono.just(DetailedHealthResponse.ComponentHealth.down("redis", true, -1, "Connection factory unavailable"));
+    }
+    return Mono.usingWhen(
+            Mono.fromCallable(() -> redisTemplate.getConnectionFactory().getReactiveConnection()),
+            connection -> probeRedis(connection).onErrorResume(ex -> Mono.just(
+                DetailedHealthResponse.ComponentHealth.down("redis", true, -1, ex.getMessage()))),
+            ReactiveRedisConnection::close)
+        .onErrorResume(ex -> Mono.just(DetailedHealthResponse.ComponentHealth.down("redis", true, -1, ex.getMessage())));
+  }
+
+  private Mono<DetailedHealthResponse.ComponentHealth> probeRedis(ReactiveRedisConnection connection) {
+    long start = System.nanoTime();
+    return connection.serverCommands()
+        .ping()
+        .map(response -> DetailedHealthResponse.ComponentHealth.up("redis", true, millisSince(start), response))
+        .timeout(Duration.ofSeconds(2))
+        .onErrorResume(ex -> Mono.just(DetailedHealthResponse.ComponentHealth.down("redis", true,
+            millisSince(start), ex.getMessage())));
+  }
+
+  private Mono<List<DetailedHealthResponse.CircuitBreakerHealth>> collectCircuitBreakerStates() {
+    if (circuitBreakerRegistry == null) {
+      return Mono.just(List.of());
+    }
+    return Mono.fromSupplier(() -> circuitBreakerRegistry.getAllCircuitBreakers().stream()
+        .map(breaker -> new DetailedHealthResponse.CircuitBreakerHealth(breaker.getName(), breaker.getState().name()))
+        .sorted(Comparator.comparing(DetailedHealthResponse.CircuitBreakerHealth::serviceName))
+        .toList());
+  }
+
+  private List<AdminAggregationProperties.Service> configuredServices() {
+    List<AdminAggregationProperties.Service> services = adminProperties.getAggregation().getServices();
+    IntStream.range(0, services.size()).forEach(index -> {
+      AdminAggregationProperties.Service service = services.get(index);
+      String key = service.getId() != null ? service.getId() : String.valueOf(index);
+      service.validate(key);
+    });
+    return services;
+  }
+
+  private static long millisSince(long start) {
+    return Duration.ofNanos(System.nanoTime() - start).toMillis();
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/model/DetailedHealthResponse.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/model/DetailedHealthResponse.java
@@ -1,0 +1,78 @@
+package com.ejada.gateway.admin.model;
+
+import com.ejada.gateway.config.AdminAggregationProperties;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Aggregated detailed health view emitted by the admin API.
+ */
+public record DetailedHealthResponse(
+    Instant timestamp,
+    ComponentHealth redis,
+    List<ComponentHealth> downstreamServices,
+    List<CircuitBreakerHealth> circuitBreakers,
+    boolean ready) {
+
+  public static DetailedHealthResponse compose(ComponentHealth redis,
+      List<ComponentHealth> downstream,
+      List<CircuitBreakerHealth> breakers) {
+    List<ComponentHealth> safeDownstream = downstream == null ? List.of() : List.copyOf(downstream);
+    List<CircuitBreakerHealth> safeBreakers = breakers == null ? List.of() : List.copyOf(breakers);
+    boolean redisReady = redis != null && redis.isHealthy();
+    boolean downstreamReady = safeDownstream.stream()
+        .filter(ComponentHealth::required)
+        .allMatch(ComponentHealth::isHealthy);
+    boolean circuitReady = safeBreakers.stream().noneMatch(CircuitBreakerHealth::isOpen);
+    return new DetailedHealthResponse(Instant.now(), redis, safeDownstream, safeBreakers,
+        redisReady && downstreamReady && circuitReady);
+  }
+
+  public record ComponentHealth(String name, String status, boolean required, long latencyMs, String message) {
+
+    public ComponentHealth {
+      name = Objects.requireNonNullElse(name, "unknown");
+      status = Objects.requireNonNullElse(status, "UNKNOWN");
+      message = Objects.requireNonNullElse(message, "");
+    }
+
+    public boolean isHealthy() {
+      return "UP".equalsIgnoreCase(status);
+    }
+
+    public static ComponentHealth up(String name, boolean required, long latencyMs, String message) {
+      return new ComponentHealth(name, "UP", required, latencyMs, message);
+    }
+
+    public static ComponentHealth down(String name, boolean required, long latencyMs, String message) {
+      return new ComponentHealth(name, "DOWN", required, latencyMs, message);
+    }
+
+    public static ComponentHealth fromSnapshot(AdminServiceSnapshot snapshot) {
+      if (snapshot == null) {
+        return new ComponentHealth("unknown", "UNKNOWN", false, -1, "No snapshot");
+      }
+      String message = snapshot.details().isEmpty() ? "" : snapshot.details().toString();
+      return new ComponentHealth(snapshot.serviceId(), snapshot.status(), snapshot.required(), snapshot.latencyMs(), message);
+    }
+
+    public static ComponentHealth unreachable(AdminAggregationProperties.Service service) {
+      String name = service.getId() != null ? service.getId() : "unknown";
+      return new ComponentHealth(name, "DOWN", service.isRequired(), -1, "Service unreachable");
+    }
+  }
+
+  public record CircuitBreakerHealth(String serviceName, String state) {
+
+    public CircuitBreakerHealth {
+      serviceName = Objects.requireNonNullElse(serviceName, "unknown");
+      state = Objects.requireNonNullElse(state, "UNKNOWN").toUpperCase(Locale.ROOT);
+    }
+
+    public boolean isOpen() {
+      return "OPEN".equalsIgnoreCase(state);
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayLoggingProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayLoggingProperties.java
@@ -1,0 +1,55 @@
+package com.ejada.gateway.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration flags governing structured access logging for the gateway.
+ */
+@ConfigurationProperties(prefix = "gateway.logging")
+public class GatewayLoggingProperties {
+
+  private AccessLog accessLog = new AccessLog();
+
+  public AccessLog getAccessLog() {
+    return accessLog;
+  }
+
+  public void setAccessLog(AccessLog accessLog) {
+    this.accessLog = accessLog == null ? new AccessLog() : accessLog;
+  }
+
+  public static class AccessLog {
+
+    private boolean enabled;
+    private List<String> skipPatterns = new ArrayList<>(List.of("/actuator/**", "/health"));
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public List<String> getSkipPatterns() {
+      return skipPatterns;
+    }
+
+    public void setSkipPatterns(List<String> skipPatterns) {
+      if (skipPatterns == null) {
+        this.skipPatterns = new ArrayList<>();
+        return;
+      }
+      List<String> sanitized = new ArrayList<>();
+      for (String pattern : skipPatterns) {
+        if (StringUtils.hasText(pattern)) {
+          sanitized.add(pattern.trim());
+        }
+      }
+      this.skipPatterns = sanitized;
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayMetricsConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayMetricsConfiguration.java
@@ -1,0 +1,35 @@
+package com.ejada.gateway.config;
+
+import com.ejada.gateway.metrics.GatewayCircuitBreakerStateMetrics;
+import com.ejada.gateway.metrics.GatewayMetrics;
+import com.ejada.gateway.metrics.GatewayMetricsWebFilter;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.server.WebFilter;
+
+/**
+ * Central configuration for custom gateway metrics and binders.
+ */
+@Configuration
+public class GatewayMetricsConfiguration {
+
+  @Bean
+  public GatewayMetrics gatewayMetrics(MeterRegistry meterRegistry) {
+    return new GatewayMetrics(meterRegistry);
+  }
+
+  @Bean
+  public WebFilter gatewayMetricsWebFilter(GatewayMetrics gatewayMetrics) {
+    return new GatewayMetricsWebFilter(gatewayMetrics);
+  }
+
+  @Bean
+  @ConditionalOnBean(CircuitBreakerRegistry.class)
+  public MeterBinder gatewayCircuitBreakerStateMetrics(CircuitBreakerRegistry registry) {
+    return new GatewayCircuitBreakerStateMetrics(registry);
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySupplementaryConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySupplementaryConfiguration.java
@@ -8,6 +8,12 @@ import org.springframework.context.annotation.Configuration;
  * that are not part of the shared starters.
  */
 @Configuration
-@EnableConfigurationProperties({SubscriptionValidationProperties.class, GatewayBffProperties.class,AdminAggregationProperties.class})
+@EnableConfigurationProperties({
+    SubscriptionValidationProperties.class,
+    GatewayBffProperties.class,
+    AdminAggregationProperties.class,
+    GatewayTracingProperties.class,
+    GatewayLoggingProperties.class
+})
 public class GatewaySupplementaryConfiguration {
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayTracingProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayTracingProperties.java
@@ -1,0 +1,33 @@
+package com.ejada.gateway.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties controlling custom tracing behaviour within the gateway.
+ */
+@ConfigurationProperties(prefix = "gateway.tracing")
+public class GatewayTracingProperties {
+
+  private EnhancedTags enhancedTags = new EnhancedTags();
+
+  public EnhancedTags getEnhancedTags() {
+    return enhancedTags;
+  }
+
+  public void setEnhancedTags(EnhancedTags enhancedTags) {
+    this.enhancedTags = enhancedTags == null ? new EnhancedTags() : enhancedTags;
+  }
+
+  public static class EnhancedTags {
+
+    private boolean enabled;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/ObservabilityConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/ObservabilityConfiguration.java
@@ -1,13 +1,24 @@
 package com.ejada.gateway.config;
 
 import com.ejada.common.context.ContextManager;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.ejada.gateway.filter.GatewayAccessLogFilter;
+import com.ejada.gateway.config.GatewayLoggingProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.common.KeyValue;
 import io.micrometer.observation.ObservationFilter;
 import io.micrometer.observation.ObservationRegistry;
+import java.util.Optional;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationRegistryCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.observation.ServerRequestObservationContext;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
 
 /**
  * Ensures that tenant and correlation metadata are attached to observations and MDC when the
@@ -18,7 +29,7 @@ import org.springframework.util.StringUtils;
 public class ObservabilityConfiguration {
 
   @Bean
-  ObservationFilter tenantObservationFilter() {
+  ObservationFilter tenantObservationFilter(GatewayTracingProperties tracingProperties) {
     return context -> {
       String tenant = ContextManager.Tenant.get();
       if (StringUtils.hasText(tenant)) {
@@ -27,6 +38,11 @@ public class ObservabilityConfiguration {
       String correlationId = ContextManager.getCorrelationId();
       if (StringUtils.hasText(correlationId)) {
         context.addHighCardinalityKeyValue(KeyValue.of("correlation.id", correlationId));
+      }
+
+      if (context instanceof ServerRequestObservationContext serverContext
+          && tracingProperties.getEnhancedTags().isEnabled()) {
+        enhanceWithGatewayTags(serverContext);
       }
       return context;
     };
@@ -37,5 +53,28 @@ public class ObservabilityConfiguration {
       ObservationFilter tenantObservationFilter) {
     return registry -> registry.observationConfig()
         .observationFilter(tenantObservationFilter);
+  }
+
+  @Bean
+  @ConditionalOnProperty(prefix = "gateway.logging.access-log", name = "enabled", havingValue = "true")
+  WebFilter gatewayAccessLogFilter(ObjectMapper objectMapper, GatewayLoggingProperties loggingProperties) {
+    return new GatewayAccessLogFilter(objectMapper, loggingProperties.getAccessLog());
+  }
+
+  private void enhanceWithGatewayTags(ServerRequestObservationContext serverContext) {
+    Object carrier = serverContext.getCarrier();
+    if (!(carrier instanceof ServerWebExchange exchange)) {
+      return;
+    }
+    Optional.ofNullable(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID))
+        .filter(StringUtils::hasText)
+        .ifPresent(tenant -> serverContext.addHighCardinalityKeyValue(KeyValue.of("tenant_id", tenant)));
+    Optional.ofNullable(exchange.getAttribute(GatewayRequestAttributes.SUBSCRIPTION_TIER))
+        .filter(StringUtils::hasText)
+        .ifPresent(tier -> serverContext.addHighCardinalityKeyValue(KeyValue.of("subscription_tier", tier)));
+    Route route = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+    if (route != null && StringUtils.hasText(route.getId())) {
+      serverContext.addHighCardinalityKeyValue(KeyValue.of("route_id", route.getId()));
+    }
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/config/ReactiveContextConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/ReactiveContextConfiguration.java
@@ -1,10 +1,12 @@
 package com.ejada.gateway.config;
 
 import com.ejada.gateway.context.ReactiveRequestContextFilter;
+import com.ejada.gateway.metrics.GatewayMetrics;
 import com.ejada.gateway.ratelimit.ReactiveRateLimiterFilter;
 import com.ejada.shared_starter_ratelimit.RateLimitProps;
 import com.ejada.starter_core.config.CoreAutoConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.tracing.Tracer;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -50,10 +52,13 @@ public class ReactiveContextConfiguration {
       RateLimitProps props,
       KeyResolver keyResolver,
       @Qualifier("jacksonObjectMapper") @Nullable ObjectMapper jacksonObjectMapper,
-      ObjectProvider<ObjectMapper> objectMapperProvider) {
+      ObjectProvider<ObjectMapper> objectMapperProvider,
+      GatewayMetrics gatewayMetrics,
+      ObjectProvider<Tracer> tracerProvider) {
     ObjectMapper mapper = (jacksonObjectMapper != null)
         ? jacksonObjectMapper
         : objectMapperProvider.getIfAvailable();
-    return new ReactiveRateLimiterFilter(redisTemplate, props, keyResolver, mapper);
+    return new ReactiveRateLimiterFilter(redisTemplate, props, keyResolver, mapper, gatewayMetrics,
+        tracerProvider != null ? tracerProvider.getIfAvailable() : null);
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/context/GatewayRequestAttributes.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/GatewayRequestAttributes.java
@@ -17,6 +17,9 @@ public final class GatewayRequestAttributes {
   /** Attribute storing the cached subscription status for the current tenant. */
   public static final String SUBSCRIPTION = GatewayRequestAttributes.class.getName() + ".subscription";
 
+  /** Attribute storing the resolved subscription tier for observability enrichment. */
+  public static final String SUBSCRIPTION_TIER = GatewayRequestAttributes.class.getName() + ".subscriptionTier";
+
   /** Attribute storing the resolved API version for versioned routes. */
   public static final String API_VERSION = GatewayRequestAttributes.class.getName() + ".apiVersion";
 

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/GatewayAccessLogFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/GatewayAccessLogFilter.java
@@ -1,0 +1,137 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import com.ejada.gateway.config.GatewayLoggingProperties;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Emits structured JSON access logs for each gateway request.
+ */
+public class GatewayAccessLogFilter implements WebFilter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GatewayAccessLogFilter.class);
+
+  private final ObjectMapper objectMapper;
+  private final List<String> skipPatterns;
+  private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+  public GatewayAccessLogFilter(ObjectMapper objectMapper, GatewayLoggingProperties.AccessLog properties) {
+    this.objectMapper = objectMapper;
+    this.skipPatterns = List.copyOf(properties.getSkipPatterns());
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    String path = exchange.getRequest().getURI().getPath();
+    if (shouldSkip(path)) {
+      return chain.filter(exchange);
+    }
+    long start = System.nanoTime();
+    return chain.filter(exchange)
+        .doFinally(signalType -> emitLog(exchange, start));
+  }
+
+  private boolean shouldSkip(String path) {
+    if (!StringUtils.hasText(path)) {
+      return false;
+    }
+    for (String pattern : skipPatterns) {
+      if (pathMatcher.match(pattern, path)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void emitLog(ServerWebExchange exchange, long startNanos) {
+    if (!LOGGER.isInfoEnabled()) {
+      return;
+    }
+    Map<String, Object> payload = buildPayload(exchange, startNanos);
+    try {
+      LOGGER.info(objectMapper.writeValueAsString(payload));
+    } catch (JsonProcessingException e) {
+      LOGGER.info("{}", payload);
+    }
+  }
+
+  private Map<String, Object> buildPayload(ServerWebExchange exchange, long startNanos) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("timestamp", Instant.now().toString());
+    payload.put("correlationId", resolveCorrelationId(exchange));
+    payload.put("tenantId", resolveTenantId(exchange));
+    ServerHttpRequest request = exchange.getRequest();
+    payload.put("method", request.getMethodValue());
+    payload.put("path", request.getURI().getRawPath());
+    int status = exchange.getResponse().getRawStatusCode() != null
+        ? exchange.getResponse().getRawStatusCode()
+        : 200;
+    payload.put("statusCode", status);
+    payload.put("duration", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos));
+    payload.put("userAgent", request.getHeaders().getFirst(HeaderNames.USER_AGENT));
+    payload.put("clientIp", resolveClientIp(request));
+    payload.put("routeId", resolveRouteId(exchange));
+    return payload;
+  }
+
+  private String resolveCorrelationId(ServerWebExchange exchange) {
+    String attribute = exchange.getAttribute(GatewayRequestAttributes.CORRELATION_ID);
+    if (StringUtils.hasText(attribute)) {
+      return attribute;
+    }
+    String header = exchange.getRequest().getHeaders().getFirst(HeaderNames.CORRELATION_ID);
+    if (StringUtils.hasText(header)) {
+      return header;
+    }
+    return ContextManager.getCorrelationId();
+  }
+
+  private String resolveTenantId(ServerWebExchange exchange) {
+    String attribute = exchange.getAttribute(GatewayRequestAttributes.TENANT_ID);
+    if (StringUtils.hasText(attribute)) {
+      return attribute;
+    }
+    String header = exchange.getRequest().getHeaders().getFirst(HeaderNames.X_TENANT_ID);
+    if (StringUtils.hasText(header)) {
+      return header;
+    }
+    return ContextManager.Tenant.get();
+  }
+
+  private String resolveClientIp(ServerHttpRequest request) {
+    String forwarded = request.getHeaders().getFirst(HeaderNames.CLIENT_IP);
+    if (StringUtils.hasText(forwarded)) {
+      return forwarded;
+    }
+    InetSocketAddress remoteAddress = request.getRemoteAddress();
+    return remoteAddress != null ? remoteAddress.getHostString() : "unknown";
+  }
+
+  private String resolveRouteId(ServerWebExchange exchange) {
+    Route route = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+    if (route != null && StringUtils.hasText(route.getId())) {
+      return route.getId();
+    }
+    return "unknown";
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/metrics/GatewayCircuitBreakerStateMetrics.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/metrics/GatewayCircuitBreakerStateMetrics.java
@@ -1,0 +1,64 @@
+package com.ejada.gateway.metrics;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MultiGauge;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Publishes circuit breaker states as gauge rows tagged by service name and state.
+ */
+public class GatewayCircuitBreakerStateMetrics implements MeterBinder {
+
+  private final CircuitBreakerRegistry circuitBreakerRegistry;
+  private final ReentrantLock lock = new ReentrantLock();
+  private MultiGauge multiGauge;
+
+  public GatewayCircuitBreakerStateMetrics(CircuitBreakerRegistry circuitBreakerRegistry) {
+    this.circuitBreakerRegistry = Objects.requireNonNull(circuitBreakerRegistry, "circuitBreakerRegistry");
+  }
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    this.multiGauge = MultiGauge.builder("gateway.circuit_breaker.state")
+        .description("Current circuit breaker states exposed by the gateway")
+        .register(registry);
+    circuitBreakerRegistry.getEventPublisher()
+        .onStateTransition(event -> refresh())
+        .onEntryAdded(event -> refresh())
+        .onEntryRemoved(event -> refresh());
+    refresh();
+  }
+
+  private void refresh() {
+    lock.lock();
+    try {
+      if (multiGauge == null) {
+        return;
+      }
+      List<MultiGauge.Row<?>> rows = circuitBreakerRegistry.getAllCircuitBreakers().stream()
+          .map(this::toRow)
+          .toList();
+      multiGauge.register(rows, true);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private MultiGauge.Row<?> toRow(CircuitBreaker circuitBreaker) {
+    CircuitBreaker.State state = circuitBreaker.getState();
+    double value = switch (state) {
+      case CLOSED -> 0.0d;
+      case HALF_OPEN -> 0.5d;
+      case OPEN -> 1.0d;
+      default -> -1.0d;
+    };
+    Tags tags = Tags.of("serviceName", circuitBreaker.getName(), "state", state.name());
+    return MultiGauge.Row.of(tags, value);
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/metrics/GatewayMetrics.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/metrics/GatewayMetrics.java
@@ -1,0 +1,95 @@
+package com.ejada.gateway.metrics;
+
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * Centralised facade for publishing custom gateway metrics via Micrometer.
+ */
+public class GatewayMetrics {
+
+  private final MeterRegistry meterRegistry;
+  private final AtomicLong subscriptionCacheHits = new AtomicLong();
+  private final AtomicLong subscriptionCacheMisses = new AtomicLong();
+
+  public GatewayMetrics(MeterRegistry meterRegistry) {
+    this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry");
+    Gauge.builder("gateway.subscription.validation.cache_hit_rate", this, GatewayMetrics::cacheHitRate)
+        .description("Ratio of subscription validations served from cache")
+        .strongReference(true)
+        .register(meterRegistry);
+  }
+
+  public void recordExchange(ServerWebExchange exchange, long durationNanos) {
+    String tenantId = valueOrDefault(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID), "anonymous");
+    HttpStatus status = exchange.getResponse().getStatusCode();
+    Integer rawStatus = exchange.getResponse().getRawStatusCode();
+    String statusCode;
+    if (status != null) {
+      statusCode = String.valueOf(status.value());
+    } else if (rawStatus != null) {
+      statusCode = String.valueOf(rawStatus);
+    } else {
+      statusCode = "200";
+    }
+    Route route = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+    String routeId = (route != null && StringUtils.hasText(route.getId())) ? route.getId() : "unknown";
+
+    meterRegistry.counter("gateway.requests.by_tenant", Tags.of("tenantId", tenantId, "statusCode", statusCode)).increment();
+
+    Timer.builder("gateway.route.latency")
+        .description("Latency distribution per gateway route")
+        .publishPercentileHistogram()
+        .publishPercentiles(0.5, 0.9, 0.95, 0.99)
+        .tags("routeId", routeId)
+        .register(meterRegistry)
+        .record(durationNanos, TimeUnit.NANOSECONDS);
+  }
+
+  public void recordRateLimitRejection(String strategy, String tenantId) {
+    String resolvedStrategy = StringUtils.hasText(strategy) ? strategy : "unknown";
+    String resolvedTenant = StringUtils.hasText(tenantId) ? tenantId : "anonymous";
+    meterRegistry.counter("gateway.ratelimit.rejections", Tags.of("strategy", resolvedStrategy, "tenantId", resolvedTenant)).increment();
+  }
+
+  public void recordSubscriptionCacheHit() {
+    subscriptionCacheHits.incrementAndGet();
+  }
+
+  public void recordSubscriptionCacheMiss() {
+    subscriptionCacheMisses.incrementAndGet();
+  }
+
+  public void recordSubscriptionValidationOutcome(String tenantId, boolean success) {
+    String resolvedTenant = valueOrDefault(tenantId, "anonymous");
+    meterRegistry.counter("gateway.subscription.validation.requests", Tags.of("tenantId", resolvedTenant)).increment();
+    if (!success) {
+      meterRegistry.counter("gateway.subscription.validation.failures", Tags.of("tenantId", resolvedTenant)).increment();
+    }
+  }
+
+  private double cacheHitRate() {
+    long hits = subscriptionCacheHits.get();
+    long misses = subscriptionCacheMisses.get();
+    long total = hits + misses;
+    if (total == 0) {
+      return 1.0d;
+    }
+    return (double) hits / total;
+  }
+
+  private String valueOrDefault(String value, String defaultValue) {
+    return StringUtils.hasText(value) ? value : defaultValue;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/metrics/GatewayMetricsWebFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/metrics/GatewayMetricsWebFilter.java
@@ -1,0 +1,28 @@
+package com.ejada.gateway.metrics;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive web filter that records request/response metrics for every gateway exchange.
+ */
+@Order(Ordered.LOWEST_PRECEDENCE - 20)
+public class GatewayMetricsWebFilter implements WebFilter {
+
+  private final GatewayMetrics gatewayMetrics;
+
+  public GatewayMetricsWebFilter(GatewayMetrics gatewayMetrics) {
+    this.gatewayMetrics = gatewayMetrics;
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    long start = System.nanoTime();
+    return chain.filter(exchange)
+        .doFinally(signalType -> gatewayMetrics.recordExchange(exchange, System.nanoTime() - start));
+  }
+}

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -198,6 +198,15 @@ gateway:
   bff:
     dashboard:
       tenant-service-uri: lb://tenant-service
+  tracing:
+    enhanced-tags:
+      enabled: false
+  logging:
+    access-log:
+      enabled: false
+      skip-patterns:
+        - /actuator/**
+        - /health
       analytics-service-uri: lb://analytics-service
       billing-service-uri: lb://billing-service
       default-period: MONTHLY

--- a/api-gateway/src/test/java/com/ejada/gateway/metrics/GatewayMetricsIntegrationTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/metrics/GatewayMetricsIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.ejada.gateway.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.common.constants.HeaderNames;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "shared.ratelimit.enabled=false",
+        "shared.security.mode=hs256",
+        "shared.security.hs256.secret=0123456789ABCDEF0123456789ABCDEF-SECRET-0123456789ABCDEF",
+        "gateway.logging.access-log.enabled=false"
+    })
+@TestPropertySource(properties = {
+    "management.endpoints.web.exposure.include=health,info",
+    "gateway.tracing.enhanced-tags.enabled=true"
+})
+class GatewayMetricsIntegrationTest {
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @Autowired
+  private MeterRegistry meterRegistry;
+
+  @Test
+  void recordsRequestMetricsPerTenant() {
+    webTestClient.get()
+        .uri("/test/metrics")
+        .accept(MediaType.APPLICATION_JSON)
+        .header(HeaderNames.X_TENANT_ID, "tenant-integration")
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    double count = meterRegistry.counter("gateway.requests.by_tenant",
+            "tenantId", "tenant-integration",
+            "statusCode", "200")
+        .count();
+    assertThat(count).isEqualTo(1.0d);
+
+    Timer timer = meterRegistry.find("gateway.route.latency")
+        .tags("routeId", "unknown")
+        .timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+  }
+
+  @TestConfiguration
+  static class TestEndpoints {
+
+    @Bean
+    SecurityWebFilterChain allowAllSecurity(ServerHttpSecurity http) {
+      return http.authorizeExchange(exchanges -> exchanges.anyExchange().permitAll())
+          .csrf(ServerHttpSecurity.CsrfSpec::disable)
+          .build();
+    }
+
+    @RestController
+    static class ProbeController {
+
+      @GetMapping("/test/metrics")
+      Mono<String> ok() {
+        return Mono.just("ok");
+      }
+    }
+  }
+}

--- a/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
@@ -2,8 +2,10 @@ package com.ejada.gateway.ratelimit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.ejada.gateway.metrics.GatewayMetrics;
 import com.ejada.shared_starter_ratelimit.RateLimitProps;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
@@ -28,6 +30,7 @@ class ReactiveRateLimiterFilterTest {
 
     private ReactiveRateLimiterFilter filter;
     private ReactiveRedisConnectionFactory connectionFactory;
+    private SimpleMeterRegistry meterRegistry;
 
     @BeforeEach
     void setUp() {
@@ -41,7 +44,9 @@ class ReactiveRateLimiterFilterTest {
         props.setRefillPerMinute(2);
         props.setKeyStrategy("tenant");
         KeyResolver keyResolver = exchange -> Mono.just("tenant-a");
-        this.filter = new ReactiveRateLimiterFilter(template, props, keyResolver, new ObjectMapper());
+        this.meterRegistry = new SimpleMeterRegistry();
+        GatewayMetrics gatewayMetrics = new GatewayMetrics(meterRegistry);
+        this.filter = new ReactiveRateLimiterFilter(template, props, keyResolver, new ObjectMapper(), gatewayMetrics, null);
         flushRedis();
     }
 

--- a/charts/grafana/gateway-observability.json
+++ b/charts/grafana/gateway-observability.json
@@ -1,0 +1,102 @@
+{
+  "title": "API Gateway Observability",
+  "uid": "gateway-observability",
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "browser",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Requests by Tenant",
+      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(gateway_requests_by_tenant_total[5m])) by (tenantId)",
+          "legendFormat": "{{tenantId}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Route Latency (p95)",
+      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8},
+      "targets": [
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum(rate(gateway_route_latency_bucket[5m])) by (le, routeId))",
+          "legendFormat": "{{routeId}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "s"},
+        "overrides": []
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Subscription Cache Hit Rate",
+      "gridPos": {"x": 0, "y": 8, "w": 8, "h": 6},
+      "targets": [
+        {
+          "refId": "C",
+          "expr": "gateway_subscription_validation_cache_hit_rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {"color": "red", "value": 0},
+              {"color": "yellow", "value": 0.7},
+              {"color": "green", "value": 0.9}
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Rate Limit Rejections (5m)",
+      "gridPos": {"x": 8, "y": 8, "w": 8, "h": 6},
+      "targets": [
+        {
+          "refId": "D",
+          "expr": "sum(rate(gateway_ratelimit_rejections_total[5m]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "none"},
+        "overrides": []
+      }
+    },
+    {
+      "type": "table",
+      "title": "Circuit Breaker State",
+      "gridPos": {"x": 16, "y": 8, "w": 8, "h": 6},
+      "targets": [
+        {
+          "refId": "E",
+          "expr": "gateway_circuit_breaker_state"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "include": ["serviceName", "state", "Value"],
+            "renameByName": {"Value": "value"}
+          }
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": []
+  }
+}

--- a/charts/prometheus/alert-rules.yaml
+++ b/charts/prometheus/alert-rules.yaml
@@ -1,0 +1,37 @@
+groups:
+  - name: gateway-observability
+    rules:
+      - alert: GatewayHighErrorRate
+        expr: sum(rate(http_server_requests_seconds_count{status=~"5.."}[5m]))
+          / sum(rate(http_server_requests_seconds_count[5m])) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High HTTP 5xx rate on the API gateway"
+          description: "More than 5% of requests resulted in 5xx errors for 5 minutes."
+      - alert: GatewayRateLimitRejectionSpike
+        expr: sum(rate(gateway_ratelimit_rejections_total[1m])) > 100
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Rate limit rejections exceeding threshold"
+          description: "Gateway rejected more than 100 requests per minute due to rate limiting."
+      - alert: GatewayCircuitBreakerOpen
+        expr: max_over_time(gateway_circuit_breaker_state{state="OPEN"}[30s]) == 1
+        for: 30s
+        labels:
+          severity: warning
+        annotations:
+          summary: "Circuit breaker held open"
+          description: "At least one circuit breaker has been open for 30 seconds."
+      - alert: GatewaySubscriptionValidationFailures
+        expr: sum(rate(gateway_subscription_validation_failures_total[5m]))
+          / sum(rate(gateway_subscription_validation_requests_total[5m])) > 0.10
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Subscription validation failure rate above 10%"
+          description: "More than 10% of subscription validations failed over the last 5 minutes."


### PR DESCRIPTION
## Summary
- introduce enhanced tracing and structured access logging with new configuration flags
- add centralized gateway metrics, rate limit instrumentation, Grafana dashboard, and Prometheus alerts
- expand admin health aggregation with dependency probes and detailed endpoint

## Testing
- mvn -pl api-gateway test *(fails: missing internal com.ejada starter artifacts in Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e1158f7500832faddb55ceb80ed78c