### PR TITLE
Enhance configuration management and validation

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -39,6 +39,15 @@
       <artifactId>spring-boot-starter-aop</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.ulisesbocchio</groupId>
+      <artifactId>jasypt-spring-boot-starter</artifactId>
+    </dependency>
+
     <!-- Shared starters & libraries -->
     <dependency>
       <groupId>com.ejada</groupId>

--- a/api-gateway/src/main/java/com/ejada/gateway/config/AdminAggregationProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/AdminAggregationProperties.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.util.StringUtils;
 
 /**
@@ -15,6 +17,8 @@ import org.springframework.util.StringUtils;
  * describe which downstream services should be queried for health/status information and how long
  * the gateway should wait for those calls before falling back to graceful degradation.
  */
+@RefreshScope
+@Validated
 @ConfigurationProperties(prefix = "gateway.admin")
 public class AdminAggregationProperties {
 

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayBffProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayBffProperties.java
@@ -1,6 +1,8 @@
 package com.ejada.gateway.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.util.StringUtils;
 
 /**
@@ -9,6 +11,8 @@ import org.springframework.util.StringUtils;
  * recompiling the gateway which is useful across environments (local, CI,
  * production).
  */
+@RefreshScope
+@Validated
 @ConfigurationProperties(prefix = "gateway.bff")
 public class GatewayBffProperties {
 

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.BooleanSpec;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
@@ -33,6 +34,7 @@ public class GatewayRoutesConfiguration {
   private static final Duration PROVIDER_TIMEOUT = Duration.ofSeconds(5);
 
   @Bean
+  @RefreshScope
   RouteLocator gatewayRoutes(RouteLocatorBuilder builder,
       GatewayRoutesProperties properties,
       ObjectProvider<GatewayRouteDefinitionProvider> dynamicProviders) {

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
@@ -15,10 +15,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * Configuration properties describing the downstream services that should be
@@ -26,6 +28,8 @@ import org.springframework.util.StringUtils;
  * documented plan so operators can declaratively manage routes per
  * environment.
  */
+@RefreshScope
+@Validated
 @ConfigurationProperties(prefix = "gateway")
 public class GatewayRoutesProperties {
 

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayWebClientProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayWebClientProperties.java
@@ -2,10 +2,14 @@ package com.ejada.gateway.config;
 
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * Tunable properties for the gateway {@link org.springframework.web.reactive.function.client.WebClient}.
  */
+@RefreshScope
+@Validated
 @ConfigurationProperties(prefix = "gateway.webclient")
 public class GatewayWebClientProperties {
 

--- a/api-gateway/src/main/java/com/ejada/gateway/config/SubscriptionValidationProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/SubscriptionValidationProperties.java
@@ -4,12 +4,16 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * Configuration properties controlling the subscription validation filter.
  */
+@RefreshScope
+@Validated
 @ConfigurationProperties(prefix = "gateway.subscription")
 public class SubscriptionValidationProperties {
 

--- a/api-gateway/src/main/java/com/ejada/gateway/config/WebClientConfig.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/WebClientConfig.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -33,6 +34,7 @@ import reactor.netty.transport.logging.AdvancedByteBufFormat;
 public class WebClientConfig {
 
   @Bean
+  @RefreshScope
   public ClientHttpConnector gatewayClientHttpConnector(GatewayWebClientProperties properties) {
     HttpClient httpClient = HttpClient.create();
     Duration connectTimeout = properties.getConnectTimeout();
@@ -65,6 +67,7 @@ public class WebClientConfig {
 
   @Bean
   @LoadBalanced
+  @RefreshScope
   public WebClient.Builder loadBalancedWebClientBuilder(ClientHttpConnector gatewayClientHttpConnector,
       GatewayWebClientProperties properties,
       ObjectProvider<ExchangeFilterFunction> customFilters) {

--- a/api-gateway/src/main/java/com/ejada/gateway/config/validation/GatewayRoutesPropertiesValidator.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/validation/GatewayRoutesPropertiesValidator.java
@@ -1,0 +1,85 @@
+package com.ejada.gateway.config.validation;
+
+import com.ejada.config.validation.ConfigurationPropertiesValidator;
+import com.ejada.config.validation.ConfigurationValidator;
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.Errors;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+/**
+ * Validates declarative route configuration before the gateway finishes
+ * starting up. This prevents invalid downstream URIs or path matchers from
+ * being registered.
+ */
+@ConfigurationPropertiesValidator
+public class GatewayRoutesPropertiesValidator extends ConfigurationValidator<GatewayRoutesProperties> {
+
+  private static final Set<String> SUPPORTED_SCHEMES = Set.of("http", "https", "lb", "ws", "wss");
+  private static final PathPatternParser PATH_PATTERN_PARSER = new PathPatternParser();
+
+  public GatewayRoutesPropertiesValidator() {
+    super(GatewayRoutesProperties.class);
+  }
+
+  @Override
+  protected void doValidate(GatewayRoutesProperties properties, Errors errors) {
+    for (Map.Entry<String, GatewayRoutesProperties.ServiceRoute> entry : properties.getRoutes().entrySet()) {
+      String key = entry.getKey();
+      GatewayRoutesProperties.ServiceRoute route = entry.getValue();
+      if (route == null) {
+        rejectValue(errors, "routes[" + key + "]", "gateway.routes.null", "Route %s must not be null", key);
+        continue;
+      }
+      try {
+        route.validate(key);
+      } catch (IllegalStateException ex) {
+        reject(errors, "gateway.routes.invalid", ex.getMessage());
+        continue;
+      }
+      validateUri(errors, key, route.getUri());
+      validatePaths(errors, key, route.getPaths());
+    }
+  }
+
+  private void validateUri(Errors errors, String key, URI uri) {
+    if (uri == null) {
+      return;
+    }
+    if (!StringUtils.hasText(uri.getScheme())) {
+      rejectValue(errors, "routes[" + key + "].uri", "gateway.routes.uri.scheme", "Route %s must declare a scheme", key);
+      return;
+    }
+    String scheme = uri.getScheme().toLowerCase();
+    if (!SUPPORTED_SCHEMES.contains(scheme)) {
+      rejectValue(errors, "routes[" + key + "].uri", "gateway.routes.uri.unsupported",
+          "Route %s URI scheme '%s' is not supported", key, scheme);
+    }
+    if (uri.getHost() == null && !"lb".equals(scheme)) {
+      rejectValue(errors, "routes[" + key + "].uri", "gateway.routes.uri.host",
+          "Route %s URI must include a host when not using lb://", key);
+    }
+  }
+
+  private void validatePaths(Errors errors, String key, Iterable<String> paths) {
+    int index = 0;
+    for (String path : paths) {
+      if (!StringUtils.hasText(path)) {
+        rejectValue(errors, "routes[" + key + "].paths[" + index + "]", "gateway.routes.path.blank",
+            "Route %s contains a blank path entry", key);
+        index++;
+        continue;
+      }
+      try {
+        PATH_PATTERN_PARSER.parse(path.trim());
+      } catch (IllegalArgumentException ex) {
+        rejectValue(errors, "routes[" + key + "].paths[" + index + "]", "gateway.routes.path.invalid",
+            "Route %s path '%s' is not a valid Spring path pattern", key, path);
+      }
+      index++;
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/validation/GatewayWebClientPropertiesValidator.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/validation/GatewayWebClientPropertiesValidator.java
@@ -1,0 +1,50 @@
+package com.ejada.gateway.config.validation;
+
+import com.ejada.config.validation.ConfigurationPropertiesValidator;
+import com.ejada.config.validation.ConfigurationValidator;
+import com.ejada.gateway.config.GatewayWebClientProperties;
+import java.time.Duration;
+import org.springframework.validation.Errors;
+
+/**
+ * Ensures gateway web client timeouts remain within sane operational bounds so
+ * misconfigured values do not result in excessive retry storms or overly short
+ * cancellation windows.
+ */
+@ConfigurationPropertiesValidator
+public class GatewayWebClientPropertiesValidator extends ConfigurationValidator<GatewayWebClientProperties> {
+
+  private static final Duration MIN_TIMEOUT = Duration.ofMillis(50);
+  private static final Duration MAX_TIMEOUT = Duration.ofMinutes(5);
+
+  public GatewayWebClientPropertiesValidator() {
+    super(GatewayWebClientProperties.class);
+  }
+
+  @Override
+  protected void doValidate(GatewayWebClientProperties target, Errors errors) {
+    validateDuration(errors, "connectTimeout", target.getConnectTimeout());
+    validateDuration(errors, "responseTimeout", target.getResponseTimeout());
+    validateDuration(errors, "readTimeout", target.getReadTimeout());
+    validateDuration(errors, "writeTimeout", target.getWriteTimeout());
+    if (target.getMaxInMemorySize() < 1024) {
+      rejectValue(errors, "maxInMemorySize", "gateway.webclient.buffer.too-small",
+          "Max in-memory size must be at least 1KB");
+    }
+  }
+
+  private void validateDuration(Errors errors, String field, Duration value) {
+    if (value == null) {
+      return;
+    }
+    if (value.isNegative() || value.isZero() || value.minus(MIN_TIMEOUT).isNegative()) {
+      rejectValue(errors, field, "gateway.webclient.timeout.too-small",
+          "Timeout %s must be greater than %s", field, MIN_TIMEOUT);
+      return;
+    }
+    if (value.compareTo(MAX_TIMEOUT) > 0) {
+      rejectValue(errors, field, "gateway.webclient.timeout.too-large",
+          "Timeout %s must be less than %s", field, MAX_TIMEOUT);
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/validation/SubscriptionValidationPropertiesValidator.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/validation/SubscriptionValidationPropertiesValidator.java
@@ -1,0 +1,63 @@
+package com.ejada.gateway.config.validation;
+
+import com.ejada.config.validation.ConfigurationPropertiesValidator;
+import com.ejada.config.validation.ConfigurationValidator;
+import com.ejada.gateway.config.SubscriptionValidationProperties;
+import java.net.URI;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.Errors;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+/**
+ * Guards the subscription validation settings to ensure cache TTLs and
+ * skip-patterns are sensible before the filter activates.
+ */
+@ConfigurationPropertiesValidator
+public class SubscriptionValidationPropertiesValidator
+    extends ConfigurationValidator<SubscriptionValidationProperties> {
+
+  private static final PathPatternParser PATH_PATTERN_PARSER = new PathPatternParser();
+
+  public SubscriptionValidationPropertiesValidator() {
+    super(SubscriptionValidationProperties.class);
+  }
+
+  @Override
+  protected void doValidate(SubscriptionValidationProperties properties, Errors errors) {
+    if (properties.getCacheTtl() != null && properties.getCacheTtl().isNegative()) {
+      rejectValue(errors, "cacheTtl", "gateway.subscription.cache.negative", "Cache TTL must not be negative");
+    }
+    if (!StringUtils.hasText(properties.getValidationUri())) {
+      rejectValue(errors, "validationUri", "gateway.subscription.validation-uri.blank",
+          "Validation URI must not be blank");
+    } else {
+      try {
+        URI uri = URI.create(properties.getValidationUri());
+        if (!StringUtils.hasText(uri.getScheme())) {
+          rejectValue(errors, "validationUri", "gateway.subscription.validation-uri.scheme",
+              "Validation URI must include a scheme");
+        }
+      } catch (IllegalArgumentException ex) {
+        rejectValue(errors, "validationUri", "gateway.subscription.validation-uri.invalid",
+            "Validation URI is not a valid URI: %s", properties.getValidationUri());
+      }
+    }
+    String[] skipPatterns = properties.getSkipPatterns();
+    if (skipPatterns != null) {
+      for (int i = 0; i < skipPatterns.length; i++) {
+        String candidate = skipPatterns[i];
+        if (!StringUtils.hasText(candidate)) {
+          rejectValue(errors, "skipPatterns[" + i + "]", "gateway.subscription.skip.blank",
+              "Skip pattern index %d must not be blank", i);
+          continue;
+        }
+        try {
+          PATH_PATTERN_PARSER.parse(candidate);
+        } catch (IllegalArgumentException ex) {
+          rejectValue(errors, "skipPatterns[" + i + "]", "gateway.subscription.skip.invalid",
+              "Skip pattern '%s' is not a valid Spring path expression", candidate);
+        }
+      }
+    }
+  }
+}

--- a/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,39 @@
+{
+  "properties": [
+    {
+      "name": "gateway.routes",
+      "type": "java.util.Map<java.lang.String, com.ejada.gateway.config.GatewayRoutesProperties$ServiceRoute>",
+      "description": "Declarative route definitions exposed through the API gateway."
+    },
+    {
+      "name": "gateway.webclient.connect-timeout",
+      "type": "java.time.Duration",
+      "description": "Connection timeout applied to downstream WebClient calls."
+    },
+    {
+      "name": "gateway.webclient.response-timeout",
+      "type": "java.time.Duration",
+      "description": "Overall response timeout for downstream WebClient calls."
+    },
+    {
+      "name": "gateway.subscription.validation-uri",
+      "type": "java.lang.String",
+      "description": "URI template used to validate tenant subscriptions before routing."
+    },
+    {
+      "name": "gateway.admin.aggregation.services",
+      "type": "java.util.List<com.ejada.gateway.config.AdminAggregationProperties$Service>",
+      "description": "Downstream admin services aggregated into the admin dashboard endpoints."
+    },
+    {
+      "name": "app.configuration-version",
+      "type": "java.lang.Long",
+      "description": "Monotonically increasing identifier representing the currently active configuration snapshot."
+    },
+    {
+      "name": "jasypt.encryptor.password",
+      "type": "java.lang.String",
+      "description": "Password used by Jasypt to decrypt ENC(...) values provided by the Config Server."
+    }
+  ]
+}

--- a/api-gateway/src/main/resources/application-dev.yaml
+++ b/api-gateway/src/main/resources/application-dev.yaml
@@ -1,0 +1,34 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  cloud:
+    config:
+      profile: dev
+      label: develop
+
+gateway:
+  webclient:
+    connect-timeout: 3s
+    response-timeout: 12s
+    read-timeout: 12s
+    write-timeout: 12s
+  subscription:
+    enabled: true
+    cache-ttl: 2m
+  defaults:
+    resilience:
+      retry:
+        retries: 2
+        backoff:
+          first-backoff: 200ms
+          max-backoff: 3s
+          factor: 2.5
+
+shared:
+  ratelimit:
+    capacity: 600
+    window: 45s
+
+app:
+  env: dev

--- a/api-gateway/src/main/resources/application-local.yaml
+++ b/api-gateway/src/main/resources/application-local.yaml
@@ -1,0 +1,29 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  cloud:
+    config:
+      profile: local
+      label: main
+
+gateway:
+  webclient:
+    connect-timeout: 2s
+    response-timeout: 10s
+    read-timeout: 10s
+    write-timeout: 10s
+  subscription:
+    enabled: false
+  defaults:
+    resilience:
+      retry:
+        retries: 1
+
+shared:
+  ratelimit:
+    capacity: 1000
+    window: 30s
+
+app:
+  env: local

--- a/api-gateway/src/main/resources/application-production.yaml
+++ b/api-gateway/src/main/resources/application-production.yaml
@@ -1,0 +1,35 @@
+spring:
+  config:
+    activate:
+      on-profile: production
+  cloud:
+    config:
+      profile: production
+      label: main
+
+gateway:
+  webclient:
+    connect-timeout: 5s
+    response-timeout: 20s
+    read-timeout: 20s
+    write-timeout: 20s
+  subscription:
+    enabled: true
+    cache-ttl: 5m
+    fail-open: false
+  defaults:
+    resilience:
+      retry:
+        retries: 4
+        backoff:
+          first-backoff: 500ms
+          max-backoff: 5s
+          factor: 3
+
+shared:
+  ratelimit:
+    capacity: 300
+    window: 1m
+
+app:
+  env: production

--- a/api-gateway/src/main/resources/application-staging.yaml
+++ b/api-gateway/src/main/resources/application-staging.yaml
@@ -1,0 +1,35 @@
+spring:
+  config:
+    activate:
+      on-profile: staging
+  cloud:
+    config:
+      profile: staging
+      label: release-candidate
+
+gateway:
+  webclient:
+    connect-timeout: 4s
+    response-timeout: 15s
+    read-timeout: 15s
+    write-timeout: 15s
+  subscription:
+    enabled: true
+    cache-ttl: 3m
+    fail-open: false
+  defaults:
+    resilience:
+      retry:
+        retries: 3
+        backoff:
+          first-backoff: 300ms
+          max-backoff: 4s
+          factor: 2.5
+
+shared:
+  ratelimit:
+    capacity: 400
+    window: 1m
+
+app:
+  env: staging

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -3,6 +3,9 @@ server:
   shutdown: graceful
 
 spring:
+  # Import remote configuration first, allowing local overrides via active profiles.
+  config:
+    import: optional:configserver:${spring.cloud.config.uri:${SPRING_CLOUD_CONFIG_URI:http://localhost:8888}}
   application:
     name: api-gateway
   main:
@@ -17,6 +20,13 @@ spring:
           jwk-set-uri: ${GATEWAY_JWK_SET_URI:}
           issuer-uri: ${GATEWAY_ISSUER_URI:}
   cloud:
+    config:
+      uri: ${SPRING_CLOUD_CONFIG_URI:http://localhost:8888}
+      profile: ${SPRING_CLOUD_CONFIG_PROFILE:${SPRING_PROFILES_ACTIVE:local}}
+      label: ${SPRING_CLOUD_CONFIG_LABEL:main}
+      username: ${SPRING_CLOUD_CONFIG_USERNAME:}
+      password: ${SPRING_CLOUD_CONFIG_PASSWORD:}
+      fail-fast: true
     compatibility-verifier:
       enabled: false
     gateway:
@@ -72,7 +82,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus,env,configprops,gateway
+        include: health,info,metrics,prometheus,env,configprops,gateway,refresh
   endpoint:
     health:
       show-details: always
@@ -248,6 +258,21 @@ gateway:
         - /api/setup/**
       strip-prefix: 1
       prefix-path: /core
+
+# Application metadata that surfaces through /actuator/info and diagnostics endpoints.
+app:
+  env: ${APP_ENV:${SPRING_PROFILES_ACTIVE:local}}
+  version: ${APP_VERSION:1.0.0}
+  configuration-version: ${APP_CONFIGURATION_VERSION:${app.configuration-version:1}}
+
+# Encryption support for secrets served by the Config Server (ENC(...) syntax).
+jasypt:
+  encryptor:
+    password: ${JASYPT_ENCRYPTOR_PASSWORD:changeit}
+    algorithm: PBEWithHmacSHA512AndAES_256
+    property:
+      prefix: ENC(
+      suffix: )
       resilience:
         enabled: true
         circuit-breaker-name: setup-service

--- a/api-gateway/src/test/java/com/ejada/gateway/config/validation/GatewayRoutesPropertiesValidatorTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/config/validation/GatewayRoutesPropertiesValidatorTest.java
@@ -1,0 +1,47 @@
+package com.ejada.gateway.config.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+
+class GatewayRoutesPropertiesValidatorTest {
+
+  private final GatewayRoutesPropertiesValidator validator = new GatewayRoutesPropertiesValidator();
+
+  @Test
+  void rejectsUnsupportedSchemeAndInvalidPath() {
+    GatewayRoutesProperties properties = new GatewayRoutesProperties();
+    GatewayRoutesProperties.ServiceRoute route = new GatewayRoutesProperties.ServiceRoute();
+    route.setId("bad-service");
+    route.setUri(URI.create("ftp://legacy-service"));
+    route.setPaths(List.of("/api/legacy/**", "invalid[pattern"));
+    properties.getRoutes().put("legacy", route);
+
+    Errors errors = new BeanPropertyBindingResult(properties, "gateway");
+    validator.validate(properties, errors);
+
+    assertThat(errors.hasErrors()).isTrue();
+    assertThat(errors.getAllErrors()).anySatisfy(objectError ->
+        assertThat(objectError.getCode()).contains("gateway.routes"));
+  }
+
+  @Test
+  void acceptsValidRouteConfiguration() {
+    GatewayRoutesProperties properties = new GatewayRoutesProperties();
+    GatewayRoutesProperties.ServiceRoute route = new GatewayRoutesProperties.ServiceRoute();
+    route.setId("tenant-service");
+    route.setUri(URI.create("lb://tenant-service"));
+    route.setPaths(List.of("/api/tenants/**"));
+    properties.getRoutes().put("tenant", route);
+
+    Errors errors = new BeanPropertyBindingResult(properties, "gateway");
+    validator.validate(properties, errors);
+
+    assertThat(errors.hasErrors()).isFalse();
+  }
+}

--- a/docs/configuration/api-gateway.html
+++ b/docs/configuration/api-gateway.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>API Gateway Configuration Reference</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; line-height: 1.6; }
+    h1 { color: #1a4d8f; }
+    table { border-collapse: collapse; width: 100%; margin-bottom: 2rem; }
+    th, td { border: 1px solid #cbd5e0; padding: 0.75rem; text-align: left; }
+    th { background-color: #f7fafc; }
+    caption { caption-side: top; text-align: left; font-weight: bold; margin-bottom: 0.5rem; }
+    code { background-color: #edf2f7; padding: 0.1rem 0.3rem; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <h1>API Gateway Configuration Reference</h1>
+  <p>
+    This document was generated from the Spring configuration metadata exposed by
+    <code>additional-spring-configuration-metadata.json</code> and
+    <code>@ConfigurationProperties</code> declarations within the API Gateway module.
+  </p>
+
+  <h2>Gateway Properties</h2>
+  <table>
+    <caption>gateway.*</caption>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>gateway.routes</code></td>
+        <td><code>Map&lt;String, ServiceRoute&gt;</code></td>
+        <td>Declarative downstream routes exposed through Spring Cloud Gateway.</td>
+        <td>Empty map</td>
+      </tr>
+      <tr>
+        <td><code>gateway.webclient.connect-timeout</code></td>
+        <td><code>Duration</code></td>
+        <td>Connection timeout applied to the reactive WebClient.</td>
+        <td>3s</td>
+      </tr>
+      <tr>
+        <td><code>gateway.webclient.response-timeout</code></td>
+        <td><code>Duration</code></td>
+        <td>Total response timeout enforced for downstream calls.</td>
+        <td>15s</td>
+      </tr>
+      <tr>
+        <td><code>gateway.subscription.validation-uri</code></td>
+        <td><code>String</code></td>
+        <td>URI template used to validate subscriptions before routing traffic.</td>
+        <td><code>lb://subscription-service/internal/subscriptions/{tenantId}</code></td>
+      </tr>
+      <tr>
+        <td><code>gateway.admin.aggregation.services</code></td>
+        <td><code>List&lt;Service&gt;</code></td>
+        <td>Downstream admin services aggregated into the admin dashboard endpoints.</td>
+        <td>Empty list</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Platform Metadata</h2>
+  <table>
+    <caption>app.*</caption>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>app.env</code></td>
+        <td><code>String</code></td>
+        <td>Current environment identifier (local, dev, staging, production).</td>
+        <td><code>dev</code></td>
+      </tr>
+      <tr>
+        <td><code>app.version</code></td>
+        <td><code>String</code></td>
+        <td>Semantic version exposed for diagnostics and telemetry.</td>
+        <td><code>1.0.0</code></td>
+      </tr>
+      <tr>
+        <td><code>app.configuration-version</code></td>
+        <td><code>Long</code></td>
+        <td>Monotonically increasing identifier bumped after each refresh event.</td>
+        <td><code>1</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Encryption</h2>
+  <table>
+    <caption>jasypt.*</caption>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>jasypt.encryptor.password</code></td>
+        <td><code>String</code></td>
+        <td>Password used to decrypt <code>ENC(...)</code> values supplied by the Config Server.</td>
+        <td><code>changeit</code></td>
+      </tr>
+      <tr>
+        <td><code>jasypt.encryptor.algorithm</code></td>
+        <td><code>String</code></td>
+        <td>Algorithm used for encryption/decryption.</td>
+        <td><code>PBEWithHmacSHA512AndAES_256</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>
+    To refresh configuration at runtime without downtime, invoke
+    <code>POST /actuator/refresh</code>. Successful refreshes are logged with the
+    incremented configuration version for auditing.
+  </p>
+</body>
+</html>

--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -58,6 +58,7 @@
     <!-- Testing utilities -->
     <mockito.version>5.2.0</mockito.version>
     <bytebuddy.agent.version>1.17.7</bytebuddy.agent.version>
+    <jasypt.version>3.0.5</jasypt.version>
 
     <!-- Static analysis -->
     <spotbugs.annotations.version>4.7.3</spotbugs.annotations.version>
@@ -212,6 +213,11 @@
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.ulisesbocchio</groupId>
+        <artifactId>jasypt-spring-boot-starter</artifactId>
+        <version>${jasypt.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/shared-lib/shared-config/pom.xml
+++ b/shared-lib/shared-config/pom.xml
@@ -35,6 +35,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.github.ulisesbocchio</groupId>
+      <artifactId>jasypt-spring-boot-starter</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <optional>true</optional>

--- a/shared-lib/shared-config/src/main/java/com/ejada/config/AppProperties.java
+++ b/shared-lib/shared-config/src/main/java/com/ejada/config/AppProperties.java
@@ -1,17 +1,32 @@
 package com.ejada.config;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 
 /**
  * Application-level configuration properties that can be centrally managed and
  * injected into services. Defaults provide sane values for local development.
  */
 @Data
+@RefreshScope
+@Validated
 @ConfigurationProperties(prefix = "app")
 public class AppProperties {
     /** Current environment (dev, staging, prod). */
+    @NotBlank(message = "Application environment must be provided")
+    @Pattern(
+        regexp = "(?i)local|dev|staging|production",
+        message = "Environment must be one of local, dev, staging or production")
     private String env = "dev";
     /** Service version for diagnostics. */
+    @NotBlank(message = "Service version must be provided")
     private String version = "1.0.0";
+    /** Monotonically increasing configuration reload counter. */
+    @Min(value = 1, message = "Configuration version must be at least 1")
+    private long configurationVersion = 1L;
 }

--- a/shared-lib/shared-config/src/main/java/com/ejada/config/CentralConfigAutoConfiguration.java
+++ b/shared-lib/shared-config/src/main/java/com/ejada/config/CentralConfigAutoConfiguration.java
@@ -1,7 +1,11 @@
 package com.ejada.config;
 
+import com.ejada.config.refresh.ConfigRefreshAuditListener;
+import com.ejada.config.refresh.ConfigVersionTracker;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.ConfigurableEnvironment;
 
 /**
  * Auto-configuration that exposes {@link AppProperties} for centralized
@@ -11,4 +15,18 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 @AutoConfiguration
 @EnableConfigurationProperties(AppProperties.class)
 public class CentralConfigAutoConfiguration {
+
+  @Bean
+  public ConfigVersionTracker configVersionTracker(ConfigurableEnvironment environment) {
+    ConfigVersionTracker tracker = new ConfigVersionTracker();
+    environment.getSystemProperties().putIfAbsent("app.configuration-version",
+        Long.toString(tracker.getCurrentVersion()));
+    return tracker;
+  }
+
+  @Bean
+  public ConfigRefreshAuditListener configRefreshAuditListener(ConfigurableEnvironment environment,
+      ConfigVersionTracker configVersionTracker) {
+    return new ConfigRefreshAuditListener(environment, configVersionTracker);
+  }
 }

--- a/shared-lib/shared-config/src/main/java/com/ejada/config/refresh/ConfigRefreshAuditListener.java
+++ b/shared-lib/shared-config/src/main/java/com/ejada/config/refresh/ConfigRefreshAuditListener.java
@@ -1,0 +1,59 @@
+package com.ejada.config.refresh;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.EnvironmentChangeEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.util.StringUtils;
+
+/**
+ * Listens for configuration refresh events (triggered via /actuator/refresh)
+ * and emits structured audit logs capturing the before/after values.
+ */
+public class ConfigRefreshAuditListener implements ApplicationListener<EnvironmentChangeEvent> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRefreshAuditListener.class);
+
+  private final ConfigurableEnvironment environment;
+  private final ConfigVersionTracker versionTracker;
+  private final Map<String, String> lastKnownValues = new ConcurrentHashMap<>();
+
+  public ConfigRefreshAuditListener(ConfigurableEnvironment environment, ConfigVersionTracker versionTracker) {
+    this.environment = environment;
+    this.versionTracker = versionTracker;
+  }
+
+  @Override
+  public void onApplicationEvent(EnvironmentChangeEvent event) {
+    long version = versionTracker.incrementAndGet();
+    event.getKeys().stream().sorted().forEach(key -> logChange(version, key));
+    environment.getSystemProperties().put("app.configuration-version", Long.toString(version));
+    if (event.getKeys().isEmpty()) {
+      LOGGER.info("Configuration refresh #{}, no keys reported", version);
+    } else {
+      LOGGER.info("Configuration refresh #{} applied to {} keys", version, event.getKeys().size());
+    }
+  }
+
+  private void logChange(long version, String key) {
+    String normalized = (key == null) ? "" : key.toLowerCase(Locale.ROOT);
+    String newValue = environment.getProperty(key);
+    String previousValue = lastKnownValues.put(key, newValue);
+    LOGGER.info("Configuration refresh #{} -> {}: {} -> {}", version, key, mask(normalized, previousValue),
+        mask(normalized, newValue));
+  }
+
+  private String mask(String key, String value) {
+    if (!StringUtils.hasText(value)) {
+      return value;
+    }
+    if (key.contains("password") || key.contains("secret") || key.contains("token")) {
+      return "****";
+    }
+    return value;
+  }
+}

--- a/shared-lib/shared-config/src/main/java/com/ejada/config/refresh/ConfigVersionTracker.java
+++ b/shared-lib/shared-config/src/main/java/com/ejada/config/refresh/ConfigVersionTracker.java
@@ -1,0 +1,21 @@
+package com.ejada.config.refresh;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Simple tracker that maintains a monotonically increasing configuration
+ * version. Each successful refresh bumps the counter allowing operators to
+ * correlate reloads with audit events.
+ */
+public class ConfigVersionTracker {
+
+  private final AtomicLong version = new AtomicLong(1L);
+
+  public long incrementAndGet() {
+    return version.incrementAndGet();
+  }
+
+  public long getCurrentVersion() {
+    return version.get();
+  }
+}

--- a/shared-lib/shared-config/src/main/java/com/ejada/config/validation/ConfigurationPropertiesValidator.java
+++ b/shared-lib/shared-config/src/main/java/com/ejada/config/validation/ConfigurationPropertiesValidator.java
@@ -1,0 +1,30 @@
+package com.ejada.config.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Meta-annotation that marks a Spring {@link org.springframework.validation.Validator}
+ * as a configuration properties validator. Validators annotated with this are
+ * automatically picked up by the {@link org.springframework.boot.context.properties.bind.Binder}
+ * during property binding.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ConfigurationPropertiesBinding
+@Component
+@Documented
+public @interface ConfigurationPropertiesValidator {
+
+  /**
+   * Alias for the underlying component name to ease bean registration when used on methods.
+   */
+  @AliasFor(annotation = Component.class, attribute = "value")
+  String value() default "";
+}

--- a/shared-lib/shared-config/src/main/java/com/ejada/config/validation/ConfigurationValidator.java
+++ b/shared-lib/shared-config/src/main/java/com/ejada/config/validation/ConfigurationValidator.java
@@ -1,0 +1,70 @@
+package com.ejada.config.validation;
+
+import java.util.Locale;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+/**
+ * Base class for configuration validators that provides helper methods for
+ * common error-reporting behaviour while delegating the actual validation logic
+ * to subclasses.
+ *
+ * @param <T> type of configuration properties being validated
+ */
+public abstract class ConfigurationValidator<T> implements Validator {
+
+  private final Class<T> targetType;
+
+  protected ConfigurationValidator(Class<T> targetType) {
+    this.targetType = targetType;
+  }
+
+  @Override
+  public final boolean supports(Class<?> clazz) {
+    return targetType.isAssignableFrom(clazz);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void validate(Object target, Errors errors) {
+    if (target == null) {
+      reject(errors, "configuration.missing", "Configuration properties instance must not be null");
+      return;
+    }
+    doValidate((T) target, errors);
+  }
+
+  /**
+   * Implementor-specific validation logic.
+   *
+   * @param target bound configuration properties
+   * @param errors binding errors collector
+   */
+  protected abstract void doValidate(T target, Errors errors);
+
+  protected void reject(Errors errors, String code, String defaultMessage, Object... args) {
+    errors.reject(code, args, defaultMessage);
+  }
+
+  protected void rejectValue(Errors errors, String field, String code, String defaultMessage, Object... args) {
+    errors.rejectValue(field, code, args, defaultMessage);
+  }
+
+  protected String maskedValue(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    if (trimmed.isEmpty()) {
+      return trimmed;
+    }
+    if (trimmed.length() <= 4) {
+      return "****";
+    }
+    return trimmed.substring(0, 2) + "****" + trimmed.substring(trimmed.length() - 2);
+  }
+
+  protected String normalizeKey(String key) {
+    return (key == null) ? "" : key.toLowerCase(Locale.ROOT);
+  }
+}

--- a/shared-lib/shared-config/src/test/java/com/ejada/config/refresh/ConfigRefreshAuditListenerTest.java
+++ b/shared-lib/shared-config/src/test/java/com/ejada/config/refresh/ConfigRefreshAuditListenerTest.java
@@ -1,0 +1,24 @@
+package com.ejada.config.refresh;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.event.EnvironmentChangeEvent;
+import org.springframework.mock.env.MockEnvironment;
+
+class ConfigRefreshAuditListenerTest {
+
+  @Test
+  void incrementsVersionAndSetsSystemProperty() {
+    MockEnvironment environment = new MockEnvironment();
+    environment.setProperty("gateway.subscription.enabled", "true");
+    ConfigVersionTracker tracker = new ConfigVersionTracker();
+    ConfigRefreshAuditListener listener = new ConfigRefreshAuditListener(environment, tracker);
+
+    listener.onApplicationEvent(new EnvironmentChangeEvent(Collections.singleton("gateway.subscription.enabled")));
+
+    assertThat(tracker.getCurrentVersion()).isEqualTo(2L);
+    assertThat(environment.getSystemProperties()).containsEntry("app.configuration-version", "2");
+  }
+}


### PR DESCRIPTION
## Summary
- integrate Spring Cloud Config client, refresh-aware application metadata, and Jasypt encryption defaults for shared configuration
- add environment-specific gateway profile YAMLs plus generated configuration metadata and HTML reference
- introduce reusable configuration validators with Gateway route/web client/subscription validation checks and refresh audit logging

## Testing
- `mvn -pl shared-lib/shared-config test -B` *(fails: shared-test-support module not published in the environment)*
- `mvn -pl shared-lib/shared-config -am test -B` *(fails: byte-buddy-agent dependency missing in local Maven cache during offline run)*

------
https://chatgpt.com/codex/tasks/task_e_68e115cdd91c832fa4766e5e43737cd4