### PR TITLE
Fix Kafka testcontainer image path issue

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -43,7 +43,7 @@ class SubscriptionApprovalConsumerIT {
             new PostgreSQLContainer<>(DockerImageName.parse("postgres:15-alpine"));
 
     private static final DockerImageName KAFKA_IMAGE =
-            DockerImageName.parse("confluentinc/cp-kafka:7.5.3")
+            DockerImageName.parse("confluentinc/cp-kafka:7.5.0")
                     .asCompatibleSubstituteFor("apache/kafka");
 
     @Container


### PR DESCRIPTION
## Summary
- align the Kafka Testcontainers image with the version used elsewhere to avoid missing startup scripts during integration tests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e144f65a4c832f9cb9ea36bf6355ff