### PR TITLE
feat: implement tenant-aware circuit breaker resilience

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
@@ -645,6 +645,8 @@ public class GatewayRoutesProperties {
       /** Optional retry configuration when invoking the downstream service. */
       private Retry retry = new Retry();
 
+      private Priority priority = Priority.NON_CRITICAL;
+
       public boolean isEnabled() {
         return enabled;
       }
@@ -693,6 +695,14 @@ public class GatewayRoutesProperties {
         this.retry = (retry == null) ? new Retry() : retry;
       }
 
+      public Priority getPriority() {
+        return (priority == null) ? Priority.NON_CRITICAL : priority;
+      }
+
+      public void setPriority(Priority priority) {
+        this.priority = (priority == null) ? Priority.NON_CRITICAL : priority;
+      }
+
       public void applyDefaults(Resilience defaults) {
         if (defaults == null) {
           return;
@@ -716,6 +726,9 @@ public class GatewayRoutesProperties {
           this.retry = new Retry();
         }
         this.retry.applyDefaults(defaults.retry);
+        if (this.priority == null) {
+          this.priority = defaults.priority;
+        }
       }
 
       void validate(String key) {
@@ -758,12 +771,14 @@ public class GatewayRoutesProperties {
             && Objects.equals(fallbackUri, that.fallbackUri)
             && fallbackStatus == that.fallbackStatus
             && Objects.equals(fallbackMessage, that.fallbackMessage)
-            && Objects.equals(retry, that.retry);
+            && Objects.equals(retry, that.retry)
+            && priority == that.priority;
       }
 
       @Override
       public int hashCode() {
-        return Objects.hash(enabled, circuitBreakerName, fallbackUri, fallbackStatus, fallbackMessage, retry);
+        return Objects.hash(enabled, circuitBreakerName, fallbackUri, fallbackStatus, fallbackMessage, retry,
+            priority);
       }
 
       @Override
@@ -774,7 +789,13 @@ public class GatewayRoutesProperties {
             + ", fallbackUri='" + fallbackUri + '\''
             + ", fallbackStatus=" + fallbackStatus
             + ", retry=" + retry
+            + ", priority=" + priority
             + '}';
+      }
+
+      public enum Priority {
+        CRITICAL,
+        NON_CRITICAL
       }
 
       /**

--- a/api-gateway/src/main/java/com/ejada/gateway/fallback/BillingFallbackPayload.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/fallback/BillingFallbackPayload.java
@@ -1,0 +1,14 @@
+package com.ejada.gateway.fallback;
+
+import java.time.Instant;
+
+/**
+ * Metadata returned to clients when billing usage events are queued because
+ * the downstream billing service is unavailable.
+ */
+public record BillingFallbackPayload(
+    String queueKey,
+    Instant queuedAt,
+    String path,
+    String method) {
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/fallback/BillingFallbackQueue.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/fallback/BillingFallbackQueue.java
@@ -1,0 +1,80 @@
+package com.ejada.gateway.fallback;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Mono;
+
+/**
+ * Persists usage events when the billing service circuit breaker opens so they
+ * can be replayed once the downstream dependency recovers.
+ */
+@Component
+public class BillingFallbackQueue {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BillingFallbackQueue.class);
+  private static final String DEFAULT_QUEUE_KEY = "gateway:billing:fallback";
+
+  private final ReactiveStringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
+  private final String queueKey;
+
+  public BillingFallbackQueue(ReactiveStringRedisTemplate redisTemplate,
+      @Qualifier("jacksonObjectMapper") ObjectProvider<ObjectMapper> primaryObjectMapper,
+      ObjectProvider<ObjectMapper> fallbackObjectMapper) {
+    this(redisTemplate, primaryObjectMapper, fallbackObjectMapper, DEFAULT_QUEUE_KEY);
+  }
+
+  public BillingFallbackQueue(ReactiveStringRedisTemplate redisTemplate,
+      ObjectProvider<ObjectMapper> primaryObjectMapper,
+      ObjectProvider<ObjectMapper> fallbackObjectMapper,
+      String queueKey) {
+    this.redisTemplate = Objects.requireNonNull(redisTemplate, "redisTemplate");
+    ObjectMapper mapper = (primaryObjectMapper != null) ? primaryObjectMapper.getIfAvailable() : null;
+    if (mapper == null && fallbackObjectMapper != null) {
+      mapper = fallbackObjectMapper.getIfAvailable();
+    }
+    if (mapper == null) {
+      mapper = new ObjectMapper();
+    }
+    this.objectMapper = mapper;
+    this.queueKey = StringUtils.hasText(queueKey) ? queueKey.trim() : DEFAULT_QUEUE_KEY;
+  }
+
+  public Mono<String> enqueue(String tenantId, ServerHttpRequest request) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("tenantId", StringUtils.hasText(tenantId) ? tenantId : "unknown");
+    payload.put("method", request.getMethodValue());
+    URI uri = request.getURI();
+    payload.put("path", uri.getPath());
+    payload.put("query", uri.getQuery());
+    payload.put("timestamp", Instant.now().toString());
+    payload.put("headers", request.getHeaders().toSingleValueMap());
+    String serialised;
+    try {
+      serialised = objectMapper.writeValueAsString(payload);
+    } catch (JsonProcessingException ex) {
+      LOGGER.warn("Failed to serialise billing fallback payload", ex);
+      serialised = payload.toString();
+    }
+    return redisTemplate.opsForList().leftPush(queueKey, serialised)
+        .doOnError(ex -> LOGGER.warn("Failed to queue billing fallback event", ex))
+        .map(ignored -> queueKey);
+  }
+
+  public String queueKey() {
+    return queueKey;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/fallback/CatalogFallbackPayload.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/fallback/CatalogFallbackPayload.java
@@ -1,0 +1,21 @@
+package com.ejada.gateway.fallback;
+
+import java.time.Instant;
+import java.util.Set;
+
+/**
+ * Snapshot of cached catalogue tier data returned when the downstream
+ * catalogue service is unavailable. Exposes the tenant's effective tier and
+ * enabled features that were last synchronised with the subscription service.
+ */
+public record CatalogFallbackPayload(
+    String tier,
+    Set<String> features,
+    Instant cachedAt) {
+
+  public CatalogFallbackPayload {
+    tier = (tier == null || tier.isBlank()) ? "unknown" : tier.trim();
+    features = (features == null) ? Set.of() : Set.copyOf(features);
+    cachedAt = (cachedAt == null) ? Instant.now() : cachedAt;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/fallback/FallbackResponse.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/fallback/FallbackResponse.java
@@ -1,10 +1,22 @@
 package com.ejada.gateway.fallback;
 
 import java.time.Instant;
+import java.util.Map;
 
 /**
- * Simple payload returned to clients when a downstream service is unavailable
- * and the gateway falls back locally.
+ * Payload returned to clients when a downstream service is unavailable and the
+ * gateway falls back locally. The payload now carries optional contextual data
+ * and metadata so individual fallbacks can expose cached artefacts or
+ * degradation hints to the caller.
  */
-public record FallbackResponse(String routeId, String message, Instant timestamp) {
+public record FallbackResponse(
+    String routeId,
+    String message,
+    Instant timestamp,
+    Object data,
+    Map<String, Object> metadata) {
+
+  public FallbackResponse {
+    metadata = (metadata == null) ? Map.of() : Map.copyOf(metadata);
+  }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/fallback/SubscriptionFallbackPayload.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/fallback/SubscriptionFallbackPayload.java
@@ -1,0 +1,32 @@
+package com.ejada.gateway.fallback;
+
+import com.ejada.gateway.subscription.SubscriptionRecord;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Snapshot of cached subscription data served when the subscription service is
+ * unavailable.
+ */
+public record SubscriptionFallbackPayload(
+    boolean active,
+    String status,
+    Instant expiresAt,
+    Instant cachedAt,
+    Set<String> features,
+    Map<String, SubscriptionRecord.FeatureAllocation> allocations) {
+
+  public static SubscriptionFallbackPayload fromRecord(SubscriptionRecord record) {
+    if (record == null) {
+      return new SubscriptionFallbackPayload(false, "UNKNOWN", null, Instant.now(), Set.of(), Map.of());
+    }
+    return new SubscriptionFallbackPayload(
+        record.isActive(),
+        record.status(),
+        record.expiresAt(),
+        record.fetchedAt(),
+        record.enabledFeatures(),
+        record.allocations());
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/resilience/CircuitBreakerDashboardController.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/resilience/CircuitBreakerDashboardController.java
@@ -1,0 +1,28 @@
+package com.ejada.gateway.resilience;
+
+import com.ejada.common.dto.BaseResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST endpoint exposing aggregated circuit breaker insights for observability dashboards.
+ */
+@RestController
+@RequestMapping("/api/v1/admin")
+public class CircuitBreakerDashboardController {
+
+  private final TenantCircuitBreakerMetrics metrics;
+
+  public CircuitBreakerDashboardController(TenantCircuitBreakerMetrics metrics) {
+    this.metrics = metrics;
+  }
+
+  @GetMapping("/circuit-breakers")
+  public Mono<BaseResponse<List<CircuitBreakerDashboardView>>> circuitBreakers() {
+    return Mono.fromSupplier(metrics::snapshotViews)
+        .map(data -> BaseResponse.success("Gateway circuit breaker dashboard", data));
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/resilience/CircuitBreakerDashboardView.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/resilience/CircuitBreakerDashboardView.java
@@ -1,0 +1,26 @@
+package com.ejada.gateway.resilience;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * View model exposed by the circuit breaker dashboard endpoint. Captures the latest state, failure
+ * rate and tenant level metadata gathered by {@link TenantCircuitBreakerMetrics}.
+ */
+public record CircuitBreakerDashboardView(
+    String name,
+    TenantCircuitBreakerMetrics.Priority priority,
+    CircuitBreaker.State state,
+    double failureRate,
+    Instant lastUpdated,
+    long fallbackCount,
+    String lastTenant,
+    Instant lastFallbackAt,
+    String lastFallbackType,
+    Map<String, Object> lastFallbackMetadata,
+    Instant lastRecoveryProbeSuccess,
+    Instant lastRecoveryProbeFailure,
+    boolean recoveryScheduled,
+    Instant recoveryScheduledAt) {
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/resilience/CircuitBreakerRecoveryTester.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/resilience/CircuitBreakerRecoveryTester.java
@@ -1,0 +1,125 @@
+package com.ejada.gateway.resilience;
+
+import com.ejada.gateway.config.AdminAggregationProperties;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerOnStateTransitionEvent;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Performs lightweight recovery probes when a circuit breaker transitions to the open state. Once
+ * the downstream service responds successfully to the configured health endpoint the scheduled
+ * probe is cancelled and the circuit breaker is allowed to recover naturally.
+ */
+@Component
+public class CircuitBreakerRecoveryTester {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CircuitBreakerRecoveryTester.class);
+
+  private final AdminAggregationProperties adminProperties;
+  private final WebClient.Builder webClientBuilder;
+  private final TenantCircuitBreakerMetrics metrics;
+  private final ConcurrentMap<String, Disposable> scheduled = new ConcurrentHashMap<>();
+  private final Set<String> monitored = ConcurrentHashMap.newKeySet();
+
+  public CircuitBreakerRecoveryTester(AdminAggregationProperties adminProperties,
+      WebClient.Builder webClientBuilder,
+      TenantCircuitBreakerMetrics metrics) {
+    this.adminProperties = Objects.requireNonNull(adminProperties, "adminProperties");
+    this.webClientBuilder = Objects.requireNonNull(webClientBuilder, "webClientBuilder");
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
+  }
+
+  public void monitor(CircuitBreaker circuitBreaker) {
+    if (circuitBreaker == null) {
+      return;
+    }
+    if (!monitored.add(circuitBreaker.getName())) {
+      return;
+    }
+    circuitBreaker.getEventPublisher().onStateTransition(event -> handleTransition(circuitBreaker, event));
+  }
+
+  private void handleTransition(CircuitBreaker circuitBreaker, CircuitBreakerOnStateTransitionEvent event) {
+    CircuitBreaker.State toState = event.getStateTransition().getToState();
+    String name = circuitBreaker.getName();
+    switch (toState) {
+      case OPEN -> schedule(name, circuitBreaker);
+      case CLOSED -> {
+        cancel(name);
+        metrics.markRecoveryIdle(name);
+      }
+      case HALF_OPEN -> runProbe(name).subscribe();
+      default -> {
+        // no-op
+      }
+    }
+  }
+
+  private void schedule(String circuitBreakerName, CircuitBreaker circuitBreaker) {
+    cancel(circuitBreakerName);
+    Duration wait = Optional.ofNullable(circuitBreaker.getCircuitBreakerConfig().getWaitDurationInOpenState())
+        .filter(d -> !d.isNegative() && !d.isZero())
+        .orElse(Duration.ofSeconds(30));
+    metrics.markRecoveryScheduled(circuitBreakerName);
+    Disposable disposable = Flux.interval(wait, wait, Schedulers.boundedElastic())
+        .flatMap(ignore -> runProbe(circuitBreakerName))
+        .subscribe();
+    scheduled.put(circuitBreakerName, disposable);
+    LOGGER.debug("Scheduled recovery probe for {} every {}", circuitBreakerName, wait);
+  }
+
+  private Mono<Void> runProbe(String circuitBreakerName) {
+    Optional<AdminAggregationProperties.Service> serviceOptional = locateService(circuitBreakerName);
+    if (serviceOptional.isEmpty()) {
+      metrics.markRecoveryProbe(circuitBreakerName, false);
+      LOGGER.debug("Skipping recovery probe for {} as no admin service mapping was found", circuitBreakerName);
+      return Mono.empty();
+    }
+    AdminAggregationProperties.Service service = serviceOptional.get();
+    Duration timeout = service.resolveTimeout(adminProperties.getAggregation().getTimeout());
+    WebClient client = webClientBuilder.clone().baseUrl(service.getUri().toString()).build();
+    return client.get()
+        .uri(service.getHealthPath())
+        .headers(headers -> service.getHeaders().forEach(headers::add))
+        .retrieve()
+        .toBodilessEntity()
+        .timeout(timeout)
+        .then(Mono.fromRunnable(() -> {
+          LOGGER.info("Recovery probe for {} succeeded", circuitBreakerName);
+          metrics.markRecoveryProbe(circuitBreakerName, true);
+          cancel(circuitBreakerName);
+        }))
+        .onErrorResume(ex -> {
+          LOGGER.debug("Recovery probe for {} failed: {}", circuitBreakerName, ex.getMessage());
+          metrics.markRecoveryProbe(circuitBreakerName, false);
+          return Mono.empty();
+        });
+  }
+
+  private Optional<AdminAggregationProperties.Service> locateService(String circuitBreakerName) {
+    return adminProperties.getAggregation().getServices().stream()
+        .filter(service -> circuitBreakerName.equalsIgnoreCase(service.getId()))
+        .findFirst();
+  }
+
+  private void cancel(String circuitBreakerName) {
+    Disposable disposable = scheduled.remove(circuitBreakerName);
+    if (disposable != null) {
+      disposable.dispose();
+      LOGGER.debug("Cancelled recovery probe for {}", circuitBreakerName);
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/resilience/TenantCircuitBreakerMetrics.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/resilience/TenantCircuitBreakerMetrics.java
@@ -1,0 +1,236 @@
+package com.ejada.gateway.resilience;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.Nullable;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Tracks tenant aware circuit breaker metrics and exposes consolidated state for the dashboard
+ * endpoint. The component binds micrometer gauges that surface the gateway specific metrics
+ * requested by operations teams while keeping additional metadata in memory for quick inspection.
+ */
+@Component
+public class TenantCircuitBreakerMetrics {
+
+  public enum Priority {
+    CRITICAL,
+    NON_CRITICAL;
+
+    public static Priority from(@Nullable String value) {
+      if (!StringUtils.hasText(value)) {
+        return NON_CRITICAL;
+      }
+      try {
+        return Priority.valueOf(value.trim().toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException ex) {
+        return NON_CRITICAL;
+      }
+    }
+  }
+
+  private final MeterRegistry meterRegistry;
+  private final ConcurrentMap<String, CircuitBreakerInsight> insights = new ConcurrentHashMap<>();
+  private final Set<String> registeredMeters = ConcurrentHashMap.newKeySet();
+  private final Set<String> monitoredBreakers = ConcurrentHashMap.newKeySet();
+
+  public TenantCircuitBreakerMetrics(MeterRegistry meterRegistry) {
+    this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry");
+  }
+
+  public void bind(CircuitBreaker circuitBreaker) {
+    if (circuitBreaker == null) {
+      return;
+    }
+    String name = circuitBreaker.getName();
+    if (!monitoredBreakers.add(name)) {
+      return;
+    }
+    insights.computeIfAbsent(name, CircuitBreakerInsight::initial);
+    registerMeters(circuitBreaker);
+    updateSnapshot(circuitBreaker);
+    circuitBreaker.getEventPublisher()
+        .onStateTransition(event -> updateSnapshot(circuitBreaker))
+        .onReset(event -> updateSnapshot(circuitBreaker))
+        .onCallNotPermitted(event -> updateSnapshot(circuitBreaker))
+        .onFailureRateExceeded(event -> updateSnapshot(circuitBreaker));
+  }
+
+  public void registerPriority(String circuitBreakerName, Priority priority) {
+    insights.compute(circuitBreakerName, (key, existing) -> {
+      CircuitBreakerInsight base = (existing != null) ? existing : CircuitBreakerInsight.initial(key);
+      return base.withPriority(priority);
+    });
+  }
+
+  public void recordFallback(String circuitBreakerName,
+      @Nullable String tenantId,
+      String fallbackType,
+      Map<String, Object> metadata) {
+    String resolvedTenant = StringUtils.hasText(tenantId) ? tenantId.trim() : "unknown";
+    insights.compute(circuitBreakerName, (key, existing) -> {
+      CircuitBreakerInsight base = (existing != null) ? existing : CircuitBreakerInsight.initial(key);
+      return base.recordFallback(resolvedTenant, fallbackType, metadata, Instant.now());
+    });
+  }
+
+  public void markRecoveryScheduled(String circuitBreakerName) {
+    insights.computeIfPresent(circuitBreakerName,
+        (key, snapshot) -> snapshot.markRecoveryScheduled(Instant.now()));
+  }
+
+  public void markRecoveryProbe(String circuitBreakerName, boolean success) {
+    insights.computeIfPresent(circuitBreakerName,
+        (key, snapshot) -> snapshot.markRecoveryProbe(success, Instant.now()));
+  }
+
+  public void markRecoveryIdle(String circuitBreakerName) {
+    insights.computeIfPresent(circuitBreakerName,
+        (key, snapshot) -> snapshot.markRecoveryIdle(Instant.now()));
+  }
+
+  public List<CircuitBreakerDashboardView> snapshotViews() {
+    List<CircuitBreakerDashboardView> views = new ArrayList<>();
+    insights.forEach((name, snapshot) -> views.add(snapshot.toView()));
+    views.sort((a, b) -> {
+      int priorityCompare = b.priority().compareTo(a.priority());
+      if (priorityCompare != 0) {
+        return priorityCompare;
+      }
+      return a.name().compareToIgnoreCase(b.name());
+    });
+    return views;
+  }
+
+  double stateValue(String circuitBreakerName, CircuitBreaker.State state) {
+    CircuitBreakerInsight snapshot = insights.get(circuitBreakerName);
+    if (snapshot == null) {
+      return 0.0d;
+    }
+    return snapshot.state() == state ? 1.0d : 0.0d;
+  }
+
+  double failureRate(String circuitBreakerName) {
+    CircuitBreakerInsight snapshot = insights.get(circuitBreakerName);
+    if (snapshot == null) {
+      return 0.0d;
+    }
+    return snapshot.failureRate();
+  }
+
+  private void updateSnapshot(CircuitBreaker circuitBreaker) {
+    insights.compute(circuitBreaker.getName(), (key, existing) -> {
+      CircuitBreakerInsight base = (existing != null) ? existing : CircuitBreakerInsight.initial(key);
+      return base.update(circuitBreaker.getState(), circuitBreaker.getMetrics().getFailureRate(), Instant.now());
+    });
+  }
+
+  private void registerMeters(CircuitBreaker circuitBreaker) {
+    EnumSet<CircuitBreaker.State> states = EnumSet.allOf(CircuitBreaker.State.class);
+    for (CircuitBreaker.State state : states) {
+      String key = circuitBreaker.getName() + ':' + state.name();
+      if (registeredMeters.add(key)) {
+        Gauge.builder("gateway_circuit_breaker_state", this,
+                metrics -> metrics.stateValue(circuitBreaker.getName(), state))
+            .description("State of resilience4j circuit breakers exposed by the gateway")
+            .tags("serviceName", circuitBreaker.getName(),
+                "state", state.name().toLowerCase(Locale.ROOT))
+            .register(meterRegistry);
+      }
+    }
+    String failureRateKey = circuitBreaker.getName() + ":failureRate";
+    if (registeredMeters.add(failureRateKey)) {
+      Gauge.builder("gateway_circuit_breaker_failure_rate", this,
+              metrics -> metrics.failureRate(circuitBreaker.getName()))
+          .description("Failure rate percentage for gateway circuit breakers")
+          .tags("serviceName", circuitBreaker.getName())
+          .register(meterRegistry);
+    }
+  }
+
+  private record CircuitBreakerInsight(
+      String name,
+      Priority priority,
+      CircuitBreaker.State state,
+      double failureRate,
+      Instant lastUpdated,
+      long fallbackCount,
+      @Nullable String lastTenant,
+      @Nullable Instant lastFallbackAt,
+      @Nullable String lastFallbackType,
+      Map<String, Object> lastFallbackMetadata,
+      @Nullable Instant lastRecoveryProbeSuccess,
+      @Nullable Instant lastRecoveryProbeFailure,
+      boolean recoveryScheduled,
+      Instant recoveryScheduledAt) {
+
+    private static CircuitBreakerInsight initial(String name) {
+      return new CircuitBreakerInsight(name, Priority.NON_CRITICAL, CircuitBreaker.State.CLOSED, 0.0d,
+          Instant.now(), 0, null, null, null, Map.of(), null, null, false, null);
+    }
+
+    private CircuitBreakerInsight withPriority(Priority priority) {
+      return new CircuitBreakerInsight(name, Optional.ofNullable(priority).orElse(this.priority), state,
+          failureRate, lastUpdated, fallbackCount, lastTenant, lastFallbackAt, lastFallbackType,
+          lastFallbackMetadata, lastRecoveryProbeSuccess, lastRecoveryProbeFailure, recoveryScheduled,
+          recoveryScheduledAt);
+    }
+
+    private CircuitBreakerInsight update(CircuitBreaker.State newState, float newFailureRate, Instant timestamp) {
+      double rate = Double.isFinite(newFailureRate) && newFailureRate >= 0 ? newFailureRate : 0.0d;
+      return new CircuitBreakerInsight(name, priority, newState, rate, timestamp, fallbackCount, lastTenant,
+          lastFallbackAt, lastFallbackType, lastFallbackMetadata, lastRecoveryProbeSuccess,
+          lastRecoveryProbeFailure, recoveryScheduled, recoveryScheduledAt);
+    }
+
+    private CircuitBreakerInsight recordFallback(String tenant, String type,
+        Map<String, Object> metadata, Instant timestamp) {
+      Map<String, Object> details = (metadata == null || metadata.isEmpty()) ? Map.of() : Map.copyOf(metadata);
+      return new CircuitBreakerInsight(name, priority, state, failureRate, timestamp,
+          fallbackCount + 1, tenant, timestamp, type, details, lastRecoveryProbeSuccess,
+          lastRecoveryProbeFailure, recoveryScheduled, recoveryScheduledAt);
+    }
+
+    private CircuitBreakerInsight markRecoveryScheduled(Instant timestamp) {
+      return new CircuitBreakerInsight(name, priority, state, failureRate, timestamp, fallbackCount, lastTenant,
+          lastFallbackAt, lastFallbackType, lastFallbackMetadata, lastRecoveryProbeSuccess,
+          lastRecoveryProbeFailure, true, timestamp);
+    }
+
+    private CircuitBreakerInsight markRecoveryProbe(boolean success, Instant timestamp) {
+      if (success) {
+        return new CircuitBreakerInsight(name, priority, state, failureRate, timestamp, fallbackCount,
+            lastTenant, lastFallbackAt, lastFallbackType, lastFallbackMetadata, timestamp,
+            lastRecoveryProbeFailure, false, recoveryScheduledAt);
+      }
+      return new CircuitBreakerInsight(name, priority, state, failureRate, timestamp, fallbackCount, lastTenant,
+          lastFallbackAt, lastFallbackType, lastFallbackMetadata, lastRecoveryProbeSuccess, timestamp,
+          true, recoveryScheduledAt);
+    }
+
+    private CircuitBreakerInsight markRecoveryIdle(Instant timestamp) {
+      return new CircuitBreakerInsight(name, priority, state, failureRate, timestamp, fallbackCount, lastTenant,
+          lastFallbackAt, lastFallbackType, lastFallbackMetadata, lastRecoveryProbeSuccess,
+          lastRecoveryProbeFailure, false, recoveryScheduledAt);
+    }
+
+    private CircuitBreakerDashboardView toView() {
+      return new CircuitBreakerDashboardView(name, priority, state, failureRate, lastUpdated, fallbackCount,
+          lastTenant, lastFallbackAt, lastFallbackType, lastFallbackMetadata, lastRecoveryProbeSuccess,
+          lastRecoveryProbeFailure, recoveryScheduled, recoveryScheduledAt);
+    }
+  }
+}

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -160,21 +160,39 @@ resilience4j:
         wait-duration-in-open-state: 30s
         permitted-number-of-calls-in-half-open-state: 5
         automatic-transition-from-open-to-half-open-enabled: true
+      critical:
+        sliding-window-size: 30
+        minimum-number-of-calls: 15
+        failure-rate-threshold: 25
+        slow-call-rate-threshold: 30
+        slow-call-duration-threshold: 1500ms
+        wait-duration-in-open-state: 20s
+        permitted-number-of-calls-in-half-open-state: 3
+        automatic-transition-from-open-to-half-open-enabled: true
+      non-critical:
+        sliding-window-size: 60
+        minimum-number-of-calls: 25
+        failure-rate-threshold: 60
+        slow-call-rate-threshold: 60
+        slow-call-duration-threshold: 3s
+        wait-duration-in-open-state: 45s
+        permitted-number-of-calls-in-half-open-state: 6
+        automatic-transition-from-open-to-half-open-enabled: true
     instances:
       tenant-service:
-        base-config: default
+        base-config: critical
       catalog-service:
-        base-config: default
+        base-config: non-critical
       subscription-service:
-        base-config: default
+        base-config: critical
       billing-service:
-        base-config: default
+        base-config: critical
       setup-service:
-        base-config: default
+        base-config: non-critical
       policy-service:
-        base-config: default
+        base-config: non-critical
       tenant-service-canary:
-        base-config: default
+        base-config: non-critical
   retry:
     configs:
       default:
@@ -237,6 +255,7 @@ gateway:
       enabled: true
       fallback-uri: forward:/fallback/default
       fallback-status: SERVICE_UNAVAILABLE
+      priority: NON_CRITICAL
       retry:
         enabled: true
         retries: 2
@@ -298,6 +317,7 @@ jasypt:
         enabled: true
         circuit-breaker-name: setup-service
         fallback-uri: forward:/fallback/setup-service
+        priority: NON_CRITICAL
     tenant:
       id: tenant-service
       uri: lb://tenant-service
@@ -327,6 +347,7 @@ jasypt:
         enabled: true
         circuit-breaker-name: tenant-service
         fallback-uri: forward:/fallback/tenant-service
+        priority: CRITICAL
     tenant-canary:
       id: tenant-service-canary
       uri: lb://tenant-service
@@ -354,6 +375,7 @@ jasypt:
         enabled: true
         circuit-breaker-name: tenant-service-canary
         fallback-uri: forward:/fallback/tenant-service
+        priority: NON_CRITICAL
     catalog:
       id: catalog-service
       uri: lb://catalog-service
@@ -370,7 +392,9 @@ jasypt:
         enabled: true
         circuit-breaker-name: catalog-service
         fallback-uri: forward:/fallback/catalog-service
+        fallback-status: OK
         fallback-message: Catalog service is currently unavailable. Please retry shortly.
+        priority: NON_CRITICAL
         retry:
           enabled: true
           retries: 3
@@ -404,6 +428,9 @@ jasypt:
         enabled: true
         circuit-breaker-name: subscription-service
         fallback-uri: forward:/fallback/subscription-service
+        fallback-status: OK
+        fallback-message: Subscription service unavailable. Serving stale subscription snapshot.
+        priority: CRITICAL
     billing:
       id: billing-service
       uri: lb://billing-service
@@ -420,6 +447,9 @@ jasypt:
         enabled: true
         circuit-breaker-name: billing-service
         fallback-uri: forward:/fallback/billing-service
+        fallback-status: ACCEPTED
+        fallback-message: Billing service is unavailable. Usage event queued for later processing.
+        priority: CRITICAL
     policy:
       id: policy-service
       uri: lb://policy-service
@@ -436,6 +466,7 @@ jasypt:
         enabled: true
         circuit-breaker-name: policy-service
         fallback-uri: forward:/fallback/default
+        priority: NON_CRITICAL
   admin:
     aggregation:
       timeout: 3s


### PR DESCRIPTION
## Summary
- add tenant-aware circuit breaker metrics, dashboard endpoint, and automated recovery probes
- implement catalog, billing, and subscription service fallbacks using cached data or queued events
- configure circuit breaker priorities and thresholds per route with updated fallback responses

## Testing
- mvn -pl api-gateway -am test *(fails: missing net.bytebuddy:byte-buddy-agent:1.17.7)*

------
https://chatgpt.com/codex/tasks/task_e_68e14ce76740832fa79c0c3e7f417885