### PR TITLE
Fix unnecessary stubs in MarketplaceCallbackOrchestratorTest

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/acl/MarketplaceCallbackOrchestratorTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/acl/MarketplaceCallbackOrchestratorTest.java
@@ -183,8 +183,6 @@ class MarketplaceCallbackOrchestratorTest {
         when(featureRepo.findBySubscriptionSubscriptionId(200L)).thenReturn(List.of());
         when(additionalServiceRepo.findBySubscriptionSubscriptionId(200L)).thenReturn(List.of());
         when(propertyRepo.findBySubscriptionSubscriptionId(200L)).thenReturn(List.of());
-        when(envIdRepo.findBySubscriptionSubscriptionId(200L)).thenReturn(List.of());
-        when(envIdMapper.toDtoList(List.of())).thenReturn(List.of());
         when(idemRepo.existsByIdempotencyKey(rqUid)).thenReturn(false);
 
         SubscriptionApprovalRequest approvalRequest = new SubscriptionApprovalRequest();


### PR DESCRIPTION
## Summary
- remove unused environment identifier stubs from MarketplaceCallbackOrchestratorTest to prevent Mockito from flagging unnecessary stubbings

## Testing
- `mvn -pl tenant-platform/subscription-service test` *(fails: requires internal com.ejada starter artifacts that are not available from Maven Central in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e142b476d0832f9f053428ff8b01ab