### PR TITLE
Fix SubscriptionApprovalConsumerIT EmbeddedKafka topic visibility

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -38,7 +38,7 @@ import org.testcontainers.utility.DockerImageName;
 @TestPropertySource(properties = "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}")
 class SubscriptionApprovalConsumerIT {
 
-    private static final String APPROVAL_TOPIC = "subscription-approvals-it";
+    static final String APPROVAL_TOPIC = "subscription-approvals-it";
     private static final String CONSUMER_GROUP = "subscription-approvals-it-group";
 
     @Container


### PR DESCRIPTION
## Summary
- remove the private modifier from the EmbeddedKafka topic constant in SubscriptionApprovalConsumerIT so the annotation can reference it during compilation

## Testing
- mvn -pl tenant-platform/subscription-service -am test -DskipITs *(fails: remote repository checksum errors while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e14942f50c832fba0d1e980161e545