### PR TITLE
Fix null outbox payload handling in subscription orchestrator

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/approval/AdminApprovalServiceTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/approval/AdminApprovalServiceTest.java
@@ -3,6 +3,7 @@ package com.ejada.subscription.service.approval;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -136,7 +137,7 @@ class AdminApprovalServiceTest {
 
         verify(approvalPublisher)
                 .publishApprovalDecision(
-                        SubscriptionApprovalAction.APPROVED,
+                        eq(SubscriptionApprovalAction.APPROVED),
                         any(UUID.class),
                         any(Subscription.class),
                         any(CustomerInfoDto.class),


### PR DESCRIPTION
## Summary
- prevent null payload values from causing `Map.of` null pointer exceptions in `MarketplaceCallbackOrchestrator`
- update the admin approval service test verification to use an argument matcher for the approval action

## Testing
- `mvn -pl tenant-platform/subscription-service -am test` *(fails: Error opening zip file or JAR manifest missing : /root/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68e141033a80832f853a02b991749608