### PR TITLE
Enable tenant provisioning properties binding

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/TenantProvisioningConfiguration.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/TenantProvisioningConfiguration.java
@@ -1,0 +1,10 @@
+package com.ejada.subscription.config;
+
+import com.ejada.common.events.provisioning.TenantProvisioningProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(TenantProvisioningProperties.class)
+public class TenantProvisioningConfiguration {
+}


### PR DESCRIPTION
## Summary
- add configuration class enabling TenantProvisioningProperties binding so the bean is available during context startup

## Testing
- not run (project requires proprietary parent BOM that is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e14b10f1d4832f854bde761f682f71