### PR TITLE
Ensure starter-core handles updated servlet and JWT expectations

### DIFF
--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/config/CoreAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/config/CoreAutoConfiguration.java
@@ -236,7 +236,7 @@ public class CoreAutoConfiguration {
       private boolean resolveFromJwt = true;
 
       /** Candidate claim names in JWT */
-      private String[] jwtClaimNames = new String[]{"tenant", "tenant_id", "tid"};
+      private String[] jwtClaimNames = new String[]{"tenant", "tenant_id", "tenantId", "tid"};
 
       /** Optional claim carrying the tenant slug in JWT */
       private String jwtTenantSlugClaim = "tenantSlug";

--- a/shared-lib/shared-starters/starter-core/src/test/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -158,6 +158,11 @@ public class MockHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
+    public String getRequestId() {
+        return null;
+    }
+
+    @Override
     public StringBuffer getRequestURL() {
         return new StringBuffer("http://" + getServerName() + requestUri);
     }


### PR DESCRIPTION
## Summary
- include `tenantId` in the default JWT claim names so tenant resolution sees camelCase claims
- implement the new Servlet 6.1 `getRequestId` method in the test mock request helper

## Testing
- mvn -pl shared-lib/shared-starters/starter-core -am test

------
https://chatgpt.com/codex/tasks/task_e_68e1aa278b4c832fb3bae1649bf04805