### PR TITLE
Ensure refresh scope is registered in central config test

### DIFF
--- a/shared-lib/shared-config/src/test/java/com/ejada/config/CentralConfigAutoConfigurationTest.java
+++ b/shared-lib/shared-config/src/test/java/com/ejada/config/CentralConfigAutoConfigurationTest.java
@@ -2,13 +2,17 @@ package com.ejada.config;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(
-	    classes = CentralConfigAutoConfiguration.class,
-	    properties = "spring.cloud.config.enabled=false"
+            classes = {
+                CentralConfigAutoConfiguration.class,
+                RefreshAutoConfiguration.class
+            },
+            properties = "spring.cloud.config.enabled=false"
         )class CentralConfigAutoConfigurationTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- include RefreshAutoConfiguration in the central config auto-configuration test so the refresh scope is available during context initialization

## Testing
- mvn -pl shared-lib/shared-config -am test *(fails: Error opening zip file or JAR manifest missing : /root/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68e13c5d75d4832fa2507d5cb9072e4e