### PR TITLE
feat: enhance gateway observability

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationController.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationController.java
@@ -3,6 +3,7 @@ package com.ejada.gateway.admin;
 import com.ejada.common.dto.BaseResponse;
 import com.ejada.gateway.admin.model.AdminOverview;
 import com.ejada.gateway.admin.model.AdminRouteView;
+import com.ejada.gateway.admin.model.DetailedHealthStatus;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,5 +34,11 @@ public class AdminAggregationController {
   public Mono<BaseResponse<List<AdminRouteView>>> routes() {
     return Mono.fromSupplier(aggregationService::describeRoutes)
         .map(data -> BaseResponse.success("Gateway route catalogue", data));
+  }
+
+  @GetMapping("/health/detailed")
+  public Mono<BaseResponse<DetailedHealthStatus>> detailedHealth() {
+    return aggregationService.fetchDetailedHealth()
+        .map(data -> BaseResponse.success("Gateway dependency health", data));
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationService.java
@@ -3,8 +3,13 @@ package com.ejada.gateway.admin;
 import com.ejada.gateway.admin.model.AdminOverview;
 import com.ejada.gateway.admin.model.AdminRouteView;
 import com.ejada.gateway.admin.model.AdminServiceSnapshot;
+import com.ejada.gateway.admin.model.DetailedHealthStatus;
+import com.ejada.gateway.admin.model.DetailedHealthStatus.CircuitBreakerHealth;
+import com.ejada.gateway.admin.model.DetailedHealthStatus.RedisHealthStatus;
 import com.ejada.gateway.config.AdminAggregationProperties;
 import com.ejada.gateway.config.GatewayRoutesProperties;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.annotation.Timed;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
@@ -13,9 +18,11 @@ import java.util.Map;
 import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -34,19 +41,42 @@ public class AdminAggregationService {
   private final WebClient.Builder webClientBuilder;
   private final AdminAggregationProperties adminProperties;
   private final GatewayRoutesProperties routesProperties;
+  private final ReactiveStringRedisTemplate redisTemplate;
+  private final CircuitBreakerRegistry circuitBreakerRegistry;
 
   public AdminAggregationService(WebClient.Builder webClientBuilder,
       AdminAggregationProperties adminProperties,
-      GatewayRoutesProperties routesProperties) {
+      GatewayRoutesProperties routesProperties,
+      ObjectProvider<ReactiveStringRedisTemplate> redisTemplateProvider,
+      ObjectProvider<CircuitBreakerRegistry> circuitBreakerRegistryProvider) {
     this.webClientBuilder = webClientBuilder;
     this.adminProperties = adminProperties;
     this.routesProperties = routesProperties;
+    this.redisTemplate = redisTemplateProvider.getIfAvailable();
+    this.circuitBreakerRegistry = circuitBreakerRegistryProvider.getIfAvailable();
   }
 
+  @Timed(value = "gateway.admin.overview", description = "Aggregated overview retrieval")
   public Mono<AdminOverview> fetchOverview() {
+    return collectDownstreamSnapshots().map(AdminOverview::fromSnapshots);
+  }
+
+  @Timed(value = "gateway.admin.routes", description = "Admin route catalogue generation")
+  public List<AdminRouteView> describeRoutes() {
+    return routesProperties.getRoutes().values().stream()
+        .sorted(Comparator.comparing(route -> {
+          String id = route.getId();
+          return id == null ? "" : id;
+        }))
+        .map(AdminRouteView::fromRoute)
+        .toList();
+  }
+
+  @Timed(value = "gateway.admin.downstream.snapshots", description = "Downstream service snapshot aggregation")
+  public Mono<List<AdminServiceSnapshot>> collectDownstreamSnapshots() {
     List<AdminAggregationProperties.Service> services = adminProperties.getAggregation().getServices();
     if (services.isEmpty()) {
-      return Mono.just(AdminOverview.empty());
+      return Mono.just(List.of());
     }
 
     IntStream.range(0, services.size()).forEach(index -> {
@@ -60,17 +90,48 @@ public class AdminAggregationService {
     return Flux.fromIterable(services)
         .flatMap(service -> fetchSnapshot(service, timeout))
         .sort(Comparator.comparing(AdminServiceSnapshot::serviceId))
-        .collectList()
-        .map(AdminOverview::fromSnapshots);
+        .collectList();
   }
 
-  public List<AdminRouteView> describeRoutes() {
-    return routesProperties.getRoutes().values().stream()
-        .sorted(Comparator.comparing(route -> {
-          String id = route.getId();
-          return id == null ? "" : id;
-        }))
-        .map(AdminRouteView::fromRoute)
+  @Timed(value = "gateway.admin.health.detailed", description = "Detailed gateway health aggregation")
+  public Mono<DetailedHealthStatus> fetchDetailedHealth() {
+    Mono<RedisHealthStatus> redisHealth = checkRedisHealth();
+    Mono<List<AdminServiceSnapshot>> downstream = collectDownstreamSnapshots();
+    Mono<List<CircuitBreakerHealth>> circuitBreakers = Mono.fromSupplier(this::collectCircuitBreakerStates);
+
+    return Mono.zip(redisHealth, downstream, circuitBreakers)
+        .map(tuple -> new DetailedHealthStatus(tuple.getT1(), tuple.getT2(), tuple.getT3()))
+        .defaultIfEmpty(DetailedHealthStatus.empty());
+  }
+
+  @Timed(value = "gateway.admin.health.redis", description = "Redis connectivity check")
+  public Mono<RedisHealthStatus> checkRedisHealth() {
+    if (redisTemplate == null) {
+      return Mono.just(RedisHealthStatus.unavailable());
+    }
+    Duration timeout = adminProperties.getAggregation().getTimeout();
+    String probeKey = adminProperties.getAggregation().getRedisProbeKey();
+    String key = (probeKey != null && !probeKey.isBlank()) ? probeKey : "gateway:health:probe";
+    return Mono.defer(() -> {
+          Instant start = Instant.now();
+          return redisTemplate.hasKey(key)
+              .timeout(timeout)
+              .map(result -> new RedisHealthStatus("UP",
+                  Duration.between(start, Instant.now()).toMillis(),
+                  Boolean.TRUE.equals(result) ? "KeyExists" : "Reachable"));
+        })
+        .onErrorResume(ex -> Mono.just(new RedisHealthStatus("DOWN", -1,
+            ex.getClass().getSimpleName() + ": " + ex.getMessage())));
+  }
+
+  @Timed(value = "gateway.admin.health.circuitbreakers", description = "Circuit breaker state capture")
+  public List<CircuitBreakerHealth> collectCircuitBreakerStates() {
+    if (circuitBreakerRegistry == null) {
+      return List.of();
+    }
+    return circuitBreakerRegistry.getAllCircuitBreakers().stream()
+        .map(cb -> new CircuitBreakerHealth(cb.getName(), cb.getState().name()))
+        .sorted(Comparator.comparing(CircuitBreakerHealth::serviceName))
         .toList();
   }
 

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/GatewayReadinessIndicator.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/GatewayReadinessIndicator.java
@@ -1,0 +1,48 @@
+package com.ejada.gateway.admin;
+
+import com.ejada.gateway.admin.model.AdminServiceSnapshot;
+import com.ejada.gateway.admin.model.AdminServiceState;
+import com.ejada.gateway.admin.model.DetailedHealthStatus;
+import org.springframework.boot.actuate.autoconfigure.health.Readiness;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.ReactiveHealthIndicator;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+/**
+ * Contributes readiness information by validating critical gateway dependencies.
+ */
+@Component
+@Readiness
+public class GatewayReadinessIndicator implements ReactiveHealthIndicator {
+
+  private final AdminAggregationService adminAggregationService;
+
+  public GatewayReadinessIndicator(AdminAggregationService adminAggregationService) {
+    this.adminAggregationService = adminAggregationService;
+  }
+
+  @Override
+  public Mono<Health> health() {
+    return adminAggregationService.fetchDetailedHealth()
+        .map(this::mapToHealth)
+        .onErrorResume(ex -> Mono.just(Health.down(ex).build()));
+  }
+
+  private Health mapToHealth(DetailedHealthStatus detailed) {
+    boolean redisUp = detailed.redis() != null && detailed.redis().isUp();
+    boolean downstreamHealthy = detailed.downstreamServices().stream()
+        .filter(AdminServiceSnapshot::required)
+        .allMatch(snapshot -> snapshot.state() != AdminServiceState.DOWN);
+    boolean breakersHealthy = detailed.circuitBreakers().stream()
+        .noneMatch(cb -> "open".equalsIgnoreCase(cb.state()));
+
+    Health.Builder builder = (redisUp && downstreamHealthy && breakersHealthy)
+        ? Health.up()
+        : Health.down();
+    builder.withDetail("redis", detailed.redis());
+    builder.withDetail("downstreamServices", detailed.downstreamServices());
+    builder.withDetail("circuitBreakers", detailed.circuitBreakers());
+    return builder.build();
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/model/DetailedHealthStatus.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/model/DetailedHealthStatus.java
@@ -1,0 +1,41 @@
+package com.ejada.gateway.admin.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Aggregated health payload for admin detailed health endpoint.
+ */
+public record DetailedHealthStatus(
+    RedisHealthStatus redis,
+    @JsonProperty("downstream-services") List<AdminServiceSnapshot> downstreamServices,
+    @JsonProperty("circuit-breakers") List<CircuitBreakerHealth> circuitBreakers) {
+
+  public DetailedHealthStatus {
+    downstreamServices = downstreamServices == null ? List.of() : List.copyOf(downstreamServices);
+    circuitBreakers = circuitBreakers == null ? List.of() : List.copyOf(circuitBreakers);
+  }
+
+  public static DetailedHealthStatus empty() {
+    return new DetailedHealthStatus(RedisHealthStatus.unavailable(), Collections.emptyList(), Collections.emptyList());
+  }
+
+  public record CircuitBreakerHealth(String serviceName, String state) {
+    public CircuitBreakerHealth {
+      Objects.requireNonNull(serviceName, "serviceName");
+      Objects.requireNonNull(state, "state");
+    }
+  }
+
+  public record RedisHealthStatus(String status, long latencyMs, String message) {
+    public static RedisHealthStatus unavailable() {
+      return new RedisHealthStatus("DOWN", -1, "Not assessed");
+    }
+
+    public boolean isUp() {
+      return "UP".equalsIgnoreCase(status);
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/AdminAggregationProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/AdminAggregationProperties.java
@@ -38,6 +38,8 @@ public class AdminAggregationProperties {
 
     private List<Service> services = new ArrayList<>();
 
+    private String redisProbeKey = "gateway:health:probe";
+
     public Duration getTimeout() {
       return timeout;
     }
@@ -52,6 +54,14 @@ public class AdminAggregationProperties {
 
     public void setServices(List<Service> services) {
       this.services = (services == null) ? new ArrayList<>() : new ArrayList<>(services);
+    }
+
+    public String getRedisProbeKey() {
+      return redisProbeKey;
+    }
+
+    public void setRedisProbeKey(String redisProbeKey) {
+      this.redisProbeKey = StringUtils.hasText(redisProbeKey) ? redisProbeKey.trim() : "gateway:health:probe";
     }
   }
 

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayLoggingProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayLoggingProperties.java
@@ -1,0 +1,44 @@
+package com.ejada.gateway.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Logging configuration dedicated to the gateway runtime.
+ */
+@ConfigurationProperties(prefix = "gateway.logging")
+public class GatewayLoggingProperties {
+
+  private final AccessLog accessLog = new AccessLog();
+
+  public AccessLog getAccessLog() {
+    return accessLog;
+  }
+
+  public static class AccessLog {
+
+    private boolean enabled = false;
+    private List<String> skipPatterns = new ArrayList<>(List.of("/actuator/**", "/health"));
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public List<String> getSkipPatterns() {
+      return skipPatterns;
+    }
+
+    public void setSkipPatterns(List<String> skipPatterns) {
+      if (skipPatterns == null) {
+        this.skipPatterns = new ArrayList<>();
+      } else {
+        this.skipPatterns = new ArrayList<>(skipPatterns);
+      }
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayMetricsConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayMetricsConfiguration.java
@@ -1,0 +1,87 @@
+package com.ejada.gateway.config;
+
+import com.ejada.gateway.filter.GatewayAccessLogFilter;
+import com.ejada.gateway.filter.GatewayMetricsFilter;
+import com.ejada.gateway.observability.GatewayTracingHelper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.tracing.Tracer;
+import jakarta.annotation.PostConstruct;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires gateway specific metrics, logging, and tracing helpers.
+ */
+@Configuration
+public class GatewayMetricsConfiguration {
+
+  private final MeterRegistry meterRegistry;
+  private final GatewayLoggingProperties loggingProperties;
+  private final GatewayTracingProperties tracingProperties;
+  private final ObjectProvider<CircuitBreakerRegistry> circuitBreakerRegistryProvider;
+  private final ObjectProvider<Tracer> tracerProvider;
+  private final Set<String> registeredCircuitBreakerMeters = ConcurrentHashMap.newKeySet();
+
+  public GatewayMetricsConfiguration(MeterRegistry meterRegistry,
+      GatewayLoggingProperties loggingProperties,
+      GatewayTracingProperties tracingProperties,
+      ObjectProvider<CircuitBreakerRegistry> circuitBreakerRegistryProvider,
+      ObjectProvider<Tracer> tracerProvider) {
+    this.meterRegistry = meterRegistry;
+    this.loggingProperties = loggingProperties;
+    this.tracingProperties = tracingProperties;
+    this.circuitBreakerRegistryProvider = circuitBreakerRegistryProvider;
+    this.tracerProvider = tracerProvider;
+  }
+
+  @Bean
+  public GatewayTracingHelper gatewayTracingHelper() {
+    return new GatewayTracingHelper(tracerProvider.getIfAvailable(), tracingProperties);
+  }
+
+  @Bean
+  public GatewayMetricsFilter gatewayMetricsFilter(GatewayTracingHelper tracingHelper) {
+    return new GatewayMetricsFilter(meterRegistry, tracingHelper);
+  }
+
+  @Bean
+  public GatewayAccessLogFilter gatewayAccessLogFilter(ObjectMapper objectMapper,
+      GatewayTracingHelper tracingHelper) {
+    return new GatewayAccessLogFilter(loggingProperties, objectMapper, tracingHelper);
+  }
+
+  @PostConstruct
+  void bindCircuitBreakerMetrics() {
+    CircuitBreakerRegistry registry = circuitBreakerRegistryProvider.getIfAvailable();
+    if (registry == null) {
+      return;
+    }
+    registry.getAllCircuitBreakers().forEach(this::registerCircuitBreakerMeters);
+    registry.getEventPublisher().onEntryAdded(event -> registerCircuitBreakerMeters(event.getAddedEntry()));
+  }
+
+  private void registerCircuitBreakerMeters(CircuitBreaker circuitBreaker) {
+    EnumSet<CircuitBreaker.State> states = EnumSet.allOf(CircuitBreaker.State.class);
+    for (CircuitBreaker.State state : states) {
+      String key = circuitBreaker.getName() + ":" + state.name();
+      if (!registeredCircuitBreakerMeters.add(key)) {
+        continue;
+      }
+      Gauge.builder("gateway.circuit_breaker.state", circuitBreaker,
+              cb -> cb.getState() == state ? 1.0 : 0.0)
+          .description("State of resilience4j circuit breakers exposed by the gateway")
+          .tags("serviceName", circuitBreaker.getName(),
+              "state", state.name().toLowerCase(Locale.ROOT))
+          .register(meterRegistry);
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySupplementaryConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySupplementaryConfiguration.java
@@ -10,6 +10,10 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  */
 @Configuration
 @EnableScheduling
-@EnableConfigurationProperties({SubscriptionValidationProperties.class, GatewayBffProperties.class,AdminAggregationProperties.class})
+@EnableConfigurationProperties({SubscriptionValidationProperties.class,
+    GatewayBffProperties.class,
+    AdminAggregationProperties.class,
+    GatewayLoggingProperties.class,
+    GatewayTracingProperties.class})
 public class GatewaySupplementaryConfiguration {
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayTracingProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayTracingProperties.java
@@ -1,0 +1,33 @@
+package com.ejada.gateway.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Gateway specific tracing configuration.
+ */
+@ConfigurationProperties(prefix = "gateway.tracing")
+public class GatewayTracingProperties {
+
+  private final EnhancedTags enhancedTags = new EnhancedTags();
+
+  public EnhancedTags getEnhancedTags() {
+    return enhancedTags;
+  }
+
+  public boolean isEnhancedTagsEnabled() {
+    return enhancedTags.isEnabled();
+  }
+
+  public static class EnhancedTags {
+
+    private boolean enabled = false;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/ReactiveContextConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/ReactiveContextConfiguration.java
@@ -1,6 +1,7 @@
 package com.ejada.gateway.config;
 
 import com.ejada.gateway.context.ReactiveRequestContextFilter;
+import com.ejada.gateway.observability.GatewayTracingHelper;
 import com.ejada.gateway.ratelimit.ReactiveRateLimiterFilter;
 import com.ejada.shared_starter_ratelimit.RateLimitProps;
 import com.ejada.starter_core.config.CoreAutoConfiguration;
@@ -54,12 +55,13 @@ public class ReactiveContextConfiguration {
       GatewayRateLimitProperties gatewayRateLimitProperties,
       @Qualifier("jacksonObjectMapper") @Nullable ObjectMapper jacksonObjectMapper,
       ObjectProvider<ObjectMapper> objectMapperProvider,
-      ObjectProvider<MeterRegistry> meterRegistryProvider) {
+      ObjectProvider<MeterRegistry> meterRegistryProvider,
+      ObjectProvider<GatewayTracingHelper> tracingHelperProvider) {
     ObjectMapper mapper = (jacksonObjectMapper != null)
         ? jacksonObjectMapper
         : objectMapperProvider.getIfAvailable();
     MeterRegistry meterRegistry = meterRegistryProvider.getIfAvailable();
     return new ReactiveRateLimiterFilter(redisTemplate, props, keyResolver, mapper,
-        gatewayRateLimitProperties, meterRegistry);
+        gatewayRateLimitProperties, meterRegistry, tracingHelperProvider.getIfAvailable());
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/GatewayAccessLogFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/GatewayAccessLogFilter.java
@@ -1,0 +1,143 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.gateway.config.GatewayLoggingProperties;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.ejada.gateway.observability.GatewayTracingHelper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Emits structured JSON logs for all gateway ingress traffic suitable for ELK ingestion.
+ */
+public class GatewayAccessLogFilter implements WebFilter, Ordered {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GatewayAccessLogFilter.class);
+
+  private final GatewayLoggingProperties loggingProperties;
+  private final ObjectMapper objectMapper;
+  private final AntPathMatcher pathMatcher = new AntPathMatcher();
+  private final GatewayTracingHelper tracingHelper;
+
+  public GatewayAccessLogFilter(GatewayLoggingProperties loggingProperties,
+      ObjectMapper objectMapper,
+      GatewayTracingHelper tracingHelper) {
+    this.loggingProperties = loggingProperties;
+    this.objectMapper = objectMapper;
+    this.tracingHelper = tracingHelper;
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE - 10;
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    GatewayLoggingProperties.AccessLog accessLog = loggingProperties.getAccessLog();
+    if (!accessLog.isEnabled()) {
+      return chain.filter(exchange);
+    }
+
+    String path = exchange.getRequest().getPath().pathWithinApplication().value();
+    if (shouldSkip(path, accessLog.getSkipPatterns())) {
+      return chain.filter(exchange);
+    }
+
+    long start = System.nanoTime();
+    return chain.filter(exchange)
+        .doFinally(signalType -> {
+          long durationMs = (System.nanoTime() - start) / 1_000_000;
+          writeAccessLog(exchange, durationMs);
+          tracingHelper.tagExchange(exchange);
+        });
+  }
+
+  private boolean shouldSkip(String path, List<String> patterns) {
+    if (patterns == null || patterns.isEmpty()) {
+      return false;
+    }
+    for (String pattern : patterns) {
+      if (StringUtils.hasText(pattern) && pathMatcher.match(pattern, path)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void writeAccessLog(ServerWebExchange exchange, long durationMs) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("timestamp", Instant.now().toString());
+    payload.put("correlationId", resolveCorrelationId(exchange));
+    payload.put("tenantId", trimToNull(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID)));
+    payload.put("method", exchange.getRequest().getMethodValue());
+    payload.put("path", exchange.getRequest().getPath().value());
+    payload.put("statusCode", exchange.getResponse().getStatusCode() != null
+        ? exchange.getResponse().getStatusCode().value()
+        : 200);
+    payload.put("duration", durationMs);
+    payload.put("userAgent", exchange.getRequest().getHeaders().getFirst("User-Agent"));
+    payload.put("clientIp", resolveClientIp(exchange.getRequest()));
+    payload.put("routeId", resolveRouteId(exchange));
+
+    try {
+      LOGGER.info(objectMapper.writeValueAsString(payload));
+    } catch (JsonProcessingException ex) {
+      LOGGER.info("{}", payload, ex);
+    }
+  }
+
+  private String resolveCorrelationId(ServerWebExchange exchange) {
+    String attribute = exchange.getAttribute(GatewayRequestAttributes.CORRELATION_ID);
+    if (StringUtils.hasText(attribute)) {
+      return attribute;
+    }
+    String header = exchange.getRequest().getHeaders().getFirst(HeaderNames.CORRELATION_ID);
+    return StringUtils.hasText(header) ? header : "unknown";
+  }
+
+  private String resolveClientIp(ServerHttpRequest request) {
+    String forwarded = request.getHeaders().getFirst(HeaderNames.CLIENT_IP);
+    if (!StringUtils.hasText(forwarded)) {
+      forwarded = request.getHeaders().getFirst("X-Forwarded-For");
+    }
+    if (StringUtils.hasText(forwarded)) {
+      return forwarded.split(",")[0].trim();
+    }
+    if (request.getRemoteAddress() != null) {
+      return request.getRemoteAddress().getAddress().getHostAddress();
+    }
+    return "unknown";
+  }
+
+  private String resolveRouteId(ServerWebExchange exchange) {
+    Route route = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+    if (route == null || !StringUtils.hasText(route.getId())) {
+      return "unknown";
+    }
+    return route.getId();
+  }
+
+  private String trimToNull(String value) {
+    if (!StringUtils.hasText(value)) {
+      return null;
+    }
+    return value.trim();
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/GatewayMetricsFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/GatewayMetricsFilter.java
@@ -1,0 +1,77 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.ejada.gateway.observability.GatewayTracingHelper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Central metrics filter that records request volumes and latency measurements.
+ */
+public class GatewayMetricsFilter implements WebFilter, Ordered {
+
+  private final MeterRegistry meterRegistry;
+  private final GatewayTracingHelper tracingHelper;
+
+  public GatewayMetricsFilter(MeterRegistry meterRegistry, GatewayTracingHelper tracingHelper) {
+    this.meterRegistry = meterRegistry;
+    this.tracingHelper = tracingHelper;
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE - 20;
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    Timer.Sample sample = Timer.start(meterRegistry);
+    long start = System.nanoTime();
+    return chain.filter(exchange)
+        .doFinally(signalType -> {
+          long duration = System.nanoTime() - start;
+          recordMetrics(exchange, sample, duration);
+          tracingHelper.tagExchange(exchange);
+        });
+  }
+
+  private void recordMetrics(ServerWebExchange exchange, Timer.Sample sample, long durationNanos) {
+    HttpStatus status = exchange.getResponse().getStatusCode();
+    int statusCode = status != null ? status.value() : HttpStatus.OK.value();
+    String tenant = trimToDefault(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID));
+    meterRegistry.counter("gateway.requests.by_tenant",
+            "tenantId", tenant,
+            "statusCode", String.valueOf(statusCode))
+        .increment();
+
+    Route route = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+    String routeId = route != null ? trimToDefault(route.getId()) : "unknown";
+    Timer timer = Timer.builder("gateway.route.latency")
+        .description("Latency of requests routed through the gateway")
+        .publishPercentileHistogram()
+        .publishPercentiles(0.5, 0.95, 0.99)
+        .tags("routeId", routeId)
+        .register(meterRegistry);
+    sample.stop(timer);
+
+    meterRegistry.timer("gateway.request.duration", "tenantId", tenant, "routeId", routeId)
+        .record(Duration.ofNanos(durationNanos));
+  }
+
+  private String trimToDefault(String value) {
+    if (!StringUtils.hasText(value)) {
+      return "unknown";
+    }
+    return value.trim();
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/observability/GatewayTracingHelper.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/observability/GatewayTracingHelper.java
@@ -1,0 +1,116 @@
+package com.ejada.gateway.observability;
+
+import com.ejada.gateway.config.GatewayTracingProperties;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import java.time.Duration;
+import java.util.Locale;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * Convenience helper for enriching spans emitted by the gateway with additional
+ * metadata and event annotations.
+ */
+public class GatewayTracingHelper {
+
+  private final Tracer tracer;
+  private final GatewayTracingProperties tracingProperties;
+
+  public GatewayTracingHelper(@Nullable Tracer tracer, GatewayTracingProperties tracingProperties) {
+    this.tracer = tracer;
+    this.tracingProperties = tracingProperties;
+  }
+
+  public boolean isEnabled() {
+    return tracer != null && tracingProperties != null && tracingProperties.isEnhancedTagsEnabled();
+  }
+
+  public void tagExchange(ServerWebExchange exchange) {
+    if (!isEnabled()) {
+      return;
+    }
+    Span span = tracer.currentSpan();
+    if (span == null) {
+      return;
+    }
+    String tenantId = trimToDefault(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID));
+    String tier = trimToDefault(exchange.getAttribute(GatewayRequestAttributes.SUBSCRIPTION_TIER));
+    Route route = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+    String routeId = route != null ? trimToDefault(route.getId()) : "unknown";
+    span.tag("tenant_id", tenantId);
+    span.tag("subscription_tier", tier);
+    span.tag("route_id", routeId);
+  }
+
+  public void recordRateLimitDecision(ServerWebExchange exchange,
+      boolean allowed,
+      long remaining,
+      long baseRemaining,
+      long burstRemaining,
+      Duration window,
+      boolean burstConsumed,
+      @Nullable String strategy) {
+    if (!isEnabled()) {
+      return;
+    }
+    Span span = tracer.currentSpan();
+    if (span == null) {
+      return;
+    }
+    String tenantId = trimToDefault(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID));
+    span.tag("rate_limit.strategy", trimToDefault(strategy));
+    span.tag("rate_limit.allowed", Boolean.toString(allowed));
+    span.event(String.format(Locale.ROOT,
+        "rate_limit decision=%s tenant=%s remaining=%d baseRemaining=%d burstRemaining=%d burst=%s windowMs=%d",
+        allowed ? "allowed" : "rejected",
+        tenantId,
+        remaining,
+        baseRemaining,
+        burstRemaining,
+        burstConsumed,
+        window != null ? window.toMillis() : -1));
+  }
+
+  public void recordSubscriptionValidation(ServerWebExchange exchange,
+      Duration duration,
+      boolean cacheHit,
+      @Nullable String routeId,
+      @Nullable String decision) {
+    if (!isEnabled()) {
+      return;
+    }
+    Span span = tracer.currentSpan();
+    if (span == null) {
+      return;
+    }
+    String tenantId = trimToDefault(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID));
+    String resolvedRoute = StringUtils.hasText(routeId) ? routeId : resolveRouteId(exchange);
+    span.event(String.format(Locale.ROOT,
+        "subscription.validation tenant=%s route=%s cacheHit=%s durationMs=%d decision=%s",
+        tenantId,
+        resolvedRoute,
+        cacheHit,
+        duration != null ? duration.toMillis() : -1,
+        trimToDefault(decision)));
+  }
+
+  private String resolveRouteId(ServerWebExchange exchange) {
+    Route route = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+    if (route == null) {
+      return "unknown";
+    }
+    return trimToDefault(route.getId());
+  }
+
+  private String trimToDefault(@Nullable String value) {
+    if (!StringUtils.hasText(value)) {
+      return "unknown";
+    }
+    return value.trim();
+  }
+}

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -205,6 +205,15 @@ resilience4j:
 
 # Declarative downstream routes consumed by GatewayRoutesConfiguration
 gateway:
+  logging:
+    access-log:
+      enabled: true
+      skip-patterns:
+        - /actuator/**
+        - /health
+  tracing:
+    enhanced-tags:
+      enabled: true
   bff:
     dashboard:
       tenant-service-uri: lb://tenant-service

--- a/api-gateway/src/test/java/com/ejada/gateway/metrics/GatewayMetricsFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/metrics/GatewayMetricsFilterTest.java
@@ -1,0 +1,62 @@
+package com.ejada.gateway.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.gateway.config.GatewayTracingProperties;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.ejada.gateway.filter.GatewayMetricsFilter;
+import com.ejada.gateway.observability.GatewayTracingHelper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class GatewayMetricsFilterTest {
+
+  private SimpleMeterRegistry meterRegistry;
+  private GatewayMetricsFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    this.meterRegistry = new SimpleMeterRegistry();
+    GatewayTracingProperties tracingProperties = new GatewayTracingProperties();
+    GatewayTracingHelper tracingHelper = new GatewayTracingHelper(null, tracingProperties);
+    this.filter = new GatewayMetricsFilter(meterRegistry, tracingHelper);
+  }
+
+  @Test
+  void recordsRequestMetricsPerTenantAndRoute() {
+    MockServerHttpRequest request = MockServerHttpRequest.get("/api/students").build();
+    MockServerWebExchange exchange = MockServerWebExchange.from(request);
+    exchange.getAttributes().put(GatewayRequestAttributes.TENANT_ID, "acme");
+    Route route = Route.async()
+        .id("students-route")
+        .uri(URI.create("http://students"))
+        .predicate(serverWebExchange -> true)
+        .build();
+    exchange.getAttributes().put(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR, route);
+
+    WebFilterChain chain = serverWebExchange -> {
+      serverWebExchange.getResponse().setStatusCode(HttpStatus.NO_CONTENT);
+      return Mono.empty();
+    };
+
+    StepVerifier.create(filter.filter(exchange, chain)).verifyComplete();
+
+    assertThat(meterRegistry.find("gateway.requests.by_tenant").counter()).isNotNull();
+    assertThat(meterRegistry.find("gateway.requests.by_tenant").counter().count()).isEqualTo(1d);
+
+    assertThat(meterRegistry.find("gateway.route.latency").timer()).isNotNull();
+    assertThat(meterRegistry.find("gateway.route.latency").timer().count()).isEqualTo(1L);
+
+    assertThat(meterRegistry.find("gateway.request.duration").timer()).isNotNull();
+  }
+}

--- a/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
@@ -3,6 +3,8 @@ package com.ejada.gateway.ratelimit;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ejada.gateway.config.GatewayRateLimitProperties;
+import com.ejada.gateway.config.GatewayTracingProperties;
+import com.ejada.gateway.observability.GatewayTracingHelper;
 import com.ejada.shared_starter_ratelimit.RateLimitProps;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -33,6 +35,7 @@ class ReactiveRateLimiterFilterTest {
     private ReactiveRateLimiterFilter filter;
     private ReactiveRedisConnectionFactory connectionFactory;
     private GatewayRateLimitProperties gatewayRateLimitProperties;
+    private GatewayTracingHelper tracingHelper;
 
     @BeforeEach
     void setUp() {
@@ -49,8 +52,9 @@ class ReactiveRateLimiterFilterTest {
         this.gatewayRateLimitProperties = new GatewayRateLimitProperties();
         gatewayRateLimitProperties.setBurstMultiplier(1.0d);
         KeyResolver keyResolver = exchange -> Mono.just("tenant-a");
+        this.tracingHelper = new GatewayTracingHelper(null, new GatewayTracingProperties());
         this.filter = new ReactiveRateLimiterFilter(template, props, keyResolver, new ObjectMapper(),
-                gatewayRateLimitProperties, new SimpleMeterRegistry());
+                gatewayRateLimitProperties, new SimpleMeterRegistry(), tracingHelper);
         flushRedis();
     }
 
@@ -97,7 +101,7 @@ class ReactiveRateLimiterFilterTest {
         ReactiveStringRedisTemplate template = new ReactiveStringRedisTemplate(connectionFactory);
         KeyResolver keyResolver = exchange -> Mono.just("tenant-b");
         ReactiveRateLimiterFilter concurrentFilter = new ReactiveRateLimiterFilter(template, props, keyResolver,
-                new ObjectMapper(), gatewayProps, new SimpleMeterRegistry());
+                new ObjectMapper(), gatewayProps, new SimpleMeterRegistry(), tracingHelper);
 
         flushRedis();
 

--- a/charts/grafana/gateway-observability-dashboard.json
+++ b/charts/grafana/gateway-observability-dashboard.json
@@ -1,0 +1,110 @@
+{
+  "id": null,
+  "title": "Gateway Observability",
+  "uid": "gateway-observability",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Requests by Tenant",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(gateway_requests_by_tenant_total{tenantId!\"unknown\"}[5m])) by (tenantId, statusCode)",
+          "legendFormat": "{{tenantId}} - {{statusCode}}"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Route Latency (P95)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(gateway_route_latency_seconds_bucket[5m])) by (le, routeId))",
+          "legendFormat": "{{routeId}}"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+    },
+    {
+      "type": "gauge",
+      "title": "Subscription Cache Hit Rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit"
+        }
+      },
+      "targets": [
+        {
+          "expr": "gateway_subscription_validation_cache_hit_rate"
+        }
+      ],
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 8 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Rate Limit Rejections",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(gateway_ratelimit_rejections_total[5m])) by (strategy, tenantId)",
+          "legendFormat": "{{strategy}} - {{tenantId}}"
+        }
+      ],
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 8 }
+    },
+    {
+      "type": "state-timeline",
+      "title": "Circuit Breaker State",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "targets": [
+        {
+          "expr": "gateway_circuit_breaker_state{state=\"open\"}",
+          "legendFormat": "{{serviceName}}"
+        }
+      ],
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 8 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Subscription Validation Duration",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(gateway_subscription_validation_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P95"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 }
+    }
+  ],
+  "templating": {
+    "list": []
+  }
+}

--- a/charts/prometheus/alert-rules.yaml
+++ b/charts/prometheus/alert-rules.yaml
@@ -1,0 +1,42 @@
+groups:
+  - name: gateway-observability
+    rules:
+      - alert: GatewayHighErrorRate
+        expr: sum(rate(gateway_requests_by_tenant_total{statusCode=~"5.."}[5m]))
+          /
+          sum(rate(gateway_requests_by_tenant_total[5m])) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Gateway error rate above 5%"
+          description: "5xx responses exceeded 5% of total gateway traffic over the last 5 minutes."
+
+      - alert: GatewayRateLimitRejectionSpike
+        expr: sum(rate(gateway_ratelimit_rejections_total[1m])) > 100
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Rate limit rejections spiking"
+          description: "Gateway is rejecting more than 100 requests per minute due to rate limiting."
+
+      - alert: GatewayCircuitBreakerOpen
+        expr: max_over_time(gateway_circuit_breaker_state{state="open"}[30s]) > 0
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: "Circuit breaker open"
+          description: "One or more circuit breakers have remained open for over 30 seconds."
+
+      - alert: GatewaySubscriptionValidationFailures
+        expr: sum(rate(gateway_subscription_validation_outcomes_total{outcome="failure"}[5m]))
+          /
+          sum(rate(gateway_subscription_validation_outcomes_total[5m])) > 0.10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Subscription validation failures >10%"
+          description: "Subscription validation failures exceeded 10% of total validations over the last 5 minutes."


### PR DESCRIPTION
## Summary
- add gateway tracing, metrics, and structured access logging filters with supporting configuration properties
- instrument subscription validation and rate limiting with span events and dedicated Micrometer metrics
- extend admin health reporting with detailed readiness data and ship Grafana dashboard plus Prometheus alert rules

## Testing
- `mvn -pl api-gateway test` *(fails: required private dependencies are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12c85bb84832f8d8e17ef2554440e