### PR TITLE
Implement centralized API version normalization

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -85,6 +85,13 @@
       <artifactId>shared-config</artifactId>
     </dependency>
 
+    <!-- API documentation for versioned routes -->
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
+      <version>2.7.0</version>
+    </dependency>
+
     <!-- Reactive Redis for rate limiting -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
@@ -10,6 +10,7 @@ import com.ejada.gateway.filter.RequestBodyTransformationGatewayFilterFactory;
 import com.ejada.gateway.filter.ResponseBodyTransformationGatewayFilterFactory;
 import com.ejada.gateway.filter.SessionAffinityGatewayFilter;
 import com.ejada.gateway.resilience.TenantCircuitBreakerMetrics;
+import com.ejada.gateway.versioning.VersionNormalizationFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -43,6 +44,7 @@ public class GatewayRoutesConfiguration {
       ObjectProvider<GatewayRouteDefinitionProvider> dynamicProviders,
       ObjectProvider<RequestBodyTransformationGatewayFilterFactory> requestTransformationFactory,
       ObjectProvider<ResponseBodyTransformationGatewayFilterFactory> responseTransformationFactory,
+      ObjectProvider<VersionNormalizationFilter> versionNormalizationFilter,
       TenantCircuitBreakerMetrics circuitBreakerMetrics) {
     RouteLocatorBuilder.Builder routes = builder.routes();
 
@@ -129,6 +131,7 @@ public class GatewayRoutesConfiguration {
               if (StringUtils.hasText(route.getPrefixPath())) {
                 filters.prefixPath(route.getPrefixPath());
               }
+              versionNormalizationFilter.ifAvailable(filters::filter);
               if (route.getVersioning().isEnabled()) {
                 filters.filter(new ApiVersioningGatewayFilter(route.getVersioning()));
               }

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayVersioningConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayVersioningConfiguration.java
@@ -1,0 +1,108 @@
+package com.ejada.gateway.config;
+
+import com.ejada.gateway.versioning.VersionMappingResolver;
+import com.ejada.gateway.versioning.VersionNormalizationFilter;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.util.StringUtils;
+
+/**
+ * Wires the central API versioning components so they can be reused across route definitions and
+ * documentation tooling.
+ */
+@Configuration
+@EnableConfigurationProperties(GatewayVersioningProperties.class)
+public class GatewayVersioningConfiguration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GatewayVersioningConfiguration.class);
+
+  @Bean
+  public VersionMappingResolver versionMappingResolver(GatewayVersioningProperties properties) {
+    return new VersionMappingResolver(properties);
+  }
+
+  @Bean
+  public VersionNormalizationFilter versionNormalizationFilter(VersionMappingResolver resolver) {
+    return new VersionNormalizationFilter(resolver);
+  }
+
+  /**
+   * Dynamically registers grouped OpenAPI definitions per API version (when springdoc is on the
+   * classpath).
+   */
+  @Bean
+  @ConditionalOnClass(GroupedOpenApi.class)
+  @ConditionalOnBean(VersionMappingResolver.class)
+  public VersionedOpenApiRegistrar versionedOpenApiRegistrar(GatewayVersioningProperties properties,
+      GenericApplicationContext context,
+      ObjectProvider<GroupedOpenApi> groupedOpenApis) {
+    return new VersionedOpenApiRegistrar(properties, context, groupedOpenApis);
+  }
+
+  static final class VersionedOpenApiRegistrar implements SmartInitializingSingleton {
+
+    private final GatewayVersioningProperties properties;
+    private final GenericApplicationContext context;
+    private final ObjectProvider<GroupedOpenApi> existingGroups;
+
+    VersionedOpenApiRegistrar(GatewayVersioningProperties properties,
+        GenericApplicationContext context,
+        ObjectProvider<GroupedOpenApi> existingGroups) {
+      this.properties = properties;
+      this.context = context;
+      this.existingGroups = existingGroups;
+    }
+
+    @Override
+    public void afterSingletonsInstantiated() {
+      if (properties.getMappings().isEmpty()) {
+        return;
+      }
+      Set<String> existing = new LinkedHashSet<>();
+      existingGroups.forEach(group -> existing.add(group.getGroup()));
+
+      properties.getMappings().forEach(mapping -> mapping.getRoutes().forEach(route -> {
+        String version = route.getTargetVersionOrSelf();
+        if (version == null) {
+          return;
+        }
+        String groupName = StringUtils.hasText(route.getDocumentationGroup())
+            ? route.getDocumentationGroup()
+            : mapping.getId() + "-" + version;
+        if (existing.contains(groupName) || context.containsBean(groupName)) {
+          return;
+        }
+        LOGGER.info("Registering OpenAPI group {} for mapping {}", groupName, mapping.getId());
+        String[] docPaths = mapping.getLegacyPaths().stream()
+            .map(this::toDocPattern)
+            .toArray(String[]::new);
+        context.registerBean(groupName, GroupedOpenApi.class, () -> GroupedOpenApi.builder()
+            .group(groupName)
+            .pathsToMatch(docPaths)
+            .build());
+        existing.add(groupName);
+      }));
+    }
+
+    private String toDocPattern(String path) {
+      if (!StringUtils.hasText(path)) {
+        return path;
+      }
+      String result = path;
+      result = result.replaceAll("\\{\\*[^/]+}", "**");
+      result = result.replaceAll("\\{([^}/]+)}", "{$1}");
+      return result;
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayVersioningProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayVersioningProperties.java
@@ -1,0 +1,371 @@
+package com.ejada.gateway.config;
+
+import com.ejada.gateway.versioning.VersionNumber;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Global API versioning metadata that enables the gateway to normalise and migrate
+ * legacy endpoints towards the newest service implementations.
+ */
+@RefreshScope
+@ConfigurationProperties(prefix = "gateway.versioning")
+public class GatewayVersioningProperties {
+
+  private boolean enabled = true;
+
+  @Valid
+  private List<Mapping> mappings = new ArrayList<>();
+
+  @Valid
+  private Compatibility compatibility = new Compatibility();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public List<Mapping> getMappings() {
+    return mappings;
+  }
+
+  public void setMappings(List<Mapping> mappings) {
+    this.mappings = (mappings == null) ? new ArrayList<>() : new ArrayList<>(mappings);
+  }
+
+  public Compatibility getCompatibility() {
+    return compatibility;
+  }
+
+  public void setCompatibility(Compatibility compatibility) {
+    this.compatibility = (compatibility == null) ? new Compatibility() : compatibility;
+  }
+
+  /**
+   * Declarative compatibility matrix describing which API versions interoperate.
+   */
+  public static class Compatibility {
+
+    private Map<String, List<String>> matrix = new LinkedHashMap<>();
+
+    public Map<String, List<String>> getMatrix() {
+      return matrix;
+    }
+
+    public void setMatrix(Map<String, List<String>> matrix) {
+      this.matrix = (matrix == null) ? new LinkedHashMap<>() : normalise(matrix);
+    }
+
+    private Map<String, List<String>> normalise(Map<String, List<String>> input) {
+      Map<String, List<String>> canonical = new LinkedHashMap<>();
+      input.forEach((key, values) -> {
+        if (!StringUtils.hasText(key)) {
+          return;
+        }
+        String canonicalKey = VersionNumber.canonicaliseOrThrow(key.trim());
+        List<String> canonicalValues = new ArrayList<>();
+        if (values != null) {
+          for (String value : values) {
+            String canonicalValue = VersionNumber.canonicaliseOrNull(value);
+            if (canonicalValue != null) {
+              canonicalValues.add(canonicalValue);
+            }
+          }
+        }
+        canonical.put(canonicalKey, canonicalValues);
+      });
+      return canonical;
+    }
+  }
+
+  /**
+   * Mapping definition describing how legacy paths should be translated to the
+   * canonical versioned endpoints.
+   */
+  public static class Mapping {
+
+    @NotBlank
+    private String id;
+
+    private String description;
+
+    private List<String> legacyPaths = new ArrayList<>();
+
+    private List<String> methods = new ArrayList<>();
+
+    private boolean fallbackToDefault = true;
+
+    private String defaultVersion;
+
+    @Valid
+    private List<Route> routes = new ArrayList<>();
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public void setDescription(String description) {
+      this.description = description;
+    }
+
+    public List<String> getLegacyPaths() {
+      return legacyPaths;
+    }
+
+    public void setLegacyPaths(List<String> legacyPaths) {
+      if (legacyPaths == null) {
+        this.legacyPaths = new ArrayList<>();
+        return;
+      }
+      List<String> processed = new ArrayList<>();
+      for (String path : legacyPaths) {
+        if (!StringUtils.hasText(path)) {
+          continue;
+        }
+        String trimmed = path.trim();
+        if (!trimmed.startsWith("/")) {
+          trimmed = '/' + trimmed;
+        }
+        processed.add(trimmed);
+      }
+      this.legacyPaths = processed;
+    }
+
+    public List<String> getMethods() {
+      return methods;
+    }
+
+    public void setMethods(List<String> methods) {
+      if (methods == null) {
+        this.methods = new ArrayList<>();
+        return;
+      }
+      LinkedHashSet<String> unique = new LinkedHashSet<>();
+      for (String method : methods) {
+        if (!StringUtils.hasText(method)) {
+          continue;
+        }
+        unique.add(method.trim().toUpperCase(Locale.ROOT));
+      }
+      this.methods = new ArrayList<>(unique);
+    }
+
+    public boolean isFallbackToDefault() {
+      return fallbackToDefault;
+    }
+
+    public void setFallbackToDefault(boolean fallbackToDefault) {
+      this.fallbackToDefault = fallbackToDefault;
+    }
+
+    public String getDefaultVersion() {
+      return defaultVersion;
+    }
+
+    public void setDefaultVersion(String defaultVersion) {
+      this.defaultVersion = VersionNumber.canonicaliseOrNull(defaultVersion);
+    }
+
+    public List<Route> getRoutes() {
+      return routes;
+    }
+
+    public void setRoutes(List<Route> routes) {
+      this.routes = (routes == null) ? new ArrayList<>() : new ArrayList<>(routes);
+    }
+
+    public void validate() {
+      if (CollectionUtils.isEmpty(legacyPaths)) {
+        throw new IllegalStateException("gateway.versioning.mappings." + id + ".legacy-paths must contain at least one entry");
+      }
+      if (CollectionUtils.isEmpty(routes)) {
+        throw new IllegalStateException("gateway.versioning.mappings." + id + ".routes must contain at least one route definition");
+      }
+      LinkedHashMap<String, List<Route>> versions = new LinkedHashMap<>();
+      for (Route route : routes) {
+        route.validate(id);
+        versions.computeIfAbsent(route.getVersion(), ignored -> new ArrayList<>()).add(route);
+      }
+      if (defaultVersion == null) {
+        defaultVersion = routes.get(0).getTargetVersionOrSelf();
+      }
+      if (!versions.containsKey(defaultVersion) && fallbackToDefault) {
+        throw new IllegalStateException("gateway.versioning.mappings." + id + " default version " + defaultVersion + " does not map to any route");
+      }
+    }
+  }
+
+  /**
+   * Target route describing the migration rule for a particular API version.
+   */
+  public static class Route {
+
+    @NotBlank
+    private String version;
+
+    private String targetVersion;
+
+    private String rewritePath;
+
+    private int weight = 100;
+
+    private boolean deprecated;
+
+    private String warning;
+
+    private String sunset;
+
+    private String policyLink;
+
+    private List<String> compatibility = new ArrayList<>();
+
+    private Map<String, String> additionalHeaders = new LinkedHashMap<>();
+
+    private String documentationGroup;
+
+    public String getVersion() {
+      return version;
+    }
+
+    public void setVersion(String version) {
+      this.version = VersionNumber.canonicaliseOrThrow(version);
+    }
+
+    public String getTargetVersion() {
+      return targetVersion;
+    }
+
+    public void setTargetVersion(String targetVersion) {
+      this.targetVersion = VersionNumber.canonicaliseOrNull(targetVersion);
+    }
+
+    public String getRewritePath() {
+      return rewritePath;
+    }
+
+    public void setRewritePath(String rewritePath) {
+      if (!StringUtils.hasText(rewritePath)) {
+        this.rewritePath = null;
+        return;
+      }
+      String value = rewritePath.trim();
+      if (!value.startsWith("/")) {
+        value = '/' + value;
+      }
+      this.rewritePath = value;
+    }
+
+    public int getWeight() {
+      return weight;
+    }
+
+    public void setWeight(int weight) {
+      this.weight = (weight <= 0) ? 1 : weight;
+    }
+
+    public boolean isDeprecated() {
+      return deprecated;
+    }
+
+    public void setDeprecated(boolean deprecated) {
+      this.deprecated = deprecated;
+    }
+
+    public String getWarning() {
+      return warning;
+    }
+
+    public void setWarning(String warning) {
+      this.warning = StringUtils.hasText(warning) ? warning.trim() : null;
+    }
+
+    public String getSunset() {
+      return sunset;
+    }
+
+    public void setSunset(String sunset) {
+      this.sunset = StringUtils.hasText(sunset) ? sunset.trim() : null;
+    }
+
+    public String getPolicyLink() {
+      return policyLink;
+    }
+
+    public void setPolicyLink(String policyLink) {
+      this.policyLink = StringUtils.hasText(policyLink) ? policyLink.trim() : null;
+    }
+
+    public List<String> getCompatibility() {
+      return compatibility;
+    }
+
+    public void setCompatibility(List<String> compatibility) {
+      if (compatibility == null) {
+        this.compatibility = new ArrayList<>();
+        return;
+      }
+      LinkedHashSet<String> canonical = new LinkedHashSet<>();
+      for (String value : compatibility) {
+        String canonicalVersion = VersionNumber.canonicaliseOrNull(value);
+        if (canonicalVersion != null) {
+          canonical.add(canonicalVersion);
+        }
+      }
+      this.compatibility = new ArrayList<>(canonical);
+    }
+
+    public Map<String, String> getAdditionalHeaders() {
+      return additionalHeaders;
+    }
+
+    public void setAdditionalHeaders(Map<String, String> additionalHeaders) {
+      this.additionalHeaders = (additionalHeaders == null)
+          ? new LinkedHashMap<>()
+          : new LinkedHashMap<>(additionalHeaders);
+    }
+
+    public String getDocumentationGroup() {
+      return documentationGroup;
+    }
+
+    public void setDocumentationGroup(String documentationGroup) {
+      this.documentationGroup = StringUtils.hasText(documentationGroup) ? documentationGroup.trim() : null;
+    }
+
+    void validate(String mappingId) {
+      Objects.requireNonNull(version, "version");
+      if (targetVersion != null && targetVersion.length() == 0) {
+        targetVersion = null;
+      }
+      if (rewritePath == null) {
+        throw new IllegalStateException("gateway.versioning.mappings." + mappingId + ".routes for version " + version + " must define a rewrite-path");
+      }
+    }
+
+    public String getTargetVersionOrSelf() {
+      return (targetVersion != null) ? targetVersion : version;
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/context/GatewayRequestAttributes.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/GatewayRequestAttributes.java
@@ -21,6 +21,14 @@ public final class GatewayRequestAttributes {
   /** Attribute storing the resolved API version for versioned routes. */
   public static final String API_VERSION = GatewayRequestAttributes.class.getName() + ".apiVersion";
 
+  /** Attribute storing the originally requested API version (if provided). */
+  public static final String API_VERSION_REQUESTED = GatewayRequestAttributes.class.getName()
+      + ".apiVersionRequested";
+
+  /** Attribute storing how the API version was resolved (header, path, default, mapping). */
+  public static final String API_VERSION_SOURCE = GatewayRequestAttributes.class.getName()
+      + ".apiVersionSource";
+
   private GatewayRequestAttributes() {
     // utility class
   }

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/ApiVersioningGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/ApiVersioningGatewayFilter.java
@@ -44,6 +44,20 @@ public class ApiVersioningGatewayFilter implements GatewayFilter {
     }
 
     ServerHttpRequest request = exchange.getRequest();
+    String presetVersion = exchange.getAttribute(GatewayRequestAttributes.API_VERSION);
+    if (StringUtils.hasText(presetVersion)) {
+      if (versioning.isPropagateHeader()) {
+        String currentHeader = request.getHeaders().getFirst(HeaderNames.API_VERSION);
+        if (!presetVersion.equalsIgnoreCase(currentHeader)) {
+          ServerHttpRequest mutated = request.mutate()
+              .headers(headers -> headers.set(HeaderNames.API_VERSION, presetVersion))
+              .build();
+          return chain.filter(exchange.mutate().request(mutated).build());
+        }
+      }
+      return chain.filter(exchange);
+    }
+
     URI originalUri = request.getURI();
     String rawPath = originalUri.getRawPath();
 

--- a/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionMappingResolver.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionMappingResolver.java
@@ -1,0 +1,286 @@
+package com.ejada.gateway.versioning;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.gateway.config.GatewayVersioningProperties;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.UriTemplate;
+import org.springframework.web.util.pattern.PathContainer;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPattern.PathMatchInfo;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+/**
+ * Resolves version normalisation rules declared via {@link GatewayVersioningProperties} for a
+ * particular incoming request. The resolver is thread-safe after construction and caches compiled
+ * path patterns for efficient lookups.
+ */
+public class VersionMappingResolver {
+
+  private final boolean enabled;
+  private final List<CompiledMapping> mappings;
+  private final Map<String, List<String>> compatibilityMatrix;
+
+  public VersionMappingResolver(GatewayVersioningProperties properties) {
+    this.enabled = properties.isEnabled();
+    this.compatibilityMatrix = normaliseCompatibility(properties.getCompatibility().getMatrix());
+    this.mappings = compileMappings(properties.getMappings());
+  }
+
+  public boolean isEnabled() {
+    return enabled && !mappings.isEmpty();
+  }
+
+  public Map<String, List<String>> getCompatibilityMatrix() {
+    return compatibilityMatrix;
+  }
+
+  private Map<String, List<String>> normaliseCompatibility(Map<String, List<String>> matrix) {
+    if (matrix == null || matrix.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<String, List<String>> canonical = new LinkedHashMap<>();
+    matrix.forEach((key, values) -> {
+      if (!StringUtils.hasText(key)) {
+        return;
+      }
+      String canonicalKey = VersionNumber.canonicaliseOrNull(key);
+      if (canonicalKey == null) {
+        return;
+      }
+      List<String> canonicalValues = new ArrayList<>();
+      if (values != null) {
+        for (String value : values) {
+          String canonicalValue = VersionNumber.canonicaliseOrNull(value);
+          if (canonicalValue != null) {
+            canonicalValues.add(canonicalValue);
+          }
+        }
+      }
+      canonical.put(canonicalKey, canonicalValues);
+    });
+    return canonical;
+  }
+
+  private List<CompiledMapping> compileMappings(List<GatewayVersioningProperties.Mapping> definitions) {
+    if (definitions == null) {
+      return List.of();
+    }
+    PathPatternParser parser = new PathPatternParser();
+    parser.setMatchOptionalTrailingSeparator(true);
+    List<CompiledMapping> compiled = new ArrayList<>(definitions.size());
+    for (GatewayVersioningProperties.Mapping mapping : definitions) {
+      mapping.validate();
+      compiled.add(new CompiledMapping(mapping, parser));
+    }
+    return compiled;
+  }
+
+  /**
+   * Attempts to resolve a version mapping for the current request.
+   */
+  public Optional<VersionMappingResult> resolve(ServerWebExchange exchange) {
+    if (!isEnabled()) {
+      return Optional.empty();
+    }
+    String method = Optional.ofNullable(exchange.getRequest().getMethod())
+        .map(HttpMethod::name)
+        .orElse(null);
+
+    List<String> candidatePaths = new ArrayList<>(2);
+    URI requestUri = exchange.getRequest().getURI();
+    candidatePaths.add(requestUri.getRawPath());
+    URI gatewayRequestUrl = exchange.getAttribute(org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR);
+    if (gatewayRequestUrl != null && !Objects.equals(gatewayRequestUrl.getRawPath(), requestUri.getRawPath())) {
+      candidatePaths.add(gatewayRequestUrl.getRawPath());
+    }
+
+    String headerVersion = VersionNumber.canonicaliseOrNull(exchange.getRequest().getHeaders().getFirst(HeaderNames.ACCEPT_VERSION));
+
+    for (CompiledMapping mapping : mappings) {
+      if (!mapping.matchesMethod(method)) {
+        continue;
+      }
+      for (String path : candidatePaths) {
+        VersionMappingResult result = mapping.resolve(path, headerVersion);
+        if (result == null) {
+          continue;
+        }
+        if (result.isUnsupported()) {
+          return Optional.of(result);
+        }
+        // Merge compatibility metadata from global matrix if available.
+        if (!compatibilityMatrix.isEmpty() && StringUtils.hasText(result.getResolvedVersion())) {
+          List<String> additional = compatibilityMatrix.get(result.getResolvedVersion());
+          if (!CollectionUtils.isEmpty(additional)) {
+            List<String> merged = new ArrayList<>(result.getCompatibility());
+            for (String value : additional) {
+              if (!merged.contains(value)) {
+                merged.add(value);
+              }
+            }
+            result = result.withCompatibility(merged);
+          }
+        }
+        return Optional.of(result);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static final class CompiledMapping {
+
+    private final GatewayVersioningProperties.Mapping configuration;
+    private final List<PatternHolder> patterns;
+    private final Map<String, List<GatewayVersioningProperties.Route>> routesByVersion;
+
+    private CompiledMapping(GatewayVersioningProperties.Mapping configuration, PathPatternParser parser) {
+      this.configuration = configuration;
+      this.patterns = compilePatterns(configuration.getLegacyPaths(), parser);
+      this.routesByVersion = indexRoutes(configuration.getRoutes());
+    }
+
+    private boolean matchesMethod(String method) {
+      if (configuration.getMethods().isEmpty() || !StringUtils.hasText(method)) {
+        return true;
+      }
+      return configuration.getMethods().contains(method.toUpperCase(Locale.ROOT));
+    }
+
+    private VersionMappingResult resolve(String path, String headerVersion) {
+      for (PatternHolder holder : patterns) {
+        PathMatchInfo info = holder.pattern.matchAndExtract(PathContainer.parsePath(path));
+        if (info == null) {
+          continue;
+        }
+        return doResolve(path, headerVersion, info, holder);
+      }
+      return null;
+    }
+
+    private VersionMappingResult doResolve(String path, String headerVersion, PathMatchInfo info, PatternHolder holder) {
+      String requestedVersion = determineRequestedVersion(headerVersion, info, path);
+      String effectiveVersion = requestedVersion;
+      List<GatewayVersioningProperties.Route> candidates = routesByVersion.getOrDefault(effectiveVersion, List.of());
+
+      if (candidates.isEmpty() && configuration.isFallbackToDefault() && configuration.getDefaultVersion() != null) {
+        effectiveVersion = configuration.getDefaultVersion();
+        candidates = routesByVersion.getOrDefault(effectiveVersion, List.of());
+      }
+
+      if (candidates.isEmpty()) {
+        if (StringUtils.hasText(requestedVersion)) {
+          return VersionMappingResult.unsupported(configuration.getId(), requestedVersion);
+        }
+        return null;
+      }
+
+      GatewayVersioningProperties.Route selected = selectWeighted(candidates);
+      String resolvedVersion = selected.getTargetVersionOrSelf();
+      String rewritten = rewritePath(path, info, selected.getRewritePath());
+
+      return VersionMappingResult.resolved(configuration.getId(), requestedVersion, resolvedVersion, rewritten,
+          selected.isDeprecated(), selected.getWarning(), selected.getSunset(), selected.getPolicyLink(),
+          List.copyOf(selected.getCompatibility()), new LinkedHashMap<>(selected.getAdditionalHeaders()),
+          selected.getDocumentationGroup(), headerVersion != null ? "header" : holder.versionSource);
+    }
+
+    private String determineRequestedVersion(String headerVersion, PathMatchInfo info, String path) {
+      if (headerVersion != null) {
+        return headerVersion;
+      }
+      Map<String, String> variables = info.getUriVariables();
+      if (variables.containsKey("version")) {
+        String canonical = VersionNumber.canonicaliseOrNull(variables.get("version"));
+        if (canonical != null) {
+          return canonical;
+        }
+      }
+      // Inspect path segments sequentially to locate the first valid version token.
+      String[] segments = path.split("/");
+      for (String segment : segments) {
+        if (!StringUtils.hasText(segment)) {
+          continue;
+        }
+        String canonical = VersionNumber.canonicaliseOrNull(segment);
+        if (canonical != null) {
+          return canonical;
+        }
+      }
+      return configuration.getDefaultVersion();
+    }
+
+    private GatewayVersioningProperties.Route selectWeighted(List<GatewayVersioningProperties.Route> candidates) {
+      if (candidates.size() == 1) {
+        return candidates.get(0);
+      }
+      int total = candidates.stream().mapToInt(GatewayVersioningProperties.Route::getWeight).sum();
+      if (total <= 0) {
+        return candidates.get(0);
+      }
+      int pick = ThreadLocalRandom.current().nextInt(total);
+      int cumulative = 0;
+      for (GatewayVersioningProperties.Route candidate : candidates) {
+        cumulative += Math.max(candidate.getWeight(), 0);
+        if (pick < cumulative) {
+          return candidate;
+        }
+      }
+      return candidates.get(candidates.size() - 1);
+    }
+
+    private String rewritePath(String originalPath, PathMatchInfo info, String template) {
+      if (!StringUtils.hasText(template)) {
+        return originalPath;
+      }
+      Map<String, String> variables = new LinkedHashMap<>(info.getUriVariables());
+      UriTemplate uriTemplate = new UriTemplate(template);
+      for (String variableName : uriTemplate.getVariableNames()) {
+        variables.putIfAbsent(variableName, "");
+      }
+      return uriTemplate.expand(variables).getPath();
+    }
+
+    private Map<String, List<GatewayVersioningProperties.Route>> indexRoutes(List<GatewayVersioningProperties.Route> routes) {
+      Map<String, List<GatewayVersioningProperties.Route>> index = new LinkedHashMap<>();
+      for (GatewayVersioningProperties.Route route : routes) {
+        index.computeIfAbsent(route.getVersion(), ignored -> new ArrayList<>()).add(route);
+      }
+      return index;
+    }
+
+    private List<PatternHolder> compilePatterns(List<String> legacyPaths, PathPatternParser parser) {
+      List<PatternHolder> holders = new ArrayList<>(legacyPaths.size());
+      for (String path : legacyPaths) {
+        PathPattern pattern = parser.parse(path);
+        holders.add(new PatternHolder(pattern, inferVersionSource(path)));
+      }
+      return holders;
+    }
+
+    private String inferVersionSource(String path) {
+      if (path.contains("{version}")) {
+        return "path-template";
+      }
+      if (path.matches(".*/v\\d+.*")) {
+        return "path";
+      }
+      return "default";
+    }
+  }
+
+  private record PatternHolder(PathPattern pattern, String versionSource) {
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionMappingResult.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionMappingResult.java
@@ -1,0 +1,198 @@
+package com.ejada.gateway.versioning;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Result returned by {@link VersionMappingResolver} describing the resolved target version and any
+ * associated metadata (headers, deprecation warnings, documentation group, etc.).
+ */
+public final class VersionMappingResult {
+
+  private final String mappingId;
+  private final String requestedVersion;
+  private final String resolvedVersion;
+  private final String rewrittenPath;
+  private final boolean unsupported;
+  private final boolean deprecated;
+  private final String warning;
+  private final String sunset;
+  private final String policyLink;
+  private final List<String> compatibility;
+  private final Map<String, String> additionalHeaders;
+  private final String documentationGroup;
+  private final String resolutionSource;
+
+  private VersionMappingResult(String mappingId,
+      String requestedVersion,
+      String resolvedVersion,
+      String rewrittenPath,
+      boolean unsupported,
+      boolean deprecated,
+      String warning,
+      String sunset,
+      String policyLink,
+      List<String> compatibility,
+      Map<String, String> additionalHeaders,
+      String documentationGroup,
+      String resolutionSource) {
+    this.mappingId = mappingId;
+    this.requestedVersion = requestedVersion;
+    this.resolvedVersion = resolvedVersion;
+    this.rewrittenPath = rewrittenPath;
+    this.unsupported = unsupported;
+    this.deprecated = deprecated;
+    this.warning = warning;
+    this.sunset = sunset;
+    this.policyLink = policyLink;
+    this.compatibility = compatibility == null ? List.of() : List.copyOf(compatibility);
+    this.additionalHeaders = additionalHeaders == null ? Map.of() : Map.copyOf(additionalHeaders);
+    this.documentationGroup = documentationGroup;
+    this.resolutionSource = resolutionSource;
+  }
+
+  public static VersionMappingResult resolved(String mappingId,
+      String requestedVersion,
+      String resolvedVersion,
+      String rewrittenPath,
+      boolean deprecated,
+      String warning,
+      String sunset,
+      String policyLink,
+      List<String> compatibility,
+      Map<String, String> additionalHeaders,
+      String documentationGroup,
+      String resolutionSource) {
+    return new VersionMappingResult(mappingId,
+        requestedVersion,
+        resolvedVersion,
+        rewrittenPath,
+        false,
+        deprecated,
+        warning,
+        sunset,
+        policyLink,
+        compatibility,
+        additionalHeaders,
+        documentationGroup,
+        resolutionSource);
+  }
+
+  public static VersionMappingResult unsupported(String mappingId, String requestedVersion) {
+    return new VersionMappingResult(mappingId,
+        requestedVersion,
+        null,
+        null,
+        true,
+        false,
+        null,
+        null,
+        null,
+        List.of(),
+        Map.of(),
+        null,
+        "unsupported");
+  }
+
+  public VersionMappingResult withCompatibility(List<String> compatibility) {
+    return new VersionMappingResult(mappingId,
+        requestedVersion,
+        resolvedVersion,
+        rewrittenPath,
+        unsupported,
+        deprecated,
+        warning,
+        sunset,
+        policyLink,
+        compatibility,
+        additionalHeaders,
+        documentationGroup,
+        resolutionSource);
+  }
+
+  public boolean isUnsupported() {
+    return unsupported;
+  }
+
+  public boolean isDeprecated() {
+    return deprecated;
+  }
+
+  public String getRequestedVersion() {
+    return requestedVersion;
+  }
+
+  public String getResolvedVersion() {
+    return resolvedVersion;
+  }
+
+  public String getRewrittenPath() {
+    return rewrittenPath;
+  }
+
+  public String getWarning() {
+    return warning;
+  }
+
+  public String getSunset() {
+    return sunset;
+  }
+
+  public String getPolicyLink() {
+    return policyLink;
+  }
+
+  public List<String> getCompatibility() {
+    return compatibility;
+  }
+
+  public Map<String, String> getAdditionalHeaders() {
+    return additionalHeaders;
+  }
+
+  public String getDocumentationGroup() {
+    return documentationGroup;
+  }
+
+  public String getResolutionSource() {
+    return resolutionSource;
+  }
+
+  public String getMappingId() {
+    return mappingId;
+  }
+
+  public VersionMappingResult mergeHeaders(Map<String, String> globalHeaders) {
+    if (globalHeaders == null || globalHeaders.isEmpty()) {
+      return this;
+    }
+    Map<String, String> merged = new LinkedHashMap<>(additionalHeaders);
+    merged.putAll(globalHeaders);
+    return new VersionMappingResult(mappingId,
+        requestedVersion,
+        resolvedVersion,
+        rewrittenPath,
+        unsupported,
+        deprecated,
+        warning,
+        sunset,
+        policyLink,
+        compatibility,
+        merged,
+        documentationGroup,
+        resolutionSource);
+  }
+
+  @Override
+  public String toString() {
+    return "VersionMappingResult{"
+        + "mappingId='" + mappingId + '\''
+        + ", requestedVersion='" + requestedVersion + '\''
+        + ", resolvedVersion='" + resolvedVersion + '\''
+        + ", rewrittenPath='" + rewrittenPath + '\''
+        + ", deprecated=" + deprecated
+        + ", warning='" + warning + '\''
+        + '}';
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionNormalizationFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionNormalizationFilter.java
@@ -1,0 +1,117 @@
+package com.ejada.gateway.versioning;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.gateway.context.GatewayRequestAttributes;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+/**
+ * Gateway filter responsible for applying the {@link VersionMappingResolver} result to incoming
+ * requests. It rewrites legacy paths, enriches request/response headers and propagates metadata for
+ * downstream services and observability.
+ */
+public class VersionNormalizationFilter implements GatewayFilter, Ordered {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(VersionNormalizationFilter.class);
+
+  private final VersionMappingResolver resolver;
+
+  public VersionNormalizationFilter(VersionMappingResolver resolver) {
+    this.resolver = resolver;
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+    if (!resolver.isEnabled()) {
+      return chain.filter(exchange);
+    }
+
+    Optional<VersionMappingResult> maybeResult = resolver.resolve(exchange);
+    if (maybeResult.isEmpty()) {
+      return chain.filter(exchange);
+    }
+
+    VersionMappingResult result = maybeResult.get();
+    if (result.isUnsupported()) {
+      LOGGER.debug("Rejecting unsupported API version {} for mapping {}", result.getRequestedVersion(), result.getMappingId());
+      return Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Requested API version is not supported"));
+    }
+
+    ServerHttpRequest request = exchange.getRequest();
+    ServerHttpRequest.Builder builder = request.mutate();
+
+    String rewrittenPath = result.getRewrittenPath();
+    if (StringUtils.hasText(rewrittenPath)) {
+      URI updated = UriComponentsBuilder.fromUri(request.getURI())
+          .replacePath(rewrittenPath)
+          .build(true)
+          .toUri();
+      builder.uri(updated);
+    }
+
+    if (StringUtils.hasText(result.getResolvedVersion())) {
+      builder.headers(httpHeaders -> httpHeaders.set(HeaderNames.API_VERSION, result.getResolvedVersion()));
+    }
+
+    if (StringUtils.hasText(result.getResolutionSource())) {
+      builder.headers(httpHeaders -> httpHeaders.set("X-Api-Version-Source", result.getResolutionSource()));
+    }
+
+    Map<String, String> additionalHeaders = result.getAdditionalHeaders();
+    if (!CollectionUtils.isEmpty(additionalHeaders)) {
+      builder.headers(httpHeaders -> additionalHeaders.forEach(httpHeaders::set));
+    }
+
+    ServerWebExchange mutated = exchange.mutate().request(builder.build()).build();
+    mutated.getAttributes().put(GatewayRequestAttributes.API_VERSION, result.getResolvedVersion());
+    mutated.getAttributes().put(GatewayRequestAttributes.API_VERSION_REQUESTED, result.getRequestedVersion());
+    mutated.getAttributes().put(GatewayRequestAttributes.API_VERSION_SOURCE, result.getResolutionSource());
+
+    if (result.isDeprecated()) {
+      mutated.getResponse().beforeCommit(() -> {
+        mutated.getResponse().getHeaders().set("Deprecation",
+            StringUtils.hasText(result.getSunset()) ? result.getSunset() : "true");
+        if (StringUtils.hasText(result.getWarning())) {
+          mutated.getResponse().getHeaders().add("X-Api-Deprecation", result.getWarning());
+        }
+        if (StringUtils.hasText(result.getSunset())) {
+          mutated.getResponse().getHeaders().set("Sunset", result.getSunset());
+        }
+        if (StringUtils.hasText(result.getPolicyLink())) {
+          mutated.getResponse().getHeaders().add("Link", '<' + result.getPolicyLink() + ">; rel=\"deprecation\"");
+        }
+        if (!result.getCompatibility().isEmpty()) {
+          mutated.getResponse().getHeaders().set("X-Api-Compatible-With", String.join(",", result.getCompatibility()));
+        }
+        return Mono.empty();
+      });
+    } else if (!result.getCompatibility().isEmpty()) {
+      mutated.getResponse().beforeCommit(() -> {
+        mutated.getResponse().getHeaders().set("X-Api-Compatible-With", String.join(",", result.getCompatibility()));
+        return Mono.empty();
+      });
+    }
+
+    return chain.filter(mutated);
+  }
+
+  @Override
+  public int getOrder() {
+    // Run early so route-specific filters can observe the normalised path and version metadata.
+    return Ordered.HIGHEST_PRECEDENCE + 10;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionNumber.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionNumber.java
@@ -83,4 +83,12 @@ public final class VersionNumber {
       return null;
     }
   }
+
+  /**
+   * Canonicalises the version or throws when invalid. Provided to improve readability when
+   * dealing with configuration metadata.
+   */
+  public static String canonicaliseOrThrow(String value) {
+    return canonicalise(value);
+  }
 }

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -223,6 +223,49 @@ resilience4j:
 
 # Declarative downstream routes consumed by GatewayRoutesConfiguration
 gateway:
+  versioning:
+    enabled: true
+    compatibility:
+      matrix:
+        v2:
+          - v1
+    mappings:
+      - id: tenant-api
+        description: Normalize legacy tenant endpoints to v2 implementations
+        default-version: v2
+        legacy-paths:
+          - /v1/tenants/{*remaining}
+          - /api/v1/tenants/{*remaining}
+        routes:
+          - version: v1
+            target-version: v2
+            rewrite-path: /v2/tenants/{remaining}
+            weight: 90
+            deprecated: true
+            warning: Tenant API v1 is deprecated and will be removed. Use Accept-Version: v2.
+            sunset: 2024-12-31T00:00:00Z
+            policy-link: https://docs.example.com/tenant-api-deprecation
+            compatibility:
+              - v1
+              - v2
+            additional-headers:
+              X-Gateway-Track: primary
+          - version: v1
+            target-version: v2
+            rewrite-path: /v2/tenants/{remaining}
+            weight: 10
+            deprecated: true
+            warning: Tenant API v1 is being migrated to v2 rollout track.
+            sunset: 2024-12-31T00:00:00Z
+            documentation-group: tenant-api-v2-canary
+            additional-headers:
+              X-Gateway-Track: canary
+          - version: v2
+            rewrite-path: /v2/tenants/{remaining}
+            weight: 100
+            compatibility:
+              - v2
+            documentation-group: tenant-api-v2
   logging:
     access-log:
       enabled: true

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
@@ -50,6 +50,8 @@ public final class HeaderNames {
     // 📜 Content / Localization
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String ACCEPT = "Accept";
+    /** Header allowing clients to request a specific API version without encoding it in the URI. */
+    public static final String ACCEPT_VERSION = "Accept-Version";
     public static final String ACCEPT_LANGUAGE = "Accept-Language";
     public static final String LOCALE = "X-Locale";
 


### PR DESCRIPTION
## Summary
- add centralized gateway versioning configuration, resolver, and normalization filter to translate legacy endpoints and emit compatibility metadata
- integrate the version normalization pipeline with existing route filters and request attributes while exposing Accept-Version header support
- configure tenant API migration mappings, document versioned routes, and pull in springdoc webflux support for per-version OpenAPI groups

## Testing
- mvn -pl api-gateway -am test *(fails: unable to download net.bytebuddy:byte-buddy-agent:1.17.7 due to network error)*

------
https://chatgpt.com/codex/tasks/task_e_68e1aa101298832fa876ba950e5480c1