### PR TITLE
Add advanced gateway patterns including aggregation and GraphQL proxy

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -121,6 +121,12 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <version>2.35.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayAggregationProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayAggregationProperties.java
@@ -1,0 +1,229 @@
+package com.ejada.gateway.config;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration for request aggregation (backend-for-frontend) routes. Each aggregation route is
+ * keyed by the logical gateway route identifier and lists downstream requests that should be
+ * fan-out/fan-in to compose the response returned to the client.
+ */
+@ConfigurationProperties(prefix = "gateway.aggregation")
+public class GatewayAggregationProperties {
+
+  private boolean enabled = false;
+
+  private Map<String, AggregationRoute> routes = new LinkedHashMap<>();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Map<String, AggregationRoute> getRoutes() {
+    return routes;
+  }
+
+  public void setRoutes(Map<String, AggregationRoute> routes) {
+    this.routes = (routes == null) ? new LinkedHashMap<>() : new LinkedHashMap<>(routes);
+  }
+
+  public Optional<AggregationRoute> findRoute(String id) {
+    if (!StringUtils.hasText(id)) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(routes.get(id.trim()));
+  }
+
+  /**
+   * Aggregation route definition containing downstream calls to execute.
+   */
+  public static class AggregationRoute {
+
+    private Duration timeout = Duration.ofSeconds(10);
+
+    private List<UpstreamRequest> upstreamRequests = new ArrayList<>();
+
+    private boolean includeErrorDetails = false;
+
+    public Duration getTimeout() {
+      return timeout;
+    }
+
+    public void setTimeout(Duration timeout) {
+      if (timeout == null || timeout.isNegative() || timeout.isZero()) {
+        return;
+      }
+      this.timeout = timeout;
+    }
+
+    public List<UpstreamRequest> getUpstreamRequests() {
+      return upstreamRequests;
+    }
+
+    public void setUpstreamRequests(List<UpstreamRequest> upstreamRequests) {
+      this.upstreamRequests = (upstreamRequests == null)
+          ? new ArrayList<>()
+          : new ArrayList<>(upstreamRequests);
+    }
+
+    public boolean isIncludeErrorDetails() {
+      return includeErrorDetails;
+    }
+
+    public void setIncludeErrorDetails(boolean includeErrorDetails) {
+      this.includeErrorDetails = includeErrorDetails;
+    }
+
+    public void validate(String routeId) {
+      Objects.requireNonNull(routeId, "routeId");
+      if (upstreamRequests.isEmpty()) {
+        throw new IllegalStateException("gateway.aggregation.routes." + routeId
+            + ".upstream-requests must contain at least one entry");
+      }
+      for (int i = 0; i < upstreamRequests.size(); i++) {
+        upstreamRequests.get(i).validate(routeId, i);
+      }
+    }
+  }
+
+  /**
+   * Downstream request definition executed as part of an aggregation route.
+   */
+  public static class UpstreamRequest {
+
+    private String id;
+
+    private URI uri;
+
+    private String uriTemplate;
+
+    private HttpMethod method = HttpMethod.GET;
+
+    private Duration timeout;
+
+    private Map<String, String> headers = new LinkedHashMap<>();
+
+    private String circuitBreakerName;
+
+    private boolean optional = false;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = StringUtils.hasText(id) ? id.trim() : null;
+    }
+
+    public URI getUri() {
+      return uri;
+    }
+
+    public void setUri(URI uri) {
+      this.uri = uri;
+      this.uriTemplate = (uri == null) ? null : uri.toString();
+    }
+
+    public void setUri(String value) {
+      if (!StringUtils.hasText(value)) {
+        this.uri = null;
+        this.uriTemplate = null;
+        return;
+      }
+      String trimmed = value.trim();
+      this.uriTemplate = trimmed;
+      if (trimmed.contains("{") || trimmed.contains("}")) {
+        this.uri = null;
+      } else {
+        this.uri = URI.create(trimmed);
+      }
+    }
+
+    public String getUriTemplate() {
+      return uriTemplate;
+    }
+
+    public HttpMethod getMethod() {
+      return method;
+    }
+
+    public void setMethod(HttpMethod method) {
+      this.method = (method == null) ? HttpMethod.GET : method;
+    }
+
+    public void setMethod(String method) {
+      if (!StringUtils.hasText(method)) {
+        this.method = HttpMethod.GET;
+        return;
+      }
+      this.method = HttpMethod.valueOf(method.trim().toUpperCase(Locale.ROOT));
+    }
+
+    public Duration getTimeout() {
+      return timeout;
+    }
+
+    public void setTimeout(Duration timeout) {
+      this.timeout = timeout;
+    }
+
+    public Map<String, String> getHeaders() {
+      return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+      this.headers = (headers == null) ? new LinkedHashMap<>() : new LinkedHashMap<>(headers);
+    }
+
+    public String getCircuitBreakerName() {
+      return circuitBreakerName;
+    }
+
+    public void setCircuitBreakerName(String circuitBreakerName) {
+      this.circuitBreakerName = StringUtils.hasText(circuitBreakerName)
+          ? circuitBreakerName.trim()
+          : null;
+    }
+
+    public boolean isOptional() {
+      return optional;
+    }
+
+    public void setOptional(boolean optional) {
+      this.optional = optional;
+    }
+
+    public Duration resolveTimeout(Duration defaultTimeout) {
+      if (timeout == null || timeout.isNegative() || timeout.isZero()) {
+        return defaultTimeout;
+      }
+      return timeout;
+    }
+
+    void validate(String routeId, int index) {
+      if (!StringUtils.hasText(id)) {
+        throw new IllegalStateException("gateway.aggregation.routes." + routeId
+            + ".upstream-requests[" + index + "].id must be provided");
+      }
+      if (!StringUtils.hasText(uriTemplate) && uri == null) {
+        throw new IllegalStateException("gateway.aggregation.routes." + routeId
+            + ".upstream-requests[" + index + "].uri must be provided");
+      }
+    }
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayFanoutProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayFanoutProperties.java
@@ -1,0 +1,143 @@
+package com.ejada.gateway.config;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration for fan-out (request splitting) behaviour. Fan-out routes trigger asynchronous
+ * notifications to secondary services without impacting the primary request flow.
+ */
+@ConfigurationProperties(prefix = "gateway.fanout")
+public class GatewayFanoutProperties {
+
+  private boolean enabled = false;
+
+  private Map<String, FanoutRoute> routes = new LinkedHashMap<>();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Map<String, FanoutRoute> getRoutes() {
+    return routes;
+  }
+
+  public void setRoutes(Map<String, FanoutRoute> routes) {
+    this.routes = (routes == null) ? new LinkedHashMap<>() : new LinkedHashMap<>(routes);
+  }
+
+  public Optional<FanoutRoute> findRoute(String id) {
+    if (!StringUtils.hasText(id)) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(routes.get(id.trim()));
+  }
+
+  /** Route definition describing the fan-out targets for a specific gateway route. */
+  public static class FanoutRoute {
+
+    private List<Target> targets = new ArrayList<>();
+
+    public List<Target> getTargets() {
+      return targets;
+    }
+
+    public void setTargets(List<Target> targets) {
+      this.targets = (targets == null) ? new ArrayList<>() : new ArrayList<>(targets);
+    }
+
+    public void validate(String routeId) {
+      if (targets.isEmpty()) {
+        throw new IllegalStateException("gateway.fanout.routes." + routeId
+            + ".targets must contain at least one entry");
+      }
+      for (int i = 0; i < targets.size(); i++) {
+        targets.get(i).validate(routeId, i);
+      }
+    }
+  }
+
+  /** Target service invoked asynchronously as part of a fan-out route. */
+  public static class Target {
+
+    private String id;
+
+    private URI uri;
+
+    private HttpMethod method = HttpMethod.POST;
+
+    private Map<String, String> headers = new LinkedHashMap<>();
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = StringUtils.hasText(id) ? id.trim() : null;
+    }
+
+    public URI getUri() {
+      return uri;
+    }
+
+    public void setUri(URI uri) {
+      this.uri = uri;
+    }
+
+    public void setUri(String value) {
+      if (!StringUtils.hasText(value)) {
+        this.uri = null;
+        return;
+      }
+      this.uri = URI.create(value.trim());
+    }
+
+    public HttpMethod getMethod() {
+      return method;
+    }
+
+    public void setMethod(HttpMethod method) {
+      this.method = (method == null) ? HttpMethod.POST : method;
+    }
+
+    public void setMethod(String method) {
+      if (!StringUtils.hasText(method)) {
+        this.method = HttpMethod.POST;
+        return;
+      }
+      this.method = HttpMethod.valueOf(method.trim().toUpperCase(Locale.ROOT));
+    }
+
+    public Map<String, String> getHeaders() {
+      return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+      this.headers = (headers == null) ? new LinkedHashMap<>() : new LinkedHashMap<>(headers);
+    }
+
+    void validate(String routeId, int index) {
+      if (!StringUtils.hasText(id)) {
+        throw new IllegalStateException("gateway.fanout.routes." + routeId
+            + ".targets[" + index + "].id must be provided");
+      }
+      if (uri == null) {
+        throw new IllegalStateException("gateway.fanout.routes." + routeId
+            + ".targets[" + index + "].uri must be provided");
+      }
+    }
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayGraphqlProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayGraphqlProperties.java
@@ -1,0 +1,85 @@
+package com.ejada.gateway.config;
+
+import java.net.URI;
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/** Configuration for the GraphQL proxy endpoint exposed by the gateway. */
+@ConfigurationProperties(prefix = "gateway.graphql")
+public class GatewayGraphqlProperties {
+
+  private boolean enabled = false;
+
+  private URI upstreamUri;
+
+  private Duration timeout = Duration.ofSeconds(10);
+
+  private int maxDepth = 10;
+
+  private int maxBreadth = 50;
+
+  private int maxComplexity = 200;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public URI getUpstreamUri() {
+    return upstreamUri;
+  }
+
+  public void setUpstreamUri(URI upstreamUri) {
+    this.upstreamUri = upstreamUri;
+  }
+
+  public void setUpstreamUri(String upstreamUri) {
+    this.upstreamUri = StringUtils.hasText(upstreamUri) ? URI.create(upstreamUri.trim()) : null;
+  }
+
+  public Duration getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(Duration timeout) {
+    if (timeout == null || timeout.isNegative() || timeout.isZero()) {
+      return;
+    }
+    this.timeout = timeout;
+  }
+
+  public int getMaxDepth() {
+    return maxDepth;
+  }
+
+  public void setMaxDepth(int maxDepth) {
+    if (maxDepth > 0) {
+      this.maxDepth = maxDepth;
+    }
+  }
+
+  public int getMaxBreadth() {
+    return maxBreadth;
+  }
+
+  public void setMaxBreadth(int maxBreadth) {
+    if (maxBreadth > 0) {
+      this.maxBreadth = maxBreadth;
+    }
+  }
+
+  public int getMaxComplexity() {
+    return maxComplexity;
+  }
+
+  public void setMaxComplexity(int maxComplexity) {
+    if (maxComplexity > 0) {
+      this.maxComplexity = maxComplexity;
+    }
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayServiceMeshProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayServiceMeshProperties.java
@@ -1,0 +1,132 @@
+package com.ejada.gateway.config;
+
+import java.nio.file.Path;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Declarative configuration for integrating the gateway with a service mesh such as Istio or
+ * Linkerd. The configuration controls propagation of tracing headers and optional mTLS client
+ * authentication for downstream calls.
+ */
+@ConfigurationProperties(prefix = "gateway.service-mesh")
+public class GatewayServiceMeshProperties {
+
+  public enum MeshType {
+    ISTIO,
+    LINKERD
+  }
+
+  private boolean enabled = false;
+
+  private MeshType type = MeshType.ISTIO;
+
+  private Mtls mtls = new Mtls();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public MeshType getType() {
+    return type;
+  }
+
+  public void setType(MeshType type) {
+    this.type = (type == null) ? MeshType.ISTIO : type;
+  }
+
+  public void setType(String type) {
+    if (!StringUtils.hasText(type)) {
+      this.type = MeshType.ISTIO;
+      return;
+    }
+    this.type = MeshType.valueOf(type.trim().toUpperCase());
+  }
+
+  public Mtls getMtls() {
+    return mtls;
+  }
+
+  public void setMtls(Mtls mtls) {
+    this.mtls = (mtls == null) ? new Mtls() : mtls;
+  }
+
+  /** mTLS settings for downstream calls. */
+  public static class Mtls {
+
+    private boolean enabled = false;
+
+    private Path keyStore;
+
+    private char[] keyStorePassword;
+
+    private Path trustStore;
+
+    private char[] trustStorePassword;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public Path getKeyStore() {
+      return keyStore;
+    }
+
+    public void setKeyStore(Path keyStore) {
+      this.keyStore = keyStore;
+    }
+
+    public void setKeyStore(String keyStore) {
+      this.keyStore = StringUtils.hasText(keyStore) ? Path.of(keyStore.trim()) : null;
+    }
+
+    public char[] getKeyStorePassword() {
+      return keyStorePassword;
+    }
+
+    public void setKeyStorePassword(char[] keyStorePassword) {
+      this.keyStorePassword = keyStorePassword;
+    }
+
+    public void setKeyStorePassword(String keyStorePassword) {
+      this.keyStorePassword = StringUtils.hasText(keyStorePassword)
+          ? keyStorePassword.toCharArray()
+          : null;
+    }
+
+    public Path getTrustStore() {
+      return trustStore;
+    }
+
+    public void setTrustStore(Path trustStore) {
+      this.trustStore = trustStore;
+    }
+
+    public void setTrustStore(String trustStore) {
+      this.trustStore = StringUtils.hasText(trustStore) ? Path.of(trustStore.trim()) : null;
+    }
+
+    public char[] getTrustStorePassword() {
+      return trustStorePassword;
+    }
+
+    public void setTrustStorePassword(char[] trustStorePassword) {
+      this.trustStorePassword = trustStorePassword;
+    }
+
+    public void setTrustStorePassword(String trustStorePassword) {
+      this.trustStorePassword = StringUtils.hasText(trustStorePassword)
+          ? trustStorePassword.toCharArray()
+          : null;
+    }
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayWebsocketProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayWebsocketProperties.java
@@ -1,0 +1,128 @@
+package com.ejada.gateway.config;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration for WebSocket proxy routes. These routes are handled separately from standard HTTP
+ * routes so we can enforce tenant-aware connection limits.
+ */
+@ConfigurationProperties(prefix = "gateway.websocket")
+public class GatewayWebsocketProperties {
+
+  private boolean enabled = false;
+
+  private int maxConnectionsPerTenant = 100;
+
+  private Map<String, WebsocketRoute> routes = new LinkedHashMap<>();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public int getMaxConnectionsPerTenant() {
+    return maxConnectionsPerTenant;
+  }
+
+  public void setMaxConnectionsPerTenant(int maxConnectionsPerTenant) {
+    if (maxConnectionsPerTenant > 0) {
+      this.maxConnectionsPerTenant = maxConnectionsPerTenant;
+    }
+  }
+
+  public Map<String, WebsocketRoute> getRoutes() {
+    return routes;
+  }
+
+  public void setRoutes(Map<String, WebsocketRoute> routes) {
+    this.routes = (routes == null) ? new LinkedHashMap<>() : new LinkedHashMap<>(routes);
+  }
+
+  public Optional<WebsocketRoute> findRoute(String id) {
+    if (!StringUtils.hasText(id)) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(routes.get(id.trim()));
+  }
+
+  /** WebSocket route definition. */
+  public static class WebsocketRoute {
+
+    private String id;
+
+    private URI uri;
+
+    private List<String> paths = new ArrayList<>();
+
+    private HttpMethod method = HttpMethod.GET;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = StringUtils.hasText(id) ? id.trim() : null;
+    }
+
+    public URI getUri() {
+      return uri;
+    }
+
+    public void setUri(URI uri) {
+      this.uri = uri;
+    }
+
+    public void setUri(String value) {
+      this.uri = StringUtils.hasText(value) ? URI.create(value.trim()) : null;
+    }
+
+    public List<String> getPaths() {
+      return paths;
+    }
+
+    public void setPaths(List<String> paths) {
+      this.paths = (paths == null) ? new ArrayList<>() : new ArrayList<>(paths);
+    }
+
+    public HttpMethod getMethod() {
+      return method;
+    }
+
+    public void setMethod(HttpMethod method) {
+      this.method = (method == null) ? HttpMethod.GET : method;
+    }
+
+    public void setMethod(String method) {
+      if (!StringUtils.hasText(method)) {
+        this.method = HttpMethod.GET;
+        return;
+      }
+      this.method = HttpMethod.valueOf(method.trim().toUpperCase(Locale.ROOT));
+    }
+
+    public void validate(String key) {
+      if (!StringUtils.hasText(id)) {
+        throw new IllegalStateException("gateway.websocket.routes." + key + ".id must be provided");
+      }
+      if (uri == null) {
+        throw new IllegalStateException("gateway.websocket.routes." + key + ".uri must be provided");
+      }
+      if (paths.isEmpty()) {
+        throw new IllegalStateException("gateway.websocket.routes." + key + ".paths must not be empty");
+      }
+    }
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GraphqlGatewayConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GraphqlGatewayConfiguration.java
@@ -1,0 +1,11 @@
+package com.ejada.gateway.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/** Registers configuration properties for the GraphQL gateway features. */
+@Configuration
+@EnableConfigurationProperties(GatewayGraphqlProperties.class)
+public class GraphqlGatewayConfiguration {
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/WebClientConfig.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/WebClientConfig.java
@@ -6,14 +6,21 @@ import io.netty.channel.ChannelOption;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ClientRequest;
@@ -22,6 +29,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.transport.logging.AdvancedByteBufFormat;
+import java.security.KeyStore;
 
 /**
  * Central {@link WebClient} configuration with sensible defaults for
@@ -29,11 +37,12 @@ import reactor.netty.transport.logging.AdvancedByteBufFormat;
  * {@code lb://} scheme resolve via Spring Cloud LoadBalancer/Eureka.
  */
 @Configuration
-@EnableConfigurationProperties(GatewayWebClientProperties.class)
+@EnableConfigurationProperties({GatewayWebClientProperties.class, GatewayServiceMeshProperties.class})
 public class WebClientConfig {
 
   @Bean
-  public ClientHttpConnector gatewayClientHttpConnector(GatewayWebClientProperties properties) {
+  public ClientHttpConnector gatewayClientHttpConnector(GatewayWebClientProperties properties,
+      GatewayServiceMeshProperties serviceMeshProperties) {
     HttpClient httpClient = HttpClient.create();
     Duration connectTimeout = properties.getConnectTimeout();
     if (connectTimeout != null) {
@@ -60,6 +69,15 @@ public class WebClientConfig {
     if (properties.isWiretap()) {
       httpClient = httpClient.wiretap("gateway-webclient", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL);
     }
+    if (serviceMeshProperties != null && serviceMeshProperties.isEnabled()
+        && serviceMeshProperties.getMtls().isEnabled()) {
+      try {
+        SslContext sslContext = buildSslContext(serviceMeshProperties.getMtls());
+        httpClient = httpClient.secure(spec -> spec.sslContext(sslContext));
+      } catch (Exception ex) {
+        throw new IllegalStateException("Failed to configure gateway mTLS", ex);
+      }
+    }
     return new ReactorClientHttpConnector(httpClient);
   }
 
@@ -84,6 +102,7 @@ public class WebClientConfig {
       propagate(contextView, builder, GatewayRequestAttributes.TENANT_ID, HeaderNames.X_TENANT_ID);
       propagate(contextView, builder, HeaderNames.USER_ID, HeaderNames.USER_ID);
       propagate(contextView, builder, GatewayRequestAttributes.API_VERSION, HeaderNames.API_VERSION);
+      propagateTraceHeaders(contextView, builder);
       return next.exchange(builder.build());
     });
   }
@@ -106,6 +125,56 @@ public class WebClientConfig {
         httpHeaders.add(headerName, text);
       }
     });
+  }
+
+  private void propagateTraceHeaders(reactor.util.context.ContextView contextView, ClientRequest.Builder builder) {
+    if (!contextView.hasKey(GatewayRequestAttributes.TRACE_HEADERS)) {
+      return;
+    }
+    Object value = contextView.get(GatewayRequestAttributes.TRACE_HEADERS);
+    if (!(value instanceof Map<?, ?> map)) {
+      return;
+    }
+    map.forEach((key, headerValue) -> {
+      if (key == null || headerValue == null) {
+        return;
+      }
+      String name = Objects.toString(key, null);
+      String text = Objects.toString(headerValue, null);
+      if (name == null || name.isBlank() || text == null || text.isBlank()) {
+        return;
+      }
+      builder.headers(httpHeaders -> {
+        if (!httpHeaders.containsKey(name)) {
+          httpHeaders.add(name, text);
+        }
+      });
+    });
+  }
+
+  private SslContext buildSslContext(GatewayServiceMeshProperties.Mtls mtls) throws Exception {
+    SslContextBuilder builder = SslContextBuilder.forClient();
+    if (mtls.getKeyStore() != null) {
+      KeyStore keyStore = loadKeyStore(mtls.getKeyStore(), mtls.getKeyStorePassword());
+      KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+      keyManagerFactory.init(keyStore, mtls.getKeyStorePassword());
+      builder.keyManager(keyManagerFactory);
+    }
+    if (mtls.getTrustStore() != null) {
+      KeyStore trustStore = loadKeyStore(mtls.getTrustStore(), mtls.getTrustStorePassword());
+      TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      trustManagerFactory.init(trustStore);
+      builder.trustManager(trustManagerFactory);
+    }
+    return builder.build();
+  }
+
+  private KeyStore loadKeyStore(java.nio.file.Path path, char[] password) throws Exception {
+    KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+    try (InputStream inputStream = Files.newInputStream(path)) {
+      keyStore.load(inputStream, password);
+    }
+    return keyStore;
   }
 }
 

--- a/api-gateway/src/main/java/com/ejada/gateway/context/GatewayRequestAttributes.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/GatewayRequestAttributes.java
@@ -20,6 +20,9 @@ public final class GatewayRequestAttributes {
   /** Attribute storing the resolved API version for versioned routes. */
   public static final String API_VERSION = GatewayRequestAttributes.class.getName() + ".apiVersion";
 
+  /** Attribute storing tracing headers to propagate to downstream services. */
+  public static final String TRACE_HEADERS = GatewayRequestAttributes.class.getName() + ".traceHeaders";
+
   private GatewayRequestAttributes() {
     // utility class
   }

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/AggregationGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/AggregationGatewayFilter.java
@@ -1,0 +1,286 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.gateway.config.GatewayAggregationProperties;
+import com.ejada.gateway.config.GatewayAggregationProperties.AggregationRoute;
+import com.ejada.gateway.config.GatewayAggregationProperties.UpstreamRequest;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.client.circuitbreaker.ReactiveCircuitBreaker;
+import org.springframework.cloud.client.circuitbreaker.ReactiveCircuitBreakerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.UriTemplate;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Gateway filter that aggregates multiple downstream calls in parallel and returns a combined JSON
+ * payload to the caller. Configured via {@link GatewayAggregationProperties} on a per-route basis.
+ */
+@Component
+public class AggregationGatewayFilter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AggregationGatewayFilter.class);
+
+  private static final String METRIC_DURATION = "gateway.aggregation.duration";
+  private static final String METRIC_OUTCOME = "gateway.aggregation.outcome";
+
+  private final GatewayAggregationProperties properties;
+  private final WebClient.Builder webClientBuilder;
+  private final ObjectMapper objectMapper;
+  private final ReactiveCircuitBreakerFactory<?, ?> circuitBreakerFactory;
+  private final MeterRegistry meterRegistry;
+
+  private final Map<String, AggregationRoute> validatedRoutes = new ConcurrentHashMap<>();
+
+  public AggregationGatewayFilter(GatewayAggregationProperties properties,
+      WebClient.Builder webClientBuilder,
+      ObjectMapper objectMapper,
+      ObjectProvider<ReactiveCircuitBreakerFactory<?, ?>> circuitBreakerFactoryProvider,
+      ObjectProvider<MeterRegistry> meterRegistryProvider) {
+    this.properties = Objects.requireNonNull(properties, "properties");
+    this.webClientBuilder = Objects.requireNonNull(webClientBuilder, "webClientBuilder");
+    this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    this.circuitBreakerFactory = circuitBreakerFactoryProvider.getIfAvailable();
+    this.meterRegistry = meterRegistryProvider.getIfAvailable();
+  }
+
+  public GatewayFilter apply(String routeId) {
+    return new RouteAggregationFilter(routeId);
+  }
+
+  private AggregationRoute resolveRouteConfig(String routeId) {
+    if (!properties.isEnabled()) {
+      return null;
+    }
+    AggregationRoute cached = validatedRoutes.get(routeId);
+    if (cached != null) {
+      return cached;
+    }
+    Optional<AggregationRoute> optional = properties.findRoute(routeId);
+    if (optional.isEmpty()) {
+      return null;
+    }
+    AggregationRoute route = optional.get();
+    route.validate(routeId);
+    validatedRoutes.put(routeId, route);
+    return route;
+  }
+
+  private class RouteAggregationFilter implements GatewayFilter {
+
+    private final String routeId;
+
+    RouteAggregationFilter(String routeId) {
+      this.routeId = routeId;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+      AggregationRoute routeConfig = resolveRouteConfig(routeId);
+      if (routeConfig == null) {
+        return chain.filter(exchange);
+      }
+
+      Timer.Sample sample = startTimer(routeId);
+
+      return Flux.fromIterable(routeConfig.getUpstreamRequests())
+          .flatMap(upstream -> executeRequest(routeId, routeConfig, upstream, exchange))
+          .collectList()
+          .flatMap(results -> renderResponse(exchange, routeConfig, results))
+          .doOnSuccess(unused -> recordOutcome(routeId, "success", sample))
+          .doOnError(ex -> recordOutcome(routeId, "error", sample))
+          .onErrorResume(ex -> handleFailure(exchange, ex));
+    }
+  }
+
+  private Mono<Void> renderResponse(ServerWebExchange exchange,
+      AggregationRoute routeConfig,
+      List<AggregationResult> results) {
+    ObjectNode root = objectMapper.createObjectNode();
+    ObjectNode data = objectMapper.createObjectNode();
+    ObjectNode errors = objectMapper.createObjectNode();
+
+    boolean hasErrors = false;
+    for (AggregationResult result : results) {
+      if (result.value() != null) {
+        data.set(result.id(), result.value());
+      } else {
+        hasErrors = true;
+        String message = routeConfig.isIncludeErrorDetails() && result.error() != null
+            ? sanitizeErrorMessage(result.error())
+            : "Unavailable";
+        errors.put(result.id(), message);
+      }
+    }
+
+    root.set("data", data);
+    if (hasErrors) {
+      root.set("errors", errors);
+    }
+
+    try {
+      byte[] payload = objectMapper.writeValueAsBytes(root);
+      exchange.getResponse().setStatusCode(HttpStatus.OK);
+      HttpHeaders headers = exchange.getResponse().getHeaders();
+      headers.setContentType(MediaType.APPLICATION_JSON);
+      DataBuffer buffer = exchange.getResponse().bufferFactory().wrap(payload);
+      return exchange.getResponse().writeWith(Mono.just(buffer));
+    } catch (Exception ex) {
+      return handleFailure(exchange, ex);
+    }
+  }
+
+  private Mono<Void> handleFailure(ServerWebExchange exchange, Throwable throwable) {
+    LOGGER.warn("Aggregation failed", throwable);
+    ObjectNode error = objectMapper.createObjectNode();
+    error.put("status", "ERROR");
+    error.put("message", "Aggregation failed");
+    if (LOGGER.isDebugEnabled()) {
+      error.put("details", sanitizeErrorMessage(throwable));
+    }
+    byte[] bytes = error.toString().getBytes(StandardCharsets.UTF_8);
+    exchange.getResponse().setStatusCode(HttpStatus.BAD_GATEWAY);
+    exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+    DataBuffer buffer = exchange.getResponse().bufferFactory().wrap(bytes);
+    return exchange.getResponse().writeWith(Mono.just(buffer));
+  }
+
+  private String sanitizeErrorMessage(Throwable throwable) {
+    String message = throwable.getMessage();
+    if (message == null) {
+      return throwable.getClass().getSimpleName();
+    }
+    return message.replaceAll("\n", " ").trim();
+  }
+
+  private Mono<AggregationResult> executeRequest(String routeId,
+      AggregationRoute routeConfig,
+      UpstreamRequest upstream,
+      ServerWebExchange exchange) {
+    Duration timeout = upstream.resolveTimeout(routeConfig.getTimeout());
+    String targetUri = resolveTargetUri(exchange, upstream);
+    WebClient.RequestBodySpec requestSpec = webClientBuilder.clone()
+        .build()
+        .method(upstream.getMethod())
+        .uri(targetUri);
+
+    if (!CollectionUtils.isEmpty(upstream.getHeaders())) {
+      requestSpec.headers(httpHeaders -> upstream.getHeaders().forEach(httpHeaders::add));
+    }
+
+    Mono<ClientResponse> responseMono = requestSpec.exchangeToMono(Mono::just);
+    if (circuitBreakerFactory != null && StringUtils.hasText(upstream.getCircuitBreakerName())) {
+      ReactiveCircuitBreaker circuitBreaker = circuitBreakerFactory.create(upstream.getCircuitBreakerName());
+      responseMono = Mono.defer(() -> circuitBreaker.run(responseMono, Mono::error));
+    }
+
+    return responseMono
+        .flatMap(clientResponse -> clientResponse.bodyToMono(JsonNode.class)
+            .timeout(timeout)
+            .map(body -> new AggregationResult(upstream.getId(), body, null)))
+        .timeout(timeout)
+        .onErrorResume(ex -> {
+          LOGGER.warn("Aggregation request {} for route {} failed: {}", upstream.getId(), routeId, ex.toString());
+          recordTargetFailure(routeId, upstream.getId());
+          if (upstream.isOptional()) {
+            return Mono.just(new AggregationResult(upstream.getId(), null, ex));
+          }
+          return Mono.just(new AggregationResult(upstream.getId(), null, ex));
+        });
+  }
+
+  private Timer.Sample startTimer(String routeId) {
+    if (meterRegistry == null) {
+      return null;
+    }
+    return Timer.start(meterRegistry);
+  }
+
+  private void recordOutcome(String routeId, String outcome, Timer.Sample sample) {
+    if (meterRegistry != null) {
+      Counter.builder(METRIC_OUTCOME)
+          .tag("route", routeId)
+          .tag("outcome", outcome)
+          .register(meterRegistry)
+          .increment();
+      if (sample != null) {
+        sample.stop(Timer.builder(METRIC_DURATION)
+            .tag("route", routeId)
+            .tag("outcome", outcome)
+            .register(meterRegistry));
+      }
+    }
+  }
+
+  private void recordTargetFailure(String routeId, String targetId) {
+    if (meterRegistry != null) {
+      Counter.builder("gateway.aggregation.target.failures")
+          .tag("route", routeId)
+          .tag("target", targetId)
+          .register(meterRegistry)
+          .increment();
+    }
+  }
+
+  private String resolveTargetUri(ServerWebExchange exchange, UpstreamRequest upstream) {
+    String template = upstream.getUriTemplate();
+    if (!StringUtils.hasText(template)) {
+      URI uri = upstream.getUri();
+      return (uri != null) ? uri.toString() : "";
+    }
+    Map<String, Object> variables = new HashMap<>();
+    Map<String, String> pathVariables = exchange.getAttributeOrDefault(
+        ServerWebExchangeUtils.URI_TEMPLATE_VARIABLES_ATTRIBUTE,
+        Collections.emptyMap());
+    variables.putAll(pathVariables);
+    exchange.getRequest().getQueryParams().forEach((key, values) -> {
+      if (!values.isEmpty() && !variables.containsKey(key)) {
+        variables.put(key, values.get(0));
+      }
+    });
+    Object tenant = exchange.getAttribute(GatewayRequestAttributes.TENANT_ID);
+    if (tenant != null && !variables.containsKey("tenantId")) {
+      variables.put("tenantId", tenant);
+    }
+    try {
+      return new UriTemplate(template).expand(variables).toString();
+    } catch (IllegalArgumentException ex) {
+      LOGGER.warn("Failed to expand aggregation URI template {}: {}", template, ex.toString());
+      return template;
+    }
+  }
+
+  private record AggregationResult(String id, JsonNode value, Throwable error) {
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/FanoutGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/FanoutGatewayFilter.java
@@ -1,0 +1,201 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.gateway.config.GatewayFanoutProperties;
+import com.ejada.gateway.config.GatewayFanoutProperties.FanoutRoute;
+import com.ejada.gateway.config.GatewayFanoutProperties.Target;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Gateway filter that performs asynchronous fan-out notifications for a configured route. The
+ * filter forwards the original request to one or more secondary services without impacting the
+ * primary request/response lifecycle.
+ */
+@Component
+public class FanoutGatewayFilter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FanoutGatewayFilter.class);
+
+  private final GatewayFanoutProperties properties;
+  private final WebClient.Builder webClientBuilder;
+  private final Map<String, FanoutRoute> validatedRoutes = new ConcurrentHashMap<>();
+
+  public FanoutGatewayFilter(GatewayFanoutProperties properties, WebClient.Builder webClientBuilder) {
+    this.properties = Objects.requireNonNull(properties, "properties");
+    this.webClientBuilder = Objects.requireNonNull(webClientBuilder, "webClientBuilder");
+  }
+
+  public GatewayFilter apply(String routeId) {
+    return new RouteFanoutFilter(routeId);
+  }
+
+  private FanoutRoute resolveRoute(String routeId) {
+    if (!properties.isEnabled()) {
+      return null;
+    }
+    FanoutRoute cached = validatedRoutes.get(routeId);
+    if (cached != null) {
+      return cached;
+    }
+    Optional<FanoutRoute> optional = properties.findRoute(routeId);
+    if (optional.isEmpty()) {
+      return null;
+    }
+    FanoutRoute route = optional.get();
+    route.validate(routeId);
+    validatedRoutes.put(routeId, route);
+    return route;
+  }
+
+  private class RouteFanoutFilter implements GatewayFilter {
+
+    private final String routeId;
+
+    RouteFanoutFilter(String routeId) {
+      this.routeId = routeId;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+      FanoutRoute route = resolveRoute(routeId);
+      if (route == null || route.getTargets().isEmpty()) {
+        return chain.filter(exchange);
+      }
+
+      return cacheBody(exchange)
+          .flatMap(body -> {
+            ServerWebExchange mutatedExchange = (body.length == 0)
+                ? exchange
+                : decorateExchange(exchange, body);
+            triggerFanout(mutatedExchange, routeId, route, body);
+            return chain.filter(mutatedExchange);
+          });
+    }
+  }
+
+  private Mono<byte[]> cacheBody(ServerWebExchange exchange) {
+    return DataBufferUtils.join(exchange.getRequest().getBody())
+        .map(dataBuffer -> {
+          byte[] bytes = new byte[dataBuffer.readableByteCount()];
+          dataBuffer.read(bytes);
+          DataBufferUtils.release(dataBuffer);
+          return bytes;
+        })
+        .defaultIfEmpty(new byte[0]);
+  }
+
+  private ServerWebExchange decorateExchange(ServerWebExchange exchange, byte[] body) {
+    ServerHttpRequest request = exchange.getRequest();
+    Flux<DataBuffer> cachedBody = Flux.defer(() -> {
+      DataBuffer buffer = exchange.getResponse().bufferFactory().wrap(body);
+      return Mono.just(buffer);
+    });
+
+    ServerHttpRequestDecorator decorated = new ServerHttpRequestDecorator(request) {
+      @Override
+      public Flux<DataBuffer> getBody() {
+        return cachedBody;
+      }
+
+      @Override
+      public HttpHeaders getHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.putAll(super.getHeaders());
+        headers.remove(HttpHeaders.CONTENT_LENGTH);
+        headers.setContentLength(body.length);
+        return headers;
+      }
+    };
+
+    return exchange.mutate().request(decorated).build();
+  }
+
+  private void triggerFanout(ServerWebExchange exchange,
+      String routeId,
+      FanoutRoute route,
+      byte[] body) {
+    Flux.fromIterable(route.getTargets())
+        .flatMap(target -> invokeTarget(exchange, routeId, target, body)
+            .onErrorResume(ex -> {
+              LOGGER.warn("Fan-out target {} for route {} failed: {}", target.getId(), routeId, ex.toString());
+              return Mono.empty();
+            }))
+        .subscribeOn(Schedulers.boundedElastic())
+        .subscribe();
+  }
+
+  private Mono<Void> invokeTarget(ServerWebExchange exchange,
+      String routeId,
+      Target target,
+      byte[] body) {
+    WebClient.RequestBodySpec spec = webClientBuilder.clone()
+        .build()
+        .method(target.getMethod())
+        .uri(target.getUri());
+
+    HttpHeaders originalHeaders = filteredHeaders(exchange.getRequest().getHeaders());
+    spec.headers(httpHeaders -> {
+      originalHeaders.forEach((name, values) -> values.forEach(value -> httpHeaders.add(name, value)));
+      if (!CollectionUtils.isEmpty(target.getHeaders())) {
+        target.getHeaders().forEach(httpHeaders::set);
+      }
+    });
+
+    boolean hasBody = body.length > 0 && allowsBody(target.getMethod());
+    if (hasBody) {
+      spec.body(BodyInserters.fromValue(body));
+    }
+
+    return spec.exchangeToMono(response -> response.releaseBody())
+        .timeout(Duration.ofSeconds(5))
+        .onErrorResume(ex -> {
+          LOGGER.warn("Fan-out invocation {} for route {} failed", target.getId(), routeId, ex);
+          return Mono.empty();
+        });
+  }
+
+  private HttpHeaders filteredHeaders(HttpHeaders source) {
+    HttpHeaders filtered = new HttpHeaders();
+    source.forEach((name, values) -> {
+      if (HttpHeaders.HOST.equalsIgnoreCase(name) || HttpHeaders.CONTENT_LENGTH.equalsIgnoreCase(name)) {
+        return;
+      }
+      filtered.put(name, new ArrayList<>(values));
+    });
+    return filtered;
+  }
+
+  private boolean allowsBody(HttpMethod method) {
+    if (method == null) {
+      return false;
+    }
+    return switch (method) {
+      case GET, HEAD, OPTIONS, TRACE -> false;
+      default -> true;
+    };
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/WebsocketConnectionLimiterFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/WebsocketConnectionLimiterFilter.java
@@ -1,0 +1,113 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.gateway.config.GatewayWebsocketProperties;
+import com.ejada.gateway.config.GatewayWebsocketProperties.WebsocketRoute;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Enforces per-tenant WebSocket connection limits and ensures tenant context is preserved for the
+ * lifetime of the WebSocket session.
+ */
+@Component
+public class WebsocketConnectionLimiterFilter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WebsocketConnectionLimiterFilter.class);
+
+  private final GatewayWebsocketProperties properties;
+  private final ConcurrentMap<String, WebsocketRoute> validatedRoutes = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, AtomicInteger> activeConnections = new ConcurrentHashMap<>();
+
+  public WebsocketConnectionLimiterFilter(GatewayWebsocketProperties properties) {
+    this.properties = Objects.requireNonNull(properties, "properties");
+  }
+
+  public GatewayFilter apply(String routeId) {
+    return new RouteLimiter(routeId);
+  }
+
+  private WebsocketRoute resolveRoute(String routeId) {
+    if (!properties.isEnabled()) {
+      return null;
+    }
+    WebsocketRoute cached = validatedRoutes.get(routeId);
+    if (cached != null) {
+      return cached;
+    }
+    Optional<WebsocketRoute> optional = properties.findRoute(routeId);
+    if (optional.isEmpty()) {
+      return null;
+    }
+    WebsocketRoute route = optional.get();
+    route.validate(routeId);
+    validatedRoutes.put(routeId, route);
+    return route;
+  }
+
+  private class RouteLimiter implements GatewayFilter {
+
+    private final String routeId;
+
+    RouteLimiter(String routeId) {
+      this.routeId = routeId;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+      WebsocketRoute route = resolveRoute(routeId);
+      if (route == null || !ServerWebExchangeUtils.isWebSocketUpgrade(exchange.getRequest())) {
+        return chain.filter(exchange);
+      }
+
+      String tenant = resolveTenant(exchange);
+      AtomicInteger counter = activeConnections.computeIfAbsent(tenant, key -> new AtomicInteger());
+      int current = counter.incrementAndGet();
+      if (current > properties.getMaxConnectionsPerTenant()) {
+        counter.decrementAndGet();
+        LOGGER.warn("Tenant {} exceeded WebSocket connection limit ({} > {})", tenant, current, properties.getMaxConnectionsPerTenant());
+        exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
+        return exchange.getResponse().setComplete();
+      }
+
+      exchange.getAttributes().put(GatewayRequestAttributes.TENANT_ID, tenant);
+
+      return chain.filter(exchange)
+          .doFinally(signalType -> {
+            int remaining = counter.decrementAndGet();
+            if (remaining <= 0) {
+              activeConnections.remove(tenant, counter);
+            }
+          });
+    }
+  }
+
+  private String resolveTenant(ServerWebExchange exchange) {
+    Object attribute = exchange.getAttribute(GatewayRequestAttributes.TENANT_ID);
+    if (attribute != null) {
+      String tenant = Objects.toString(attribute, null);
+      if (StringUtils.hasText(tenant)) {
+        return tenant;
+      }
+    }
+    String header = exchange.getRequest().getHeaders().getFirst("X-Tenant-Id");
+    if (StringUtils.hasText(header)) {
+      return header.trim();
+    }
+    return "anonymous";
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/graphql/GraphqlProxyController.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/graphql/GraphqlProxyController.java
@@ -1,0 +1,63 @@
+package com.ejada.gateway.graphql;
+
+import com.ejada.gateway.config.GatewayGraphqlProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+/** GraphQL proxy endpoint that performs lightweight query analysis before forwarding downstream. */
+@RestController
+@ConditionalOnProperty(prefix = "gateway.graphql", name = "enabled", havingValue = "true")
+public class GraphqlProxyController {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GraphqlProxyController.class);
+
+  private final GatewayGraphqlProperties properties;
+  private final GraphqlQueryAnalyzer analyzer;
+  private final WebClient webClient;
+
+  public GraphqlProxyController(GatewayGraphqlProperties properties,
+      GraphqlQueryAnalyzer analyzer,
+      WebClient.Builder webClientBuilder) {
+    this.properties = Objects.requireNonNull(properties, "properties");
+    this.analyzer = Objects.requireNonNull(analyzer, "analyzer");
+    if (properties.getUpstreamUri() == null) {
+      throw new IllegalStateException("gateway.graphql.upstream-uri must be configured when GraphQL is enabled");
+    }
+    this.webClient = webClientBuilder.clone().build();
+  }
+
+  @PostMapping(path = "/graphql", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  public Mono<ResponseEntity<JsonNode>> proxy(@RequestBody GraphqlRequest request) {
+    if (request == null || !StringUtils.hasText(request.query())) {
+      throw new ResponseStatusException(org.springframework.http.HttpStatus.BAD_REQUEST, "GraphQL query must be provided");
+    }
+
+    analyzer.assertWithinLimits(request.query(), properties);
+
+    return webClient.post()
+        .uri(properties.getUpstreamUri())
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .retrieve()
+        .toEntity(JsonNode.class)
+        .timeout(properties.getTimeout())
+        .doOnError(ex -> LOGGER.warn("GraphQL proxy failed: {}", ex.toString()));
+  }
+
+  public record GraphqlRequest(String query, String operationName, Map<String, Object> variables) {
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/graphql/GraphqlQueryAnalyzer.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/graphql/GraphqlQueryAnalyzer.java
@@ -1,0 +1,112 @@
+package com.ejada.gateway.graphql;
+
+import com.ejada.gateway.config.GatewayGraphqlProperties;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Performs a lightweight structural analysis of GraphQL queries to estimate depth, breadth and
+ * complexity. This avoids forwarding expensive queries to downstream services.
+ */
+@Component
+public class GraphqlQueryAnalyzer {
+
+  private static final Set<String> KEYWORDS = Set.of(
+      "query",
+      "mutation",
+      "subscription",
+      "fragment",
+      "on",
+      "true",
+      "false",
+      "null");
+
+  public Analysis analyze(String query) {
+    if (!StringUtils.hasText(query)) {
+      return new Analysis(0, 0, 0);
+    }
+
+    int depth = 0;
+    int maxDepth = 0;
+    Map<Integer, Integer> breadthPerLevel = new HashMap<>();
+    int complexity = 0;
+
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    char[] chars = query.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      char c = chars[i];
+      if (inString) {
+        if (c == stringDelimiter && (i == 0 || chars[i - 1] != '\\')) {
+          inString = false;
+        }
+        continue;
+      }
+      if (c == '\"' || c == '\'') {
+        inString = true;
+        stringDelimiter = c;
+        continue;
+      }
+      if (c == '#') {
+        while (i < chars.length && chars[i] != '\n') {
+          i++;
+        }
+        continue;
+      }
+      if (c == '{') {
+        depth++;
+        if (depth > maxDepth) {
+          maxDepth = depth;
+        }
+        breadthPerLevel.putIfAbsent(depth, 0);
+        continue;
+      }
+      if (c == '}') {
+        depth = Math.max(0, depth - 1);
+        continue;
+      }
+      if (Character.isLetter(c) || c == '_') {
+        int start = i;
+        while (i + 1 < chars.length && (Character.isLetterOrDigit(chars[i + 1]) || chars[i + 1] == '_')) {
+          i++;
+        }
+        String token = new String(chars, start, i - start + 1);
+        if (KEYWORDS.contains(token)) {
+          continue;
+        }
+        complexity++;
+        int level = Math.max(depth, 1);
+        breadthPerLevel.merge(level, 1, Integer::sum);
+      }
+    }
+
+    int breadth = breadthPerLevel.values().stream().mapToInt(Integer::intValue).max().orElse(0);
+    return new Analysis(maxDepth, breadth, complexity);
+  }
+
+  public void assertWithinLimits(String query, GatewayGraphqlProperties properties) {
+    Analysis analysis = analyze(query);
+    if (analysis.depth() > properties.getMaxDepth()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "GraphQL query depth exceeds limit of " + properties.getMaxDepth());
+    }
+    if (analysis.breadth() > properties.getMaxBreadth()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "GraphQL query breadth exceeds limit of " + properties.getMaxBreadth());
+    }
+    if (analysis.complexity() > properties.getMaxComplexity()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "GraphQL query complexity exceeds limit of " + properties.getMaxComplexity());
+    }
+  }
+
+  public record Analysis(int depth, int breadth, int complexity) {
+  }
+}
+

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -201,6 +201,53 @@ gateway:
       analytics-service-uri: lb://analytics-service
       billing-service-uri: lb://billing-service
       default-period: MONTHLY
+  aggregation:
+    enabled: true
+    routes:
+      tenant-dashboard:
+        timeout: 4s
+        upstream-requests:
+          - id: tenant
+            uri: lb://tenant-service/api/v1/tenants/{tenantId}
+            circuit-breaker-name: agg-tenant
+          - id: subscriptions
+            uri: lb://subscription-service/api/v1/subscriptions?tenantId={tenantId}
+            circuit-breaker-name: agg-subscriptions
+            timeout: 3s
+          - id: usage
+            uri: lb://analytics-service/api/v1/analytics/tenants/{tenantId}/usage-summary
+            optional: true
+  fanout:
+    enabled: true
+    routes:
+      subscription-service:
+        targets:
+          - id: audit-log
+            uri: lb://audit-service/internal/audit/events
+            method: POST
+            headers:
+              X-Audit-Event: subscription-change
+  service-mesh:
+    enabled: true
+    type: istio
+    mtls:
+      enabled: false
+  graphql:
+    enabled: true
+    upstream-uri: lb://graphql-service/graphql
+    timeout: 5s
+    max-depth: 12
+    max-breadth: 80
+    max-complexity: 400
+  websocket:
+    enabled: true
+    max-connections-per-tenant: 50
+    routes:
+      notification-stream:
+        id: notification-stream
+        uri: lb://notification-service
+        paths:
+          - /ws/notifications
   defaults:
     resilience:
       enabled: true
@@ -390,6 +437,12 @@ gateway:
         enabled: true
         circuit-breaker-name: policy-service
         fallback-uri: forward:/fallback/default
+    dashboard:
+      id: tenant-dashboard
+      uri: no://op
+      paths:
+        - /api/dashboard
+      strip-prefix: 0
   admin:
     aggregation:
       timeout: 3s

--- a/api-gateway/src/test/java/com/ejada/gateway/filter/AggregationGatewayFilterIntegrationTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/filter/AggregationGatewayFilterIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.ejada.gateway.filter;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AggregationGatewayFilterIntegrationTest {
+
+  private static final WireMockServer WIREMOCK = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @AfterAll
+  void stopWireMock() {
+    WIREMOCK.stop();
+  }
+
+  @DynamicPropertySource
+  static void gatewayProperties(DynamicPropertyRegistry registry) {
+    if (!WIREMOCK.isRunning()) {
+      WIREMOCK.start();
+    }
+    registry.add("shared.security.mode", () -> "hs256");
+    registry.add("shared.security.hs256.secret", () -> "aggregation-test-secret-0123456789");
+    registry.add("shared.security.resource-server.enabled", () -> "false");
+    registry.add("shared.ratelimit.enabled", () -> "false");
+    registry.add("gateway.subscription.enabled", () -> "false");
+
+    String base = "http://localhost:" + WIREMOCK.port();
+    registry.add("gateway.routes.dashboard.id", () -> "dashboard");
+    registry.add("gateway.routes.dashboard.uri", () -> "no://op");
+    registry.add("gateway.routes.dashboard.paths[0]", () -> "/api/dashboard");
+    registry.add("gateway.routes.dashboard.strip-prefix", () -> "0");
+
+    registry.add("gateway.aggregation.enabled", () -> "true");
+    registry.add("gateway.aggregation.routes.dashboard.timeout", () -> "PT4S");
+    registry.add("gateway.aggregation.routes.dashboard.upstream-requests[0].id", () -> "profile");
+    registry.add("gateway.aggregation.routes.dashboard.upstream-requests[0].uri", () -> base + "/tenant/{tenantId}");
+    registry.add("gateway.aggregation.routes.dashboard.upstream-requests[0].circuit-breaker-name", () -> "agg-profile");
+    registry.add("gateway.aggregation.routes.dashboard.upstream-requests[1].id", () -> "subscriptions");
+    registry.add("gateway.aggregation.routes.dashboard.upstream-requests[1].uri", () -> base + "/subscriptions?tenantId={tenantId}");
+    registry.add("gateway.aggregation.routes.dashboard.upstream-requests[1].timeout", () -> "PT3S");
+    registry.add("gateway.aggregation.routes.dashboard.upstream-requests[1].circuit-breaker-name", () -> "agg-subscriptions");
+    registry.add("gateway.aggregation.routes.dashboard.upstream-requests[2].id", () -> "usage");
+    registry.add("gateway.aggregation.routes.dashboard.upstream-requests[2].uri", () -> base + "/usage/{tenantId}");
+    registry.add("gateway.aggregation.routes.dashboard.upstream-requests[2].optional", () -> "true");
+  }
+
+  @Test
+  void aggregatesDownstreamResponsesAndCapturesFailures() {
+    stubFor(get(urlEqualTo("/tenant/tenant-1"))
+        .willReturn(okJson("{\"id\":\"tenant-1\",\"name\":\"Tenant One\"}")));
+    stubFor(get(urlEqualTo("/subscriptions?tenantId=tenant-1"))
+        .willReturn(okJson("[{\"id\":\"sub-1\"}]")));
+    stubFor(get(urlEqualTo("/usage/tenant-1"))
+        .willReturn(aResponse().withStatus(500)));
+
+    webTestClient.get()
+        .uri("/api/dashboard")
+        .header("X-Tenant-Id", "tenant-1")
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .jsonPath("$.data.profile.id").isEqualTo("tenant-1")
+        .jsonPath("$.data.subscriptions[0].id").isEqualTo("sub-1")
+        .jsonPath("$.errors.usage").isEqualTo("Unavailable");
+  }
+}
+

--- a/api-gateway/src/test/java/com/ejada/gateway/filter/FanoutGatewayFilterIntegrationTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/filter/FanoutGatewayFilterIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.ejada.gateway.filter;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.client.VerificationException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FanoutGatewayFilterIntegrationTest {
+
+  private static final WireMockServer WIREMOCK = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @AfterAll
+  void stopWireMock() {
+    WIREMOCK.stop();
+  }
+
+  @DynamicPropertySource
+  static void gatewayProperties(DynamicPropertyRegistry registry) {
+    if (!WIREMOCK.isRunning()) {
+      WIREMOCK.start();
+    }
+    registry.add("shared.security.mode", () -> "hs256");
+    registry.add("shared.security.hs256.secret", () -> "fanout-test-secret-0123456789");
+    registry.add("shared.security.resource-server.enabled", () -> "false");
+    registry.add("shared.ratelimit.enabled", () -> "false");
+    registry.add("gateway.subscription.enabled", () -> "false");
+
+    String base = "http://localhost:" + WIREMOCK.port();
+    registry.add("gateway.routes.primary.id", () -> "primary");
+    registry.add("gateway.routes.primary.uri", () -> base + "/primary");
+    registry.add("gateway.routes.primary.paths[0]", () -> "/api/primary");
+    registry.add("gateway.routes.primary.strip-prefix", () -> "0");
+
+    registry.add("gateway.fanout.enabled", () -> "true");
+    registry.add("gateway.fanout.routes.primary.targets[0].id", () -> "audit");
+    registry.add("gateway.fanout.routes.primary.targets[0].uri", () -> base + "/audit");
+    registry.add("gateway.fanout.routes.primary.targets[0].method", () -> "POST");
+    registry.add("gateway.fanout.routes.primary.targets[0].headers.X-Audit-Event", () -> "primary-change");
+  }
+
+  @Test
+  void fanoutDoesNotBlockPrimaryResponse() throws Exception {
+    stubFor(post(urlEqualTo("/primary"))
+        .willReturn(aResponse().withStatus(202)));
+    stubFor(post(urlEqualTo("/audit"))
+        .willReturn(aResponse().withStatus(204)));
+
+    webTestClient.post()
+        .uri("/api/primary")
+        .header("X-Tenant-Id", "tenant-1")
+        .bodyValue("{\"event\":\"test\"}")
+        .exchange()
+        .expectStatus().isAccepted();
+
+    // fan-out happens asynchronously, so poll for verification
+    int attempts = 0;
+    VerificationException last = null;
+    while (attempts++ < 10) {
+      try {
+        verify(postRequestedFor(urlEqualTo("/audit")));
+        last = null;
+        break;
+      } catch (VerificationException ex) {
+        last = ex;
+        Thread.sleep(100);
+      }
+    }
+    if (last != null) {
+      throw last;
+    }
+
+    verify(postRequestedFor(urlEqualTo("/primary")));
+  }
+}
+

--- a/api-gateway/src/test/java/com/ejada/gateway/graphql/GraphqlProxyControllerIntegrationTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/graphql/GraphqlProxyControllerIntegrationTest.java
@@ -1,0 +1,85 @@
+package com.ejada.gateway.graphql;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GraphqlProxyControllerIntegrationTest {
+
+  private static final WireMockServer WIREMOCK = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @AfterAll
+  void stopWireMock() {
+    WIREMOCK.stop();
+  }
+
+  @DynamicPropertySource
+  static void graphqlProperties(DynamicPropertyRegistry registry) {
+    if (!WIREMOCK.isRunning()) {
+      WIREMOCK.start();
+    }
+    registry.add("shared.security.mode", () -> "hs256");
+    registry.add("shared.security.hs256.secret", () -> "graphql-test-secret-0123456789");
+    registry.add("shared.security.resource-server.enabled", () -> "false");
+    registry.add("shared.ratelimit.enabled", () -> "false");
+    registry.add("gateway.subscription.enabled", () -> "false");
+
+    String base = "http://localhost:" + WIREMOCK.port();
+    registry.add("gateway.graphql.enabled", () -> "true");
+    registry.add("gateway.graphql.upstream-uri", () -> base + "/graphql");
+    registry.add("gateway.graphql.timeout", () -> "PT3S");
+    registry.add("gateway.graphql.max-depth", () -> "8");
+    registry.add("gateway.graphql.max-breadth", () -> "20");
+    registry.add("gateway.graphql.max-complexity", () -> "3");
+  }
+
+  @Test
+  void proxiesGraphqlRequestsWithAnalysis() {
+    stubFor(post(urlEqualTo("/graphql"))
+        .willReturn(aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody("{\"data\":{\"me\":{\"id\":\"123\"}}}")));
+
+    webTestClient.post()
+        .uri("/graphql")
+        .bodyValue(Map.of("query", "query { me { id } }"))
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .jsonPath("$.data.me.id").isEqualTo("123");
+
+    verify(postRequestedFor(urlEqualTo("/graphql")));
+  }
+
+  @Test
+  void rejectsQueriesExceedingComplexity() {
+    webTestClient.post()
+        .uri("/graphql")
+        .bodyValue(Map.of("query", "query { a { b { c { d } } } }"))
+        .exchange()
+        .expectStatus().isBadRequest();
+  }
+}
+


### PR DESCRIPTION
## Summary
- add configuration properties for aggregation, fan-out, service mesh, GraphQL, and WebSocket features and register them with the gateway
- implement aggregation, fan-out, and WebSocket limiter filters plus a GraphQL proxy controller with query analysis
- enhance the shared WebClient for mesh tracing/mTLS and cover the new behaviours with WireMock-based integration tests

## Testing
- `mvn -pl api-gateway test` *(fails: required com.ejada starter dependencies are unavailable from Maven Central in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e115c1b1a4832fa74f4143264a888c