### PR TITLE
Handle analytics Flyway checksum mismatch

### DIFF
--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/config/FlywayRepairConfig.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/config/FlywayRepairConfig.java
@@ -1,0 +1,18 @@
+package com.ejada.analytics.config;
+
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayRepairConfig {
+
+    @Bean
+    public FlywayMigrationStrategy flywayRepairMigrationStrategy() {
+        return flyway -> {
+            flyway.repair();
+            flyway.migrate();
+        };
+    }
+}

--- a/tenant-platform/analytics-service/src/main/resources/db/migration/common/V2__ensure_usage_event_table.sql
+++ b/tenant-platform/analytics-service/src/main/resources/db/migration/common/V2__ensure_usage_event_table.sql
@@ -1,0 +1,15 @@
+-- Ensure the usage_event table exists before materialized views are refreshed.
+create table if not exists usage_event (
+  usage_event_id        bigserial primary key,
+  rq_uid                uuid        not null,
+  token_hash            varchar(64),
+  payload               jsonb       not null,
+  ext_product_id        bigint      not null,
+  received_at           timestamptz not null default now(),
+  processed             boolean     not null default true,
+  status_code           varchar(32) not null,
+  status_desc           varchar(128) not null,
+  status_dtls           jsonb
+);
+
+comment on table usage_event is 'Immutable audit of Track Product Consumption requests & outcomes';


### PR DESCRIPTION
## Summary
- add a Flyway migration strategy so the analytics service repairs the schema history before migrating
- provide a follow-up migration that provisions the usage_event table when missing

## Testing
- mvn -pl tenant-platform/analytics-service -am test *(fails: network is unreachable while downloading net.bytebuddy:byte-buddy-agent)*

------
https://chatgpt.com/codex/tasks/task_e_68e1160a20e8832fa41fc6bff83df669