### PR TITLE
Add shared data module for tenant-aware repositories

### DIFF
--- a/sec-service/pom.xml
+++ b/sec-service/pom.xml
@@ -66,6 +66,10 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
+      <artifactId>shared-data</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
       <artifactId>starter-data</artifactId>
     </dependency>
     <dependency>

--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -15,6 +15,7 @@
     <module>shared-quality</module>
     <module>shared-bom</module>
     <module>shared-common</module>
+    <module>shared-data</module>
     <module>shared-lib-crypto</module>
     <module>shared-starters</module>
     <module>shared-test-support</module> 
@@ -70,6 +71,11 @@
       <dependency>
         <groupId>com.ejada</groupId>
         <artifactId>shared-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>shared-data</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/shared-lib/shared-data/pom.xml
+++ b/shared-lib/shared-data/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>shared-lib</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>shared-data</artifactId>
+  <name>Shared Data</name>
+  <description>Tenant-aware repository infrastructure for EJADA multi-tenant services.</description>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-jpa</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjweaver</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+          <parameters>true</parameters>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.ejada.shared.data</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
## Summary
- register the shared-data module with the shared-lib aggregator and dependency management so the tenant-aware infrastructure is published
- add the shared-data module POM with the Spring, AspectJ, and starter-core dependencies needed by TenantAwareRepository
- depend on the new shared-data artifact from sec-service so TenantAwareRepository resolves during compilation

## Testing
- mvn -pl shared-lib/shared-data -am compile
- mvn -pl sec-service -am compile *(fails: multiple upstream Maven BOM downloads return HTML error pages instead of POMs)*

------
https://chatgpt.com/codex/tasks/task_e_68e1af965c84832fbb8a38b4b2860b07