### PR TITLE
Fix shared-config validation dependency and refresh event import

### DIFF
--- a/shared-lib/shared-config/pom.xml
+++ b/shared-lib/shared-config/pom.xml
@@ -21,6 +21,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>

--- a/shared-lib/shared-config/src/main/java/com/ejada/config/refresh/ConfigRefreshAuditListener.java
+++ b/shared-lib/shared-config/src/main/java/com/ejada/config/refresh/ConfigRefreshAuditListener.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.event.EnvironmentChangeEvent;
+import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.util.StringUtils;

--- a/shared-lib/shared-config/src/test/java/com/ejada/config/refresh/ConfigRefreshAuditListenerTest.java
+++ b/shared-lib/shared-config/src/test/java/com/ejada/config/refresh/ConfigRefreshAuditListenerTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.context.event.EnvironmentChangeEvent;
+import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.mock.env.MockEnvironment;
 
 class ConfigRefreshAuditListenerTest {


### PR DESCRIPTION
## Summary
- add the Spring Boot validation starter so jakarta validation annotations resolve in shared-config
- align the config refresh listener and its test with the Spring Cloud EnvironmentChangeEvent package

## Testing
- mvn -pl shared-lib/shared-config -am -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e13ace1c0c832f95abdcd475b320b8