### PR TITLE
feat: add tenant-aware response cache and request coalescing

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -74,6 +74,10 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
+      <artifactId>starter-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
       <artifactId>shared-common</artifactId>
     </dependency>
     <dependency>

--- a/api-gateway/src/main/java/com/ejada/gateway/cache/CacheInvalidationListener.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/cache/CacheInvalidationListener.java
@@ -1,0 +1,95 @@
+package com.ejada.gateway.cache;
+
+import com.ejada.gateway.config.GatewayCacheProperties;
+import com.ejada.gateway.transformation.ResponseCacheService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Listens for downstream domain events and invalidates cached responses when
+ * catalog or tenant data changes.
+ */
+@Component
+public class CacheInvalidationListener {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CacheInvalidationListener.class);
+
+  private final GatewayCacheProperties properties;
+
+  private final ResponseCacheService cacheService;
+
+  private final ObjectMapper objectMapper;
+
+  public CacheInvalidationListener(GatewayCacheProperties properties,
+      ResponseCacheService cacheService,
+      ObjectMapper objectMapper) {
+    this.properties = properties;
+    this.cacheService = cacheService;
+    this.objectMapper = objectMapper;
+  }
+
+  @KafkaListener(topics = "${gateway.cache.topics.tenant-updated:tenant.updated}",
+      groupId = "${gateway.cache.kafka.group-id:gateway-cache}")
+  public void onTenantUpdated(String payload) {
+    if (!properties.isEnabled()) {
+      return;
+    }
+    extractField(payload, "tenantId")
+        .ifPresentOrElse(tenant -> invalidateTenantCaches(tenant),
+            () -> LOGGER.debug("tenant.updated event missing tenantId"));
+  }
+
+  @KafkaListener(topics = "${gateway.cache.topics.catalog-plan-updated:catalog.plan.updated}",
+      groupId = "${gateway.cache.kafka.group-id:gateway-cache}")
+  public void onCatalogPlanUpdated(String payload) {
+    if (!properties.isEnabled()) {
+      return;
+    }
+    invalidateRoute("catalog-plans");
+    invalidateRoute("catalog-features");
+  }
+
+  private void invalidateTenantCaches(String tenantId) {
+    properties.getRouteById("tenant-by-id")
+        .ifPresent(route -> cacheService.invalidateRouteForTenant(route, tenantId)
+            .doOnError(ex -> LOGGER.warn("Failed to invalidate tenant cache for {}", tenantId, ex))
+            .subscribe());
+    properties.getRouteById("catalog-plans")
+        .ifPresent(route -> cacheService.invalidateRouteForTenant(route, tenantId)
+            .subscribe());
+    properties.getRouteById("catalog-features")
+        .ifPresent(route -> cacheService.invalidateRouteForTenant(route, tenantId)
+            .subscribe());
+  }
+
+  private void invalidateRoute(String routeId) {
+    properties.getRouteById(routeId)
+        .ifPresent(route -> cacheService.invalidateRoute(route)
+            .doOnError(ex -> LOGGER.warn("Failed to invalidate cache route {}", routeId, ex))
+            .subscribe());
+  }
+
+  private Optional<String> extractField(String payload, String fieldName) {
+    if (!StringUtils.hasText(payload)) {
+      return Optional.empty();
+    }
+    try {
+      JsonNode node = objectMapper.readTree(payload);
+      JsonNode field = node.path(fieldName);
+      if (field.isMissingNode() || !field.isTextual()) {
+        return Optional.empty();
+      }
+      String value = field.asText();
+      return StringUtils.hasText(value) ? Optional.of(value) : Optional.empty();
+    } catch (Exception ex) {
+      LOGGER.debug("Failed to parse cache invalidation payload", ex);
+      return Optional.empty();
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/cache/CacheRefreshService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/cache/CacheRefreshService.java
@@ -1,0 +1,115 @@
+package com.ejada.gateway.cache;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.gateway.config.GatewayCacheProperties.RouteCacheProperties;
+import com.ejada.gateway.transformation.ResponseCacheService;
+import com.ejada.gateway.transformation.ResponseCacheService.CacheMetadata;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+/**
+ * Issues background refresh requests so stale cache entries are revalidated
+ * without blocking live requests and performs scheduled warmups.
+ */
+@Component
+public class CacheRefreshService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CacheRefreshService.class);
+
+  private final ResponseCacheService cacheService;
+
+  private final ServerProperties serverProperties;
+
+  private final AtomicReference<WebClient> clientReference = new AtomicReference<>();
+
+  public CacheRefreshService(ResponseCacheService cacheService,
+      ServerProperties serverProperties,
+      ObjectProvider<WebClient.Builder> builderProvider) {
+    this.cacheService = cacheService;
+    this.serverProperties = serverProperties;
+    WebClient.Builder builder = Optional.ofNullable(builderProvider.getIfAvailable())
+        .orElseGet(WebClient::builder);
+    this.clientReference.set(builder.baseUrl(localBaseUrl()).build());
+  }
+
+  public void scheduleRevalidation(CacheMetadata metadata) {
+    if (metadata == null || !cacheService.isCacheEnabled()) {
+      return;
+    }
+    if (cacheService.isRefreshInFlight(metadata)) {
+      return;
+    }
+    cacheService.trackRefreshStart(metadata);
+    dispatch(metadata.method(), metadata.canonicalPath(), metadata.canonicalQuery(), metadata.tenantId(),
+        metadata.route() != null && metadata.route().isTenantScoped(), true)
+        .doFinally(signal -> cacheService.trackRefreshComplete(metadata))
+        .subscribe();
+  }
+
+  public Mono<Void> warmRoute(RouteCacheProperties route, String candidatePath, String tenantId) {
+    if (route == null || !cacheService.isCacheEnabled() || !StringUtils.hasText(candidatePath)) {
+      return Mono.empty();
+    }
+    HttpMethod method = route.getMethod() != null ? route.getMethod() : HttpMethod.GET;
+    String path = candidatePath;
+    String query = "-";
+    int queryIndex = candidatePath.indexOf('?');
+    if (queryIndex >= 0) {
+      path = candidatePath.substring(0, queryIndex);
+      query = candidatePath.substring(queryIndex + 1);
+    }
+    return dispatch(method, path, query, tenantId, route.isTenantScoped(), true);
+  }
+
+  private Mono<Void> dispatch(HttpMethod method,
+      String path,
+      String query,
+      String tenantId,
+      boolean tenantScoped,
+      boolean forceRefresh) {
+    WebClient client = clientReference.get();
+    if (client == null) {
+      return Mono.empty();
+    }
+    HttpMethod verb = method != null ? method : HttpMethod.GET;
+    UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromPath(path);
+    if (StringUtils.hasText(query) && !"-".equals(query)) {
+      uriBuilder.query(query);
+    }
+    return client.method(verb)
+        .uri(uriBuilder.build(true).toUri())
+        .headers(headers -> {
+          if (tenantScoped && StringUtils.hasText(tenantId)) {
+            headers.add(HeaderNames.X_TENANT_ID, tenantId);
+          }
+          if (forceRefresh) {
+            headers.add(HttpHeaders.CACHE_CONTROL, "max-age=0, no-cache");
+          }
+          headers.add(HttpHeaders.ACCEPT, "application/json");
+        })
+        .retrieve()
+        .toBodilessEntity()
+        .timeout(Duration.ofSeconds(10))
+        .doOnError(ex -> LOGGER.debug("Background cache refresh failed for {} {}", verb, path, ex))
+        .onErrorResume(ex -> Mono.empty())
+        .then();
+  }
+
+  private String localBaseUrl() {
+    Integer configuredPort = serverProperties.getPort();
+    int port = (configuredPort == null || configuredPort == 0) ? 8000 : configuredPort;
+    return "http://127.0.0.1:" + port;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/cache/CacheWarmupScheduler.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/cache/CacheWarmupScheduler.java
@@ -1,0 +1,77 @@
+package com.ejada.gateway.cache;
+
+import com.ejada.gateway.config.GatewayCacheProperties;
+import com.ejada.gateway.config.GatewayCacheProperties.RouteCacheProperties;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Mono;
+
+/**
+ * Periodically warms cacheable routes to reduce cold-start latency for tenants.
+ */
+@Component
+public class CacheWarmupScheduler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CacheWarmupScheduler.class);
+
+  private final GatewayCacheProperties properties;
+
+  private final CacheRefreshService cacheRefreshService;
+
+  public CacheWarmupScheduler(GatewayCacheProperties properties,
+      CacheRefreshService cacheRefreshService) {
+    this.properties = properties;
+    this.cacheRefreshService = cacheRefreshService;
+  }
+
+  @Scheduled(fixedDelayString = "${gateway.cache.warm-interval:PT15M}")
+  public void warm() {
+    if (!properties.isEnabled()) {
+      return;
+    }
+    List<RouteCacheProperties> warmable = properties.getRoutes().stream()
+        .filter(RouteCacheProperties::isWarm)
+        .toList();
+    if (warmable.isEmpty()) {
+      return;
+    }
+    List<String> tenants = properties.getWarmTenants();
+    if (CollectionUtils.isEmpty(tenants)) {
+      tenants = List.of("anonymous");
+    }
+    for (RouteCacheProperties route : warmable) {
+      List<String> tenantTargets = route.isTenantScoped()
+          ? tenants
+          : List.of("global");
+      for (String tenant : tenantTargets) {
+        resolveWarmPath(route, tenant)
+            .ifPresent(path -> cacheRefreshService.warmRoute(route, path, tenant)
+                .doOnError(ex -> LOGGER.debug("Warmup call failed for route {} tenant {}", route.getId(), tenant, ex))
+                .onErrorResume(ex -> Mono.empty())
+                .subscribe());
+      }
+    }
+  }
+
+  private Optional<String> resolveWarmPath(RouteCacheProperties route, String tenant) {
+    String path = route.normalisedWarmPath();
+    if (!StringUtils.hasText(path)) {
+      return Optional.empty();
+    }
+    if (route.hasPathVariable()) {
+      if (!StringUtils.hasText(tenant) || "anonymous".equalsIgnoreCase(tenant)) {
+        return Optional.empty();
+      }
+      String sanitizedTenant = tenant.toLowerCase(Locale.ROOT);
+      path = path.replaceAll("\\{[^}]+\\}", sanitizedTenant);
+    }
+    return Optional.of(path);
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayCacheProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayCacheProperties.java
@@ -1,21 +1,41 @@
 package com.ejada.gateway.config;
 
 import java.time.Duration;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
 
 /**
- * Configuration properties for gateway response caching.
+ * Configuration properties for gateway response caching and warmup.
  */
 @ConfigurationProperties(prefix = "gateway.cache")
 public class GatewayCacheProperties {
 
+  private static final PathPatternParser PATH_PATTERN_PARSER = new PathPatternParser();
+
   private boolean enabled;
 
-  private Map<String, Duration> ttlMap = new LinkedHashMap<>();
+  private Duration warmInterval = Duration.ofMinutes(15);
+
+  private List<String> warmTenants = new ArrayList<>();
+
+  private final List<RouteCacheProperties> routes = new ArrayList<>();
+
+  private final Topics topics = new Topics();
+
+  private final Kafka kafka = new Kafka();
 
   public boolean isEnabled() {
     return enabled;
@@ -25,28 +45,296 @@ public class GatewayCacheProperties {
     this.enabled = enabled;
   }
 
-  public Map<String, Duration> getTtlMap() {
-    return ttlMap;
+  public Duration getWarmInterval() {
+    return warmInterval;
   }
 
-  public void setTtlMap(Map<String, Duration> ttlMap) {
-    LinkedHashMap<String, Duration> copy = new LinkedHashMap<>();
-    if (ttlMap != null) {
-      ttlMap.forEach((key, value) -> {
-        if (!StringUtils.hasText(key) || value == null) {
-          return;
+  public void setWarmInterval(Duration warmInterval) {
+    if (warmInterval == null || warmInterval.isNegative()) {
+      this.warmInterval = Duration.ofMinutes(15);
+      return;
+    }
+    this.warmInterval = warmInterval;
+  }
+
+  public List<String> getWarmTenants() {
+    return Collections.unmodifiableList(warmTenants);
+  }
+
+  public void setWarmTenants(List<String> warmTenants) {
+    this.warmTenants.clear();
+    if (warmTenants == null) {
+      return;
+    }
+    warmTenants.stream()
+        .filter(StringUtils::hasText)
+        .map(String::trim)
+        .map(value -> value.toLowerCase(Locale.ROOT))
+        .forEach(this.warmTenants::add);
+  }
+
+  public List<RouteCacheProperties> getRoutes() {
+    return Collections.unmodifiableList(routes);
+  }
+
+  public void setRoutes(List<RouteCacheProperties> routeConfigs) {
+    this.routes.clear();
+    if (routeConfigs == null) {
+      return;
+    }
+    routeConfigs.stream()
+        .filter(Objects::nonNull)
+        .forEach(route -> this.routes.add(route.initialise()));
+  }
+
+  public Optional<RouteCacheProperties> getRouteById(String id) {
+    if (!StringUtils.hasText(id)) {
+      return Optional.empty();
+    }
+    return routes.stream()
+        .filter(route -> id.equals(route.getId()))
+        .findFirst();
+  }
+
+  public Optional<RouteCacheProperties> resolve(String routeId, ServerWebExchange exchange) {
+    if (!enabled) {
+      return Optional.empty();
+    }
+    return routes.stream()
+        .filter(route -> route.matches(routeId, exchange))
+        .findFirst();
+  }
+
+  public Topics getTopics() {
+    return topics;
+  }
+
+  public Kafka getKafka() {
+    return kafka;
+  }
+
+  public static class Topics {
+
+    private String tenantUpdated = "tenant.updated";
+
+    private String catalogPlanUpdated = "catalog.plan.updated";
+
+    public String getTenantUpdated() {
+      return tenantUpdated;
+    }
+
+    public void setTenantUpdated(String tenantUpdated) {
+      if (StringUtils.hasText(tenantUpdated)) {
+        this.tenantUpdated = tenantUpdated.trim();
+      }
+    }
+
+    public String getCatalogPlanUpdated() {
+      return catalogPlanUpdated;
+    }
+
+    public void setCatalogPlanUpdated(String catalogPlanUpdated) {
+      if (StringUtils.hasText(catalogPlanUpdated)) {
+        this.catalogPlanUpdated = catalogPlanUpdated.trim();
+      }
+    }
+  }
+
+  public static class Kafka {
+
+    private String groupId = "gateway-cache";
+
+    public String getGroupId() {
+      return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+      if (StringUtils.hasText(groupId)) {
+        this.groupId = groupId.trim();
+      }
+    }
+  }
+
+  public static class RouteCacheProperties {
+
+    private String id;
+
+    private String routeId;
+
+    private HttpMethod method = HttpMethod.GET;
+
+    private String path;
+
+    private Duration ttl = Duration.ZERO;
+
+    private Duration staleTtl;
+
+    private boolean warm;
+
+    private boolean tenantScoped = true;
+
+    private String warmPath;
+
+    private transient PathPattern pathPattern;
+
+    RouteCacheProperties initialise() {
+      if (StringUtils.hasText(path)) {
+        this.pathPattern = PATH_PATTERN_PARSER.parse(path.trim());
+      }
+      return this;
+    }
+
+    public boolean matches(String candidateRouteId, ServerWebExchange exchange) {
+      if (!StringUtils.hasText(path) || pathPattern == null) {
+        return false;
+      }
+      if (method != null && exchange.getRequest().getMethod() != method) {
+        return false;
+      }
+      if (StringUtils.hasText(routeId) && !Objects.equals(routeId, candidateRouteId)) {
+        return false;
+      }
+      ServerHttpRequest request = exchange.getRequest();
+      return pathPattern.matches(request.getPath().pathWithinApplication());
+    }
+
+    public String cacheKeyPrefix() {
+      if (StringUtils.hasText(id)) {
+        return id;
+      }
+      if (StringUtils.hasText(routeId)) {
+        return routeId;
+      }
+      return pathPattern != null ? pathPattern.getPatternString() : "unknown";
+    }
+
+    public Duration resolvedTtl() {
+      if (ttl == null || ttl.isNegative() || ttl.isZero()) {
+        return Duration.ZERO;
+      }
+      return ttl;
+    }
+
+    public Duration resolvedStaleTtl() {
+      if (staleTtl == null) {
+        Duration base = resolvedTtl();
+        if (base.isZero()) {
+          return Duration.ZERO;
         }
-        copy.put(key.trim(), value);
-      });
+        return base.dividedBy(2);
+      }
+      if (staleTtl.isNegative()) {
+        return Duration.ZERO;
+      }
+      return staleTtl;
     }
-    this.ttlMap = copy;
+
+    public String normalisedWarmPath() {
+      if (StringUtils.hasText(warmPath)) {
+        return warmPath;
+      }
+      return path;
+    }
+
+    public boolean hasPathVariable() {
+      return pathPattern != null && pathPattern.getPatternString().contains("{");
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = StringUtils.hasText(id) ? id.trim() : null;
+    }
+
+    public String getRouteId() {
+      return routeId;
+    }
+
+    public void setRouteId(String routeId) {
+      this.routeId = StringUtils.hasText(routeId) ? routeId.trim() : null;
+    }
+
+    public HttpMethod getMethod() {
+      return method;
+    }
+
+    public void setMethod(HttpMethod method) {
+      this.method = method;
+    }
+
+    public String getPath() {
+      return path;
+    }
+
+    public void setPath(String path) {
+      this.path = path;
+      if (StringUtils.hasText(path)) {
+        this.pathPattern = PATH_PATTERN_PARSER.parse(path.trim());
+      }
+    }
+
+    public Duration getTtl() {
+      return ttl;
+    }
+
+    public void setTtl(Duration ttl) {
+      this.ttl = ttl;
+    }
+
+    public Duration getStaleTtl() {
+      return staleTtl;
+    }
+
+    public void setStaleTtl(Duration staleTtl) {
+      this.staleTtl = staleTtl;
+    }
+
+    public boolean isWarm() {
+      return warm;
+    }
+
+    public void setWarm(boolean warm) {
+      this.warm = warm;
+    }
+
+    public boolean isTenantScoped() {
+      return tenantScoped;
+    }
+
+    public void setTenantScoped(boolean tenantScoped) {
+      this.tenantScoped = tenantScoped;
+    }
+
+    public String getWarmPath() {
+      return warmPath;
+    }
+
+    public void setWarmPath(String warmPath) {
+      this.warmPath = StringUtils.hasText(warmPath) ? warmPath.trim() : null;
+    }
+
+    public PathPattern getPathPattern() {
+      return pathPattern;
+    }
+
+    @Override
+    public String toString() {
+      return "RouteCacheProperties{" +
+          "id='" + id + '\'' +
+          ", routeId='" + routeId + '\'' +
+          ", method=" + method +
+          ", path='" + path + '\'' +
+          ", ttl=" + ttl +
+          ", staleTtl=" + staleTtl +
+          ", warm=" + warm +
+          ", tenantScoped=" + tenantScoped +
+          '}';
+    }
   }
 
-  public Duration resolveTtl(String routeId) {
-    if (!StringUtils.hasText(routeId)) {
-      return null;
-    }
-    return ttlMap.get(routeId);
+  public String describeRoutes() {
+    return routes.stream().map(RouteCacheProperties::toString).collect(Collectors.joining(","));
   }
 }
-

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayTransformationConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayTransformationConfiguration.java
@@ -1,6 +1,7 @@
 package com.ejada.gateway.config;
 
 import com.ejada.gateway.filter.RequestBodyTransformationGatewayFilterFactory;
+import com.ejada.gateway.cache.CacheRefreshService;
 import com.ejada.gateway.filter.ResponseBodyTransformationGatewayFilterFactory;
 import com.ejada.gateway.metrics.GatewayMetrics;
 import com.ejada.gateway.transformation.HeaderTransformationService;
@@ -69,8 +70,12 @@ public class GatewayTransformationConfiguration {
   public ResponseBodyTransformationGatewayFilterFactory responseBodyTransformationGatewayFilterFactory(
       HeaderTransformationService headerTransformationService,
       ResponseBodyTransformer responseBodyTransformer,
-      ObjectProvider<ResponseCacheService> cacheServiceProvider) {
-    return new ResponseBodyTransformationGatewayFilterFactory(headerTransformationService, responseBodyTransformer, cacheServiceProvider.getIfAvailable());
+      ObjectProvider<ResponseCacheService> cacheServiceProvider,
+      ObjectProvider<CacheRefreshService> cacheRefreshServiceProvider) {
+    return new ResponseBodyTransformationGatewayFilterFactory(headerTransformationService,
+        responseBodyTransformer,
+        cacheServiceProvider.getIfAvailable(),
+        cacheRefreshServiceProvider.getIfAvailable());
   }
 }
 

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/ReactiveRequestCoalescingFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/ReactiveRequestCoalescingFilter.java
@@ -1,0 +1,122 @@
+package com.ejada.gateway.filter;
+
+import com.ejada.gateway.transformation.ResponseCacheService;
+import com.ejada.gateway.transformation.ResponseCacheService.CacheMetadata;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+/**
+ * Deduplicates in-flight GET requests targeting the same cacheable resource so a
+ * single downstream call satisfies concurrent gateway clients.
+ */
+@Component
+public class ReactiveRequestCoalescingFilter implements GlobalFilter, Ordered {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveRequestCoalescingFilter.class);
+
+  private final ResponseCacheService cacheService;
+
+  private final Sinks.Many<CoalescedRequest> requestSink;
+
+  private final ConcurrentMap<String, Mono<Void>> inFlight = new ConcurrentHashMap<>();
+
+  public ReactiveRequestCoalescingFilter(ResponseCacheService cacheService) {
+    this.cacheService = cacheService;
+    this.requestSink = Sinks.many().multicast().onBackpressureBuffer();
+    this.requestSink.asFlux()
+        .groupBy(CoalescedRequest::key)
+        .flatMap(group -> group.concatMap(this::process))
+        .subscribe();
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+    if (!cacheService.isCacheEnabled() || !isCoalescable(exchange)) {
+      return chain.filter(exchange);
+    }
+    String routeId = resolveRouteId(exchange);
+    CacheMetadata metadata = cacheService.buildMetadata(routeId, exchange).orElse(null);
+    if (metadata == null) {
+      return chain.filter(exchange);
+    }
+    if (clientBypassesCache(exchange.getRequest().getHeaders())) {
+      return chain.filter(exchange);
+    }
+    String key = metadata.cacheKey();
+    Sinks.One<Void> completion = Sinks.one();
+    Sinks.EmitResult result = requestSink.tryEmitNext(new CoalescedRequest(key, metadata, exchange, chain, completion));
+    if (result.isFailure()) {
+      LOGGER.debug("Failed to emit coalesced request for key {} due to {}", key, result);
+      return chain.filter(exchange);
+    }
+    return completion.asMono();
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.HIGHEST_PRECEDENCE + 10;
+  }
+
+  private Mono<Void> process(CoalescedRequest request) {
+    Mono<Void> cached = inFlight.computeIfAbsent(request.key(), key ->
+        Mono.defer(() -> request.chain().filter(request.exchange()))
+            .doFinally(signal -> inFlight.remove(key))
+            .cache());
+    return cached
+        .doOnError(request.completion()::tryEmitError)
+        .doOnSuccess(ignored -> request.completion().tryEmitEmpty())
+        .doOnCancel(() -> request.completion().tryEmitEmpty())
+        .onErrorResume(ex -> Mono.empty());
+  }
+
+  private boolean isCoalescable(ServerWebExchange exchange) {
+    HttpMethod method = exchange.getRequest().getMethod();
+    if (method != HttpMethod.GET) {
+      return false;
+    }
+    return true;
+  }
+
+  private boolean clientBypassesCache(HttpHeaders headers) {
+    if (headers == null) {
+      return false;
+    }
+    String cacheControl = headers.getFirst(HttpHeaders.CACHE_CONTROL);
+    if (cacheControl != null) {
+      String lower = cacheControl.toLowerCase();
+      if (lower.contains("no-cache") || lower.contains("no-store") || lower.contains("max-age=0")) {
+        return true;
+      }
+    }
+    return headers.getOrEmpty(HttpHeaders.PRAGMA).stream()
+        .map(String::toLowerCase)
+        .anyMatch(value -> value.contains("no-cache"));
+  }
+
+  private String resolveRouteId(ServerWebExchange exchange) {
+    Object routeAttr = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+    if (routeAttr instanceof org.springframework.cloud.gateway.route.Route route) {
+      return route.getId();
+    }
+    return null;
+  }
+
+  private record CoalescedRequest(String key,
+                                  CacheMetadata metadata,
+                                  ServerWebExchange exchange,
+                                  GatewayFilterChain chain,
+                                  Sinks.One<Void> completion) {
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/transformation/ResponseCacheService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/transformation/ResponseCacheService.java
@@ -2,22 +2,36 @@ package com.ejada.gateway.transformation;
 
 import com.ejada.common.context.ContextManager;
 import com.ejada.gateway.config.GatewayCacheProperties;
+import com.ejada.gateway.config.GatewayCacheProperties.RouteCacheProperties;
 import com.ejada.gateway.context.GatewayRequestAttributes;
 import com.ejada.gateway.metrics.GatewayMetrics;
+import com.ejada.gateway.metrics.GatewayMetrics.CacheState;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.DigestUtils;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
@@ -38,6 +52,8 @@ public class ResponseCacheService {
 
   private final GatewayMetrics metrics;
 
+  private final Map<String, Instant> refreshInFlight = new ConcurrentHashMap<>();
+
   public ResponseCacheService(GatewayCacheProperties properties,
       ReactiveStringRedisTemplate redisTemplate,
       ObjectMapper objectMapper,
@@ -52,46 +68,73 @@ public class ResponseCacheService {
     return properties.isEnabled() && redisTemplate != null;
   }
 
-  public Mono<Optional<CachedResponse>> find(String routeId, ServerWebExchange exchange) {
-    if (!isCacheEnabled()) {
-      return Mono.just(Optional.empty());
-    }
-    Duration ttl = properties.resolveTtl(routeId);
-    if (ttl == null || ttl.isZero() || ttl.isNegative()) {
-      return Mono.just(Optional.empty());
-    }
-    String key = buildKey(routeId, exchange);
-    return redisTemplate.opsForValue().get(key)
-        .flatMap(serialized -> deserialize(serialized)
-            .map(value -> {
-              metrics.recordCacheHit();
-              return Mono.just(Optional.of(value));
-            })
-            .orElseGet(() -> {
-              metrics.recordCacheMiss();
-              return Mono.just(Optional.empty());
-            }))
-        .switchIfEmpty(Mono.defer(() -> {
-          metrics.recordCacheMiss();
-          return Mono.empty();
-        }))
-        .switchIfEmpty(Mono.just(Optional.empty()));
+  public Optional<RouteCacheProperties> resolveRoute(String routeId, ServerWebExchange exchange) {
+    return properties.resolve(routeId, exchange);
   }
 
-  public Mono<Void> store(String routeId, ServerWebExchange exchange, CachedResponse response) {
+  public Optional<CacheMetadata> buildMetadata(String routeId, ServerWebExchange exchange) {
+    return resolveRoute(routeId, exchange).flatMap(route -> buildMetadata(route, exchange));
+  }
+
+  public Optional<CacheMetadata> buildMetadata(RouteCacheProperties route, ServerWebExchange exchange) {
+    if (route == null) {
+      return Optional.empty();
+    }
+    Duration ttl = route.resolvedTtl();
+    if (ttl.isZero()) {
+      return Optional.empty();
+    }
+    String tenantId = resolveTenant(exchange, route);
+    String canonicalPath = exchange.getRequest().getPath().pathWithinApplication().value();
+    String canonicalQuery = canonicalQuery(exchange.getRequest().getQueryParams());
+    HttpMethod method = exchange.getRequest().getMethod();
+    if (method == null) {
+      method = HttpMethod.GET;
+    }
+    String signatureSource = method.name() + ':' + canonicalPath + '?' + canonicalQuery;
+    String signature = DigestUtils.sha1DigestAsHex(signatureSource.getBytes(StandardCharsets.UTF_8));
+    String cacheKey = CACHE_PREFIX + route.cacheKeyPrefix() + ':' + tenantId + ':' + signature;
+    return Optional.of(new CacheMetadata(route, tenantId, cacheKey, canonicalPath, canonicalQuery, method));
+  }
+
+  public Mono<CacheResult> find(String routeId, ServerWebExchange exchange) {
     if (!isCacheEnabled()) {
+      return Mono.just(CacheResult.noRoute());
+    }
+    Optional<CacheMetadata> metadataOptional = buildMetadata(routeId, exchange);
+    if (metadataOptional.isEmpty()) {
+      return Mono.just(CacheResult.noRoute());
+    }
+    CacheMetadata metadata = metadataOptional.get();
+    String cacheKey = metadata.cacheKey();
+    return redisTemplate.opsForValue().get(cacheKey)
+        .flatMap(serialized -> deserialize(serialized)
+            .map(cached -> Mono.just(evaluateCachedEntry(metadata, cached, exchange)))
+            .orElseGet(() -> Mono.just(CacheResult.miss(metadata))))
+        .switchIfEmpty(Mono.fromSupplier(() -> CacheResult.miss(metadata)))
+        .doOnNext(result -> {
+          if (result != null && result.isMiss()) {
+            metrics.recordCacheMiss(metadata.route().cacheKeyPrefix(), metadata.canonicalPath());
+          }
+        });
+  }
+
+  public Mono<Void> store(CacheMetadata metadata, CachedResponse response) {
+    if (!isCacheEnabled() || metadata == null) {
       return Mono.empty();
     }
-    Duration ttl = properties.resolveTtl(routeId);
-    if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+    Duration ttl = metadata.route().resolvedTtl();
+    if (ttl.isZero()) {
       return Mono.empty();
     }
-    String key = buildKey(routeId, exchange);
+    Duration staleTtl = metadata.route().resolvedStaleTtl();
+    Duration redisTtl = ttl.plus(staleTtl);
     try {
       String serialized = objectMapper.writeValueAsString(response);
       return redisTemplate.opsForValue()
-          .set(key, serialized, ttl)
-          .doOnError(ex -> LOGGER.warn("Failed to store cached response for {}", key, ex))
+          .set(metadata.cacheKey(), serialized, redisTtl)
+          .doOnSuccess(ignored -> LOGGER.debug("Cached response for {}", metadata.cacheKey()))
+          .doOnError(ex -> LOGGER.warn("Failed to store cached response for {}", metadata.cacheKey(), ex))
           .then();
     } catch (Exception ex) {
       LOGGER.warn("Failed to serialise cached response", ex);
@@ -103,13 +146,52 @@ public class ResponseCacheService {
     if (!isCacheEnabled()) {
       return Mono.empty();
     }
-    String key = buildKey(routeId, exchange);
-    return redisTemplate.opsForValue()
-        .delete(key)
+    Optional<CacheMetadata> metadataOptional = buildMetadata(routeId, exchange);
+    if (metadataOptional.isEmpty()) {
+      return Mono.empty();
+    }
+    return invalidate(metadataOptional.get());
+  }
+
+  public Mono<Void> invalidate(CacheMetadata metadata) {
+    if (!isCacheEnabled() || metadata == null) {
+      return Mono.empty();
+    }
+    return redisTemplate.opsForValue().delete(metadata.cacheKey()).then();
+  }
+
+  public Mono<Void> invalidateRoute(RouteCacheProperties route) {
+    if (!isCacheEnabled() || route == null) {
+      return Mono.empty();
+    }
+    String pattern = CACHE_PREFIX + route.cacheKeyPrefix() + ":*";
+    return invalidateByPattern(pattern);
+  }
+
+  public Mono<Void> invalidateRouteForTenant(RouteCacheProperties route, String tenantId) {
+    if (!isCacheEnabled() || route == null || !StringUtils.hasText(tenantId)) {
+      return Mono.empty();
+    }
+    String pattern = CACHE_PREFIX + route.cacheKeyPrefix() + ':' + tenantId.toLowerCase(Locale.ROOT) + ":*";
+    return invalidateByPattern(pattern);
+  }
+
+  public Mono<Void> invalidateByPattern(String pattern) {
+    if (!isCacheEnabled() || !StringUtils.hasText(pattern)) {
+      return Mono.empty();
+    }
+    ScanOptions options = ScanOptions.scanOptions().match(pattern).count(1000).build();
+    return redisTemplate.scan(options)
+        .flatMap(key -> redisTemplate.opsForValue().delete(key).thenReturn(key))
+        .doOnNext(key -> LOGGER.debug("Invalidated cache entry {}", key))
         .then();
   }
 
-  public CachedResponse snapshotResponse(ServerHttpResponse response, byte[] body) {
+  public CachedResponse snapshotResponse(RouteCacheProperties route,
+      ServerHttpResponse response,
+      byte[] body,
+      String etag,
+      Instant capturedAt) {
     HttpHeaders headers = new HttpHeaders();
     response.getHeaders().forEach((key, values) -> {
       if ("X-Cache".equalsIgnoreCase(key)) {
@@ -117,20 +199,93 @@ public class ResponseCacheService {
       }
       headers.put(key, List.copyOf(values));
     });
-    int status = (response.getStatusCode() != null) ? response.getStatusCode().value() : 200;
-    return new CachedResponse(status, headers, body);
+    applyCacheHeaders(headers, route, etag, capturedAt, false);
+    int status = (response.getStatusCode() != null) ? response.getStatusCode().value() : HttpStatus.OK.value();
+    Instant expiresAt = capturedAt.plus(route.resolvedTtl());
+    Instant staleAt = expiresAt.plus(route.resolvedStaleTtl());
+    return new CachedResponse(status, headers, body, etag, capturedAt, expiresAt, staleAt);
   }
 
-  private String buildKey(String routeId, ServerWebExchange exchange) {
-    StringBuilder builder = new StringBuilder(CACHE_PREFIX).append(routeId).append(':');
-    builder.append(exchange.getRequest().getPath().pathWithinApplication().value());
-    builder.append(':').append(canonicalQuery(exchange.getRequest().getQueryParams()));
-    String tenantId = Optional.ofNullable(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID))
-        .map(Object::toString)
-        .filter(value -> !value.isBlank())
-        .orElseGet(() -> Optional.ofNullable(ContextManager.Tenant.get()).orElse("anonymous"));
-    builder.append(':').append(tenantId);
-    return builder.toString();
+  public void applyCacheHeaders(HttpHeaders headers,
+      RouteCacheProperties route,
+      String etag,
+      Instant cachedAt,
+      boolean stale) {
+    if (headers == null || route == null) {
+      return;
+    }
+    if (StringUtils.hasText(etag)) {
+      headers.setETag(etag);
+    }
+    Duration ttl = route.resolvedTtl();
+    Duration staleTtl = route.resolvedStaleTtl();
+    CacheControl control = CacheControl.maxAge(ttl)
+        .staleWhileRevalidate(staleTtl)
+        .cachePublic();
+    headers.setCacheControl(control.getHeaderValue());
+    if (cachedAt != null) {
+      long ageSeconds = Math.max(0, Duration.between(cachedAt, Instant.now()).getSeconds());
+      headers.set(HttpHeaders.AGE, Long.toString(ageSeconds));
+    }
+    if (stale) {
+      headers.add("Warning", "110 - Response is stale");
+    }
+  }
+
+  public String generateEtag(byte[] body) {
+    if (body == null || body.length == 0) {
+      return '"' + Base64.getEncoder().encodeToString(new byte[0]) + '"';
+    }
+    byte[] digest = DigestUtils.md5Digest(body);
+    return '"' + Base64.getUrlEncoder().withoutPadding().encodeToString(digest) + '"';
+  }
+
+  public void trackRefreshStart(CacheMetadata metadata) {
+    if (metadata == null) {
+      return;
+    }
+    refreshInFlight.put(metadata.cacheKey(), Instant.now());
+  }
+
+  public void trackRefreshComplete(CacheMetadata metadata) {
+    if (metadata == null) {
+      return;
+    }
+    refreshInFlight.remove(metadata.cacheKey());
+  }
+
+  public boolean isRefreshInFlight(CacheMetadata metadata) {
+    if (metadata == null) {
+      return false;
+    }
+    return refreshInFlight.containsKey(metadata.cacheKey());
+  }
+
+  private CacheResult evaluateCachedEntry(CacheMetadata metadata,
+      CachedResponse cached,
+      ServerWebExchange exchange) {
+    Instant now = Instant.now();
+    if (cached.staleAt().isBefore(now)) {
+      metrics.recordCacheMiss(metadata.route().cacheKeyPrefix(), metadata.canonicalPath());
+      return CacheResult.miss(metadata);
+    }
+    boolean fresh = !cached.expiresAt().isBefore(now);
+    CacheState state = fresh ? CacheState.FRESH : CacheState.STALE;
+    metrics.recordCacheHit(metadata.route().cacheKeyPrefix(), metadata.canonicalPath(), state);
+    List<String> noneMatch = exchange.getRequest().getHeaders().getIfNoneMatch();
+    if (fresh && !CollectionUtils.isEmpty(noneMatch) && noneMatch.contains(cached.etag())) {
+      return CacheResult.notModified(metadata, cached);
+    }
+    return CacheResult.hit(metadata, cached, state);
+  }
+
+  private Optional<CachedResponse> deserialize(String serialized) {
+    try {
+      return Optional.of(objectMapper.readValue(serialized, CachedResponse.class));
+    } catch (Exception ex) {
+      LOGGER.warn("Failed to deserialize cached response", ex);
+      return Optional.empty();
+    }
   }
 
   private String canonicalQuery(MultiValueMap<String, String> params) {
@@ -154,23 +309,70 @@ public class ResponseCacheService {
         .orElse("-");
   }
 
-  private Optional<CachedResponse> deserialize(String serialized) {
-    try {
-      return Optional.of(objectMapper.readValue(serialized, CachedResponse.class));
-    } catch (Exception ex) {
-      LOGGER.warn("Failed to deserialize cached response", ex);
-      return Optional.empty();
+  private String resolveTenant(ServerWebExchange exchange, RouteCacheProperties route) {
+    if (!route.isTenantScoped()) {
+      return "global";
+    }
+    return Optional.ofNullable(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID))
+        .map(Object::toString)
+        .filter(StringUtils::hasText)
+        .or(() -> Optional.ofNullable(ContextManager.Tenant.get()))
+        .map(value -> value.toLowerCase(Locale.ROOT))
+        .orElse("anonymous");
+  }
+
+  public record CacheMetadata(RouteCacheProperties route,
+                              String tenantId,
+                              String cacheKey,
+                              String canonicalPath,
+                              String canonicalQuery,
+                              HttpMethod method) {
+  }
+
+  public record CacheResult(CacheMetadata metadata,
+                            CachedResponse response,
+                            CacheState state) {
+
+    public static CacheResult noRoute() {
+      return new CacheResult(null, null, null);
+    }
+
+    public static CacheResult miss(CacheMetadata metadata) {
+      return new CacheResult(metadata, null, null);
+    }
+
+    public static CacheResult hit(CacheMetadata metadata, CachedResponse response, CacheState state) {
+      return new CacheResult(metadata, response, state);
+    }
+
+    public static CacheResult notModified(CacheMetadata metadata, CachedResponse response) {
+      return new CacheResult(metadata, response, CacheState.NOT_MODIFIED);
+    }
+
+    public boolean hasRoute() {
+      return metadata != null && metadata.route() != null;
+    }
+
+    public boolean isMiss() {
+      return hasRoute() && response == null;
     }
   }
 
   public record CachedResponse(@JsonProperty("status") int status,
                                @JsonProperty("headers") HttpHeaders headers,
-                               @JsonProperty("body") byte[] body) {
+                               @JsonProperty("body") byte[] body,
+                               @JsonProperty("etag") String etag,
+                               @JsonProperty("cachedAt") Instant cachedAt,
+                               @JsonProperty("expiresAt") Instant expiresAt,
+                               @JsonProperty("staleAt") Instant staleAt) {
     @JsonCreator
     public CachedResponse {
       Objects.requireNonNull(headers, "headers");
       Objects.requireNonNull(body, "body");
+      Objects.requireNonNull(etag, "etag");
+      Objects.requireNonNull(cachedAt, "cachedAt");
+      Objects.requireNonNull(expiresAt, "expiresAt");
+      Objects.requireNonNull(staleAt, "staleAt");
     }
   }
 }
-

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -229,6 +229,41 @@ gateway:
       skip-patterns:
         - /actuator/**
         - /health
+  cache:
+    enabled: true
+    warm-interval: 10m
+    warm-tenants:
+      - demo
+    topics:
+      tenant-updated: tenant.updated
+      catalog-plan-updated: catalog.plan.updated
+    kafka:
+      group-id: gateway-cache
+    routes:
+      - id: catalog-plans
+        route-id: catalog-service
+        method: GET
+        path: /api/v1/catalog/plans
+        ttl: 1h
+        stale-ttl: 30m
+        warm: true
+        tenant-scoped: true
+      - id: catalog-features
+        route-id: catalog-service
+        method: GET
+        path: /api/v1/catalog/features
+        ttl: 30m
+        stale-ttl: 15m
+        warm: true
+        tenant-scoped: true
+      - id: tenant-by-id
+        route-id: tenant-service
+        method: GET
+        path: /api/v1/tenants/{id}
+        ttl: 5m
+        stale-ttl: 5m
+        warm: false
+        tenant-scoped: true
   tracing:
     enhanced-tags:
       enabled: true


### PR DESCRIPTION
## Summary
- implement Redis-backed response caching with stale-while-revalidate metadata and configurable cache routes
- add reactive request coalescing, cache warmup scheduler, and Kafka-driven invalidation for catalog and tenant resources
- propagate Cache-Control and ETag handling through the response filter while recording per-route cache metrics

## Testing
- mvn -pl api-gateway -am test *(fails: missing net.bytebuddy:byte-buddy-agent 1.17.7 in local Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a3b4e9f0832f88efebb5c254397a