### PR TITLE
feat: implement tenant-aware weighted load balancing

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationController.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/AdminAggregationController.java
@@ -4,9 +4,11 @@ import com.ejada.common.dto.BaseResponse;
 import com.ejada.gateway.admin.model.AdminOverview;
 import com.ejada.gateway.admin.model.AdminRouteView;
 import com.ejada.gateway.admin.model.DetailedHealthStatus;
+import com.ejada.gateway.loadbalancer.LoadBalancerHealthCheckAggregator;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
@@ -40,5 +42,12 @@ public class AdminAggregationController {
   public Mono<BaseResponse<DetailedHealthStatus>> detailedHealth() {
     return aggregationService.fetchDetailedHealth()
         .map(data -> BaseResponse.success("Gateway dependency health", data));
+  }
+
+  @GetMapping("/loadbalancer/health")
+  public Mono<BaseResponse<List<LoadBalancerHealthCheckAggregator.InstanceState>>> loadBalancerHealth(
+      @RequestParam(name = "serviceId", required = false) String serviceId) {
+    return Mono.fromSupplier(() -> aggregationService.collectLoadBalancerHealth(serviceId))
+        .map(data -> BaseResponse.success("Load balancer health", data));
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/model/AdminRouteView.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/model/AdminRouteView.java
@@ -28,7 +28,8 @@ public record AdminRouteView(
     Map<String, String> requestHeaders,
     boolean resilienceEnabled,
     String fallbackUri,
-    String circuitBreakerName) {
+    String circuitBreakerName,
+    String loadBalancingStrategy) {
 
   public static AdminRouteView fromRoute(GatewayRoutesProperties.ServiceRoute route) {
     GatewayRoutesProperties.ServiceRoute.Versioning versioning = route.getVersioning();
@@ -56,6 +57,7 @@ public record AdminRouteView(
         Map.copyOf(route.getRequestHeaders()),
         resilience.isEnabled(),
         resilience.isEnabled() ? resilience.resolvedFallbackUri(route.getId()) : null,
-        resilience.isEnabled() ? resilience.resolvedCircuitBreakerName(route.getId()) : null);
+        resilience.isEnabled() ? resilience.resolvedCircuitBreakerName(route.getId()) : null,
+        route.getLbStrategy().name());
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesConfiguration.java
@@ -206,10 +206,11 @@ public class GatewayRoutesConfiguration {
     String affinitySummary = route.getSessionAffinity().isEnabled()
         ? route.getSessionAffinity().toString()
         : "SessionAffinity{enabled=false}";
+    String lbSummary = route.getLbStrategy().name();
     String prefixSummary = StringUtils.hasText(route.getPrefixPath()) ? route.getPrefixPath() : "/";
     if (route.getMethods().isEmpty()) {
       LOGGER.info(
-          "Registered route {} -> {} ({} prefix={}) resilience={} versioning={} weight={} affinity={}",
+          "Registered route {} -> {} ({} prefix={}) resilience={} versioning={} weight={} affinity={} lb={}",
           route.getId(),
           route.getUri(),
           route.getPaths(),
@@ -217,10 +218,11 @@ public class GatewayRoutesConfiguration {
           resilienceSummary,
           versionSummary,
           weightSummary,
-          affinitySummary);
+          affinitySummary,
+          lbSummary);
     } else {
       LOGGER.info(
-          "Registered route {} -> {} ({}, methods={}, prefix={}) resilience={} versioning={} weight={} affinity={}",
+          "Registered route {} -> {} ({}, methods={}, prefix={}) resilience={} versioning={} weight={} affinity={} lb={}",
           route.getId(),
           route.getUri(),
           route.getPaths(),
@@ -229,7 +231,8 @@ public class GatewayRoutesConfiguration {
           resilienceSummary,
           versionSummary,
           weightSummary,
-          affinitySummary);
+          affinitySummary,
+          lbSummary);
     }
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRoutesProperties.java
@@ -114,6 +114,9 @@ public class GatewayRoutesProperties {
     /** Session affinity preferences for stateful downstream services. */
     private SessionAffinity sessionAffinity = new SessionAffinity();
 
+    /** Load balancing strategy to apply when forwarding traffic to this route. */
+    private LoadBalancingStrategy lbStrategy = LoadBalancingStrategy.DEFAULT;
+
     public String getId() {
       return id;
     }
@@ -232,6 +235,18 @@ public class GatewayRoutesProperties {
       this.sessionAffinity = (sessionAffinity == null) ? new SessionAffinity() : sessionAffinity;
     }
 
+    public LoadBalancingStrategy getLbStrategy() {
+      return lbStrategy;
+    }
+
+    public void setLbStrategy(LoadBalancingStrategy lbStrategy) {
+      this.lbStrategy = (lbStrategy == null) ? LoadBalancingStrategy.DEFAULT : lbStrategy;
+    }
+
+    public void setLbStrategy(String lbStrategy) {
+      this.lbStrategy = LoadBalancingStrategy.from(lbStrategy);
+    }
+
     public void applyDefaults(RouteDefaults defaults) {
       if (defaults == null) {
         return;
@@ -319,6 +334,7 @@ public class GatewayRoutesProperties {
           + ", versioning=" + versioning
           + ", weight=" + weight
           + ", sessionAffinity=" + sessionAffinity
+          + ", lbStrategy=" + lbStrategy
           + '}';
     }
 
@@ -340,13 +356,14 @@ public class GatewayRoutesProperties {
           && Objects.equals(requestHeaders, that.requestHeaders)
           && Objects.equals(versioning, that.versioning)
           && Objects.equals(weight, that.weight)
-          && Objects.equals(sessionAffinity, that.sessionAffinity);
+          && Objects.equals(sessionAffinity, that.sessionAffinity)
+          && lbStrategy == that.lbStrategy;
     }
 
     @Override
     public int hashCode() {
       return Objects.hash(id, uri, paths, methods, stripPrefix, prefixPath, resilience, requestHeaders,
-          versioning, weight, sessionAffinity);
+          versioning, weight, sessionAffinity, lbStrategy);
     }
 
     /**
@@ -619,6 +636,22 @@ public class GatewayRoutesProperties {
             ", cookieName='" + cookieName + '\'' +
             ", headerName='" + headerName + '\'' +
             '}';
+      }
+    }
+
+    public enum LoadBalancingStrategy {
+      DEFAULT,
+      WEIGHTED_RESPONSE_TIME;
+
+      static LoadBalancingStrategy from(String value) {
+        if (!StringUtils.hasText(value)) {
+          return DEFAULT;
+        }
+        try {
+          return LoadBalancingStrategy.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+          throw new IllegalStateException("Unsupported load balancing strategy: " + value, ex);
+        }
       }
     }
 

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/LoadBalancerConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/LoadBalancerConfiguration.java
@@ -1,0 +1,58 @@
+package com.ejada.gateway.loadbalancer;
+
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerClientFactory;
+import org.springframework.cloud.loadbalancer.annotation.LoadBalancerClients;
+import org.springframework.cloud.loadbalancer.core.ReactorServiceInstanceLoadBalancer;
+import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Central configuration that replaces the default round-robin load balancer with the
+ * {@link TenantAffinityLoadBalancer} and ensures service instances are enriched with dynamic
+ * weighting metadata.
+ */
+@Configuration
+@LoadBalancerClients
+public class LoadBalancerConfiguration {
+
+  @Bean
+  public LoadBalancerHealthCheckAggregator loadBalancerHealthCheckAggregator() {
+    return new LoadBalancerHealthCheckAggregator();
+  }
+
+  @Bean
+  public WebSocketStickTable webSocketStickTable(
+      @Value("${gateway.loadbalancer.websocket-stickiness-ttl:PT15M}") java.time.Duration ttl) {
+    return new WebSocketStickTable(ttl);
+  }
+
+  @Bean
+  @Primary
+  public ServiceInstanceListSupplier serviceInstanceListSupplier(ConfigurableApplicationContext context,
+      LoadBalancerHealthCheckAggregator aggregator) {
+    ServiceInstanceListSupplier delegate = ServiceInstanceListSupplier.builder()
+        .withDiscoveryClient()
+        .withCaching()
+        .build(context);
+    return new WeightedServiceInstanceListSupplier(delegate, aggregator);
+  }
+
+  @Bean
+  public ReactorServiceInstanceLoadBalancer reactorServiceInstanceLoadBalancer(
+      LoadBalancerClientFactory clientFactory,
+      LoadBalancerHealthCheckAggregator aggregator,
+      GatewayRoutesProperties routesProperties,
+      WebSocketStickTable stickTable,
+      @Value("${spring.cloud.loadbalancer.zone:}") String localZone) {
+    String serviceId = clientFactory.getName();
+    ObjectProvider<ServiceInstanceListSupplier> provider = clientFactory
+        .getLazyProvider(serviceId, ServiceInstanceListSupplier.class);
+    return new TenantAffinityLoadBalancer(serviceId, provider, aggregator, routesProperties, stickTable, localZone);
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/LoadBalancerHealthCheckAggregator.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/LoadBalancerHealthCheckAggregator.java
@@ -1,0 +1,387 @@
+package com.ejada.gateway.loadbalancer;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.util.StringUtils;
+
+/**
+ * Maintains rolling insight into the health of discovered service instances so custom load
+ * balancing strategies can make informed decisions. The aggregator consumes metadata published by
+ * service discovery, blends it with locally observed latency samples and produces an effective
+ * weight for each instance.
+ */
+public class LoadBalancerHealthCheckAggregator {
+
+  private static final double DEFAULT_HEALTH_SCORE = 1.0d;
+  private static final double MIN_WEIGHT = 0.0d;
+  private static final double MAX_WEIGHT = 1.0d;
+  private static final double DEFAULT_BASELINE_RESPONSE_TIME_MS = 250d;
+
+  private final ConcurrentMap<String, InstanceState> stateByInstance = new ConcurrentHashMap<>();
+  private final double baselineResponseTimeMs;
+  private final Clock clock;
+
+  public LoadBalancerHealthCheckAggregator() {
+    this(Duration.ofMillis((long) DEFAULT_BASELINE_RESPONSE_TIME_MS), Clock.systemUTC());
+  }
+
+  public LoadBalancerHealthCheckAggregator(Duration baselineResponseTime) {
+    this(baselineResponseTime, Clock.systemUTC());
+  }
+
+  public LoadBalancerHealthCheckAggregator(Duration baselineResponseTime, Clock clock) {
+    this.baselineResponseTimeMs = Math.max(1d,
+        baselineResponseTime != null ? baselineResponseTime.toMillis() : DEFAULT_BASELINE_RESPONSE_TIME_MS);
+    this.clock = (clock != null) ? clock : Clock.systemUTC();
+  }
+
+  /** Updates or creates the aggregated state for the supplied instance. */
+  public InstanceState update(ServiceInstance instance) {
+    Objects.requireNonNull(instance, "instance");
+    return stateByInstance.compute(instanceKey(instance), (key, existing) -> merge(instance, existing));
+  }
+
+  /** Records an observed response time so future weight calculations can react to live traffic. */
+  public void recordResponseTime(ServiceInstance instance, Duration responseTime) {
+    if (instance == null || responseTime == null) {
+      return;
+    }
+    double latency = Math.max(1d, responseTime.toMillis());
+    stateByInstance.compute(instanceKey(instance), (key, existing) -> {
+      InstanceState base = (existing != null) ? existing : merge(instance, null);
+      double measured = (base.sampleCount > 0)
+          ? ((base.measuredResponseTimeMs * base.sampleCount) + latency) / (base.sampleCount + 1)
+          : latency;
+      int samples = base.sampleCount + 1;
+      double effectiveWeight = computeWeight(base.healthScore, measured, base.availability, base.rolloutPhase);
+      return base.withMeasurements(measured, samples, effectiveWeight, Instant.now(clock));
+    });
+  }
+
+  /** Snapshot of all tracked instance states sorted by service and instance id. */
+  public List<InstanceState> snapshot() {
+    return snapshot(null);
+  }
+
+  /** Snapshot filtered by service id (if provided). */
+  public List<InstanceState> snapshot(String serviceId) {
+    return stateByInstance.values().stream()
+        .filter(state -> !StringUtils.hasText(serviceId) || serviceId.equals(state.serviceId))
+        .sorted(Comparator.comparing(InstanceState::getServiceId)
+            .thenComparing(InstanceState::getInstanceId))
+        .map(InstanceState::copy)
+        .collect(Collectors.toCollection(ArrayList::new));
+  }
+
+  private InstanceState merge(ServiceInstance instance, InstanceState existing) {
+    Map<String, String> metadata = instance.getMetadata();
+    double healthScore = resolveHealthScore(metadata, existing);
+    double metadataLatency = resolveResponseTime(metadata, existing);
+    double measuredLatency = (existing != null && existing.sampleCount > 0)
+        ? existing.measuredResponseTimeMs
+        : metadataLatency;
+    Availability availability = resolveAvailability(metadata, existing);
+    String rollout = resolveRolloutPhase(metadata, existing);
+    String zone = resolveZone(metadata, existing);
+    Instant now = Instant.now(clock);
+    double weight = computeWeight(healthScore, measuredLatency, availability, rollout);
+    return new InstanceState(
+        instance.getServiceId(),
+        resolveInstanceId(instance),
+        zone,
+        healthScore,
+        metadataLatency,
+        measuredLatency,
+        existing != null ? existing.sampleCount : 0,
+        availability,
+        rollout,
+        weight,
+        now);
+  }
+
+  private double resolveHealthScore(Map<String, String> metadata, InstanceState existing) {
+    double fallback = existing != null ? existing.healthScore : DEFAULT_HEALTH_SCORE;
+    return clamp(resolveDouble(metadata, fallback, "healthScore", "health-score", "health_score"));
+  }
+
+  private double resolveResponseTime(Map<String, String> metadata, InstanceState existing) {
+    double fallback = (existing != null && existing.metadataResponseTimeMs > 0)
+        ? existing.metadataResponseTimeMs
+        : baselineResponseTimeMs;
+    double value = resolveDouble(metadata, fallback,
+        "avgResponseTimeMs",
+        "avg-response-time",
+        "average-response-time",
+        "response-time-ms");
+    return (value > 0) ? value : fallback;
+  }
+
+  private Availability resolveAvailability(Map<String, String> metadata, InstanceState existing) {
+    Availability fallback = existing != null ? existing.availability : Availability.UP;
+    String raw = firstNonBlank(metadata,
+        "availability",
+        "status",
+        "state",
+        "healthStatus");
+    if (!StringUtils.hasText(raw)) {
+      return fallback;
+    }
+    String candidate = raw.trim().toUpperCase(Locale.ROOT);
+    if ("OUT_OF_SERVICE".equals(candidate) || "DRAINING".equals(candidate)) {
+      return Availability.DEGRADED;
+    }
+    try {
+      return Availability.valueOf(candidate);
+    } catch (IllegalArgumentException ex) {
+      return fallback;
+    }
+  }
+
+  private String resolveRolloutPhase(Map<String, String> metadata, InstanceState existing) {
+    String fallback = existing != null ? existing.rolloutPhase : "steady";
+    String value = firstNonBlank(metadata,
+        "rolloutPhase",
+        "rollout-phase",
+        "deploymentPhase",
+        "deployment-phase",
+        "deployment");
+    if (!StringUtils.hasText(value)) {
+      return fallback;
+    }
+    return value.trim();
+  }
+
+  private String resolveZone(Map<String, String> metadata, InstanceState existing) {
+    String fallback = existing != null ? existing.zone : "unknown";
+    String value = firstNonBlank(metadata,
+        "zone",
+        "zoneId",
+        "zone-id",
+        "cloud.zone",
+        "spring-cloud-loadbalancer-zone");
+    if (!StringUtils.hasText(value)) {
+      return fallback;
+    }
+    return value.trim();
+  }
+
+  private double resolveDouble(Map<String, String> metadata, double fallback, String... keys) {
+    for (String key : keys) {
+      if (!metadata.containsKey(key)) {
+        continue;
+      }
+      String raw = metadata.get(key);
+      if (!StringUtils.hasText(raw)) {
+        continue;
+      }
+      try {
+        return Double.parseDouble(raw.trim());
+      } catch (NumberFormatException ignored) {
+        // ignore malformed values and continue
+      }
+    }
+    return fallback;
+  }
+
+  private String firstNonBlank(Map<String, String> metadata, String... keys) {
+    for (String key : keys) {
+      String value = metadata.get(key);
+      if (StringUtils.hasText(value)) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  private double computeWeight(double healthScore, double responseTimeMs, Availability availability,
+      String rolloutPhase) {
+    double health = clamp(healthScore);
+    double latency = (responseTimeMs > 0) ? responseTimeMs : baselineResponseTimeMs;
+    double latencyScore = baselineResponseTimeMs / (baselineResponseTimeMs + latency);
+    latencyScore = clamp(latencyScore);
+    double weight = health * latencyScore;
+    if (availability == Availability.DEGRADED) {
+      weight *= 0.5d;
+    } else if (availability == Availability.DOWN) {
+      return 0d;
+    }
+    if (StringUtils.hasText(rolloutPhase)) {
+      String normalized = rolloutPhase.trim().toLowerCase(Locale.ROOT);
+      if (normalized.contains("warm") || normalized.contains("canary")) {
+        weight *= 0.6d;
+      } else if (normalized.contains("drain")) {
+        weight *= 0.2d;
+      }
+    }
+    return clamp(weight);
+  }
+
+  private static double clamp(double value) {
+    if (Double.isNaN(value)) {
+      return MIN_WEIGHT;
+    }
+    if (value < MIN_WEIGHT) {
+      return MIN_WEIGHT;
+    }
+    if (value > MAX_WEIGHT) {
+      return MAX_WEIGHT;
+    }
+    return value;
+  }
+
+  private String instanceKey(ServiceInstance instance) {
+    return instance.getServiceId() + '@' + resolveInstanceId(instance);
+  }
+
+  public static String resolveInstanceId(ServiceInstance instance) {
+    if (instance == null) {
+      return "unknown";
+    }
+    String instanceId = instance.getInstanceId();
+    if (StringUtils.hasText(instanceId)) {
+      return instanceId;
+    }
+    String host = instance.getHost();
+    int port = instance.getPort();
+    return host + ':' + port;
+  }
+
+  /** Canonical instance availability derived from discovery metadata. */
+  public enum Availability {
+    UP,
+    DEGRADED,
+    DOWN
+  }
+
+  /** Immutable snapshot of an instance's computed health state. */
+  public static final class InstanceState {
+
+    private final String serviceId;
+    private final String instanceId;
+    private final String zone;
+    private final double healthScore;
+    private final double metadataResponseTimeMs;
+    private final double measuredResponseTimeMs;
+    private final int sampleCount;
+    private final Availability availability;
+    private final String rolloutPhase;
+    private final double effectiveWeight;
+    private final Instant updatedAt;
+
+    private InstanceState(String serviceId,
+        String instanceId,
+        String zone,
+        double healthScore,
+        double metadataResponseTimeMs,
+        double measuredResponseTimeMs,
+        int sampleCount,
+        Availability availability,
+        String rolloutPhase,
+        double effectiveWeight,
+        Instant updatedAt) {
+      this.serviceId = serviceId;
+      this.instanceId = instanceId;
+      this.zone = zone;
+      this.healthScore = healthScore;
+      this.metadataResponseTimeMs = metadataResponseTimeMs;
+      this.measuredResponseTimeMs = measuredResponseTimeMs;
+      this.sampleCount = sampleCount;
+      this.availability = availability;
+      this.rolloutPhase = rolloutPhase;
+      this.effectiveWeight = effectiveWeight;
+      this.updatedAt = updatedAt;
+    }
+
+    private InstanceState withMeasurements(double measuredResponseTimeMs, int sampleCount,
+        double effectiveWeight, Instant updatedAt) {
+      return new InstanceState(serviceId, instanceId, zone, healthScore, metadataResponseTimeMs,
+          measuredResponseTimeMs, sampleCount, availability, rolloutPhase, effectiveWeight, updatedAt);
+    }
+
+    private InstanceState copy() {
+      return new InstanceState(serviceId, instanceId, zone, healthScore, metadataResponseTimeMs,
+          measuredResponseTimeMs, sampleCount, availability, rolloutPhase, effectiveWeight, updatedAt);
+    }
+
+    public String getServiceId() {
+      return serviceId;
+    }
+
+    public String getInstanceId() {
+      return instanceId;
+    }
+
+    public String getZone() {
+      return zone;
+    }
+
+    public double getHealthScore() {
+      return healthScore;
+    }
+
+    public double getMetadataResponseTimeMs() {
+      return metadataResponseTimeMs;
+    }
+
+    public double getMeasuredResponseTimeMs() {
+      return measuredResponseTimeMs;
+    }
+
+    public int getSampleCount() {
+      return sampleCount;
+    }
+
+    public Availability getAvailability() {
+      return availability;
+    }
+
+    public String getRolloutPhase() {
+      return rolloutPhase;
+    }
+
+    public double getEffectiveWeight() {
+      return effectiveWeight;
+    }
+
+    public Instant getUpdatedAt() {
+      return updatedAt;
+    }
+
+    public double getAverageResponseTimeMs() {
+      if (sampleCount > 0 && measuredResponseTimeMs > 0) {
+        return measuredResponseTimeMs;
+      }
+      if (metadataResponseTimeMs > 0) {
+        return metadataResponseTimeMs;
+      }
+      return measuredResponseTimeMs > 0 ? measuredResponseTimeMs : DEFAULT_BASELINE_RESPONSE_TIME_MS;
+    }
+
+    @Override
+    public String toString() {
+      return "InstanceState{"
+          + "serviceId='" + serviceId + '\''
+          + ", instanceId='" + instanceId + '\''
+          + ", zone='" + zone + '\''
+          + ", healthScore=" + healthScore
+          + ", averageResponseTimeMs=" + getAverageResponseTimeMs()
+          + ", sampleCount=" + sampleCount
+          + ", availability=" + availability
+          + ", rolloutPhase='" + rolloutPhase + '\''
+          + ", effectiveWeight=" + effectiveWeight
+          + ", updatedAt=" + updatedAt
+          + '}';
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/TenantAffinityLoadBalancer.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/TenantAffinityLoadBalancer.java
@@ -1,0 +1,278 @@
+package com.ejada.gateway.loadbalancer;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import com.ejada.gateway.config.GatewayRoutesProperties.ServiceRoute;
+import com.ejada.gateway.config.GatewayRoutesProperties.ServiceRoute.LoadBalancingStrategy;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.DefaultRequest;
+import org.springframework.cloud.client.loadbalancer.DefaultResponse;
+import org.springframework.cloud.client.loadbalancer.EmptyResponse;
+import org.springframework.cloud.client.loadbalancer.Request;
+import org.springframework.cloud.client.loadbalancer.RequestData;
+import org.springframework.cloud.client.loadbalancer.RequestDataContext;
+import org.springframework.cloud.client.loadbalancer.Response;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.cloud.loadbalancer.core.ReactorServiceInstanceLoadBalancer;
+import org.springframework.cloud.loadbalancer.core.RoundRobinLoadBalancer;
+import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Mono;
+
+/**
+ * Custom load balancer that blends tenant affinity, consistent hashing, zone preference and
+ * response-time aware weighting. The implementation falls back to round-robin when a route does not
+ * opt-in via {@code gateway.routes[].lb-strategy = weighted-response-time}.
+ */
+public class TenantAffinityLoadBalancer implements ReactorServiceInstanceLoadBalancer {
+
+  private static final Duration DEFAULT_STICKY_TTL = Duration.ofMinutes(15);
+
+  private final String serviceId;
+  private final ObjectProvider<ServiceInstanceListSupplier> supplierProvider;
+  private final LoadBalancerHealthCheckAggregator aggregator;
+  private final GatewayRoutesProperties routesProperties;
+  private final RoundRobinLoadBalancer fallback;
+  private final WebSocketStickTable stickTable;
+  private final String localZone;
+
+  public TenantAffinityLoadBalancer(String serviceId,
+      ObjectProvider<ServiceInstanceListSupplier> supplierProvider,
+      LoadBalancerHealthCheckAggregator aggregator,
+      GatewayRoutesProperties routesProperties,
+      WebSocketStickTable stickTable,
+      String localZone) {
+    this.serviceId = Objects.requireNonNull(serviceId, "serviceId");
+    this.supplierProvider = Objects.requireNonNull(supplierProvider, "supplierProvider");
+    this.aggregator = Objects.requireNonNull(aggregator, "aggregator");
+    this.routesProperties = Objects.requireNonNull(routesProperties, "routesProperties");
+    this.stickTable = (stickTable != null) ? stickTable : new WebSocketStickTable(DEFAULT_STICKY_TTL);
+    this.localZone = localZone;
+    this.fallback = new RoundRobinLoadBalancer(supplierProvider, serviceId);
+  }
+
+  @Override
+  public Mono<Response<ServiceInstance>> choose(Request request) {
+    ServiceInstanceListSupplier supplier = supplierProvider.getIfAvailable();
+    if (supplier == null) {
+      return Mono.just(new EmptyResponse());
+    }
+    return supplier.get(request)
+        .next()
+        .flatMap(instances -> selectInstance(request, instances));
+  }
+
+  private Mono<Response<ServiceInstance>> selectInstance(Request request, List<ServiceInstance> instances) {
+    if (instances == null || instances.isEmpty()) {
+      return Mono.just(new EmptyResponse());
+    }
+    if (!shouldUseWeightedStrategy(request)) {
+      return fallback.choose(request);
+    }
+
+    List<WeightedInstance> candidates = instances.stream()
+        .map(instance -> new WeightedInstance(instance, aggregator.update(instance)))
+        .filter(candidate -> candidate.state().getAvailability() != LoadBalancerHealthCheckAggregator.Availability.DOWN)
+        .filter(candidate -> candidate.state().getEffectiveWeight() > 0d)
+        .sorted(Comparator.comparingDouble((WeightedInstance candidate) -> candidate.state().getEffectiveWeight()).reversed())
+        .collect(Collectors.toCollection(ArrayList::new));
+
+    if (candidates.isEmpty()) {
+      return fallback.choose(request);
+    }
+
+    String tenantId = resolveTenantId(request);
+    RequestData requestData = resolveRequestData(request);
+    boolean websocket = requestData != null && isWebSocket(requestData.getHeaders());
+    String connectionKey = websocket ? resolveStickinessKey(requestData, tenantId) : null;
+
+    Optional<ServiceInstance> stickyMatch = Optional.empty();
+    if (connectionKey != null) {
+      stickyMatch = stickTable.lookup(connectionKey, serviceId,
+          candidates.stream().map(WeightedInstance::instance).toList());
+    }
+
+    ServiceInstance chosen;
+    if (stickyMatch.isPresent()) {
+      chosen = stickyMatch.get();
+    } else if (StringUtils.hasText(tenantId)) {
+      chosen = selectByRendezvous(tenantId, candidates);
+    } else {
+      chosen = selectByWeight(candidates);
+    }
+
+    if (chosen == null) {
+      return fallback.choose(request);
+    }
+
+    if (connectionKey != null) {
+      stickTable.record(connectionKey, chosen);
+    }
+
+    return Mono.just(new DefaultResponse(chosen));
+  }
+
+  private boolean shouldUseWeightedStrategy(Request<?> request) {
+    String routeId = resolveRouteId(request);
+    if (!StringUtils.hasText(routeId)) {
+      return false;
+    }
+    return routesProperties.findRouteById(routeId)
+        .map(ServiceRoute::getLbStrategy)
+        .map(strategy -> strategy == LoadBalancingStrategy.WEIGHTED_RESPONSE_TIME)
+        .orElse(false);
+  }
+
+  private String resolveRouteId(Request<?> request) {
+    RequestData requestData = resolveRequestData(request);
+    if (requestData == null) {
+      return null;
+    }
+    Object attr = requestData.getAttributes().get(ServerWebExchangeUtils.GATEWAY_ROUTE_ID_ATTR);
+    if (attr instanceof String text && StringUtils.hasText(text)) {
+      return text;
+    }
+    return null;
+  }
+
+  private RequestData resolveRequestData(Request<?> request) {
+    if (request instanceof DefaultRequest<?> defaultRequest) {
+      Object context = defaultRequest.getContext();
+      if (context instanceof RequestDataContext dataContext) {
+        return dataContext.getClientRequest();
+      }
+    }
+    if (request instanceof RequestDataContext dataContext) {
+      return dataContext.getClientRequest();
+    }
+    if (request != null && request.getContext() instanceof RequestDataContext dataContext) {
+      return dataContext.getClientRequest();
+    }
+    return null;
+  }
+
+  private String resolveTenantId(Request<?> request) {
+    RequestData requestData = resolveRequestData(request);
+    if (requestData == null) {
+      return null;
+    }
+    String tenant = requestData.getHeaders().getFirst(HeaderNames.X_TENANT_ID);
+    if (StringUtils.hasText(tenant)) {
+      return tenant.trim();
+    }
+    Object attributeTenant = requestData.getAttributes().get(HeaderNames.X_TENANT_ID);
+    return attributeTenant instanceof String text && StringUtils.hasText(text) ? text.trim() : null;
+  }
+
+  private boolean isWebSocket(HttpHeaders headers) {
+    if (headers == null) {
+      return false;
+    }
+    String upgrade = headers.getFirst(HttpHeaders.UPGRADE);
+    return StringUtils.hasText(upgrade) && "websocket".equalsIgnoreCase(upgrade.trim());
+  }
+
+  private String resolveStickinessKey(RequestData requestData, String tenantId) {
+    HttpHeaders headers = requestData.getHeaders();
+    String websocketKey = headers.getFirst("Sec-WebSocket-Key");
+    String connectionId = headers.getFirst("X-Connection-Id");
+    String base = StringUtils.hasText(websocketKey) ? websocketKey : connectionId;
+    if (!StringUtils.hasText(base)) {
+      URI uri = requestData.getUrl();
+      base = (uri != null) ? uri.toString() : "";
+    }
+    String tenant = StringUtils.hasText(tenantId) ? tenantId : "anonymous";
+    return tenant + ':' + base;
+  }
+
+  private ServiceInstance selectByRendezvous(String key, List<WeightedInstance> candidates) {
+    List<WeightedInstance> scoped = preferZone(candidates);
+    double bestScore = Double.NEGATIVE_INFINITY;
+    WeightedInstance best = null;
+    for (WeightedInstance candidate : scoped) {
+      double weight = candidate.state().getEffectiveWeight();
+      if (weight <= 0d) {
+        continue;
+      }
+      double hash = unitHash(key, candidate.instanceKey());
+      double score = weight / -Math.log(hash == 0d ? Double.MIN_VALUE : hash);
+      if (score > bestScore) {
+        bestScore = score;
+        best = candidate;
+      }
+    }
+    if (best != null) {
+      return best.instance();
+    }
+    return selectByWeight(candidates);
+  }
+
+  private ServiceInstance selectByWeight(List<WeightedInstance> candidates) {
+    List<WeightedInstance> scoped = preferZone(candidates);
+    double total = scoped.stream().mapToDouble(candidate -> Math.max(0d, candidate.state().getEffectiveWeight())).sum();
+    if (total <= 0d) {
+      return candidates.isEmpty() ? null : candidates.get(0).instance();
+    }
+    double threshold = ThreadLocalRandom.current().nextDouble(total);
+    double running = 0d;
+    for (WeightedInstance candidate : scoped) {
+      running += Math.max(0d, candidate.state().getEffectiveWeight());
+      if (running >= threshold) {
+        return candidate.instance();
+      }
+    }
+    return scoped.get(scoped.size() - 1).instance();
+  }
+
+  private List<WeightedInstance> preferZone(List<WeightedInstance> candidates) {
+    if (!StringUtils.hasText(localZone)) {
+      return candidates;
+    }
+    List<WeightedInstance> sameZone = candidates.stream()
+        .filter(candidate -> localZone.equalsIgnoreCase(candidate.state().getZone()))
+        .collect(Collectors.toList());
+    return sameZone.isEmpty() ? candidates : sameZone;
+  }
+
+  private double unitHash(String tenantKey, String instanceId) {
+    byte[] data = (tenantKey + '|' + instanceId).getBytes(StandardCharsets.UTF_8);
+    long hash = 1469598103934665603L; // FNV-1a 64-bit offset basis
+    for (byte b : data) {
+      hash ^= (b & 0xff);
+      hash *= 1099511628211L;
+    }
+    long bits = (hash >>> 11) | 0x3ff0000000000000L;
+    double value = Double.longBitsToDouble(bits) - 1.0d;
+    if (value <= 0d || value >= 1d) {
+      return 0.5d;
+    }
+    return value;
+  }
+
+  private record WeightedInstance(ServiceInstance instance, LoadBalancerHealthCheckAggregator.InstanceState state) {
+
+    ServiceInstance instance() {
+      return instance;
+    }
+
+    LoadBalancerHealthCheckAggregator.InstanceState state() {
+      return state;
+    }
+
+    String instanceKey() {
+      return state.getInstanceId();
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/WebSocketStickTable.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/WebSocketStickTable.java
@@ -1,0 +1,67 @@
+package com.ejada.gateway.loadbalancer;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.util.StringUtils;
+
+/**
+ * Maintains sticky associations for WebSocket handshakes so upgraded connections continue to use
+ * the same downstream instance. Entries expire after a configurable TTL to avoid leaking memory.
+ */
+public class WebSocketStickTable {
+
+  private final ConcurrentMap<String, StickRecord> records = new ConcurrentHashMap<>();
+  private final Duration ttl;
+  private final Clock clock;
+
+  public WebSocketStickTable(Duration ttl) {
+    this(ttl, Clock.systemUTC());
+  }
+
+  public WebSocketStickTable(Duration ttl, Clock clock) {
+    this.ttl = (ttl == null || ttl.isNegative() || ttl.isZero()) ? Duration.ofMinutes(10) : ttl;
+    this.clock = (clock != null) ? clock : Clock.systemUTC();
+  }
+
+  public Optional<ServiceInstance> lookup(String key, String serviceId, List<ServiceInstance> candidates) {
+    if (!StringUtils.hasText(key)) {
+      return Optional.empty();
+    }
+    StickRecord record = records.get(key);
+    if (record == null) {
+      return Optional.empty();
+    }
+    if (record.expiresAt().isBefore(Instant.now(clock))) {
+      records.remove(key, record);
+      return Optional.empty();
+    }
+    return candidates.stream()
+        .filter(instance -> serviceId.equals(instance.getServiceId()))
+        .filter(instance -> record.instanceId().equals(LoadBalancerHealthCheckAggregator.resolveInstanceId(instance)))
+        .findFirst();
+  }
+
+  public void record(String key, ServiceInstance instance) {
+    if (!StringUtils.hasText(key) || instance == null) {
+      return;
+    }
+    StickRecord record = new StickRecord(instance.getServiceId(),
+        LoadBalancerHealthCheckAggregator.resolveInstanceId(instance),
+        Instant.now(clock).plus(ttl));
+    records.put(key, record);
+  }
+
+  public Map<String, StickRecord> snapshot() {
+    return Map.copyOf(records);
+  }
+
+  public record StickRecord(String serviceId, String instanceId, Instant expiresAt) {
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/WeightedServiceInstanceListSupplier.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/WeightedServiceInstanceListSupplier.java
@@ -1,0 +1,109 @@
+package com.ejada.gateway.loadbalancer;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.loadbalancer.core.DelegatingServiceInstanceListSupplier;
+import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import reactor.core.publisher.Flux;
+
+/**
+ * Decorates the configured {@link ServiceInstanceListSupplier} to attach computed weights and zone
+ * metadata from {@link LoadBalancerHealthCheckAggregator}. Downstream load balancers can use the
+ * enriched metadata to influence routing decisions without duplicating the calculations.
+ */
+public class WeightedServiceInstanceListSupplier extends DelegatingServiceInstanceListSupplier {
+
+  public static final String METADATA_WEIGHT = "gateway.lb.weight";
+  public static final String METADATA_ZONE = "gateway.lb.zone";
+  public static final String METADATA_AVAILABILITY = "gateway.lb.availability";
+  public static final String METADATA_HEALTH = "gateway.lb.health-score";
+  public static final String METADATA_RESPONSE_TIME = "gateway.lb.response-time";
+
+  private final LoadBalancerHealthCheckAggregator aggregator;
+
+  public WeightedServiceInstanceListSupplier(ServiceInstanceListSupplier delegate,
+      LoadBalancerHealthCheckAggregator aggregator) {
+    super(delegate);
+    this.aggregator = Objects.requireNonNull(aggregator, "aggregator");
+  }
+
+  @Override
+  public Flux<List<ServiceInstance>> get() {
+    return super.get().map(this::enrichInstances);
+  }
+
+  @Override
+  public Flux<List<ServiceInstance>> get(org.springframework.cloud.client.loadbalancer.Request request) {
+    return super.get(request).map(this::enrichInstances);
+  }
+
+  private List<ServiceInstance> enrichInstances(List<ServiceInstance> instances) {
+    List<ServiceInstance> result = new ArrayList<>(instances.size());
+    for (ServiceInstance instance : instances) {
+      LoadBalancerHealthCheckAggregator.InstanceState state = aggregator.update(instance);
+      Map<String, String> metadata = new LinkedHashMap<>(instance.getMetadata());
+      metadata.put(METADATA_WEIGHT, Double.toString(state.getEffectiveWeight()));
+      metadata.put(METADATA_ZONE, state.getZone());
+      metadata.put(METADATA_AVAILABILITY, state.getAvailability().name());
+      metadata.put(METADATA_HEALTH, Double.toString(state.getHealthScore()));
+      metadata.put(METADATA_RESPONSE_TIME, Double.toString(state.getAverageResponseTimeMs()));
+      result.add(new MetadataServiceInstance(instance, metadata));
+    }
+    return result;
+  }
+
+  private static final class MetadataServiceInstance implements ServiceInstance {
+
+    private final ServiceInstance delegate;
+    private final Map<String, String> metadata;
+
+    private MetadataServiceInstance(ServiceInstance delegate, Map<String, String> metadata) {
+      this.delegate = delegate;
+      this.metadata = Map.copyOf(metadata);
+    }
+
+    @Override
+    public String getInstanceId() {
+      return delegate.getInstanceId();
+    }
+
+    @Override
+    public String getServiceId() {
+      return delegate.getServiceId();
+    }
+
+    @Override
+    public String getHost() {
+      return delegate.getHost();
+    }
+
+    @Override
+    public int getPort() {
+      return delegate.getPort();
+    }
+
+    @Override
+    public boolean isSecure() {
+      return delegate.isSecure();
+    }
+
+    @Override
+    public java.net.URI getUri() {
+      return delegate.getUri();
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+      return metadata;
+    }
+
+    @Override
+    public String getScheme() {
+      return delegate.getScheme();
+    }
+  }
+}

--- a/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -6,6 +6,11 @@
       "description": "Declarative route definitions exposed through the API gateway."
     },
     {
+      "name": "gateway.routes.*.lb-strategy",
+      "type": "java.lang.String",
+      "description": "Load balancing strategy for a route (default or weighted-response-time)."
+    },
+    {
       "name": "gateway.webclient.connect-timeout",
       "type": "java.time.Duration",
       "description": "Connection timeout applied to downstream WebClient calls."

--- a/api-gateway/src/test/java/com/ejada/gateway/loadbalancer/LoadBalancerHealthCheckAggregatorTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/loadbalancer/LoadBalancerHealthCheckAggregatorTest.java
@@ -1,0 +1,61 @@
+package com.ejada.gateway.loadbalancer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.ServiceInstance;
+
+class LoadBalancerHealthCheckAggregatorTest {
+
+  private final LoadBalancerHealthCheckAggregator aggregator =
+      new LoadBalancerHealthCheckAggregator(Duration.ofMillis(200));
+
+  @Test
+  void updateShouldBlendMetadataIntoState() {
+    ServiceInstance instance = serviceInstance("tenant-service-1", "tenant-service", 8080,
+        Map.of(
+            "healthScore", "0.8",
+            "avgResponseTimeMs", "120",
+            "zone", "europe-west",
+            "availability", "UP"));
+
+    LoadBalancerHealthCheckAggregator.InstanceState state = aggregator.update(instance);
+
+    assertThat(state.getServiceId()).isEqualTo("tenant-service");
+    assertThat(state.getInstanceId()).isEqualTo("tenant-service-1");
+    assertThat(state.getZone()).isEqualTo("europe-west");
+    assertThat(state.getHealthScore()).isEqualTo(0.8d);
+    assertThat(state.getAverageResponseTimeMs()).isBetween(100d, 150d);
+    assertThat(state.getEffectiveWeight()).isGreaterThan(0.3d);
+  }
+
+  @Test
+  void recordResponseTimeShouldPenaliseSlowInstances() {
+    ServiceInstance instance = serviceInstance("tenant-service-2", "tenant-service", 8081,
+        Map.of(
+            "healthScore", "1.0",
+            "avgResponseTimeMs", "110",
+            "zone", "us-east",
+            "availability", "UP"));
+
+    LoadBalancerHealthCheckAggregator.InstanceState baseline = aggregator.update(instance);
+    aggregator.recordResponseTime(instance, Duration.ofMillis(1200));
+    LoadBalancerHealthCheckAggregator.InstanceState updated = aggregator.snapshot("tenant-service").stream()
+        .filter(state -> state.getInstanceId().equals("tenant-service-2"))
+        .findFirst()
+        .orElseThrow();
+
+    assertThat(updated.getEffectiveWeight()).isLessThan(baseline.getEffectiveWeight());
+    assertThat(updated.getAverageResponseTimeMs()).isGreaterThan(baseline.getAverageResponseTimeMs());
+  }
+
+  private ServiceInstance serviceInstance(String id, String serviceId, int port, Map<String, String> metadata) {
+    Map<String, String> copy = new HashMap<>(metadata);
+    DefaultServiceInstance instance = new DefaultServiceInstance(id, serviceId, "localhost", port, false, copy);
+    return instance;
+  }
+}

--- a/api-gateway/src/test/java/com/ejada/gateway/loadbalancer/TenantAffinityLoadBalancerTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/loadbalancer/TenantAffinityLoadBalancerTest.java
@@ -1,0 +1,194 @@
+package com.ejada.gateway.loadbalancer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import com.ejada.gateway.config.GatewayRoutesProperties.ServiceRoute;
+import com.ejada.gateway.config.GatewayRoutesProperties.ServiceRoute.LoadBalancingStrategy;
+import java.net.URI;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.DefaultRequest;
+import org.springframework.cloud.client.loadbalancer.Request;
+import org.springframework.cloud.client.loadbalancer.RequestData;
+import org.springframework.cloud.client.loadbalancer.RequestDataContext;
+import org.springframework.cloud.client.loadbalancer.Response;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.LinkedMultiValueMap;
+
+class TenantAffinityLoadBalancerTest {
+
+  private GatewayRoutesProperties routesProperties;
+  private LoadBalancerHealthCheckAggregator aggregator;
+  private TenantAffinityLoadBalancer loadBalancer;
+  private StaticServiceInstanceListSupplier baseSupplier;
+  private WeightedServiceInstanceListSupplier weightedSupplier;
+
+  @BeforeEach
+  void setUp() {
+    routesProperties = new GatewayRoutesProperties();
+    ServiceRoute route = new ServiceRoute();
+    route.setId("tenant-route");
+    route.setUri(URI.create("lb://tenant-service"));
+    route.setPaths(List.of("/"));
+    route.setLbStrategy(LoadBalancingStrategy.WEIGHTED_RESPONSE_TIME);
+    routesProperties.getRoutes().put("tenant", route);
+
+    aggregator = new LoadBalancerHealthCheckAggregator(Duration.ofMillis(200));
+
+    List<ServiceInstance> instances = List.of(
+        instance("tenant-service-1", "zone-a", 8080, 0.9, 90),
+        instance("tenant-service-2", "zone-a", 8081, 0.8, 150),
+        instance("tenant-service-3", "zone-b", 8082, 0.7, 200));
+
+    baseSupplier = new StaticServiceInstanceListSupplier("tenant-service", instances);
+    weightedSupplier = new WeightedServiceInstanceListSupplier(baseSupplier, aggregator);
+
+    ObjectProvider<ServiceInstanceListSupplier> provider = new StaticObjectProvider<>(weightedSupplier);
+    loadBalancer = new TenantAffinityLoadBalancer("tenant-service", provider, aggregator, routesProperties,
+        new WebSocketStickTable(Duration.ofMinutes(5)), "zone-a");
+  }
+
+  @Test
+  void chooseShouldBeConsistentForTenant() {
+    Request<?> request = requestWithTenant("tenant-route", "tenant-alpha");
+
+    Response<ServiceInstance> first = loadBalancer.choose(request).block();
+    Response<ServiceInstance> second = loadBalancer.choose(request).block();
+
+    assertThat(first).isNotNull();
+    assertThat(first.getServer()).isNotNull();
+    assertThat(second).isNotNull();
+    assertThat(second.getServer()).isNotNull();
+    assertThat(second.getServer().getInstanceId()).isEqualTo(first.getServer().getInstanceId());
+  }
+
+  @Test
+  void websocketStickTableShouldReuseInstanceWithoutTenant() {
+    Request<?> request = websocketRequest("tenant-route", "handshake-key-1");
+
+    ServiceInstance first = loadBalancer.choose(request).map(Response::getServer).block();
+    ServiceInstance second = loadBalancer.choose(request).map(Response::getServer).block();
+
+    assertThat(first).isNotNull();
+    assertThat(second).isNotNull();
+    assertThat(second.getInstanceId()).isEqualTo(first.getInstanceId());
+  }
+
+  private ServiceInstance instance(String id, String zone, int port, double health, double responseTime) {
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("zone", zone);
+    metadata.put("healthScore", Double.toString(health));
+    metadata.put("avgResponseTimeMs", Double.toString(responseTime));
+    metadata.put("availability", "UP");
+    return new DefaultServiceInstance(id, "tenant-service", "localhost", port, false, metadata);
+  }
+
+  private Request<?> requestWithTenant(String routeId, String tenant) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("X-Tenant-Id", tenant);
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put(ServerWebExchangeUtils.GATEWAY_ROUTE_ID_ATTR, routeId);
+    RequestData data = new RequestData(HttpMethod.GET, URI.create("http://gateway/test"), headers,
+        new LinkedMultiValueMap<>(), attributes);
+    RequestDataContext context = new RequestDataContext(data);
+    return new DefaultRequest<>(context);
+  }
+
+  private Request<?> websocketRequest(String routeId, String websocketKey) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(HttpHeaders.UPGRADE, "websocket");
+    headers.add("Sec-WebSocket-Key", websocketKey);
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put(ServerWebExchangeUtils.GATEWAY_ROUTE_ID_ATTR, routeId);
+    RequestData data = new RequestData(HttpMethod.GET, URI.create("http://gateway/ws"), headers,
+        new LinkedMultiValueMap<>(), attributes);
+    RequestDataContext context = new RequestDataContext(data);
+    return new DefaultRequest<>(context);
+  }
+
+  private static class StaticServiceInstanceListSupplier implements ServiceInstanceListSupplier {
+
+    private final String serviceId;
+    private final List<ServiceInstance> instances;
+
+    private StaticServiceInstanceListSupplier(String serviceId, List<ServiceInstance> instances) {
+      this.serviceId = serviceId;
+      this.instances = List.copyOf(instances);
+    }
+
+    @Override
+    public String getServiceId() {
+      return serviceId;
+    }
+
+    @Override
+    public reactor.core.publisher.Flux<List<ServiceInstance>> get() {
+      return reactor.core.publisher.Flux.just(instances);
+    }
+
+    @Override
+    public reactor.core.publisher.Flux<List<ServiceInstance>> get(Request request) {
+      return get();
+    }
+  }
+
+  private static class StaticObjectProvider<T> implements ObjectProvider<T> {
+
+    private final T value;
+
+    private StaticObjectProvider(T value) {
+      this.value = value;
+    }
+
+    @Override
+    public T getObject(Object... args) {
+      return value;
+    }
+
+    @Override
+    public T getIfAvailable() {
+      return value;
+    }
+
+    @Override
+    public T getIfAvailable(java.util.function.Supplier<T> supplier) {
+      return value != null ? value : supplier.get();
+    }
+
+    @Override
+    public T getIfUnique() {
+      return value;
+    }
+
+    @Override
+    public T getIfUnique(java.util.function.Supplier<T> supplier) {
+      return value != null ? value : supplier.get();
+    }
+
+    @Override
+    public T getObject() {
+      return value;
+    }
+
+    @Override
+    public java.util.stream.Stream<T> stream() {
+      return value != null ? java.util.stream.Stream.of(value) : java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<T> orderedStream() {
+      return stream();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a load-balancer configuration that enriches service instances with health-aware weights and routes requests through a tenant affinity load balancer
- extend gateway route metadata and admin surfaces to expose the new weighted-response-time strategy and load-balancer health snapshots
- cover the new aggregator and load balancer behaviour with dedicated unit tests

## Testing
- mvn -pl api-gateway test *(fails: missing internal com.ejada artifacts and testcontainers/chaos-monkey dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1aec657c4832f85266c08fcd23825