### PR TITLE
Align mock HttpServletRequest with Jakarta Servlet 6

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/test/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -39,6 +39,11 @@ public class MockHttpServletRequest implements HttpServletRequest {
     private String serverName = "localhost";
     private String requestUri = "/";
 
+    @Override
+    public String getAuthType() {
+        return null;
+    }
+
     public void addHeader(String name, String value) {
         Objects.requireNonNull(name, "name");
         headers.computeIfAbsent(name.toLowerCase(Locale.ROOT), key -> new ArrayList<>()).add(value);
@@ -188,12 +193,6 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
     @Override
     public boolean isRequestedSessionIdFromURL() {
-        return false;
-    }
-
-    @Override
-    @Deprecated
-    public boolean isRequestedSessionIdFromUrl() {
         return false;
     }
 
@@ -349,12 +348,6 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
     @Override
     public RequestDispatcher getRequestDispatcher(String path) {
-        return null;
-    }
-
-    @Override
-    @Deprecated
-    public String getRealPath(String path) {
         return null;
     }
 


### PR DESCRIPTION
## Summary
- implement the `getAuthType` method in the lightweight `MockHttpServletRequest`
- drop overrides for servlet API methods that no longer exist in Jakarta Servlet 6

## Testing
- mvn -pl shared-lib/shared-starters/starter-core -am test *(fails: Error opening zip file or JAR manifest missing : /root/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a51a5de0832f8b67542e68e35c9e