### PR TITLE
feat: add gateway transformation and caching filters

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -25,6 +25,12 @@
       <artifactId>spring-cloud-starter-gateway</artifactId>
     </dependency>
 
+    <!-- JSONPath support for payload transformations -->
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+    </dependency>
+
     <!-- Spring Security resource server (reactive) -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayCacheProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayCacheProperties.java
@@ -1,0 +1,52 @@
+package com.ejada.gateway.config;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration properties for gateway response caching.
+ */
+@ConfigurationProperties(prefix = "gateway.cache")
+public class GatewayCacheProperties {
+
+  private boolean enabled;
+
+  private Map<String, Duration> ttlMap = new LinkedHashMap<>();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Map<String, Duration> getTtlMap() {
+    return ttlMap;
+  }
+
+  public void setTtlMap(Map<String, Duration> ttlMap) {
+    LinkedHashMap<String, Duration> copy = new LinkedHashMap<>();
+    if (ttlMap != null) {
+      ttlMap.forEach((key, value) -> {
+        if (!StringUtils.hasText(key) || value == null) {
+          return;
+        }
+        copy.put(key.trim(), value);
+      });
+    }
+    this.ttlMap = copy;
+  }
+
+  public Duration resolveTtl(String routeId) {
+    if (!StringUtils.hasText(routeId)) {
+      return null;
+    }
+    return ttlMap.get(routeId);
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayLimitsProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayLimitsProperties.java
@@ -1,0 +1,42 @@
+package com.ejada.gateway.config;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.unit.DataSize;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration properties for gateway request limits.
+ */
+@ConfigurationProperties(prefix = "gateway.limits")
+public class GatewayLimitsProperties {
+
+  private Map<String, DataSize> maxRequestSize = new LinkedHashMap<>();
+
+  public Map<String, DataSize> getMaxRequestSize() {
+    return maxRequestSize;
+  }
+
+  public void setMaxRequestSize(Map<String, DataSize> maxRequestSize) {
+    LinkedHashMap<String, DataSize> copy = new LinkedHashMap<>();
+    if (maxRequestSize != null) {
+      maxRequestSize.forEach((key, value) -> {
+        if (!StringUtils.hasText(key) || value == null) {
+          return;
+        }
+        copy.put(key.trim(), value);
+      });
+    }
+    this.maxRequestSize = copy;
+  }
+
+  public DataSize resolveMaxSize(String routeId) {
+    if (!StringUtils.hasText(routeId)) {
+      return null;
+    }
+    return maxRequestSize.get(routeId);
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayTransformationConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayTransformationConfiguration.java
@@ -1,0 +1,76 @@
+package com.ejada.gateway.config;
+
+import com.ejada.gateway.filter.RequestBodyTransformationGatewayFilterFactory;
+import com.ejada.gateway.filter.ResponseBodyTransformationGatewayFilterFactory;
+import com.ejada.gateway.metrics.GatewayMetrics;
+import com.ejada.gateway.transformation.HeaderTransformationService;
+import com.ejada.gateway.transformation.ResponseBodyTransformer;
+import com.ejada.gateway.transformation.ResponseCacheService;
+import com.ejada.gateway.transformation.TransformationRuleCache;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+
+/**
+ * Configuration wiring for gateway transformation and caching components.
+ */
+@Configuration
+@EnableConfigurationProperties({GatewayTransformationProperties.class, GatewayCacheProperties.class, GatewayLimitsProperties.class})
+public class GatewayTransformationConfiguration {
+
+  @Bean
+  public TransformationRuleCache transformationRuleCache(GatewayTransformationProperties properties) {
+    return new TransformationRuleCache(properties);
+  }
+
+  @Bean
+  public HeaderTransformationService headerTransformationService(GatewayTransformationProperties properties) {
+    return new HeaderTransformationService(properties);
+  }
+
+  @Bean
+  public GatewayMetrics gatewayMetrics(MeterRegistry meterRegistry) {
+    return new GatewayMetrics(meterRegistry);
+  }
+
+  @Bean
+  public RequestBodyTransformationGatewayFilterFactory requestBodyTransformationGatewayFilterFactory(
+      TransformationRuleCache ruleCache,
+      HeaderTransformationService headerTransformationService,
+      GatewayLimitsProperties limitsProperties,
+      GatewayMetrics gatewayMetrics) {
+    return new RequestBodyTransformationGatewayFilterFactory(ruleCache, headerTransformationService, limitsProperties, gatewayMetrics);
+  }
+
+  @Bean
+  public ResponseCacheService responseCacheService(GatewayCacheProperties cacheProperties,
+      ObjectProvider<ReactiveStringRedisTemplate> redisTemplateProvider,
+      ObjectMapper objectMapper,
+      GatewayMetrics metrics) {
+    ReactiveStringRedisTemplate redisTemplate = redisTemplateProvider.getIfAvailable();
+    return new ResponseCacheService(cacheProperties, redisTemplate, objectMapper, metrics);
+  }
+
+  @Bean
+  public ResponseBodyTransformer responseBodyTransformer(GatewayTransformationProperties properties,
+      ObjectMapper objectMapper,
+      GatewayMetrics metrics,
+      ObjectProvider<BuildProperties> buildPropertiesProvider) {
+    BuildProperties buildProperties = buildPropertiesProvider.getIfAvailable();
+    return new ResponseBodyTransformer(properties, objectMapper, metrics, buildProperties);
+  }
+
+  @Bean
+  public ResponseBodyTransformationGatewayFilterFactory responseBodyTransformationGatewayFilterFactory(
+      HeaderTransformationService headerTransformationService,
+      ResponseBodyTransformer responseBodyTransformer,
+      ObjectProvider<ResponseCacheService> cacheServiceProvider) {
+    return new ResponseBodyTransformationGatewayFilterFactory(headerTransformationService, responseBodyTransformer, cacheServiceProvider.getIfAvailable());
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayTransformationProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayTransformationProperties.java
@@ -1,0 +1,440 @@
+package com.ejada.gateway.config;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration properties for request/response transformations and header manipulation.
+ */
+@ConfigurationProperties(prefix = "gateway.transformation")
+public class GatewayTransformationProperties {
+
+  private final RequestTransformations request = new RequestTransformations();
+
+  private final ResponseTransformations response = new ResponseTransformations();
+
+  private final HeaderTransformations headers = new HeaderTransformations();
+
+  public RequestTransformations getRequest() {
+    return request;
+  }
+
+  public ResponseTransformations getResponse() {
+    return response;
+  }
+
+  public HeaderTransformations getHeaders() {
+    return headers;
+  }
+
+  /**
+   * Holder for request transformation rules keyed by route identifier.
+   */
+  public static class RequestTransformations {
+
+    private final AtomicLong version = new AtomicLong();
+
+    private Map<String, RouteTransformation> routes = new LinkedHashMap<>();
+
+    public Map<String, RouteTransformation> getRoutes() {
+      return routes;
+    }
+
+    public void setRoutes(Map<String, RouteTransformation> routes) {
+      LinkedHashMap<String, RouteTransformation> copy = new LinkedHashMap<>();
+      if (routes != null) {
+        routes.forEach((key, value) -> {
+          if (!StringUtils.hasText(key) || value == null) {
+            return;
+          }
+          copy.put(key.trim(), value);
+        });
+      }
+      this.routes = copy;
+      version.incrementAndGet();
+    }
+
+    public RouteTransformation findRoute(String routeId) {
+      if (!StringUtils.hasText(routeId)) {
+        return null;
+      }
+      return routes.get(routeId);
+    }
+
+    public long getVersion() {
+      return version.get();
+    }
+  }
+
+  /**
+   * Indicates whether response wrapping is enabled.
+   */
+  public static class ResponseTransformations {
+
+    private boolean wrapEnabled = false;
+
+    private String version = "unknown";
+
+    public boolean isWrapEnabled() {
+      return wrapEnabled;
+    }
+
+    public void setWrapEnabled(boolean wrapEnabled) {
+      this.wrapEnabled = wrapEnabled;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    public void setVersion(String version) {
+      if (!StringUtils.hasText(version)) {
+        this.version = "unknown";
+        return;
+      }
+      this.version = version.trim();
+    }
+  }
+
+  /**
+   * Header transformation rules for requests and responses.
+   */
+  public static class HeaderTransformations {
+
+    private Map<String, HeaderRuleSet> routes = new LinkedHashMap<>();
+
+    public Map<String, HeaderRuleSet> getRoutes() {
+      return routes;
+    }
+
+    public void setRoutes(Map<String, HeaderRuleSet> routes) {
+      LinkedHashMap<String, HeaderRuleSet> copy = new LinkedHashMap<>();
+      if (routes != null) {
+        routes.forEach((key, value) -> {
+          if (!StringUtils.hasText(key) || value == null) {
+            return;
+          }
+          copy.put(key.trim(), value);
+        });
+      }
+      this.routes = copy;
+    }
+
+    public HeaderRuleSet findRoute(String routeId) {
+      if (!StringUtils.hasText(routeId)) {
+        return null;
+      }
+      return routes.get(routeId);
+    }
+  }
+
+  /**
+   * Group of header operations. Supports global rules and request/response specific overrides.
+   */
+  public static class HeaderRuleSet {
+
+    private HeaderOperations global = new HeaderOperations();
+
+    private HeaderOperations request = new HeaderOperations();
+
+    private HeaderOperations response = new HeaderOperations();
+
+    public HeaderOperations getGlobal() {
+      return global;
+    }
+
+    public void setGlobal(HeaderOperations global) {
+      this.global = (global == null) ? new HeaderOperations() : global;
+    }
+
+    public HeaderOperations getRequest() {
+      return request;
+    }
+
+    public void setRequest(HeaderOperations request) {
+      this.request = (request == null) ? new HeaderOperations() : request;
+    }
+
+    public HeaderOperations getResponse() {
+      return response;
+    }
+
+    public void setResponse(HeaderOperations response) {
+      this.response = (response == null) ? new HeaderOperations() : response;
+    }
+
+    public List<HeaderValue> getAdd() {
+      return global.getAdd();
+    }
+
+    public void setAdd(List<HeaderValue> add) {
+      global.setAdd(add);
+    }
+
+    public List<String> getRemove() {
+      return global.getRemove();
+    }
+
+    public void setRemove(List<String> remove) {
+      global.setRemove(remove);
+    }
+
+    public List<HeaderValue> getModify() {
+      return global.getModify();
+    }
+
+    public void setModify(List<HeaderValue> modify) {
+      global.setModify(modify);
+    }
+
+    public HeaderOperations resolveRequestOperations() {
+      return HeaderOperations.combine(global, request);
+    }
+
+    public HeaderOperations resolveResponseOperations() {
+      return HeaderOperations.combine(global, response);
+    }
+  }
+
+  /**
+   * Describes a request transformation rule for JSON payloads.
+   */
+  public static class RouteTransformation {
+
+    private List<RequestRule> rules = new ArrayList<>();
+
+    public List<RequestRule> getRules() {
+      return rules;
+    }
+
+    public void setRules(List<RequestRule> rules) {
+      if (CollectionUtils.isEmpty(rules)) {
+        this.rules = new ArrayList<>();
+        return;
+      }
+      List<RequestRule> copy = new ArrayList<>();
+      for (RequestRule rule : rules) {
+        if (rule != null && StringUtils.hasText(rule.getJsonPath())) {
+          copy.add(rule);
+        }
+      }
+      this.rules = copy;
+    }
+  }
+
+  /**
+   * Rule definition referencing a JSONPath expression and an operation.
+   */
+  public static class RequestRule {
+
+    private String jsonPath;
+
+    private RequestOperation operation = RequestOperation.SET;
+
+    private Object value;
+
+    private String targetPath;
+
+    public String getJsonPath() {
+      return jsonPath;
+    }
+
+    public void setJsonPath(String jsonPath) {
+      if (!StringUtils.hasText(jsonPath)) {
+        this.jsonPath = null;
+        return;
+      }
+      this.jsonPath = jsonPath.trim();
+    }
+
+    public RequestOperation getOperation() {
+      return operation;
+    }
+
+    public void setOperation(RequestOperation operation) {
+      this.operation = (operation == null) ? RequestOperation.SET : operation;
+    }
+
+    public void setOperation(String operation) {
+      if (!StringUtils.hasText(operation)) {
+        this.operation = RequestOperation.SET;
+        return;
+      }
+      try {
+        this.operation = RequestOperation.valueOf(operation.trim().toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException ex) {
+        this.operation = RequestOperation.SET;
+      }
+    }
+
+    public Object getValue() {
+      return value;
+    }
+
+    public void setValue(Object value) {
+      this.value = value;
+    }
+
+    public String getTargetPath() {
+      return targetPath;
+    }
+
+    public void setTargetPath(String targetPath) {
+      this.targetPath = StringUtils.hasText(targetPath) ? targetPath.trim() : null;
+    }
+
+  }
+
+  /**
+   * Supported request transformation operations.
+   */
+  public enum RequestOperation {
+    REMOVE,
+    SET,
+    ADD_IF_MISSING,
+    RENAME
+  }
+
+  /**
+   * Header operations containing add/remove/modify lists.
+   */
+  public static class HeaderOperations {
+
+    private List<HeaderValue> add = new ArrayList<>();
+
+    private List<String> remove = new ArrayList<>();
+
+    private List<HeaderValue> modify = new ArrayList<>();
+
+    public List<HeaderValue> getAdd() {
+      return add;
+    }
+
+    public void setAdd(List<HeaderValue> add) {
+      this.add = sanitizeHeaderValues(add);
+    }
+
+    public List<String> getRemove() {
+      return remove;
+    }
+
+    public void setRemove(List<String> remove) {
+      if (CollectionUtils.isEmpty(remove)) {
+        this.remove = new ArrayList<>();
+        return;
+      }
+      List<String> cleaned = new ArrayList<>();
+      for (String entry : remove) {
+        if (StringUtils.hasText(entry)) {
+          cleaned.add(entry.trim());
+        }
+      }
+      this.remove = cleaned;
+    }
+
+    public List<HeaderValue> getModify() {
+      return modify;
+    }
+
+    public void setModify(List<HeaderValue> modify) {
+      this.modify = sanitizeHeaderValues(modify);
+    }
+
+    public boolean isEmpty() {
+      return add.isEmpty() && remove.isEmpty() && modify.isEmpty();
+    }
+
+    public static HeaderOperations combine(HeaderOperations first, HeaderOperations second) {
+      HeaderOperations combined = new HeaderOperations();
+      if (first != null) {
+        combined.add.addAll(first.getAdd());
+        combined.remove.addAll(first.getRemove());
+        combined.modify.addAll(first.getModify());
+      }
+      if (second != null) {
+        combined.add.addAll(second.getAdd());
+        combined.remove.addAll(second.getRemove());
+        combined.modify.addAll(second.getModify());
+      }
+      return combined;
+    }
+
+    private List<HeaderValue> sanitizeHeaderValues(List<HeaderValue> values) {
+      if (CollectionUtils.isEmpty(values)) {
+        return new ArrayList<>();
+      }
+      List<HeaderValue> cleaned = new ArrayList<>();
+      for (HeaderValue value : values) {
+        if (value == null) {
+          continue;
+        }
+        String name = value.getName();
+        if (!StringUtils.hasText(name)) {
+          continue;
+        }
+        cleaned.add(value);
+      }
+      return cleaned;
+    }
+  }
+
+  /**
+   * Simple header name/value pair.
+   */
+  public static class HeaderValue {
+
+    private String name;
+
+    private String value;
+
+    public HeaderValue() {
+    }
+
+    public HeaderValue(String name, String value) {
+      this.name = name;
+      this.value = value;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = StringUtils.hasText(name) ? name.trim() : null;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof HeaderValue that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, value);
+    }
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/RequestBodyTransformationGatewayFilterFactory.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/RequestBodyTransformationGatewayFilterFactory.java
@@ -1,0 +1,154 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.gateway.config.GatewayLimitsProperties;
+import com.ejada.gateway.config.GatewayTransformationProperties.HeaderOperations;
+import com.ejada.gateway.metrics.GatewayMetrics;
+import com.ejada.gateway.transformation.HeaderTransformationService;
+import com.ejada.gateway.transformation.RequestBodyTransformer;
+import com.ejada.gateway.transformation.TransformationRuleCache;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.core.Ordered;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Gateway filter that applies JSON request transformations and enforces size limits.
+ */
+public class RequestBodyTransformationGatewayFilterFactory {
+
+  private final RequestBodyTransformer requestBodyTransformer;
+
+  private final HeaderTransformationService headerTransformationService;
+
+  private final GatewayLimitsProperties limitsProperties;
+
+  private final TransformationRuleCache ruleCache;
+
+  public RequestBodyTransformationGatewayFilterFactory(TransformationRuleCache ruleCache,
+      HeaderTransformationService headerTransformationService,
+      GatewayLimitsProperties limitsProperties,
+      GatewayMetrics metrics) {
+    this.ruleCache = Objects.requireNonNull(ruleCache, "ruleCache");
+    this.requestBodyTransformer = new RequestBodyTransformer(ruleCache, metrics);
+    this.headerTransformationService = Objects.requireNonNull(headerTransformationService, "headerTransformationService");
+    this.limitsProperties = Objects.requireNonNull(limitsProperties, "limitsProperties");
+  }
+
+  public GatewayFilter apply(String routeId) {
+    return new RequestBodyTransformationGatewayFilter(routeId);
+  }
+
+  private class RequestBodyTransformationGatewayFilter implements GatewayFilter, Ordered {
+
+    private final String routeId;
+
+    RequestBodyTransformationGatewayFilter(String routeId) {
+      this.routeId = routeId;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+      Route route = exchange.getAttribute(org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+      String effectiveRouteId = (route != null) ? route.getId() : routeId;
+
+      HeaderOperations headerOperations = headerTransformationService.resolveRequestOperations(effectiveRouteId);
+      DataSize maxSize = limitsProperties.resolveMaxSize(effectiveRouteId);
+
+      ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+          .headers(httpHeaders -> headerTransformationService.applyRequestHeaders(httpHeaders, headerOperations))
+          .build();
+
+      ServerWebExchange mutatedExchange = exchange.mutate().request(mutatedRequest).build();
+
+      boolean hasBodyRules = !ruleCache.resolveRequestRules(effectiveRouteId).isEmpty();
+      boolean shouldTransformBody = hasBodyRules && shouldTransformBody(mutatedRequest.getHeaders().getContentType());
+
+      if (maxSize != null) {
+        long contentLength = mutatedRequest.getHeaders().getContentLength();
+        if (contentLength > 0 && contentLength > maxSize.toBytes()) {
+          return rejectLargeRequest(mutatedExchange);
+        }
+      }
+
+      if (!shouldTransformBody && maxSize == null) {
+        return chain.filter(mutatedExchange);
+      }
+
+      return DataBufferUtils.join(mutatedRequest.getBody())
+          .flatMap(buffer -> {
+            int readable = buffer.readableByteCount();
+            if (maxSize != null && readable > maxSize.toBytes()) {
+              DataBufferUtils.release(buffer);
+              return rejectLargeRequest(mutatedExchange);
+            }
+            byte[] bodyBytes = new byte[readable];
+            buffer.read(bodyBytes);
+            DataBufferUtils.release(buffer);
+
+            byte[] transformed = bodyBytes;
+            if (shouldTransformBody && readable > 0) {
+              transformed = requestBodyTransformer.transform(effectiveRouteId, bodyBytes);
+            }
+
+            DataBufferFactory bufferFactory = mutatedExchange.getResponse().bufferFactory();
+            Flux<DataBuffer> newBody = Flux.defer(() -> {
+              DataBuffer newBuffer = bufferFactory.wrap(transformed);
+              return Mono.just(newBuffer);
+            });
+
+            ServerHttpRequest decorated = new ServerHttpRequestDecorator(mutatedRequest) {
+              @Override
+              public Flux<DataBuffer> getBody() {
+                return newBody;
+              }
+            };
+
+            return chain.filter(mutatedExchange.mutate().request(decorated).build());
+          })
+          .switchIfEmpty(chain.filter(mutatedExchange));
+    }
+
+    private boolean shouldTransformBody(MediaType contentType) {
+      if (contentType == null) {
+        return true;
+      }
+      if (MediaType.APPLICATION_JSON.includes(contentType)) {
+        return true;
+      }
+      String subtype = contentType.getSubtype();
+      return subtype != null && subtype.endsWith("+json");
+    }
+
+    private Mono<Void> rejectLargeRequest(ServerWebExchange exchange) {
+      exchange.getResponse().setStatusCode(org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE);
+      exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+      byte[] payload = ("{" +
+          "\"status\":\"ERROR\"," +
+          "\"code\":\"ERR_REQUEST_TOO_LARGE\"," +
+          "\"message\":\"Request body exceeds the configured maximum\"}")
+          .getBytes(StandardCharsets.UTF_8);
+      DataBuffer buffer = exchange.getResponse().bufferFactory().wrap(payload);
+      return exchange.getResponse().writeWith(Mono.just(buffer));
+    }
+
+    @Override
+    public int getOrder() {
+      return Ordered.HIGHEST_PRECEDENCE + 50;
+    }
+  }
+
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/ResponseBodyTransformationGatewayFilterFactory.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/ResponseBodyTransformationGatewayFilterFactory.java
@@ -1,0 +1,196 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.gateway.config.GatewayTransformationProperties.HeaderOperations;
+import com.ejada.gateway.transformation.HeaderTransformationService;
+import com.ejada.gateway.transformation.ResponseBodyTransformer;
+import com.ejada.gateway.transformation.ResponseCacheService;
+import com.ejada.gateway.transformation.ResponseCacheService.CachedResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.core.Ordered;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Gateway filter that wraps responses, applies header changes, and integrates caching.
+ */
+public class ResponseBodyTransformationGatewayFilterFactory {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResponseBodyTransformationGatewayFilterFactory.class);
+
+  private final HeaderTransformationService headerTransformationService;
+
+  private final ResponseBodyTransformer responseBodyTransformer;
+
+  private final ResponseCacheService responseCacheService;
+
+  public ResponseBodyTransformationGatewayFilterFactory(HeaderTransformationService headerTransformationService,
+      ResponseBodyTransformer responseBodyTransformer,
+      ResponseCacheService responseCacheService) {
+    this.headerTransformationService = headerTransformationService;
+    this.responseBodyTransformer = responseBodyTransformer;
+    this.responseCacheService = responseCacheService;
+  }
+
+  public GatewayFilter apply(String routeId) {
+    return new ResponseTransformationGatewayFilter(routeId);
+  }
+
+  private class ResponseTransformationGatewayFilter implements GatewayFilter, Ordered {
+
+    private final String routeId;
+
+    ResponseTransformationGatewayFilter(String routeId) {
+      this.routeId = routeId;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+      Route route = exchange.getAttribute(org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+      String effectiveRouteId = (route != null) ? route.getId() : routeId;
+
+      HeaderOperations responseHeaders = headerTransformationService.resolveResponseOperations(effectiveRouteId);
+
+      long startNanos = System.nanoTime();
+      exchange.getAttributes().put("gateway.response.start", startNanos);
+
+      if (responseCacheService != null && shouldInvalidateCache(exchange.getRequest().getMethod())) {
+        return responseCacheService.invalidate(effectiveRouteId, exchange)
+            .then(chain.filter(exchange));
+      }
+
+      if (isCacheable(exchange)) {
+        return responseCacheService.find(effectiveRouteId, exchange)
+            .flatMap(optional -> optional
+                .map(cached -> writeCachedResponse(exchange, cached, responseHeaders))
+                .orElseGet(() -> proceedWithDecoration(exchange, chain, effectiveRouteId, responseHeaders, startNanos, true)))
+            .switchIfEmpty(proceedWithDecoration(exchange, chain, effectiveRouteId, responseHeaders, startNanos, true));
+      }
+
+      return proceedWithDecoration(exchange, chain, effectiveRouteId, responseHeaders, startNanos, false);
+    }
+
+    private Mono<Void> proceedWithDecoration(ServerWebExchange exchange,
+        GatewayFilterChain chain,
+        String effectiveRouteId,
+        HeaderOperations responseHeaders,
+        long startNanos,
+        boolean cacheEligible) {
+      ServerHttpResponse originalResponse = exchange.getResponse();
+      DataBufferFactory bufferFactory = originalResponse.bufferFactory();
+      boolean cachingActive = cacheEligible && responseCacheService != null && responseCacheService.isCacheEnabled();
+
+      ServerHttpResponseDecorator decorated = new ServerHttpResponseDecorator(originalResponse) {
+        @Override
+        public Mono<Void> writeWith(org.reactivestreams.Publisher<? extends DataBuffer> body) {
+          Flux<? extends DataBuffer> bodyFlux = Flux.from(body);
+          return DataBufferUtils.join(bodyFlux)
+              .flatMap(buffer -> {
+                byte[] originalBytes = new byte[buffer.readableByteCount()];
+                buffer.read(originalBytes);
+                DataBufferUtils.release(buffer);
+
+                HttpStatus status = getStatusCode();
+                MediaType contentType = getHeaders().getContentType();
+                byte[] processed = originalBytes;
+
+                if (responseBodyTransformer.isWrapEnabled(contentType)) {
+                  processed = responseBodyTransformer.wrapBody(exchange, originalBytes, status, startNanos);
+                }
+
+                headerTransformationService.applyResponseHeaders(getHeaders(), responseHeaders);
+
+                if (cachingActive) {
+                  originalResponse.getHeaders().set("X-Cache", "MISS");
+                }
+
+                byte[] finalBytes = processed;
+                getHeaders().setContentLength(finalBytes.length);
+                DataBuffer wrap = bufferFactory.wrap(finalBytes);
+
+                Mono<Void> writeMono = super.writeWith(Mono.just(wrap));
+
+                if (cachingActive && isSuccessful(status)) {
+                  CachedResponse snapshot = responseCacheService.snapshotResponse(this, processed);
+                  return responseCacheService.store(effectiveRouteId, exchange, snapshot)
+                      .onErrorResume(ex -> {
+                        LOGGER.warn("Failed to store response in cache", ex);
+                        return Mono.empty();
+                      })
+                      .then(writeMono);
+                }
+                return writeMono;
+              })
+              .switchIfEmpty(super.writeWith(body))
+              .onErrorResume(ex -> {
+                LOGGER.warn("Failed to process response body", ex);
+                return super.writeWith(body);
+              });
+        }
+
+        @Override
+        public Mono<Void> writeAndFlushWith(org.reactivestreams.Publisher<? extends org.reactivestreams.Publisher<? extends DataBuffer>> body) {
+          return writeWith(Flux.from(body).flatMapSequential(publisher -> publisher));
+        }
+      };
+
+      exchange.getResponse().beforeCommit(() -> {
+        headerTransformationService.applyResponseHeaders(exchange.getResponse().getHeaders(), responseHeaders);
+        return Mono.empty();
+      });
+
+      return chain.filter(exchange.mutate().response(decorated).build());
+    }
+
+    private Mono<Void> writeCachedResponse(ServerWebExchange exchange,
+        CachedResponse cachedResponse,
+        HeaderOperations responseHeaders) {
+      ServerHttpResponse response = exchange.getResponse();
+      response.setStatusCode(HttpStatus.valueOf(cachedResponse.status()));
+      HttpHeaders headers = response.getHeaders();
+      headers.clear();
+      headers.putAll(cachedResponse.headers());
+      headerTransformationService.applyResponseHeaders(headers, responseHeaders);
+      headers.set("X-Cache", "HIT");
+      headers.setContentLength(cachedResponse.body().length);
+      DataBuffer buffer = response.bufferFactory().wrap(cachedResponse.body());
+      return response.writeWith(Mono.just(buffer));
+    }
+
+    private boolean isCacheable(ServerWebExchange exchange) {
+      return responseCacheService != null
+          && responseCacheService.isCacheEnabled()
+          && HttpMethod.GET.equals(exchange.getRequest().getMethod());
+    }
+
+    private boolean shouldInvalidateCache(HttpMethod method) {
+      if (method == null) {
+        return false;
+      }
+      return method == HttpMethod.POST || method == HttpMethod.PUT || method == HttpMethod.DELETE;
+    }
+
+    private boolean isSuccessful(HttpStatus status) {
+      return status != null && status.is2xxSuccessful();
+    }
+
+    @Override
+    public int getOrder() {
+      return Ordered.LOWEST_PRECEDENCE - 50;
+    }
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/metrics/GatewayMetrics.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/metrics/GatewayMetrics.java
@@ -1,0 +1,64 @@
+package com.ejada.gateway.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Centralised gateway metrics for transformation and caching concerns.
+ */
+public class GatewayMetrics {
+
+  private final Counter requestTransformations;
+
+  private final Counter responseTransformations;
+
+  private final AtomicLong cacheHits = new AtomicLong();
+
+  private final AtomicLong cacheMisses = new AtomicLong();
+
+  public GatewayMetrics(MeterRegistry meterRegistry) {
+    this.requestTransformations = Counter.builder("gateway.transformation.applied")
+        .tag("phase", "request")
+        .description("Number of request transformations applied by the gateway")
+        .register(meterRegistry);
+
+    this.responseTransformations = Counter.builder("gateway.transformation.applied")
+        .tag("phase", "response")
+        .description("Number of response transformations applied by the gateway")
+        .register(meterRegistry);
+
+    Gauge.builder("gateway.cache.hit_rate", this, GatewayMetrics::calculateHitRate)
+        .description("Cache hit ratio for gateway response caching")
+        .register(meterRegistry);
+  }
+
+  public void recordRequestTransformation() {
+    requestTransformations.increment();
+  }
+
+  public void recordResponseTransformation() {
+    responseTransformations.increment();
+  }
+
+  public void recordCacheHit() {
+    cacheHits.incrementAndGet();
+  }
+
+  public void recordCacheMiss() {
+    cacheMisses.incrementAndGet();
+  }
+
+  double calculateHitRate() {
+    long hits = cacheHits.get();
+    long misses = cacheMisses.get();
+    long total = hits + misses;
+    if (total == 0) {
+      return 0.0d;
+    }
+    return (double) hits / total;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/transformation/CompiledRequestRule.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/transformation/CompiledRequestRule.java
@@ -1,0 +1,74 @@
+package com.ejada.gateway.transformation;
+
+import com.ejada.gateway.config.GatewayTransformationProperties.RequestOperation;
+import com.ejada.gateway.config.GatewayTransformationProperties.RequestRule;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+
+/**
+ * Value object bundling a compiled JSONPath and its transformation semantics.
+ */
+public class CompiledRequestRule {
+
+  private final RequestRule rule;
+
+  private final JsonPath path;
+
+  private final JsonPath target;
+
+  public CompiledRequestRule(RequestRule rule, JsonPath path, JsonPath target) {
+    this.rule = rule;
+    this.path = path;
+    this.target = target;
+  }
+
+  public RequestRule getRule() {
+    return rule;
+  }
+
+  public boolean apply(DocumentContext context) {
+    if (context == null) {
+      return false;
+    }
+    RequestOperation operation = rule.getOperation();
+    return switch (operation) {
+      case REMOVE -> remove(context);
+      case RENAME -> rename(context);
+      case ADD_IF_MISSING -> addIfMissing(context);
+      case SET -> set(context);
+    };
+  }
+
+  private boolean remove(DocumentContext context) {
+    context.delete(path);
+    return true;
+  }
+
+  private boolean rename(DocumentContext context) {
+    if (target == null) {
+      return false;
+    }
+    Object value = context.read(path);
+    if (value == null) {
+      return false;
+    }
+    context.delete(path);
+    context.set(target, value);
+    return true;
+  }
+
+  private boolean addIfMissing(DocumentContext context) {
+    Object current = context.read(path);
+    if (current != null) {
+      return false;
+    }
+    context.set(path, rule.getValue());
+    return true;
+  }
+
+  private boolean set(DocumentContext context) {
+    context.set(path, rule.getValue());
+    return true;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/transformation/HeaderTransformationService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/transformation/HeaderTransformationService.java
@@ -1,0 +1,65 @@
+package com.ejada.gateway.transformation;
+
+import com.ejada.gateway.config.GatewayTransformationProperties;
+import com.ejada.gateway.config.GatewayTransformationProperties.HeaderOperations;
+import com.ejada.gateway.config.GatewayTransformationProperties.HeaderRuleSet;
+import com.ejada.gateway.config.GatewayTransformationProperties.HeaderValue;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
+
+/**
+ * Applies declarative header mutations to requests and responses.
+ */
+public class HeaderTransformationService {
+
+  private final GatewayTransformationProperties properties;
+
+  public HeaderTransformationService(GatewayTransformationProperties properties) {
+    this.properties = Objects.requireNonNull(properties, "properties");
+  }
+
+  public HeaderOperations resolveRequestOperations(String routeId) {
+    HeaderRuleSet ruleSet = properties.getHeaders().findRoute(routeId);
+    return ruleSet != null ? ruleSet.resolveRequestOperations() : new HeaderOperations();
+  }
+
+  public HeaderOperations resolveResponseOperations(String routeId) {
+    HeaderRuleSet ruleSet = properties.getHeaders().findRoute(routeId);
+    return ruleSet != null ? ruleSet.resolveResponseOperations() : new HeaderOperations();
+  }
+
+  public void applyRequestHeaders(HttpHeaders headers, HeaderOperations operations) {
+    apply(headers, operations);
+  }
+
+  public void applyResponseHeaders(HttpHeaders headers, HeaderOperations operations) {
+    apply(headers, operations);
+  }
+
+  private void apply(HttpHeaders headers, HeaderOperations operations) {
+    if (headers == null || operations == null || operations.isEmpty()) {
+      return;
+    }
+    List<HeaderValue> add = operations.getAdd();
+    for (HeaderValue value : add) {
+      if (value == null || !StringUtils.hasText(value.getName())) {
+        continue;
+      }
+      headers.add(value.getName(), value.getValue());
+    }
+
+    for (String remove : operations.getRemove()) {
+      headers.remove(remove);
+    }
+
+    for (HeaderValue modify : operations.getModify()) {
+      if (modify == null || !StringUtils.hasText(modify.getName())) {
+        continue;
+      }
+      headers.set(modify.getName(), modify.getValue());
+    }
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/transformation/RequestBodyTransformer.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/transformation/RequestBodyTransformer.java
@@ -1,0 +1,59 @@
+package com.ejada.gateway.transformation;
+
+import com.ejada.gateway.metrics.GatewayMetrics;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies compiled request transformation rules to JSON payloads.
+ */
+public class RequestBodyTransformer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RequestBodyTransformer.class);
+
+  private final TransformationRuleCache ruleCache;
+
+  private final GatewayMetrics metrics;
+
+  public RequestBodyTransformer(TransformationRuleCache ruleCache, GatewayMetrics metrics) {
+    this.ruleCache = Objects.requireNonNull(ruleCache, "ruleCache");
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
+  }
+
+  public byte[] transform(String routeId, byte[] original) {
+    List<CompiledRequestRule> rules = ruleCache.resolveRequestRules(routeId);
+    if (rules.isEmpty() || original == null || original.length == 0) {
+      return original;
+    }
+
+    try {
+      DocumentContext context = JsonPath.using(BASE_CONFIGURATION)
+          .parse(new String(original, StandardCharsets.UTF_8));
+      boolean mutated = false;
+      for (CompiledRequestRule rule : rules) {
+        if (rule.apply(context)) {
+          mutated = true;
+        }
+      }
+      if (!mutated) {
+        return original;
+      }
+      metrics.recordRequestTransformation();
+      return context.jsonString().getBytes(StandardCharsets.UTF_8);
+    } catch (Exception ex) {
+      LOGGER.warn("Failed to apply request transformations for route {}", routeId, ex);
+      return original;
+    }
+  }
+}
+
+  private static final Configuration BASE_CONFIGURATION = Configuration.defaultConfiguration()
+      .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL, Option.SUPPRESS_EXCEPTIONS, Option.CREATE_PATH);
+

--- a/api-gateway/src/main/java/com/ejada/gateway/transformation/ResponseBodyTransformer.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/transformation/ResponseBodyTransformer.java
@@ -1,0 +1,137 @@
+package com.ejada.gateway.transformation;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.common.enums.StatusEnums.ApiStatus;
+import com.ejada.gateway.config.GatewayTransformationProperties;
+import com.ejada.gateway.metrics.GatewayMetrics;
+import com.ejada.common.context.ContextManager;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * Wraps downstream responses with the platform {@link BaseResponse} envelope.
+ */
+public class ResponseBodyTransformer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResponseBodyTransformer.class);
+
+  private final GatewayTransformationProperties properties;
+
+  private final ObjectMapper objectMapper;
+
+  private final GatewayMetrics metrics;
+
+  private final BuildProperties buildProperties;
+
+  public ResponseBodyTransformer(GatewayTransformationProperties properties,
+      ObjectMapper objectMapper,
+      GatewayMetrics metrics,
+      BuildProperties buildProperties) {
+    this.properties = Objects.requireNonNull(properties, "properties");
+    this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
+    this.buildProperties = buildProperties;
+  }
+
+  public boolean isWrapEnabled(MediaType contentType) {
+    if (!properties.getResponse().isWrapEnabled()) {
+      return false;
+    }
+    if (contentType == null) {
+      return true;
+    }
+    return MediaType.APPLICATION_JSON.includes(contentType)
+        || MediaType.APPLICATION_PROBLEM_JSON.includes(contentType)
+        || (contentType.getSubtype() != null && contentType.getSubtype().endsWith("+json"));
+  }
+
+  public byte[] wrapBody(ServerWebExchange exchange, byte[] original, HttpStatus status, long startNanos) {
+    if (original == null) {
+      original = new byte[0];
+    }
+    Object payload = null;
+    try {
+      if (original.length > 0) {
+        payload = objectMapper.readValue(original, Object.class);
+      }
+    } catch (Exception ex) {
+      LOGGER.debug("Response body is not JSON, skipping wrapping", ex);
+      return original;
+    }
+
+    try {
+      JsonNode jsonNode = (payload != null) ? objectMapper.valueToTree(payload) : null;
+      if (jsonNode instanceof ObjectNode objectNode
+          && objectNode.hasNonNull("status")
+          && objectNode.has("code")
+          && objectNode.has("data")) {
+        attachMetadata(exchange, objectNode, startNanos);
+        metrics.recordResponseTransformation();
+        return objectMapper.writeValueAsBytes(objectNode);
+      }
+
+      ApiStatus apiStatus = (status != null && status.is2xxSuccessful()) ? ApiStatus.SUCCESS : ApiStatus.ERROR;
+      String code = (status != null) ? status.value() + "" : "200";
+      String message = (status != null) ? status.getReasonPhrase() : null;
+
+      Map<String, Object> envelope = new LinkedHashMap<>();
+      envelope.put("metadata", buildMetadata(exchange, startNanos));
+      envelope.put("payload", payload);
+
+      BaseResponse<Map<String, Object>> wrapped = BaseResponse.<Map<String, Object>>builder()
+          .status(apiStatus)
+          .code(code)
+          .message(message)
+          .data(envelope)
+          .build();
+      metrics.recordResponseTransformation();
+      return objectMapper.writeValueAsBytes(wrapped);
+    } catch (Exception ex) {
+      LOGGER.warn("Failed to wrap response body", ex);
+      return original;
+    }
+  }
+
+  private void attachMetadata(ServerWebExchange exchange, ObjectNode node, long startNanos) {
+    Map<String, Object> metadata = buildMetadata(exchange, startNanos);
+    node.set("metadata", objectMapper.valueToTree(metadata));
+  }
+
+  private Map<String, Object> buildMetadata(ServerWebExchange exchange, long startNanos) {
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    String correlationId = exchange.getAttribute(GatewayRequestAttributes.CORRELATION_ID);
+    if (!StringUtils.hasText(correlationId)) {
+      correlationId = exchange.getRequest().getHeaders().getFirst("X-Correlation-Id");
+    }
+    if (!StringUtils.hasText(correlationId)) {
+      correlationId = ContextManager.getCorrelationId();
+    }
+    if (StringUtils.hasText(correlationId)) {
+      metadata.put("requestId", correlationId);
+    }
+
+    long elapsedMillis = (startNanos > 0) ? Duration.ofNanos(System.nanoTime() - startNanos).toMillis() : 0L;
+    metadata.put("processingTime", elapsedMillis);
+
+    String version = properties.getResponse().getVersion();
+    if (buildProperties != null && StringUtils.hasText(buildProperties.getVersion())) {
+      version = buildProperties.getVersion();
+    }
+    metadata.put("version", version);
+    return metadata;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/transformation/ResponseCacheService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/transformation/ResponseCacheService.java
@@ -1,0 +1,176 @@
+package com.ejada.gateway.transformation;
+
+import com.ejada.common.context.ContextManager;
+import com.ejada.gateway.config.GatewayCacheProperties;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.ejada.gateway.metrics.GatewayMetrics;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Manages caching of GET responses in Redis.
+ */
+public class ResponseCacheService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResponseCacheService.class);
+
+  private static final String CACHE_PREFIX = "gateway:cache:";
+
+  private final GatewayCacheProperties properties;
+
+  private final ReactiveStringRedisTemplate redisTemplate;
+
+  private final ObjectMapper objectMapper;
+
+  private final GatewayMetrics metrics;
+
+  public ResponseCacheService(GatewayCacheProperties properties,
+      ReactiveStringRedisTemplate redisTemplate,
+      ObjectMapper objectMapper,
+      GatewayMetrics metrics) {
+    this.properties = Objects.requireNonNull(properties, "properties");
+    this.redisTemplate = redisTemplate;
+    this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
+  }
+
+  public boolean isCacheEnabled() {
+    return properties.isEnabled() && redisTemplate != null;
+  }
+
+  public Mono<Optional<CachedResponse>> find(String routeId, ServerWebExchange exchange) {
+    if (!isCacheEnabled()) {
+      return Mono.just(Optional.empty());
+    }
+    Duration ttl = properties.resolveTtl(routeId);
+    if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+      return Mono.just(Optional.empty());
+    }
+    String key = buildKey(routeId, exchange);
+    return redisTemplate.opsForValue().get(key)
+        .flatMap(serialized -> deserialize(serialized)
+            .map(value -> {
+              metrics.recordCacheHit();
+              return Mono.just(Optional.of(value));
+            })
+            .orElseGet(() -> {
+              metrics.recordCacheMiss();
+              return Mono.just(Optional.empty());
+            }))
+        .switchIfEmpty(Mono.defer(() -> {
+          metrics.recordCacheMiss();
+          return Mono.empty();
+        }))
+        .switchIfEmpty(Mono.just(Optional.empty()));
+  }
+
+  public Mono<Void> store(String routeId, ServerWebExchange exchange, CachedResponse response) {
+    if (!isCacheEnabled()) {
+      return Mono.empty();
+    }
+    Duration ttl = properties.resolveTtl(routeId);
+    if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+      return Mono.empty();
+    }
+    String key = buildKey(routeId, exchange);
+    try {
+      String serialized = objectMapper.writeValueAsString(response);
+      return redisTemplate.opsForValue()
+          .set(key, serialized, ttl)
+          .doOnError(ex -> LOGGER.warn("Failed to store cached response for {}", key, ex))
+          .then();
+    } catch (Exception ex) {
+      LOGGER.warn("Failed to serialise cached response", ex);
+      return Mono.empty();
+    }
+  }
+
+  public Mono<Void> invalidate(String routeId, ServerWebExchange exchange) {
+    if (!isCacheEnabled()) {
+      return Mono.empty();
+    }
+    String key = buildKey(routeId, exchange);
+    return redisTemplate.opsForValue()
+        .delete(key)
+        .then();
+  }
+
+  public CachedResponse snapshotResponse(ServerHttpResponse response, byte[] body) {
+    HttpHeaders headers = new HttpHeaders();
+    response.getHeaders().forEach((key, values) -> {
+      if ("X-Cache".equalsIgnoreCase(key)) {
+        return;
+      }
+      headers.put(key, List.copyOf(values));
+    });
+    int status = (response.getStatusCode() != null) ? response.getStatusCode().value() : 200;
+    return new CachedResponse(status, headers, body);
+  }
+
+  private String buildKey(String routeId, ServerWebExchange exchange) {
+    StringBuilder builder = new StringBuilder(CACHE_PREFIX).append(routeId).append(':');
+    builder.append(exchange.getRequest().getPath().pathWithinApplication().value());
+    builder.append(':').append(canonicalQuery(exchange.getRequest().getQueryParams()));
+    String tenantId = Optional.ofNullable(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID))
+        .map(Object::toString)
+        .filter(value -> !value.isBlank())
+        .orElseGet(() -> Optional.ofNullable(ContextManager.Tenant.get()).orElse("anonymous"));
+    builder.append(':').append(tenantId);
+    return builder.toString();
+  }
+
+  private String canonicalQuery(MultiValueMap<String, String> params) {
+    if (params == null || params.isEmpty()) {
+      return "-";
+    }
+    return params.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .map(entry -> {
+          List<String> values = entry.getValue();
+          if (values == null || values.isEmpty()) {
+            return entry.getKey();
+          }
+          return values.stream()
+              .sorted()
+              .map(value -> entry.getKey() + '=' + value)
+              .reduce((left, right) -> left + '&' + right)
+              .orElse(entry.getKey());
+        })
+        .reduce((left, right) -> left + '&' + right)
+        .orElse("-");
+  }
+
+  private Optional<CachedResponse> deserialize(String serialized) {
+    try {
+      return Optional.of(objectMapper.readValue(serialized, CachedResponse.class));
+    } catch (Exception ex) {
+      LOGGER.warn("Failed to deserialize cached response", ex);
+      return Optional.empty();
+    }
+  }
+
+  public record CachedResponse(@JsonProperty("status") int status,
+                               @JsonProperty("headers") HttpHeaders headers,
+                               @JsonProperty("body") byte[] body) {
+    @JsonCreator
+    public CachedResponse {
+      Objects.requireNonNull(headers, "headers");
+      Objects.requireNonNull(body, "body");
+    }
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/transformation/TransformationRuleCache.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/transformation/TransformationRuleCache.java
@@ -1,0 +1,87 @@
+package com.ejada.gateway.transformation;
+
+import com.ejada.gateway.config.GatewayTransformationProperties;
+import com.ejada.gateway.config.GatewayTransformationProperties.RequestTransformations;
+import com.ejada.gateway.config.GatewayTransformationProperties.RouteTransformation;
+import com.ejada.gateway.config.GatewayTransformationProperties.RequestRule;
+import com.ejada.gateway.config.GatewayTransformationProperties.RequestOperation;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Maintains a cached view of compiled JSONPath expressions for request transformation rules.
+ */
+public class TransformationRuleCache {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TransformationRuleCache.class);
+
+  private final GatewayTransformationProperties properties;
+
+  private final ConcurrentMap<String, CachedRequestRules> requestRuleCache = new ConcurrentHashMap<>();
+
+  private volatile long requestVersion = -1L;
+
+  public TransformationRuleCache(GatewayTransformationProperties properties) {
+    this.properties = Objects.requireNonNull(properties, "properties");
+  }
+
+  public List<CompiledRequestRule> resolveRequestRules(String routeId) {
+    if (routeId == null) {
+      return Collections.emptyList();
+    }
+
+    RequestTransformations request = properties.getRequest();
+    long version = request.getVersion();
+
+    if (version != requestVersion) {
+      requestRuleCache.clear();
+      requestVersion = version;
+    }
+
+    CachedRequestRules cached = requestRuleCache.compute(routeId, (key, existing) -> {
+      if (existing != null && existing.version == version) {
+        return existing;
+      }
+      RouteTransformation routeTransformation = request.findRoute(routeId);
+      if (routeTransformation == null || routeTransformation.getRules().isEmpty()) {
+        return new CachedRequestRules(version, Collections.emptyList());
+      }
+      List<CompiledRequestRule> compiled = routeTransformation.getRules().stream()
+          .map(this::compileRule)
+          .filter(Objects::nonNull)
+          .toList();
+      return new CachedRequestRules(version, compiled);
+    });
+
+    return cached.rules;
+  }
+
+  private CompiledRequestRule compileRule(RequestRule rule) {
+    try {
+      JsonPath path = JsonPath.using(BASE_CONFIGURATION).compile(rule.getJsonPath());
+      JsonPath target = null;
+      if (rule.getOperation() == RequestOperation.RENAME && rule.getTargetPath() != null) {
+        target = JsonPath.using(BASE_CONFIGURATION).compile(rule.getTargetPath());
+      }
+      return new CompiledRequestRule(rule, path, target);
+    } catch (Exception ex) {
+      LOGGER.warn("Failed to compile JSONPath expression {}", rule.getJsonPath(), ex);
+      return null;
+    }
+  }
+
+  private record CachedRequestRules(long version, List<CompiledRequestRule> rules) {
+  }
+}
+
+  private static final Configuration BASE_CONFIGURATION = Configuration.defaultConfiguration()
+      .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL, Option.SUPPRESS_EXCEPTIONS, Option.CREATE_PATH);
+


### PR DESCRIPTION
## Summary
- add transformation properties and configuration beans to wire request/response/header rules and caching support
- implement request body filter for JSONPath manipulations, header updates, and per-route body size enforcement
- wrap responses in BaseResponse envelopes, apply header rules, and integrate Redis-backed caching with metrics tracking

## Testing
- `mvn -pl api-gateway test` *(fails: missing internal artifacts such as com.ejada:starter-core:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e115b6831c832f8473c395689f3198