### PR TITLE
Implement ServletRequest#getProtocolRequestId in mock request

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/test/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -293,6 +293,11 @@ public class MockHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
+    public String getProtocolRequestId() {
+        return null;
+    }
+
+    @Override
     public String getScheme() {
         return "http";
     }


### PR DESCRIPTION
## Summary
- add the new ServletRequest#getProtocolRequestId implementation to the MockHttpServletRequest test stub so it matches the Jakarta Servlet API

## Testing
- ⚠️ `mvn -pl shared-lib/shared-starters/starter-core test -DskipITs` *(fails early while downloading dependencies from maven-restlet due to repeated checksum validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a89beed8832fbd2ce6d289b6b460