### PR TITLE
Implement production-ready tenant resolution pipeline

### DIFF
--- a/shared-lib/shared-starters/starter-core/pom.xml
+++ b/shared-lib/shared-starters/starter-core/pom.xml
@@ -125,6 +125,21 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-resource-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-jose</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/DefaultTenantResolver.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/DefaultTenantResolver.java
@@ -1,82 +1,437 @@
 package com.ejada.starter_core.tenant;
 
+import com.ejada.common.constants.HeaderNames;
 import com.ejada.starter_core.config.CoreAutoConfiguration.CoreProps;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.slf4j.MDC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+/**
+ * Production tenant resolver capable of resolving tenants from JWTs, headers,
+ * subdomains and administrative paths. The resolver validates every resolved
+ * tenant against the provided {@link TenantDirectory} before returning it to
+ * the {@link TenantContextContributor}.
+ */
 public class DefaultTenantResolver implements TenantResolver {
 
-    private final CoreProps.Tenant cfg;
+    private static final Logger log = LoggerFactory.getLogger(DefaultTenantResolver.class);
 
-    // >>> This is the constructor CoreAutoConfiguration calls <<<
-    public DefaultTenantResolver(CoreProps.Tenant cfg) {
-        this.cfg = cfg;
+    private static final Pattern SLUG_PATTERN = Pattern.compile("^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ADMIN_PATH_PATTERN = Pattern.compile("/api/v\\d+/admin/tenants/([0-9a-fA-F-]{36})");
+
+    private final CoreProps.Tenant cfg;
+    private final TenantDirectory directory;
+    private final ConcurrentMap<String, CachedTenant> subdomainCache;
+    private final Duration subdomainCacheTtl;
+    private final Set<String> reservedSubdomains;
+
+    public DefaultTenantResolver(CoreProps.Tenant cfg, TenantDirectory directory) {
+        this.cfg = Objects.requireNonNull(cfg, "cfg");
+        this.directory = Objects.requireNonNull(directory, "directory");
+        this.subdomainCache = new ConcurrentHashMap<>();
+        long ttlSeconds = Math.max(0, cfg.getSubdomainCacheTtlSeconds());
+        this.subdomainCacheTtl = ttlSeconds == 0 ? Duration.ZERO : Duration.ofSeconds(ttlSeconds);
+        this.reservedSubdomains = Arrays.stream(Optional.ofNullable(cfg.getReservedSubdomains()).orElse(new String[0]))
+                .map(s -> s.toLowerCase(Locale.ROOT))
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
     }
 
     @Override
     public TenantResolution resolve(HttpServletRequest request) {
-        String fromHeader = trimToNull(request.getHeader(cfg.getHeaderName()));
-        String fromQuery = trimToNull(request.getParameter(cfg.getQueryParam()));
-        String fromJwt = null;
-        if (cfg.isResolveFromJwt()) {
-            fromJwt = tenantFromJwtIfAvailable(cfg.getJwtClaimNames());
+        if (request == null) {
+            return TenantResolution.absent();
         }
 
-        TenantResolution resolution = cfg.isPreferHeaderOverJwt()
-                ? resolveInOrder(fromHeader, fromQuery, fromJwt)
-                : resolveInOrder(fromJwt, fromHeader, fromQuery);
+        TenantResolution[] attempts = new TenantResolution[] {
+                resolveFromJwt(),
+                resolveFromHeader(request),
+                resolveFromSubdomain(request),
+                resolveFromAdminPath(request)
+        };
 
-        if (resolution.hasTenant()) {
-            MDC.put(cfg.getMdcKey(), resolution.tenantId());
-        } else {
-            MDC.remove(cfg.getMdcKey());
-        }
-        return resolution;
-    }
-
-    private static TenantResolution resolveInOrder(String... candidates) {
-        for (String candidate : candidates) {
-            TenantResolution resolution = TenantIdValidator.validate(candidate);
-            if (!resolution.isAbsent()) {
-                return resolution;
+        for (TenantResolution attempt : attempts) {
+            if (attempt == null || attempt.isAbsent()) {
+                continue;
+            }
+            if (attempt.hasTenant()) {
+                logResolvedTenant(attempt, request);
+                return attempt;
+            }
+            if (attempt.hasError()) {
+                logResolutionError(attempt, request);
+                return attempt;
             }
         }
+
+        if (cfg.isFailIfTenantMissing()) {
+            TenantResolution failure = TenantResolution.error(tenantMissingError(), null, TenantSource.NONE);
+            logResolutionError(failure, request);
+            return failure;
+        }
+
+        log.debug("Tenant resolution skipped for {} {}", request.getMethod(), safePath(request));
         return TenantResolution.absent();
     }
 
-    private static String trimToNull(String s) {
-        return (s == null || s.isBlank()) ? null : s.trim();
+    private TenantResolution resolveFromJwt() {
+        if (!cfg.isResolveFromJwt()) {
+            return TenantResolution.absent();
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return TenantResolution.absent();
+        }
+
+        Map<String, Object> claims = extractJwtClaims(authentication);
+        String idClaim = firstClaim(claims, cfg.getJwtClaimNames());
+        if (StringUtils.hasText(idClaim)) {
+            TenantResolution byId = resolveByIdCandidate(idClaim, TenantSource.JWT);
+            if (!byId.isAbsent()) {
+                return byId;
+            }
+        }
+
+        String slugClaimName = cfg.getJwtTenantSlugClaim();
+        if (StringUtils.hasText(slugClaimName)) {
+            String slugClaim = trimToNull(asString(claims.get(slugClaimName)));
+            if (StringUtils.hasText(slugClaim)) {
+                return resolveBySlugCandidate(slugClaim, TenantSource.JWT);
+            }
+        }
+
+        return TenantResolution.absent();
     }
 
     @SuppressWarnings("unchecked")
-    private static String tenantFromJwtIfAvailable(String[] claimNames) {
+    private Map<String, Object> extractJwtClaims(Authentication authentication) {
+        if (authentication == null) {
+            return Map.of();
+        }
         try {
-            Class<?> scClass = Class.forName("org.springframework.security.core.context.SecurityContextHolder");
-            Object context = scClass.getMethod("getContext").invoke(null);
-            if (context == null) return null;
-            Object auth = context.getClass().getMethod("getAuthentication").invoke(context);
-            if (auth == null) return null;
-
-            Object jwt;
-            try {
-                jwt = auth.getClass().getMethod("getToken").invoke(auth);
-            } catch (NoSuchMethodException ex) {
-                return null; // not a JwtAuthenticationToken
+            Class<?> jwtAuthClass = Class.forName("org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken");
+            if (!jwtAuthClass.isInstance(authentication)) {
+                return Map.of();
             }
-            Object claims = jwt.getClass().getMethod("getClaims").invoke(jwt);
-            if (!(claims instanceof Map)) return null;
-            Map<String, Object> map = (Map<String, Object>) claims;
-
-            for (String name : claimNames) {
-                Object v = map.get(name);
-                if (v != null) return Objects.toString(v, null);
+            Object jwtToken = jwtAuthClass.getMethod("getToken").invoke(authentication);
+            if (jwtToken == null) {
+                return Map.of();
             }
-        } catch (Throwable ignore) { /* security not on classpath or structure differs */ }
+            Object claims = jwtToken.getClass().getMethod("getClaims").invoke(jwtToken);
+            if (claims instanceof Map<?, ?> map) {
+                return (Map<String, Object>) map;
+            }
+        } catch (ClassNotFoundException ex) {
+            log.debug("JWT authentication class not on classpath; skipping claim extraction");
+        } catch (ReflectiveOperationException ex) {
+            log.warn("Failed to extract JWT claims for tenant resolution", ex);
+        }
+        return Map.of();
+    }
+
+    private TenantResolution resolveFromHeader(HttpServletRequest request) {
+        if (!cfg.isAllowHeaderResolution()) {
+            return TenantResolution.absent();
+        }
+
+        String headerName = cfg.getHeaderName();
+        String headerValue = trimToNull(request.getHeader(headerName));
+        if (headerValue == null) {
+            return TenantResolution.absent();
+        }
+
+        if (cfg.isRequireApiKeyForHeader() && !hasApiKeyAuthentication(request)) {
+            return TenantResolution.error(tenantApiKeyRequiredError(headerName), headerValue, TenantSource.HEADER);
+        }
+
+        return resolveByIdCandidate(headerValue, TenantSource.HEADER);
+    }
+
+    private TenantResolution resolveFromSubdomain(HttpServletRequest request) {
+        if (!cfg.isAllowSubdomainResolution()) {
+            return TenantResolution.absent();
+        }
+
+        String host = extractHost(request);
+        if (!StringUtils.hasText(host)) {
+            return TenantResolution.absent();
+        }
+        String[] parts = host.split("\\.");
+        if (parts.length < 3) {
+            return TenantResolution.absent();
+        }
+
+        String candidate = parts[0].toLowerCase(Locale.ROOT);
+        if (reservedSubdomains.contains(candidate)) {
+            return TenantResolution.absent();
+        }
+
+        TenantResolution cached = resolveFromCache(candidate);
+        if (cached != null) {
+            return cached;
+        }
+
+        TenantResolution resolution = resolveBySlugCandidate(candidate, TenantSource.SUBDOMAIN);
+        cacheSubdomain(candidate, resolution);
+        return resolution;
+    }
+
+    private TenantResolution resolveFromAdminPath(HttpServletRequest request) {
+        if (!cfg.isAllowPathResolution()) {
+            return TenantResolution.absent();
+        }
+
+        String path = request.getRequestURI();
+        if (!StringUtils.hasText(path)) {
+            return TenantResolution.absent();
+        }
+
+        Matcher matcher = ADMIN_PATH_PATTERN.matcher(path);
+        if (!matcher.find()) {
+            return TenantResolution.absent();
+        }
+
+        if (!hasSuperAdminAuthority()) {
+            return TenantResolution.error(tenantSuperAdminRequiredError(), matcher.group(1), TenantSource.ADMIN_PATH);
+        }
+
+        return resolveByIdCandidate(matcher.group(1), TenantSource.ADMIN_PATH);
+    }
+
+    private TenantResolution resolveByIdCandidate(String raw, TenantSource source) {
+        String value = trimToNull(raw);
+        if (value == null) {
+            return TenantResolution.absent();
+        }
+        UUID tenantId;
+        try {
+            tenantId = UUID.fromString(value);
+        } catch (IllegalArgumentException ex) {
+            return TenantResolution.invalid(value, source);
+        }
+
+        Optional<TenantDirectory.TenantRecord> record = directory.findById(tenantId);
+        return evaluateRecord(record, value, source);
+    }
+
+    private TenantResolution resolveBySlugCandidate(String raw, TenantSource source) {
+        String slug = normalizeSlug(raw);
+        if (slug == null) {
+            return TenantResolution.invalid(raw, source);
+        }
+
+        Optional<TenantDirectory.TenantRecord> record = directory.findBySlug(slug);
+        return evaluateRecord(record, slug, source);
+    }
+
+    private TenantResolution evaluateRecord(Optional<TenantDirectory.TenantRecord> optional,
+                                            String rawValue,
+                                            TenantSource source) {
+        if (optional.isEmpty()) {
+            return TenantResolution.error(tenantNotFoundError(), rawValue, source);
+        }
+
+        TenantDirectory.TenantRecord record = optional.get();
+        if (record.isInactive()) {
+            return TenantResolution.error(tenantInactiveError(), rawValue, source);
+        }
+
+        return TenantResolution.present(record.id().toString(), source);
+    }
+
+    private void cacheSubdomain(String subdomain, TenantResolution resolution) {
+        if (subdomainCacheTtl.isZero() || !resolution.hasTenant()) {
+            return;
+        }
+        Instant expiresAt = Instant.now().plus(subdomainCacheTtl);
+        subdomainCache.put(subdomain, new CachedTenant(resolution.tenantId(), expiresAt));
+    }
+
+    private TenantResolution resolveFromCache(String subdomain) {
+        if (subdomainCacheTtl.isZero()) {
+            return null;
+        }
+        CachedTenant cached = subdomainCache.get(subdomain);
+        if (cached == null) {
+            return null;
+        }
+        if (cached.isExpired()) {
+            subdomainCache.remove(subdomain, cached);
+            return null;
+        }
+        return TenantResolution.present(cached.tenantId, TenantSource.SUBDOMAIN);
+    }
+
+    private boolean hasApiKeyAuthentication(HttpServletRequest request) {
+        if (StringUtils.hasText(trimToNull(request.getHeader(HeaderNames.API_KEY)))) {
+            return true;
+        }
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
+        }
+        String simpleName = authentication.getClass().getSimpleName();
+        if (simpleName.contains("ApiKey")) {
+            return true;
+        }
+        if (authentication.getAuthorities() != null) {
+            for (GrantedAuthority authority : authentication.getAuthorities()) {
+                String value = authority.getAuthority();
+                if (value != null && ("ROLE_API_CLIENT".equals(value) || "ROLE_SERVICE".equals(value))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean hasSuperAdminAuthority() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
+        }
+        if (authentication.getAuthorities() == null) {
+            return false;
+        }
+        for (GrantedAuthority authority : authentication.getAuthorities()) {
+            String value = authority.getAuthority();
+            if (value == null) {
+                continue;
+            }
+            if ("SUPER_ADMIN".equals(value) || "ROLE_SUPER_ADMIN".equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String extractHost(HttpServletRequest request) {
+        String host = trimToNull(request.getHeader("Host"));
+        if (!StringUtils.hasText(host)) {
+            host = trimToNull(request.getServerName());
+        }
+        if (host == null) {
+            return null;
+        }
+        int colon = host.indexOf(':');
+        return colon >= 0 ? host.substring(0, colon) : host;
+    }
+
+    private static String normalizeSlug(String slug) {
+        String normalized = trimToNull(slug);
+        if (normalized == null) {
+            return null;
+        }
+        normalized = normalized.toLowerCase(Locale.ROOT);
+        if (!SLUG_PATTERN.matcher(normalized).matches()) {
+            return null;
+        }
+        return normalized;
+    }
+
+    private static String firstClaim(Map<String, Object> claims, String[] names) {
+        if (claims == null || names == null) {
+            return null;
+        }
+        for (String name : names) {
+            if (!StringUtils.hasText(name)) {
+                continue;
+            }
+            Object value = claims.get(name);
+            String asString = trimToNull(asString(value));
+            if (asString != null) {
+                return asString;
+            }
+        }
         return null;
     }
+
+    private static String asString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String s) {
+            return s;
+        }
+        return value.toString();
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static String safePath(HttpServletRequest request) {
+        try {
+            return request.getRequestURI();
+        } catch (Exception ex) {
+            return "<unknown>";
+        }
+    }
+
+    private static TenantError tenantMissingError() {
+        return TenantError.badRequest("TENANT_REQUIRED", "Tenant identification required");
+    }
+
+    private static TenantError tenantNotFoundError() {
+        return TenantError.notFound("TENANT_NOT_FOUND", "Tenant not available");
+    }
+
+    private static TenantError tenantInactiveError() {
+        return TenantError.forbidden("TENANT_INACTIVE", "Service unavailable");
+    }
+
+    private static TenantError tenantApiKeyRequiredError(String headerName) {
+        String message = "API key authentication required to use " + headerName;
+        return TenantError.unauthorized("TENANT_API_KEY_REQUIRED", message);
+    }
+
+    private static TenantError tenantSuperAdminRequiredError() {
+        return TenantError.forbidden("TENANT_SUPER_ADMIN_REQUIRED", "Super admin privileges required");
+    }
+
+    private static void logResolvedTenant(TenantResolution resolution, HttpServletRequest request) {
+        if (!log.isDebugEnabled()) {
+            return;
+        }
+        log.debug("Resolved tenant {} via {} for {} {}", resolution.tenantId(), resolution.source(),
+                request.getMethod(), safePath(request));
+    }
+
+    private static void logResolutionError(TenantResolution resolution, HttpServletRequest request) {
+        TenantError error = resolution.error();
+        String message = error != null ? error.code() : "TENANT_ERROR";
+        log.warn("Tenant resolution error (source={}, status={}): {} on {} {}", resolution.source(),
+                error != null ? error.httpStatus() : "n/a", message, request.getMethod(), safePath(request));
+    }
+
+    private record CachedTenant(String tenantId, Instant expiresAt) {
+        private boolean isExpired() {
+            return expiresAt != null && Instant.now().isAfter(expiresAt);
+        }
+    }
 }
+

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantDirectory.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantDirectory.java
@@ -1,0 +1,80 @@
+package com.ejada.starter_core.tenant;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Pluggable directory used by {@link TenantResolver} implementations to look up
+ * tenant metadata from the hosting application. Applications are expected to
+ * provide a concrete implementation backed by their persistence layer or an
+ * external directory service.
+ */
+public interface TenantDirectory {
+
+    /**
+     * Resolve tenant information by its canonical UUID identifier.
+     *
+     * @param tenantId security tenant identifier
+     * @return optional tenant metadata
+     */
+    Optional<TenantRecord> findById(UUID tenantId);
+
+    /**
+     * Resolve tenant information by its human readable slug/code.
+     *
+     * @param slug tenant slug (case insensitive)
+     * @return optional tenant metadata
+     */
+    Optional<TenantRecord> findBySlug(String slug);
+
+    /**
+     * Resolve tenant information using a public subdomain (case insensitive).
+     * Implementations may simply delegate to {@link #findBySlug(String)} if the
+     * subdomain and slug are equivalent in the data model.
+     *
+     * @param subdomain public subdomain
+     * @return optional tenant metadata
+     */
+    default Optional<TenantRecord> findBySubdomain(String subdomain) {
+        return findBySlug(subdomain);
+    }
+
+    /**
+     * Represents a lightweight view of a tenant used purely for request
+     * scoping. Implementations should avoid exposing sensitive data here.
+     *
+     * @param id canonical UUID identifier used for security scoping
+     * @param slug optional human readable slug/code (lower case)
+     * @param active whether the tenant is currently active
+     */
+    record TenantRecord(UUID id, String slug, boolean active) {
+        public TenantRecord {
+            if (id == null) {
+                throw new IllegalArgumentException("id is required");
+            }
+        }
+
+        public boolean isInactive() {
+            return !active;
+        }
+    }
+
+    /**
+     * A no-op directory that never resolves tenants. Useful for tests or
+     * disabling multi-tenancy explicitly.
+     */
+    static TenantDirectory noop() {
+        return new TenantDirectory() {
+            @Override
+            public Optional<TenantRecord> findById(UUID tenantId) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<TenantRecord> findBySlug(String slug) {
+                return Optional.empty();
+            }
+        };
+    }
+}
+

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantError.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantError.java
@@ -1,0 +1,36 @@
+package com.ejada.starter_core.tenant;
+
+import java.util.Objects;
+
+/**
+ * Error descriptor returned as part of {@link TenantResolution} when the
+ * resolver determines that the incoming request cannot be associated with a
+ * tenant.
+ */
+public record TenantError(int httpStatus, String code, String message) {
+
+    public TenantError {
+        if (httpStatus < 100 || httpStatus > 599) {
+            throw new IllegalArgumentException("Invalid HTTP status: " + httpStatus);
+        }
+        code = Objects.requireNonNullElse(code, "TENANT_ERROR");
+        message = Objects.requireNonNullElse(message, "Tenant resolution failed");
+    }
+
+    public static TenantError badRequest(String code, String message) {
+        return new TenantError(400, code, message);
+    }
+
+    public static TenantError unauthorized(String code, String message) {
+        return new TenantError(401, code, message);
+    }
+
+    public static TenantError forbidden(String code, String message) {
+        return new TenantError(403, code, message);
+    }
+
+    public static TenantError notFound(String code, String message) {
+        return new TenantError(404, code, message);
+    }
+}
+

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantFilter.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantFilter.java
@@ -3,6 +3,7 @@ package com.ejada.starter_core.tenant;
 import com.ejada.common.context.ContextManager;
 import com.ejada.starter_core.config.CoreAutoConfiguration.CoreProps;
 import com.ejada.starter_core.web.FilterSkipUtils;
+import com.ejada.starter_core.tenant.TenantError;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -42,8 +43,13 @@ public class TenantFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
             throws ServletException, IOException {
         TenantResolution resolution = resolver.resolve(req);
-        if (resolution.isInvalid()) {
-            res.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid " + cfg.getHeaderName());
+        if (resolution.hasError()) {
+            TenantError error = resolution.error();
+            if (error == null || resolution.isInvalid()) {
+                res.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid " + cfg.getHeaderName());
+            } else {
+                res.sendError(error.httpStatus(), error.message());
+            }
             return;
         }
 

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantIdValidator.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantIdValidator.java
@@ -22,8 +22,8 @@ final class TenantIdValidator {
             return TenantResolution.absent();
         }
         if (!TENANT_PATTERN.matcher(trimmed).matches()) {
-            return TenantResolution.invalid(trimmed);
+            return TenantResolution.invalid(trimmed, TenantSource.NONE);
         }
-        return TenantResolution.present(trimmed);
+        return TenantResolution.present(trimmed, TenantSource.NONE);
     }
 }

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantSource.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/tenant/TenantSource.java
@@ -1,0 +1,20 @@
+package com.ejada.starter_core.tenant;
+
+/**
+ * Origin of a resolved tenant identifier. Useful for logging/debugging and for
+ * applying conditional policies when multiple resolution strategies are
+ * enabled.
+ */
+public enum TenantSource {
+    /** No tenant information available. */
+    NONE,
+    /** Tenant resolved from an authenticated JWT. */
+    JWT,
+    /** Tenant resolved from the {@code X-Tenant-Id} header. */
+    HEADER,
+    /** Tenant resolved from the request subdomain. */
+    SUBDOMAIN,
+    /** Tenant resolved from an administrative path segment. */
+    ADMIN_PATH
+}
+

--- a/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/tenant/DefaultTenantResolverTest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/com/ejada/starter_core/tenant/DefaultTenantResolverTest.java
@@ -1,0 +1,152 @@
+package com.ejada.starter_core.tenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.starter_core.config.CoreAutoConfiguration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+class DefaultTenantResolverTest {
+
+    private CoreAutoConfiguration.CoreProps.Tenant tenantProps;
+    private InMemoryTenantDirectory directory;
+    private DefaultTenantResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        CoreAutoConfiguration.CoreProps props = new CoreAutoConfiguration.CoreProps();
+        tenantProps = props.getTenant();
+        tenantProps.setFailIfTenantMissing(false);
+        tenantProps.setAllowHeaderResolution(true);
+        tenantProps.setAllowSubdomainResolution(true);
+        tenantProps.setAllowPathResolution(true);
+        directory = new InMemoryTenantDirectory();
+        resolver = new DefaultTenantResolver(tenantProps, directory);
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void resolvesTenantFromJwtClaim() {
+        UUID tenantId = UUID.randomUUID();
+        directory.add(tenantId, "acme", true);
+        setJwtAuthentication(Map.of("tenantId", tenantId.toString()));
+
+        TenantResolution resolution = resolver.resolve(new MockHttpServletRequest());
+
+        assertThat(resolution.hasTenant()).isTrue();
+        assertThat(resolution.tenantId()).isEqualTo(tenantId.toString());
+        assertThat(resolution.source()).isEqualTo(TenantSource.JWT);
+    }
+
+    @Test
+    void rejectsHeaderResolutionWithoutApiKey() {
+        UUID tenantId = UUID.randomUUID();
+        directory.add(tenantId, "acme", true);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(tenantProps.getHeaderName(), tenantId.toString());
+
+        TenantResolution resolution = resolver.resolve(request);
+
+        assertThat(resolution.hasError()).isTrue();
+        assertThat(resolution.error().httpStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void resolvesHeaderWhenApiKeyPresent() {
+        UUID tenantId = UUID.randomUUID();
+        directory.add(tenantId, "acme", true);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(tenantProps.getHeaderName(), tenantId.toString());
+        request.addHeader("X-API-Key", "test");
+
+        TenantResolution resolution = resolver.resolve(request);
+
+        assertThat(resolution.hasTenant()).isTrue();
+        assertThat(resolution.tenantId()).isEqualTo(tenantId.toString());
+        assertThat(resolution.source()).isEqualTo(TenantSource.HEADER);
+    }
+
+    @Test
+    void inactiveTenantIsForbidden() {
+        UUID tenantId = UUID.randomUUID();
+        directory.add(tenantId, "acme", false);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(tenantProps.getHeaderName(), tenantId.toString());
+        request.addHeader("X-API-Key", "test");
+
+        TenantResolution resolution = resolver.resolve(request);
+
+        assertThat(resolution.hasError()).isTrue();
+        assertThat(resolution.error().httpStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void resolvesTenantFromSubdomain() {
+        UUID tenantId = UUID.randomUUID();
+        directory.add(tenantId, "acme", true);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServerName("acme.example.com");
+
+        TenantResolution resolution = resolver.resolve(request);
+
+        assertThat(resolution.hasTenant()).isTrue();
+        assertThat(resolution.tenantId()).isEqualTo(tenantId.toString());
+        assertThat(resolution.source()).isEqualTo(TenantSource.SUBDOMAIN);
+    }
+
+    private void setJwtAuthentication(Map<String, Object> claims) {
+        Jwt jwt = new Jwt("token", Instant.now(), Instant.now().plusSeconds(300),
+                Map.of("alg", "none"), claims);
+        JwtAuthenticationToken authentication = new JwtAuthenticationToken(jwt);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private static final class InMemoryTenantDirectory implements TenantDirectory {
+
+        private final Map<UUID, TenantRecord> byId = new HashMap<>();
+        private final Map<String, TenantRecord> bySlug = new HashMap<>();
+
+        void add(UUID id, String slug, boolean active) {
+            TenantRecord record = new TenantRecord(id, slug != null ? slug.toLowerCase(Locale.ROOT) : null, active);
+            byId.put(id, record);
+            if (record.slug() != null) {
+                bySlug.put(record.slug(), record);
+            }
+        }
+
+        @Override
+        public Optional<TenantRecord> findById(UUID tenantId) {
+            return Optional.ofNullable(byId.get(tenantId));
+        }
+
+        @Override
+        public Optional<TenantRecord> findBySlug(String slug) {
+            if (slug == null) {
+                return Optional.empty();
+            }
+            return Optional.ofNullable(bySlug.get(slug.toLowerCase(Locale.ROOT)));
+        }
+
+        @Override
+        public Optional<TenantRecord> findBySubdomain(String subdomain) {
+            return findBySlug(subdomain);
+        }
+    }
+}
+

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/multitenancy/JpaTenantDirectory.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/multitenancy/JpaTenantDirectory.java
@@ -1,0 +1,52 @@
+package com.ejada.tenant.multitenancy;
+
+import com.ejada.starter_core.tenant.TenantDirectory;
+import com.ejada.tenant.model.Tenant;
+import com.ejada.tenant.repository.TenantRepository;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+/**
+ * Database backed implementation of {@link TenantDirectory} for the tenant
+ * service. Uses the shared tenant table to resolve tenants by UUID or public
+ * slug (code).
+ */
+@Component
+public class JpaTenantDirectory implements TenantDirectory {
+
+    private final TenantRepository repository;
+
+    public JpaTenantDirectory(TenantRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Optional<TenantRecord> findById(UUID tenantId) {
+        if (tenantId == null) {
+            return Optional.empty();
+        }
+        return repository.findBySecurityTenantIdAndIsDeletedFalse(tenantId)
+                .flatMap(this::mapTenant);
+    }
+
+    @Override
+    public Optional<TenantRecord> findBySlug(String slug) {
+        if (slug == null) {
+            return Optional.empty();
+        }
+        return repository.findByCodeIgnoreCaseAndIsDeletedFalse(slug)
+                .flatMap(this::mapTenant);
+    }
+
+    private Optional<TenantRecord> mapTenant(Tenant tenant) {
+        if (tenant == null || tenant.getSecurityTenantId() == null) {
+            return Optional.empty();
+        }
+        boolean active = tenant.isActive() && !tenant.isDeleted();
+        String slug = tenant.getCode() != null ? tenant.getCode().toLowerCase(Locale.ROOT) : null;
+        return Optional.of(new TenantRecord(tenant.getSecurityTenantId(), slug, active));
+    }
+}
+

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
@@ -4,6 +4,7 @@ package com.ejada.tenant.repository;
 import com.ejada.tenant.model.Tenant;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -31,4 +32,8 @@ public interface TenantRepository extends JpaRepository<Tenant, Integer> {
     boolean existsByCodeAndIsDeletedFalseAndIdNot(String code, Integer id);
 
     boolean existsByNameIgnoreCaseAndIsDeletedFalseAndIdNot(String name, Integer id);
+
+    Optional<Tenant> findBySecurityTenantIdAndIsDeletedFalse(UUID securityTenantId);
+
+    Optional<Tenant> findByCodeIgnoreCaseAndIsDeletedFalse(String code);
 }


### PR DESCRIPTION
## Summary
- replace the shared tenant resolver with a layered strategy that evaluates JWT claims, API headers, subdomains, and privileged admin paths while validating tenant status and caching lookups
- introduce a pluggable `TenantDirectory` abstraction with concrete JPA-backed implementation in the tenant service so requests are only accepted for active tenants
- update context contributors, filters, and the reactive gateway to propagate the richer resolution results and add unit coverage for the new resolver behavior

## Testing
- `mvn -pl shared-lib/shared-starters/starter-core -am -DskipTests package`
- `mvn -pl shared-lib/shared-starters/starter-core -am test` *(fails: ByteBuddy dependency download corrupt in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1481bcce4832f81a43d4d1f6ce8a6