### PR TITLE
Add ServletConnection stub to MockHttpServletRequest test double

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/test/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -3,6 +3,7 @@ package org.springframework.mock.web;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletInputStream;
@@ -404,6 +405,11 @@ public class MockHttpServletRequest implements HttpServletRequest {
     @Override
     public DispatcherType getDispatcherType() {
         return DispatcherType.REQUEST;
+    }
+
+    @Override
+    public ServletConnection getServletConnection() {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- implement the new ServletConnection contract in the MockHttpServletRequest test double to satisfy the updated ServletRequest interface

## Testing
- mvn -pl shared-lib/shared-starters/starter-core test *(fails: missing com.ejada:shared-common and com.ejada:shared-config dependencies from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a6b94bdc832fa06fd75d6a64da2e