### PR TITLE
Implement tenant-aware repository base and role hierarchy enum

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/domain/RoleLevel.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/RoleLevel.java
@@ -1,0 +1,36 @@
+package com.ejada.sec.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum RoleLevel {
+    PLATFORM_ADMIN(100, "EJADA_OFFICER", "Platform administrator with cross-tenant access"),
+    TENANT_ADMIN(80, "TENANT_ADMIN", "Tenant owner with full tenant control"),
+    TENANT_OFFICER(60, "TENANT_OFFICER", "Tenant staff with elevated permissions"),
+    TENANT_USER(40, "TENANT_USER", "Regular tenant user"),
+    END_USER(20, "END_USER", "Read-only consumer"),
+    GUEST(0, "GUEST", "Unauthenticated access");
+
+    private final int level;
+    private final String roleCode;
+    private final String description;
+
+    RoleLevel(int level, String roleCode, String description) {
+        this.level = level;
+        this.roleCode = roleCode;
+        this.description = description;
+    }
+
+    public boolean hasHigherOrEqualPrivilege(RoleLevel other) {
+        return this.level >= other.level;
+    }
+
+    public static RoleLevel fromRoleCode(String roleCode) {
+        for (RoleLevel level : values()) {
+            if (level.roleCode.equals(roleCode)) {
+                return level;
+            }
+        }
+        return GUEST;
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/repository/PrivilegeRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/PrivilegeRepository.java
@@ -1,17 +1,21 @@
 package com.ejada.sec.repository;
 
+import com.ejada.data.repository.TenantAwareRepository;
 import com.ejada.sec.domain.Privilege;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface PrivilegeRepository extends JpaRepository<Privilege, Long> {
+public interface PrivilegeRepository extends TenantAwareRepository<Privilege, Long> {
+
+    Optional<Privilege> findByIdAndTenantId(Long id, UUID tenantId);
 
     Optional<Privilege> findByTenantIdAndCode(UUID tenantId, String code);
 
     List<Privilege> findAllByTenantId(UUID tenantId);
 
     List<Privilege> findAllByTenantIdAndResourceAndAction(UUID tenantId, String resource, String action);
+
+    void deleteByIdAndTenantId(Long id, UUID tenantId);
 }

--- a/sec-service/src/main/java/com/ejada/sec/repository/RefreshTokenRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/RefreshTokenRepository.java
@@ -1,7 +1,7 @@
 package com.ejada.sec.repository;
 
+import com.ejada.data.repository.TenantAwareRepository;
 import com.ejada.sec.domain.RefreshToken;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,7 +11,25 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+public interface RefreshTokenRepository extends TenantAwareRepository<RefreshToken, Long> {
+
+    default Optional<RefreshToken> findByIdAndTenantId(Long id, UUID tenantId) {
+        return findByIdAndUserTenantId(id, tenantId);
+    }
+
+    Optional<RefreshToken> findByIdAndUserTenantId(Long id, UUID tenantId);
+
+    default List<RefreshToken> findAllByTenantId(UUID tenantId) {
+        return findAllByUserTenantId(tenantId);
+    }
+
+    List<RefreshToken> findAllByUserTenantId(UUID tenantId);
+
+    default void deleteByIdAndTenantId(Long id, UUID tenantId) {
+        deleteByIdAndUserTenantId(id, tenantId);
+    }
+
+    void deleteByIdAndUserTenantId(Long id, UUID tenantId);
 
     Optional<RefreshToken> findByToken(String token);
 

--- a/sec-service/src/main/java/com/ejada/sec/repository/RoleRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/RoleRepository.java
@@ -1,17 +1,21 @@
 package com.ejada.sec.repository;
 
+import com.ejada.data.repository.TenantAwareRepository;
 import com.ejada.sec.domain.Role;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface RoleRepository extends JpaRepository<Role, Long> {
+public interface RoleRepository extends TenantAwareRepository<Role, Long> {
+
+    Optional<Role> findByIdAndTenantId(Long id, UUID tenantId);
 
     Optional<Role> findByTenantIdAndCode(UUID tenantId, String code);
 
     List<Role> findAllByTenantId(UUID tenantId);
 
     boolean existsByTenantIdAndCode(UUID tenantId, String code);
+
+    void deleteByIdAndTenantId(Long id, UUID tenantId);
 }

--- a/sec-service/src/main/java/com/ejada/sec/repository/UserRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/UserRepository.java
@@ -1,13 +1,15 @@
 package com.ejada.sec.repository;
 
+import com.ejada.data.repository.TenantAwareRepository;
 import com.ejada.sec.domain.User;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends TenantAwareRepository<User, Long> {
+
+    Optional<User> findByIdAndTenantId(Long id, UUID tenantId);
 
     Optional<User> findByTenantIdAndUsername(UUID tenantId, String username);
 
@@ -18,4 +20,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByTenantIdAndEmail(UUID tenantId, String email);
 
     List<User> findAllByTenantId(UUID tenantId);
+
+    void deleteByIdAndTenantId(Long id, UUID tenantId);
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/GrantServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/GrantServiceImpl.java
@@ -31,7 +31,7 @@ public class GrantServiceImpl implements GrantService {
   @Audited(action = AuditAction.UPDATE, entity = "UserRole", dataClass = DataClass.CREDENTIALS,
       message = "Assign roles to user")
   public void assignRolesToUser(AssignRolesToUserRequest req) {
-    User user = userRepository.findById(req.getUserId())
+    User user = userRepository.findByIdSecure(req.getUserId())
         .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));
     var roles = resolver.rolesByCodes(req.getTenantId(), req.getRoleCodes());
     roles.forEach(role -> {
@@ -47,7 +47,7 @@ public class GrantServiceImpl implements GrantService {
   @Audited(action = AuditAction.UPDATE, entity = "UserRole", dataClass = DataClass.CREDENTIALS,
       message = "Revoke roles from user")
   public void revokeRolesFromUser(RevokeRolesFromUserRequest req) {
-    User user = userRepository.findById(req.getUserId())
+    User user = userRepository.findByIdSecure(req.getUserId())
         .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));
     user.getRoles().removeIf(ur -> req.getRoleCodes().contains(ur.getRole().getCode()));
     userRepository.save(user);
@@ -85,7 +85,7 @@ public class GrantServiceImpl implements GrantService {
   @Audited(action = AuditAction.UPDATE, entity = "UserPrivilege", dataClass = DataClass.CREDENTIALS,
       message = "Set user privilege override")
   public void setUserPrivilegeOverride(SetUserPrivilegeOverrideRequest req) {
-    User user = userRepository.findById(req.getUserId())
+    User user = userRepository.findByIdSecure(req.getUserId())
         .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));
     Privilege p = privilegeRepository.findByTenantIdAndCode(req.getTenantId(), req.getPrivilegeCode())
         .orElseThrow(() -> new NoSuchElementException("Privilege not found: " + req.getPrivilegeCode()));

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/PrivilegeServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/PrivilegeServiceImpl.java
@@ -41,7 +41,7 @@ public class PrivilegeServiceImpl implements PrivilegeService {
   public BaseResponse<PrivilegeDto> update(Long id, UpdatePrivilegeRequest req) {
     Privilege p =
         repository
-            .findById(id)
+            .findByIdSecure(id)
             .orElseThrow(() -> new NoSuchElementException("Privilege not found: " + id));
     mapper.updateEntity(p, req);
     p = repository.save(p);
@@ -54,7 +54,7 @@ public class PrivilegeServiceImpl implements PrivilegeService {
   @Override
   public BaseResponse<Void> delete(Long id) {
     return repository
-        .findById(id)
+        .findByIdSecure(id)
         .map(
             privilege -> {
               UUID tenantId = privilege.getTenantId();
@@ -75,7 +75,7 @@ public class PrivilegeServiceImpl implements PrivilegeService {
         .orElseGet(
             () ->
                 repository
-                    .findById(id)
+                    .findByIdSecure(id)
                     .map(mapper::toDto)
                     .map(
                         dto -> {
@@ -92,7 +92,7 @@ public class PrivilegeServiceImpl implements PrivilegeService {
         .map(list -> BaseResponse.success("Privileges listed", list))
         .orElseGet(
             () -> {
-              List<PrivilegeDto> list = mapper.toDto(repository.findAllByTenantId(tenantId));
+              List<PrivilegeDto> list = mapper.toDto(repository.findAllSecure());
               cache.set(privListKeySuffix(tenantId), list);
               return BaseResponse.success("Privileges listed", list);
             });

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/RefreshTokenServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/RefreshTokenServiceImpl.java
@@ -39,7 +39,7 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
   @Override
   public String issue(Long userId, boolean revokeExistingSessions, String rotatedFrom) {
     var now = Instant.now();
-    User user = userRepository.findById(userId)
+    User user = userRepository.findByIdSecure(userId)
         .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
 
     if (revokeExistingSessions) {

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/RoleServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/RoleServiceImpl.java
@@ -47,7 +47,7 @@ public class RoleServiceImpl implements RoleService {
   @Override
   public BaseResponse<RoleDto> update(Long roleId, UpdateRoleRequest req) {
       log.info("Updating role {}", roleId);
-      Role role = roleRepository.findById(roleId)
+      Role role = roleRepository.findByIdSecure(roleId)
           .orElseThrow(() -> new NoSuchElementException("Role not found: " + roleId));
       roleMapper.updateEntity(role, req);
       role = roleRepository.save(role);
@@ -62,7 +62,7 @@ public class RoleServiceImpl implements RoleService {
   public BaseResponse<Void> delete(Long roleId) {
       log.info("Deleting role {}", roleId);
       roleRepository
-          .findById(roleId)
+          .findByIdSecure(roleId)
           .ifPresent(role -> {
             roleRepository.delete(role);
             cache.delete(roleKeySuffix(role.getId()));
@@ -86,7 +86,7 @@ public class RoleServiceImpl implements RoleService {
               })
           .orElseGet(
               () ->
-                  roleRepository.findById(roleId)
+                  roleRepository.findByIdSecure(roleId)
                       .map(r -> roleMapper.toDto(r, resolver))
                       .map(
                           dto -> {
@@ -109,7 +109,7 @@ public class RoleServiceImpl implements RoleService {
           .orElseGet(
               () -> {
                 List<RoleDto> list =
-                    roleMapper.toDto(roleRepository.findAllByTenantId(tenantId), resolver);
+                    roleMapper.toDto(roleRepository.findAllSecure(), resolver);
                 cache.set(roleListKeySuffix(tenantId), list);
                 return BaseResponse.success("Roles listed", list);
               });

--- a/sec-service/src/test/java/com/ejada/sec/repository/UserRepositoryTenantIsolationTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/repository/UserRepositoryTenantIsolationTest.java
@@ -1,0 +1,81 @@
+package com.ejada.sec.repository;
+
+import com.ejada.common.context.ContextManager;
+import com.ejada.sec.domain.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class UserRepositoryTenantIsolationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private UUID tenantOne;
+    private UUID tenantTwo;
+    private Long tenantOneUserId;
+
+    @BeforeEach
+    void setUp() {
+        tenantOne = UUID.randomUUID();
+        tenantTwo = UUID.randomUUID();
+
+        tenantOneUserId = userRepository.save(buildUser(tenantOne, "tenant1@example.com", "tenant1"))
+                .getId();
+        userRepository.save(buildUser(tenantTwo, "tenant2@example.com", "tenant2"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        ContextManager.Tenant.clear();
+    }
+
+    @Test
+    void findByIdSecureReturnsOnlyCurrentTenantUser() {
+        ContextManager.Tenant.set(tenantOne.toString());
+        assertThat(userRepository.findByIdSecure(tenantOneUserId)).isPresent();
+
+        ContextManager.Tenant.set(tenantTwo.toString());
+        assertThat(userRepository.findByIdSecure(tenantOneUserId)).isEmpty();
+    }
+
+    @Test
+    void findAllSecureFiltersByTenantContext() {
+        ContextManager.Tenant.set(tenantOne.toString());
+        List<User> tenantOneUsers = userRepository.findAllSecure();
+        assertThat(tenantOneUsers)
+                .hasSize(1)
+                .allMatch(user -> user.getTenantId().equals(tenantOne));
+
+        ContextManager.Tenant.set(tenantTwo.toString());
+        List<User> tenantTwoUsers = userRepository.findAllSecure();
+        assertThat(tenantTwoUsers)
+                .hasSize(1)
+                .allMatch(user -> user.getTenantId().equals(tenantTwo));
+    }
+
+    private User buildUser(UUID tenantId, String email, String username) {
+        User user = User.builder()
+                .tenantId(tenantId)
+                .email(email)
+                .username(username)
+                .passwordHash("hash")
+                .enabled(true)
+                .locked(false)
+                .build();
+        user.setCreatedAt(LocalDateTime.now());
+        user.setUpdatedAt(LocalDateTime.now());
+        user.setCreatedBy("system");
+        user.setUpdatedBy("system");
+        return user;
+    }
+}

--- a/sec-service/src/test/java/com/ejada/sec/service/impl/RefreshTokenServiceImplTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/service/impl/RefreshTokenServiceImplTest.java
@@ -46,7 +46,7 @@ class RefreshTokenServiceImplTest {
   void issueGeneratesTokenWithConfiguredTtlAndDeletesExistingOnes() {
     UUID tenantId = UUID.randomUUID();
     User user = User.builder().id(5L).tenantId(tenantId).build();
-    when(userRepository.findById(5L)).thenReturn(Optional.of(user));
+    when(userRepository.findByIdSecure(5L)).thenReturn(Optional.of(user));
     when(refreshTokenRepository.findActiveTokensByUserId(eq(5L), any())).thenReturn(java.util.Collections.emptyList());
     when(refreshTokenRepository.findActiveTokensByTenant(eq(tenantId), any())).thenReturn(java.util.Collections.emptyList());
     when(refreshTokenRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
@@ -74,7 +74,7 @@ class RefreshTokenServiceImplTest {
 
     UUID tenantId = UUID.randomUUID();
     User user = User.builder().id(7L).tenantId(tenantId).build();
-    when(userRepository.findById(7L)).thenReturn(Optional.of(user));
+    when(userRepository.findByIdSecure(7L)).thenReturn(Optional.of(user));
 
     var stored = new ArrayList<RefreshToken>();
     Instant base = Instant.now();
@@ -120,7 +120,7 @@ class RefreshTokenServiceImplTest {
 
     UUID tenantId = UUID.randomUUID();
     User user = User.builder().id(11L).tenantId(tenantId).build();
-    when(userRepository.findById(11L)).thenReturn(Optional.of(user));
+    when(userRepository.findByIdSecure(11L)).thenReturn(Optional.of(user));
 
     var stored = new ArrayList<RefreshToken>();
     Instant base = Instant.now();

--- a/shared-lib/shared-data/src/main/java/com/ejada/data/repository/TenantAwareRepository.java
+++ b/shared-lib/shared-data/src/main/java/com/ejada/data/repository/TenantAwareRepository.java
@@ -1,0 +1,41 @@
+package com.ejada.data.repository;
+
+import com.ejada.starter_core.context.TenantContextResolver;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Base repository enforcing tenant isolation.
+ * All queries automatically filter by current tenant context.
+ */
+@NoRepositoryBean
+public interface TenantAwareRepository<T, ID> extends JpaRepository<T, ID> {
+
+    // Find by ID with tenant check
+    default Optional<T> findByIdSecure(ID id) {
+        UUID tenantId = TenantContextResolver.requireTenantId();
+        return findByIdAndTenantId(id, tenantId);
+    }
+
+    Optional<T> findByIdAndTenantId(ID id, UUID tenantId);
+
+    // List all for current tenant
+    default List<T> findAllSecure() {
+        UUID tenantId = TenantContextResolver.requireTenantId();
+        return findAllByTenantId(tenantId);
+    }
+
+    List<T> findAllByTenantId(UUID tenantId);
+
+    // Delete with tenant check
+    default void deleteSecure(ID id) {
+        UUID tenantId = TenantContextResolver.requireTenantId();
+        deleteByIdAndTenantId(id, tenantId);
+    }
+
+    void deleteByIdAndTenantId(ID id, UUID tenantId);
+}

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/TenantContextResolver.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/context/TenantContextResolver.java
@@ -1,0 +1,34 @@
+package com.ejada.starter_core.context;
+
+import com.ejada.common.context.ContextManager;
+import com.ejada.common.exception.ValidationException;
+
+import java.util.UUID;
+
+/**
+ * Utilities for resolving the current tenant identifier from the shared {@link ContextManager}.
+ */
+public final class TenantContextResolver {
+
+    private TenantContextResolver() {
+        // utility class
+    }
+
+    /**
+     * Resolve the current tenant identifier from the {@link ContextManager}.
+     *
+     * @return the parsed tenant identifier
+     * @throws ValidationException if the tenant context is missing or malformed
+     */
+    public static UUID requireTenantId() {
+        String raw = ContextManager.Tenant.get();
+        if (raw == null || raw.isBlank()) {
+            throw new ValidationException("Tenant context is required", "TENANT_CONTEXT_MISSING");
+        }
+        try {
+            return UUID.fromString(raw);
+        } catch (IllegalArgumentException ex) {
+            throw new ValidationException("Invalid tenant ID format", ex.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared TenantAwareRepository base with secure tenant-scoped helpers and wire it into security repositories
- update services and tests to use tenant-aware lookups and validate tenant isolation for user queries
- introduce a RoleLevel hierarchy enum and shared TenantContextResolver utility

## Testing
- mvn -pl sec-service test *(fails: missing internal com.ejada starter artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a9c4690c832f992ae466a6f7d12e