### PR TITLE
feat(sec): enforce hierarchical role management

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/domain/Role.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/Role.java
@@ -7,31 +7,127 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+/**
+ * Role entity representing a hierarchical role within a tenant.
+ * Roles are organized by level (0-100) where higher levels have more privileges.
+ */
 @Entity
 @Table(
-  name = "roles",
-    uniqueConstraints = @UniqueConstraint(name = "ux_roles_tenant_code", columnNames = {"tenant_id", "code"})
+    name = "roles",
+    uniqueConstraints = @UniqueConstraint(
+        name = "ux_roles_tenant_code",
+        columnNames = {"tenant_id", "code"}
+    ),
+    indexes = {
+        @Index(name = "ix_roles_tenant_id", columnList = "tenant_id"),
+        @Index(name = "ix_roles_level", columnList = "role_level"),
+        @Index(name = "ix_roles_system", columnList = "is_system_role")
+    }
 )
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Role extends AuditableEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /**
+     * Tenant this role belongs to.
+     * Platform-level roles use a special "platform" tenant ID.
+     */
     @Column(name = "tenant_id", nullable = false)
     private UUID tenantId;
 
+    /**
+     * Unique code identifying this role (e.g., "TENANT_ADMIN", "USER").
+     * Must be unique within a tenant.
+     */
     @Column(nullable = false, length = 64)
-    private String code; // ADMIN, USER...
+    private String code;
 
+    /**
+     * Human-readable role name for display.
+     */
     @Column(nullable = false, length = 128)
     private String name;
 
+    /**
+     * Hierarchical level determining role privileges and management capabilities.
+     * Higher values = more privileged.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role_level", nullable = false, length = 50)
+    @Builder.Default
+    private RoleLevel level = RoleLevel.TENANT_USER;
+
+    /**
+     * Indicates if this is a system-defined role that cannot be deleted.
+     * System roles are created during tenant provisioning.
+     */
+    @Column(name = "is_system_role", nullable = false)
+    @Builder.Default
+    private Boolean systemRole = false;
+
+    /**
+     * Optional description of role capabilities.
+     */
+    @Column(length = 500)
+    private String description;
+
+    /**
+     * Users assigned to this role.
+     */
     @OneToMany(mappedBy = "role", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private Set<UserRole> userRoles = new HashSet<>();
 
+    /**
+     * Privileges granted to this role.
+     */
     @OneToMany(mappedBy = "role", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private Set<RolePrivilege> rolePrivileges = new HashSet<>();
+
+    /**
+     * Checks if this role can manage another role based on hierarchy level.
+     *
+     * @param targetRole the role to compare against
+     * @return {@code true} if this role is strictly higher in the hierarchy
+     */
+    public boolean canManage(Role targetRole) {
+        return this.level.hasHigherPrivilege(targetRole.level);
+    }
+
+    /**
+     * Checks if this is a platform-level role.
+     *
+     * @return {@code true} if this role represents platform administration
+     */
+    public boolean isPlatformRole() {
+        return this.level.isPlatformRole();
+    }
+
+    /**
+     * Checks if this is a tenant administrative role.
+     *
+     * @return {@code true} if this role is tenant admin or officer
+     */
+    public boolean isTenantAdminRole() {
+        return this.level.isTenantAdminRole();
+    }
+
+    /**
+     * Prevents deletion of system roles.
+     */
+    @PreRemove
+    public void preventSystemRoleDeletion() {
+        if (Boolean.TRUE.equals(systemRole)) {
+            throw new IllegalStateException(
+                "Cannot delete system role: " + code + ". System roles are protected.");
+        }
+    }
 }

--- a/sec-service/src/main/java/com/ejada/sec/domain/RoleLevel.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/RoleLevel.java
@@ -1,36 +1,260 @@
 package com.ejada.sec.domain;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Defines the hierarchical levels for roles in the system.
+ *
+ * <p>The level determines a role's position in the hierarchy, where higher
+ * numeric values represent more privileged roles. This hierarchy is used to
+ * enforce management rules such as "users can only manage users with lower roles."
+ *
+ * <p><b>Hierarchy Rules:</b>
+ * <ul>
+ *   <li>A user can only manage users with strictly lower role levels</li>
+ *   <li>A user can only assign roles with strictly lower levels</li>
+ *   <li>Platform admins (PLATFORM_ADMIN) are exempt from these rules</li>
+ *   <li>Same-tenant requirement applies for non-platform roles</li>
+ * </ul>
+ *
+ * <p><b>Example Scenarios:</b>
+ * <pre>
+ * TENANT_ADMIN (80) can manage:
+ *   ✓ TENANT_OFFICER (60)
+ *   ✓ TENANT_USER (40)
+ *   ✓ END_USER (20)
+ *   ✗ PLATFORM_ADMIN (100) - higher level
+ *   ✗ Other TENANT_ADMIN (80) - same level
+ *
+ * TENANT_OFFICER (60) can manage:
+ *   ✓ TENANT_USER (40)
+ *   ✓ END_USER (20)
+ *   ✗ TENANT_ADMIN (80) - higher level
+ *   ✗ Other TENANT_OFFICER (60) - same level
+ * </pre>
+ */
 @Getter
+@RequiredArgsConstructor
 public enum RoleLevel {
-    PLATFORM_ADMIN(100, "EJADA_OFFICER", "Platform administrator with cross-tenant access"),
-    TENANT_ADMIN(80, "TENANT_ADMIN", "Tenant owner with full tenant control"),
-    TENANT_OFFICER(60, "TENANT_OFFICER", "Tenant staff with elevated permissions"),
-    TENANT_USER(40, "TENANT_USER", "Regular tenant user"),
-    END_USER(20, "END_USER", "Read-only consumer"),
-    GUEST(0, "GUEST", "Unauthenticated access");
 
+    /**
+     * Platform administrator with cross-tenant access and system-wide privileges.
+     * Can manage all tenants, users, and system configuration.
+     */
+    PLATFORM_ADMIN(100, "EJADA_OFFICER", "Platform Administrator",
+        "Full platform access across all tenants with system configuration privileges"),
+
+    /**
+     * Tenant owner with full control over their tenant.
+     * Can manage billing, subscription, and all users within the tenant.
+     */
+    TENANT_ADMIN(80, "TENANT_ADMIN", "Tenant Administrator",
+        "Full control over tenant including billing, users, and configuration"),
+
+    /**
+     * Tenant manager with elevated privileges within the tenant.
+     * Can manage regular users but not other admins or officers.
+     */
+    TENANT_OFFICER(60, "TENANT_OFFICER", "Tenant Officer",
+        "Manage regular users and content within tenant, limited configuration access"),
+
+    /**
+     * Regular tenant user with standard application access.
+     * Can perform CRUD operations on their own data.
+     */
+    TENANT_USER(40, "TENANT_USER", "Regular User",
+        "Standard application access with CRUD on own data"),
+
+    /**
+     * Read-only consumer with minimal permissions.
+     * Typically used for public-facing or customer portal access.
+     */
+    END_USER(20, "END_USER", "End User",
+        "Read-only consumer access to published content"),
+
+    /**
+     * Unauthenticated access level.
+     * Only public endpoints are accessible.
+     */
+    GUEST(0, "GUEST", "Guest",
+        "Unauthenticated access to public endpoints only");
+
+    /**
+     * Numeric level determining hierarchy position (0-100).
+     * Higher values = more privileged roles.
+     */
     private final int level;
+
+    /**
+     * Role code matching the database role.code column.
+     * Used for lookups and assignments.
+     */
     private final String roleCode;
+
+    /**
+     * Human-readable role name for UI display.
+     */
+    private final String displayName;
+
+    /**
+     * Detailed description of role capabilities.
+     */
     private final String description;
 
-    RoleLevel(int level, String roleCode, String description) {
-        this.level = level;
-        this.roleCode = roleCode;
-        this.description = description;
-    }
-
+    /**
+     * Checks if this role has higher or equal privilege level than another role.
+     *
+     * <p><b>Usage:</b>
+     * <pre>{@code
+     * RoleLevel admin = RoleLevel.TENANT_ADMIN;
+     * RoleLevel user = RoleLevel.TENANT_USER;
+     *
+     * admin.hasHigherOrEqualPrivilege(user);  // true (80 >= 40)
+     * user.hasHigherOrEqualPrivilege(admin);  // false (40 >= 80)
+     * admin.hasHigherOrEqualPrivilege(admin); // true (80 >= 80)
+     * }</pre>
+     *
+     * @param other the role level to compare against
+     * @return true if this role's level >= other's level
+     */
     public boolean hasHigherOrEqualPrivilege(RoleLevel other) {
         return this.level >= other.level;
     }
 
+    /**
+     * Checks if this role has strictly higher privilege level than another role.
+     *
+     * <p>Use this for management rules: "can only manage users with lower roles"
+     *
+     * @param other the role level to compare against
+     * @return true if this role's level > other's level
+     */
+    public boolean hasHigherPrivilege(RoleLevel other) {
+        return this.level > other.level;
+    }
+
+    /**
+     * Checks if this is a platform-level role (cross-tenant access).
+     *
+     * @return true if this is PLATFORM_ADMIN
+     */
+    public boolean isPlatformRole() {
+        return this == PLATFORM_ADMIN;
+    }
+
+    /**
+     * Checks if this is a tenant-level administrative role.
+     *
+     * @return true if this is TENANT_ADMIN or TENANT_OFFICER
+     */
+    public boolean isTenantAdminRole() {
+        return this == TENANT_ADMIN || this == TENANT_OFFICER;
+    }
+
+    /**
+     * Gets role level by role code.
+     *
+     * <p><b>Example:</b>
+     * <pre>{@code
+     * RoleLevel level = RoleLevel.fromRoleCode("TENANT_ADMIN");
+     * // Returns: TENANT_ADMIN (level 80)
+     *
+     * RoleLevel unknown = RoleLevel.fromRoleCode("INVALID");
+     * // Returns: GUEST (level 0) - default fallback
+     * }</pre>
+     *
+     * @param roleCode the role code to look up
+     * @return matching RoleLevel or GUEST if not found
+     */
     public static RoleLevel fromRoleCode(String roleCode) {
-        for (RoleLevel level : values()) {
-            if (level.roleCode.equals(roleCode)) {
-                return level;
-            }
+        if (roleCode == null || roleCode.isBlank()) {
+            return GUEST;
         }
-        return GUEST;
+
+        return Arrays.stream(values())
+            .filter(level -> level.roleCode.equalsIgnoreCase(roleCode))
+            .findFirst()
+            .orElse(GUEST);
+    }
+
+    /**
+     * Gets all role levels that are manageable by this role level.
+     *
+     * <p>Returns all levels with strictly lower numeric value.
+     *
+     * <p><b>Example:</b>
+     * <pre>{@code
+     * RoleLevel.TENANT_ADMIN.getManageableRoles();
+     * // Returns: [TENANT_OFFICER, TENANT_USER, END_USER, GUEST]
+     *
+     * RoleLevel.TENANT_USER.getManageableRoles();
+     * // Returns: [END_USER, GUEST]
+     * }</pre>
+     *
+     * @return list of role levels this role can manage
+     */
+    public List<RoleLevel> getManageableRoles() {
+        return Arrays.stream(values())
+            .filter(level -> this.level > level.level)
+            .sorted(Comparator.comparingInt(RoleLevel::getLevel).reversed())
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets all role levels that can be assigned by this role level.
+     * Same as getManageableRoles() - you can only assign roles you can manage.
+     *
+     * @return list of role levels this role can assign
+     */
+    public List<RoleLevel> getAssignableRoles() {
+        return getManageableRoles();
+    }
+
+    /**
+     * Validates if this role can manage a target role.
+     *
+     * @param targetRole the role to check management permission for
+     * @return true if this role can manage the target role
+     */
+    public boolean canManage(RoleLevel targetRole) {
+        return this.level > targetRole.level;
+    }
+
+    /**
+     * Validates if this role can assign a specific role.
+     *
+     * @param roleToAssign the role to check assignment permission for
+     * @return true if this role can assign the specified role
+     */
+    public boolean canAssign(RoleLevel roleToAssign) {
+        return this.level > roleToAssign.level;
+    }
+
+    /**
+     * Gets the highest role level from a collection of role codes.
+     *
+     * @param roleCodes collection of role codes
+     * @return highest RoleLevel or GUEST if collection is empty
+     */
+    public static RoleLevel getHighestLevel(List<String> roleCodes) {
+        if (roleCodes == null || roleCodes.isEmpty()) {
+            return GUEST;
+        }
+
+        return roleCodes.stream()
+            .map(RoleLevel::fromRoleCode)
+            .max(Comparator.comparingInt(RoleLevel::getLevel))
+            .orElse(GUEST);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s (Level %d)", displayName, level);
     }
 }

--- a/sec-service/src/main/java/com/ejada/sec/repository/RoleRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/RoleRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -55,4 +56,6 @@ public interface RoleRepository extends TenantAwareRepository<Role, Long> {
     Optional<Role> findByTenantIdAndCode(UUID tenantId, String code);
 
     boolean existsByTenantIdAndCode(UUID tenantId, String code);
+
+    List<Role> findByTenantIdAndCodeIn(UUID tenantId, Collection<String> codes);
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/RoleHierarchyService.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/RoleHierarchyService.java
@@ -1,0 +1,246 @@
+package com.ejada.sec.service;
+
+import com.ejada.sec.domain.Role;
+import com.ejada.sec.domain.RoleLevel;
+import com.ejada.sec.domain.User;
+import com.ejada.sec.domain.UserRole;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Service responsible for enforcing role hierarchy rules and validating
+ * management permissions based on role levels.
+ *
+ * <p><b>Core Rules:</b>
+ * <ol>
+ *   <li>Users can only manage users with strictly lower role levels</li>
+ *   <li>Users can only assign roles with strictly lower levels</li>
+ *   <li>Platform admins bypass tenant restrictions</li>
+ *   <li>Non-platform users require same-tenant for management</li>
+ * </ol>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RoleHierarchyService {
+
+    /**
+     * Gets the highest role level a user currently holds.
+     *
+     * @param user the user to check
+     * @return highest RoleLevel the user has or {@link RoleLevel#GUEST}
+     */
+    public RoleLevel getUserHighestRole(User user) {
+        if (user == null || user.getRoles() == null || user.getRoles().isEmpty()) {
+            return RoleLevel.GUEST;
+        }
+
+        return user.getRoles().stream()
+            .map(UserRole::getRole)
+            .map(Role::getLevel)
+            .max((a, b) -> Integer.compare(a.getLevel(), b.getLevel()))
+            .orElse(RoleLevel.GUEST);
+    }
+
+    /**
+     * Gets all role levels a user currently holds.
+     *
+     * @param user the user to check
+     * @return set of all RoleLevels the user has
+     */
+    public Set<RoleLevel> getUserRoleLevels(User user) {
+        if (user == null || user.getRoles() == null) {
+            return Set.of(RoleLevel.GUEST);
+        }
+
+        return user.getRoles().stream()
+            .map(UserRole::getRole)
+            .map(Role::getLevel)
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Checks if actor user can perform management actions on target user.
+     *
+     * @param actor the user attempting to manage
+     * @param target the user being managed
+     * @return true if management is allowed
+     */
+    public boolean canManageUser(User actor, User target) {
+        if (actor == null || target == null) {
+            log.warn("Cannot validate management: actor or target is null");
+            return false;
+        }
+
+        if (actor.getId().equals(target.getId())) {
+            log.debug("User {} cannot manage themselves", actor.getId());
+            return false;
+        }
+
+        RoleLevel actorLevel = getUserHighestRole(actor);
+        RoleLevel targetLevel = getUserHighestRole(target);
+
+        if (actorLevel.isPlatformRole()) {
+            log.debug("Platform admin {} can manage user {}", actor.getId(), target.getId());
+            return true;
+        }
+
+        if (!actor.getTenantId().equals(target.getTenantId())) {
+            log.debug("User {} cannot manage user {} - different tenants", actor.getId(), target.getId());
+            return false;
+        }
+
+        boolean canManage = actorLevel.hasHigherPrivilege(targetLevel);
+
+        log.debug("User {} (level {}) {} manage user {} (level {})",
+            actor.getId(), actorLevel.getLevel(),
+            canManage ? "CAN" : "CANNOT",
+            target.getId(), targetLevel.getLevel());
+
+        return canManage;
+    }
+
+    /**
+     * Checks if user can assign a specific role to another user.
+     *
+     * @param actor the user attempting to assign role
+     * @param targetRole the role being assigned
+     * @return true if assignment is allowed
+     */
+    public boolean canAssignRole(User actor, Role targetRole) {
+        if (actor == null || targetRole == null) {
+            log.warn("Cannot validate role assignment: actor or role is null");
+            return false;
+        }
+
+        RoleLevel actorLevel = getUserHighestRole(actor);
+
+        if (actorLevel.isPlatformRole()) {
+            log.debug("Platform admin {} can assign any role", actor.getId());
+            return true;
+        }
+
+        if (!actor.getTenantId().equals(targetRole.getTenantId())) {
+            log.debug("User {} cannot assign role {} - different tenants", actor.getId(), targetRole.getCode());
+            return false;
+        }
+
+        boolean canAssign = actorLevel.hasHigherPrivilege(targetRole.getLevel());
+
+        log.debug("User {} (level {}) {} assign role {} (level {})",
+            actor.getId(), actorLevel.getLevel(),
+            canAssign ? "CAN" : "CANNOT",
+            targetRole.getCode(), targetRole.getLevel().getLevel());
+
+        return canAssign;
+    }
+
+    /**
+     * Gets all roles a user is permitted to assign from a given set.
+     */
+    public Set<Role> getAssignableRoles(User actor, Set<Role> allRoles) {
+        if (actor == null || allRoles == null || allRoles.isEmpty()) {
+            return Set.of();
+        }
+
+        RoleLevel actorLevel = getUserHighestRole(actor);
+        UUID actorTenantId = actor.getTenantId();
+
+        if (actorLevel.isPlatformRole()) {
+            return allRoles;
+        }
+
+        return allRoles.stream()
+            .filter(role -> role.getTenantId().equals(actorTenantId))
+            .filter(role -> actorLevel.hasHigherPrivilege(role.getLevel()))
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Validates if actor can revoke a role from target user.
+     */
+    public boolean canRevokeRole(User actor, User targetUser, Role roleToRevoke) {
+        if (!canManageUser(actor, targetUser)) {
+            return false;
+        }
+
+        return canAssignRole(actor, roleToRevoke);
+    }
+
+    /**
+     * Checks if user can modify another user (enable/disable etc.).
+     */
+    public boolean canModifyUser(User actor, User target) {
+        return canManageUser(actor, target);
+    }
+
+    /**
+     * Checks if user can delete another user.
+     */
+    public boolean canDeleteUser(User actor, User target) {
+        if (!canManageUser(actor, target)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Gets list of role levels that are manageable by given role level.
+     */
+    public List<RoleLevel> getManageableRoleLevels(RoleLevel actorLevel) {
+        return actorLevel.getManageableRoles();
+    }
+
+    /**
+     * Validates role assignment request for business logic violations.
+     */
+    public RoleAssignmentValidation validateRoleAssignment(
+        User actor, User targetUser, List<Role> rolesToAssign) {
+
+        RoleAssignmentValidation validation = new RoleAssignmentValidation();
+
+        if (!canManageUser(actor, targetUser)) {
+            validation.addError(String.format(
+                "Cannot manage user %s - insufficient privileges or different tenant",
+                targetUser.getUsername()));
+            return validation;
+        }
+
+        for (Role role : rolesToAssign) {
+            if (!canAssignRole(actor, role)) {
+                validation.addError(String.format(
+                    "Cannot assign role '%s' (level %d) - insufficient privileges",
+                    role.getCode(), role.getLevel().getLevel()));
+            }
+        }
+
+        return validation;
+    }
+
+    /**
+     * Helper class for role assignment validation results.
+     */
+    @Getter
+    public static class RoleAssignmentValidation {
+        private boolean valid = true;
+        private final List<String> errors = new ArrayList<>();
+
+        public void addError(String error) {
+            this.valid = false;
+            this.errors.add(error);
+        }
+
+        public String getErrorMessage() {
+            return String.join("; ", errors);
+        }
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/GrantServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/GrantServiceImpl.java
@@ -3,97 +3,284 @@ package com.ejada.sec.service.impl;
 import com.ejada.audit.starter.api.AuditAction;
 import com.ejada.audit.starter.api.DataClass;
 import com.ejada.audit.starter.api.annotations.Audited;
-import com.ejada.sec.domain.*;
-import com.ejada.sec.dto.*;
+import com.ejada.sec.domain.Privilege;
+import com.ejada.sec.domain.Role;
+import com.ejada.sec.domain.RolePrivilege;
+import com.ejada.sec.domain.RolePrivilegeId;
+import com.ejada.sec.domain.User;
+import com.ejada.sec.domain.UserPrivilege;
+import com.ejada.sec.domain.UserPrivilegeId;
+import com.ejada.sec.domain.UserRole;
+import com.ejada.sec.domain.UserRoleId;
+import com.ejada.sec.dto.AssignRolesToUserRequest;
+import com.ejada.sec.dto.GrantPrivilegesToRoleRequest;
+import com.ejada.sec.dto.RevokePrivilegesFromRoleRequest;
+import com.ejada.sec.dto.RevokeRolesFromUserRequest;
+import com.ejada.sec.dto.SetUserPrivilegeOverrideRequest;
 import com.ejada.sec.mapper.ReferenceResolver;
-import com.ejada.sec.repository.*;
+import com.ejada.sec.repository.PrivilegeRepository;
+import com.ejada.sec.repository.RolePrivilegeRepository;
+import com.ejada.sec.repository.RoleRepository;
+import com.ejada.sec.repository.UserPrivilegeRepository;
+import com.ejada.sec.repository.UserRepository;
+import com.ejada.sec.repository.UserRoleRepository;
 import com.ejada.sec.service.GrantService;
+import com.ejada.sec.service.RoleHierarchyService;
+import com.ejada.sec.util.SecurityContextUtils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+/**
+ * Service for managing role and privilege assignments with hierarchy enforcement.
+ * All operations validate role hierarchy rules before making changes.
+ */
 @Service
 @RequiredArgsConstructor
+@Transactional
+@Slf4j
 public class GrantServiceImpl implements GrantService {
 
-  private final UserRepository userRepository;
-  private final RoleRepository roleRepository;
-  private final PrivilegeRepository privilegeRepository;
-  private final UserRoleRepository userRoleRepository;
-  private final RolePrivilegeRepository rolePrivilegeRepository;
-  private final UserPrivilegeRepository userPrivilegeRepository;
-  private final ReferenceResolver resolver;
+    private final RoleHierarchyService roleHierarchyService;
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final PrivilegeRepository privilegeRepository;
+    private final UserRoleRepository userRoleRepository;
+    private final RolePrivilegeRepository rolePrivilegeRepository;
+    private final UserPrivilegeRepository userPrivilegeRepository;
+    private final ReferenceResolver resolver;
 
-  @Transactional
-  @Override
-  @Audited(action = AuditAction.UPDATE, entity = "UserRole", dataClass = DataClass.CREDENTIALS,
-      message = "Assign roles to user")
-  public void assignRolesToUser(AssignRolesToUserRequest req) {
-    User user = userRepository.findByIdSecure(req.getUserId())
-        .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));
-    var roles = resolver.rolesByCodes(req.getTenantId(), req.getRoleCodes());
-    roles.forEach(role -> {
-      var id = new UserRoleId(user.getId(), role.getId());
-      if (!userRoleRepository.existsById(id)) {
-        userRoleRepository.save(UserRole.builder().id(id).user(user).role(role).build());
-      }
-    });
-  }
+    @Override
+    @Audited(
+        action = AuditAction.UPDATE,
+        entity = "UserRole",
+        dataClass = DataClass.CREDENTIALS,
+        message = "Assign roles to user"
+    )
+    public void assignRolesToUser(AssignRolesToUserRequest req) {
+        Long currentUserId = SecurityContextUtils.getCurrentUserId();
+        User currentUser = userRepository.findByIdSecure(currentUserId)
+            .orElseThrow(() -> new SecurityException("Current user not found"));
 
-  @Transactional
-  @Override
-  @Audited(action = AuditAction.UPDATE, entity = "UserRole", dataClass = DataClass.CREDENTIALS,
-      message = "Revoke roles from user")
-  public void revokeRolesFromUser(RevokeRolesFromUserRequest req) {
-    User user = userRepository.findByIdSecure(req.getUserId())
-        .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));
-    user.getRoles().removeIf(ur -> req.getRoleCodes().contains(ur.getRole().getCode()));
-    userRepository.save(user);
-  }
+        User targetUser = userRepository.findByIdSecure(req.getUserId())
+            .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));
 
-  @Transactional
-  @Override
-  @Audited(action = AuditAction.UPDATE, entity = "RolePrivilege", dataClass = DataClass.CREDENTIALS,
-      message = "Grant privileges to role")
-  public void grantPrivilegesToRole(GrantPrivilegesToRoleRequest req) {
-    Role role = roleRepository.findByTenantIdAndCode(req.getTenantId(), req.getRoleCode())
-        .orElseThrow(() -> new NoSuchElementException("Role not found: " + req.getRoleCode()));
-    var privs = resolver.privilegesByCodes(req.getTenantId(), req.getPrivilegeCodes());
-    privs.forEach(p -> {
-      var id = new RolePrivilegeId(role.getId(), p.getId());
-      if (!rolePrivilegeRepository.existsById(id)) {
-        rolePrivilegeRepository.save(RolePrivilege.builder().id(id).role(role).privilege(p).build());
-      }
-    });
-  }
+        if (!roleHierarchyService.canManageUser(currentUser, targetUser)) {
+            log.warn("User {} attempted to manage user {} - insufficient privileges",
+                currentUser.getId(), targetUser.getId());
+            throw new AccessDeniedException(String.format(
+                "Cannot manage user %s - insufficient privileges or different tenant",
+                targetUser.getUsername()));
+        }
 
-  @Transactional
-  @Override
-  @Audited(action = AuditAction.UPDATE, entity = "RolePrivilege", dataClass = DataClass.CREDENTIALS,
-      message = "Revoke privileges from role")
-  public void revokePrivilegesFromRole(RevokePrivilegesFromRoleRequest req) {
-    Role role = roleRepository.findByTenantIdAndCode(req.getTenantId(), req.getRoleCode())
-        .orElseThrow(() -> new NoSuchElementException("Role not found: " + req.getRoleCode()));
-    role.getRolePrivileges().removeIf(rp -> req.getPrivilegeCodes().contains(rp.getPrivilege().getCode()));
-    roleRepository.save(role);
-  }
+        List<String> requestedCodes = req.getRoleCodes();
+        if (requestedCodes == null || requestedCodes.isEmpty()) {
+            log.debug("No roles provided for assignment to user {}", targetUser.getId());
+            return;
+        }
 
-  @Transactional
-  @Override
-  @Audited(action = AuditAction.UPDATE, entity = "UserPrivilege", dataClass = DataClass.CREDENTIALS,
-      message = "Set user privilege override")
-  public void setUserPrivilegeOverride(SetUserPrivilegeOverrideRequest req) {
-    User user = userRepository.findByIdSecure(req.getUserId())
-        .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));
-    Privilege p = privilegeRepository.findByTenantIdAndCode(req.getTenantId(), req.getPrivilegeCode())
-        .orElseThrow(() -> new NoSuchElementException("Privilege not found: " + req.getPrivilegeCode()));
+        Set<String> uniqueCodes = new HashSet<>(requestedCodes);
+        List<Role> rolesToAssign = roleRepository.findByTenantIdAndCodeIn(
+            targetUser.getTenantId(), uniqueCodes);
 
-    var id = new UserPrivilegeId(user.getId(), p.getId());
-    var up = userPrivilegeRepository.findById(id)
-        .orElse(UserPrivilege.builder().id(id).user(user).privilege(p).build());
-    up.setGranted(Boolean.TRUE.equals(req.getGranted()));
-    userPrivilegeRepository.save(up);
-  }
+        if (rolesToAssign.size() != uniqueCodes.size()) {
+            throw new IllegalArgumentException("One or more role codes not found in tenant");
+        }
+
+        for (Role role : rolesToAssign) {
+            if (!roleHierarchyService.canAssignRole(currentUser, role)) {
+                log.warn("User {} attempted to assign role {} (level {}) - insufficient privileges",
+                    currentUser.getId(), role.getCode(), role.getLevel().getLevel());
+                throw new AccessDeniedException(String.format(
+                    "Cannot assign role '%s' (level %d) - insufficient privileges",
+                    role.getCode(), role.getLevel().getLevel()));
+            }
+        }
+
+        rolesToAssign.forEach(role -> {
+            UserRoleId id = new UserRoleId(targetUser.getId(), role.getId());
+            if (!userRoleRepository.existsById(id)) {
+                userRoleRepository.save(
+                    UserRole.builder()
+                        .id(id)
+                        .user(targetUser)
+                        .role(role)
+                        .build()
+                );
+                log.info("User {} assigned role {} (level {}) to user {}",
+                    currentUser.getId(), role.getCode(), role.getLevel().getLevel(), targetUser.getId());
+            }
+        });
+    }
+
+    @Override
+    @Audited(
+        action = AuditAction.UPDATE,
+        entity = "UserRole",
+        dataClass = DataClass.CREDENTIALS,
+        message = "Revoke roles from user"
+    )
+    public void revokeRolesFromUser(RevokeRolesFromUserRequest req) {
+        Long currentUserId = SecurityContextUtils.getCurrentUserId();
+        User currentUser = userRepository.findByIdSecure(currentUserId)
+            .orElseThrow(() -> new SecurityException("Current user not found"));
+
+        User targetUser = userRepository.findByIdSecure(req.getUserId())
+            .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));
+
+        if (!roleHierarchyService.canManageUser(currentUser, targetUser)) {
+            throw new AccessDeniedException("Cannot manage user - insufficient privileges");
+        }
+
+        List<String> requestedCodes = req.getRoleCodes();
+        if (requestedCodes == null || requestedCodes.isEmpty()) {
+            log.debug("No roles provided for revocation from user {}", targetUser.getId());
+            return;
+        }
+
+        List<Role> rolesToRevoke = targetUser.getRoles().stream()
+            .map(UserRole::getRole)
+            .filter(role -> requestedCodes.contains(role.getCode()))
+            .collect(Collectors.toList());
+
+        for (Role role : rolesToRevoke) {
+            if (!roleHierarchyService.canRevokeRole(currentUser, targetUser, role)) {
+                log.warn("User {} attempted to revoke role {} from user {} - insufficient privileges",
+                    currentUser.getId(), role.getCode(), targetUser.getId());
+                throw new AccessDeniedException(String.format(
+                    "Cannot revoke role '%s' - insufficient privileges",
+                    role.getCode()));
+            }
+        }
+
+        targetUser.getRoles().removeIf(ur -> requestedCodes.contains(ur.getRole().getCode()));
+        userRepository.save(targetUser);
+
+        log.info("User {} revoked roles {} from user {}",
+            currentUser.getId(), requestedCodes, targetUser.getId());
+    }
+
+    @Override
+    @Audited(
+        action = AuditAction.UPDATE,
+        entity = "RolePrivilege",
+        dataClass = DataClass.CREDENTIALS,
+        message = "Grant privileges to role"
+    )
+    public void grantPrivilegesToRole(GrantPrivilegesToRoleRequest req) {
+        Long currentUserId = SecurityContextUtils.getCurrentUserId();
+        User currentUser = userRepository.findByIdSecure(currentUserId)
+            .orElseThrow(() -> new SecurityException("Current user not found"));
+
+        Role role = roleRepository.findByTenantIdAndCode(req.getTenantId(), req.getRoleCode())
+            .orElseThrow(() -> new NoSuchElementException("Role not found: " + req.getRoleCode()));
+
+        if (!roleHierarchyService.canAssignRole(currentUser, role)) {
+            log.warn("User {} attempted to grant privileges to role {} (level {}) - insufficient privileges",
+                currentUser.getId(), role.getCode(), role.getLevel().getLevel());
+            throw new AccessDeniedException(String.format(
+                "Cannot modify role '%s' (level %d) - insufficient privileges",
+                role.getCode(), role.getLevel().getLevel()));
+        }
+
+        List<Privilege> privileges = resolver.privilegesByCodes(req.getTenantId(), req.getPrivilegeCodes());
+
+        privileges.forEach(privilege -> {
+            RolePrivilegeId id = new RolePrivilegeId(role.getId(), privilege.getId());
+            if (!rolePrivilegeRepository.existsById(id)) {
+                rolePrivilegeRepository.save(
+                    RolePrivilege.builder()
+                        .id(id)
+                        .role(role)
+                        .privilege(privilege)
+                        .build()
+                );
+            }
+        });
+
+        log.info("User {} granted {} privileges to role {}",
+            currentUser.getId(), privileges.size(), role.getCode());
+    }
+
+    @Override
+    @Audited(
+        action = AuditAction.UPDATE,
+        entity = "RolePrivilege",
+        dataClass = DataClass.CREDENTIALS,
+        message = "Revoke privileges from role"
+    )
+    public void revokePrivilegesFromRole(RevokePrivilegesFromRoleRequest req) {
+        Long currentUserId = SecurityContextUtils.getCurrentUserId();
+        User currentUser = userRepository.findByIdSecure(currentUserId)
+            .orElseThrow(() -> new SecurityException("Current user not found"));
+
+        Role role = roleRepository.findByTenantIdAndCode(req.getTenantId(), req.getRoleCode())
+            .orElseThrow(() -> new NoSuchElementException("Role not found: " + req.getRoleCode()));
+
+        if (!roleHierarchyService.canAssignRole(currentUser, role)) {
+            throw new AccessDeniedException("Cannot modify role - insufficient privileges");
+        }
+
+        List<String> privilegeCodes = req.getPrivilegeCodes();
+        if (privilegeCodes == null || privilegeCodes.isEmpty()) {
+            log.debug("No privilege codes provided for revocation from role {}", role.getCode());
+            return;
+        }
+
+        role.getRolePrivileges().removeIf(
+            rp -> privilegeCodes.contains(rp.getPrivilege().getCode())
+        );
+        roleRepository.save(role);
+
+        log.info("User {} revoked privileges from role {}",
+            currentUser.getId(), role.getCode());
+    }
+
+    @Override
+    @Audited(
+        action = AuditAction.UPDATE,
+        entity = "UserPrivilege",
+        dataClass = DataClass.CREDENTIALS,
+        message = "Set user privilege override"
+    )
+    public void setUserPrivilegeOverride(SetUserPrivilegeOverrideRequest req) {
+        Long currentUserId = SecurityContextUtils.getCurrentUserId();
+        User currentUser = userRepository.findByIdSecure(currentUserId)
+            .orElseThrow(() -> new SecurityException("Current user not found"));
+
+        User targetUser = userRepository.findByIdSecure(req.getUserId())
+            .orElseThrow(() -> new NoSuchElementException("User not found: " + req.getUserId()));
+
+        if (!roleHierarchyService.canManageUser(currentUser, targetUser)) {
+            throw new AccessDeniedException("Cannot manage user - insufficient privileges");
+        }
+
+        Privilege privilege = privilegeRepository.findByTenantIdAndCode(
+            req.getTenantId(), req.getPrivilegeCode())
+            .orElseThrow(() -> new NoSuchElementException("Privilege not found: " + req.getPrivilegeCode()));
+
+        UserPrivilegeId id = new UserPrivilegeId(targetUser.getId(), privilege.getId());
+        UserPrivilege userPrivilege = userPrivilegeRepository.findById(id)
+            .orElse(UserPrivilege.builder()
+                .id(id)
+                .user(targetUser)
+                .privilege(privilege)
+                .build());
+
+        userPrivilege.setGranted(Boolean.TRUE.equals(req.getGranted()));
+        userPrivilege.setNotedBy(currentUserId);
+        userPrivilege.setNotedAt(java.time.Instant.now());
+        userPrivilegeRepository.save(userPrivilege);
+
+        log.info("User {} set privilege override {} = {} for user {}",
+            currentUser.getId(), privilege.getCode(), req.getGranted(), targetUser.getId());
+    }
 }

--- a/sec-service/src/main/java/com/ejada/sec/util/SecurityContextUtils.java
+++ b/sec-service/src/main/java/com/ejada/sec/util/SecurityContextUtils.java
@@ -1,0 +1,107 @@
+package com.ejada.sec.util;
+
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * Utility methods for extracting details from the Spring Security context.
+ */
+public final class SecurityContextUtils {
+
+    private SecurityContextUtils() {
+    }
+
+    /**
+     * Resolve the current authenticated user's identifier.
+     *
+     * @return user identifier as {@link Long}
+     * @throws AuthenticationCredentialsNotFoundException if no authenticated user is present
+     */
+    public static Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new AuthenticationCredentialsNotFoundException("No authenticated user found");
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        Long fromPrincipal = resolveIdFromPrincipal(principal);
+        if (fromPrincipal != null) {
+            return fromPrincipal;
+        }
+
+        Long fromName = parseLong(authentication.getName());
+        if (fromName != null) {
+            return fromName;
+        }
+
+        throw new AuthenticationCredentialsNotFoundException("Unable to resolve current user identifier");
+    }
+
+    private static Long resolveIdFromPrincipal(Object principal) {
+        if (principal == null) {
+            return null;
+        }
+
+        if (principal instanceof Long value) {
+            return value;
+        }
+
+        if (principal instanceof Integer intValue) {
+            return intValue.longValue();
+        }
+
+        if (principal instanceof Jwt jwt) {
+            Long id = extractLongClaim(jwt, "uid");
+            if (id != null) {
+                return id;
+            }
+            id = extractLongClaim(jwt, "user_id");
+            if (id != null) {
+                return id;
+            }
+            return parseLong(jwt.getSubject());
+        }
+
+        if (principal instanceof UserDetails details) {
+            return parseLong(details.getUsername());
+        }
+
+        if (principal instanceof String str) {
+            return parseLong(str);
+        }
+
+        return null;
+    }
+
+    private static Long extractLongClaim(Jwt jwt, String claimName) {
+        Object claim = jwt.getClaim(claimName);
+        if (claim == null) {
+            return null;
+        }
+
+        if (claim instanceof Number number) {
+            return number.longValue();
+        }
+
+        if (claim instanceof String str) {
+            return parseLong(str);
+        }
+
+        return null;
+    }
+
+    private static Long parseLong(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.valueOf(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+}

--- a/sec-service/src/main/resources/db/migration/postgresql/V7__add_role_hierarchy.sql
+++ b/sec-service/src/main/resources/db/migration/postgresql/V7__add_role_hierarchy.sql
@@ -1,0 +1,245 @@
+-- ============================================
+-- V7: Add Role Hierarchy System
+-- ============================================
+-- Adds hierarchical levels to roles to enforce management rules:
+-- "Users can only manage users with lower role levels"
+
+-- Add new columns to roles table
+ALTER TABLE roles 
+ADD COLUMN IF NOT EXISTS role_level VARCHAR(50) NOT NULL DEFAULT 'TENANT_USER',
+ADD COLUMN IF NOT EXISTS is_system_role BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN IF NOT EXISTS description VARCHAR(500);
+
+-- Create index for role level queries (improves performance)
+CREATE INDEX IF NOT EXISTS ix_roles_level ON roles(role_level);
+CREATE INDEX IF NOT EXISTS ix_roles_system ON roles(is_system_role);
+
+-- ============================================
+-- Update Existing Roles with Appropriate Levels
+-- ============================================
+
+-- Platform Admins (EJADA Officers)
+UPDATE roles 
+SET role_level = 'PLATFORM_ADMIN', 
+    is_system_role = true,
+    description = 'Platform administrator with cross-tenant access and system-wide privileges'
+WHERE code = 'EJADA_OFFICER';
+
+-- Tenant Admins (Tenant Owners)
+UPDATE roles 
+SET role_level = 'TENANT_ADMIN', 
+    is_system_role = true,
+    description = 'Tenant owner with full control over tenant including billing and user management'
+WHERE code = 'TENANT_ADMIN';
+
+-- Tenant Officers (Tenant Managers)
+UPDATE roles 
+SET role_level = 'TENANT_OFFICER', 
+    is_system_role = true,
+    description = 'Tenant manager with elevated privileges, can manage regular users'
+WHERE code = 'TENANT_OFFICER';
+
+-- Regular Users
+UPDATE roles 
+SET role_level = 'TENANT_USER', 
+    is_system_role = true,
+    description = 'Standard application user with CRUD access to own data'
+WHERE code IN ('USER', 'TENANT_USER');
+
+-- End Users (Read-only consumers)
+UPDATE roles 
+SET role_level = 'END_USER', 
+    is_system_role = true,
+    description = 'Read-only consumer with minimal permissions'
+WHERE code = 'END_USER';
+
+-- ============================================
+-- Constraints for Data Integrity
+-- ============================================
+
+-- Ensure role_level has valid values
+ALTER TABLE roles 
+ADD CONSTRAINT IF NOT EXISTS ck_role_level_valid 
+CHECK (role_level IN (
+    'PLATFORM_ADMIN', 
+    'TENANT_ADMIN', 
+    'TENANT_OFFICER', 
+    'TENANT_USER', 
+    'END_USER', 
+    'GUEST'
+));
+
+-- Prevent deletion of system roles via constraint (soft constraint)
+ALTER TABLE roles 
+ADD CONSTRAINT IF NOT EXISTS ck_system_role_protection 
+CHECK (is_system_role = false OR id IS NOT NULL);
+
+-- ============================================
+-- Create View for Role Hierarchy Analysis
+-- ============================================
+
+CREATE OR REPLACE VIEW role_hierarchy_view AS
+SELECT 
+    r.id,
+    r.tenant_id,
+    r.code,
+    r.name,
+    r.role_level,
+    CASE r.role_level
+        WHEN 'PLATFORM_ADMIN' THEN 100
+        WHEN 'TENANT_ADMIN' THEN 80
+        WHEN 'TENANT_OFFICER' THEN 60
+        WHEN 'TENANT_USER' THEN 40
+        WHEN 'END_USER' THEN 20
+        ELSE 0
+    END AS level_numeric,
+    r.is_system_role,
+    (SELECT COUNT(*) FROM user_roles ur WHERE ur.role_id = r.id) AS user_count,
+    (SELECT COUNT(*) FROM role_privileges rp WHERE rp.role_id = r.id) AS privilege_count,
+    r.created_at,
+    r.updated_at
+FROM roles r
+ORDER BY level_numeric DESC, r.tenant_id, r.code;
+
+-- ============================================
+-- Function to Get User's Highest Role Level
+-- ============================================
+
+CREATE OR REPLACE FUNCTION get_user_highest_role_level(p_user_id BIGINT)
+RETURNS VARCHAR(50) AS $$
+DECLARE
+    v_highest_level VARCHAR(50);
+BEGIN
+    SELECT r.role_level
+    INTO v_highest_level
+    FROM user_roles ur
+    JOIN roles r ON ur.role_id = r.id
+    WHERE ur.user_id = p_user_id
+    ORDER BY 
+        CASE r.role_level
+            WHEN 'PLATFORM_ADMIN' THEN 100
+            WHEN 'TENANT_ADMIN' THEN 80
+            WHEN 'TENANT_OFFICER' THEN 60
+            WHEN 'TENANT_USER' THEN 40
+            WHEN 'END_USER' THEN 20
+            ELSE 0
+        END DESC
+    LIMIT 1;
+    
+    RETURN COALESCE(v_highest_level, 'GUEST');
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================
+-- Function to Check If User Can Manage Another User
+-- ============================================
+
+CREATE OR REPLACE FUNCTION can_user_manage_user(
+    p_actor_id BIGINT,
+    p_target_id BIGINT
+)
+RETURNS BOOLEAN AS $$
+DECLARE
+    v_actor_level INT;
+    v_target_level INT;
+    v_actor_tenant UUID;
+    v_target_tenant UUID;
+    v_actor_role_level VARCHAR(50);
+BEGIN
+    -- Cannot manage yourself
+    IF p_actor_id = p_target_id THEN
+        RETURN FALSE;
+    END IF;
+    
+    -- Get actor's highest role level and tenant
+    SELECT 
+        CASE r.role_level
+            WHEN 'PLATFORM_ADMIN' THEN 100
+            WHEN 'TENANT_ADMIN' THEN 80
+            WHEN 'TENANT_OFFICER' THEN 60
+            WHEN 'TENANT_USER' THEN 40
+            WHEN 'END_USER' THEN 20
+            ELSE 0
+        END,
+        u.tenant_id,
+        r.role_level
+    INTO v_actor_level, v_actor_tenant, v_actor_role_level
+    FROM users u
+    JOIN user_roles ur ON ur.user_id = u.id
+    JOIN roles r ON ur.role_id = r.id
+    WHERE u.id = p_actor_id
+    ORDER BY 
+        CASE r.role_level
+            WHEN 'PLATFORM_ADMIN' THEN 100
+            WHEN 'TENANT_ADMIN' THEN 80
+            WHEN 'TENANT_OFFICER' THEN 60
+            WHEN 'TENANT_USER' THEN 40
+            WHEN 'END_USER' THEN 20
+            ELSE 0
+        END DESC
+    LIMIT 1;
+    
+    -- Get target's highest role level and tenant
+    SELECT 
+        CASE r.role_level
+            WHEN 'PLATFORM_ADMIN' THEN 100
+            WHEN 'TENANT_ADMIN' THEN 80
+            WHEN 'TENANT_OFFICER' THEN 60
+            WHEN 'TENANT_USER' THEN 40
+            WHEN 'END_USER' THEN 20
+            ELSE 0
+        END,
+        u.tenant_id
+    INTO v_target_level, v_target_tenant
+    FROM users u
+    JOIN user_roles ur ON ur.user_id = u.id
+    JOIN roles r ON ur.role_id = r.id
+    WHERE u.id = p_target_id
+    ORDER BY 
+        CASE r.role_level
+            WHEN 'PLATFORM_ADMIN' THEN 100
+            WHEN 'TENANT_ADMIN' THEN 80
+            WHEN 'TENANT_OFFICER' THEN 60
+            WHEN 'TENANT_USER' THEN 40
+            WHEN 'END_USER' THEN 20
+            ELSE 0
+        END DESC
+    LIMIT 1;
+    
+    v_actor_role_level := COALESCE(v_actor_role_level, 'GUEST');
+    v_actor_level := COALESCE(v_actor_level, 0);
+    v_target_level := COALESCE(v_target_level, 0);
+
+    -- Platform admins can manage anyone
+    IF v_actor_role_level = 'PLATFORM_ADMIN' THEN
+        RETURN TRUE;
+    END IF;
+    
+    -- For non-platform users, must be same tenant
+    IF v_actor_tenant IS DISTINCT FROM v_target_tenant THEN
+        RETURN FALSE;
+    END IF;
+    
+    -- Actor must have strictly higher level
+    RETURN v_actor_level > v_target_level;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================
+-- Comments for Documentation
+-- ============================================
+
+COMMENT ON COLUMN roles.role_level IS 
+'Hierarchical level: PLATFORM_ADMIN (100) > TENANT_ADMIN (80) > TENANT_OFFICER (60) > TENANT_USER (40) > END_USER (20) > GUEST (0)';
+
+COMMENT ON COLUMN roles.is_system_role IS 
+'System roles are created during tenant provisioning and cannot be deleted';
+
+COMMENT ON VIEW role_hierarchy_view IS 
+'Provides hierarchical view of roles with numeric levels for easy sorting and comparison';
+
+COMMENT ON FUNCTION get_user_highest_role_level(BIGINT) IS 
+'Returns the highest role level code for a given user';
+
+COMMENT ON FUNCTION can_user_manage_user(BIGINT, BIGINT) IS 
+'Checks if actor user can manage target user based on role hierarchy rules';


### PR DESCRIPTION
## Summary
- add a RoleLevel enum and migrate roles to include hierarchical metadata and protections
- introduce a RoleHierarchyService plus security context utilities to validate role assignments
- enforce hierarchy-aware checks in GrantService and add a migration for role levels and helper database functions

## Testing
- mvn -pl sec-service -am test *(fails: Error opening zip file for net.bytebuddy:byte-buddy-agent:1.17.7)*

------
https://chatgpt.com/codex/tasks/task_e_68e1af81f0a4832fbcdbc1b29af2b6de