### PR TITLE
feat: add cached permission evaluation service

### DIFF
--- a/sec-service/pom.xml
+++ b/sec-service/pom.xml
@@ -30,11 +30,27 @@
     </properties>
 
   <dependencies>
-<dependency>
-  <groupId>org.postgresql</groupId>
-  <artifactId>postgresql</artifactId>
-  <scope>runtime</scope>
-</dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>

--- a/sec-service/src/main/java/com/ejada/sec/config/PermissionCacheConfig.java
+++ b/sec-service/src/main/java/com/ejada/sec/config/PermissionCacheConfig.java
@@ -1,0 +1,100 @@
+package com.ejada.sec.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.NoOpCacheManager;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.cache.interceptor.KeyGenerator;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configures caching for permission resolution with monitoring support.
+ */
+@Configuration
+@EnableCaching
+@Slf4j
+@RequiredArgsConstructor
+public class PermissionCacheConfig {
+
+    private final ObjectProvider<MeterRegistry> meterRegistryProvider;
+
+    @Value("${sec.permissions.cache.ttl-minutes:5}")
+    private int cacheTtlMinutes;
+
+    @Value("${sec.permissions.cache.max-size:10000}")
+    private long cacheMaxSize;
+
+    @Value("${sec.permissions.cache.enabled:true}")
+    private boolean cacheEnabled;
+
+    /**
+     * Creates the primary cache manager backed by Caffeine.
+     */
+    @Bean
+    @Primary
+    public CacheManager permissionCacheManager() {
+        if (!cacheEnabled) {
+            log.warn("Permission caching is DISABLED - expect poor performance");
+            return new NoOpCacheManager();
+        }
+
+        MeterRegistry meterRegistry = meterRegistryProvider.getIfAvailable();
+
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(List.of(
+            buildCache("user-permissions", meterRegistry),
+            buildCache("user-permission-map", meterRegistry),
+            buildCache("resource-permissions", meterRegistry),
+            buildCache("role-privileges", meterRegistry)
+        ));
+        cacheManager.initializeCaches();
+
+        log.info("Permission cache initialized: TTL={}min, MaxSize={}, Enabled={}",
+            cacheTtlMinutes, cacheMaxSize, cacheEnabled);
+
+        return cacheManager;
+    }
+
+    private CaffeineCache buildCache(String name, MeterRegistry meterRegistry) {
+        com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache =
+            Caffeine.newBuilder()
+                .maximumSize(cacheMaxSize)
+                .expireAfterWrite(cacheTtlMinutes, TimeUnit.MINUTES)
+                .recordStats()
+                .build();
+
+        if (meterRegistry != null) {
+            CaffeineCacheMetrics.monitor(meterRegistry, nativeCache, name);
+        }
+
+        log.info("Created cache '{}' with TTL={}min, MaxSize={}", name, cacheTtlMinutes, cacheMaxSize);
+        return new CaffeineCache(name, nativeCache, true);
+    }
+
+    /**
+     * Custom key generator suitable for multi-parameter methods.
+     */
+    @Bean
+    public KeyGenerator permissionKeyGenerator() {
+        return (target, method, params) -> {
+            StringBuilder key = new StringBuilder();
+            for (Object param : params) {
+                key.append(param != null ? param : "null").append(":");
+            }
+            return key.toString();
+        };
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/repository/RolePrivilegeRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/RolePrivilegeRepository.java
@@ -5,9 +5,13 @@ import com.ejada.sec.domain.RolePrivilegeId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
+@Repository
 public interface RolePrivilegeRepository extends JpaRepository<RolePrivilege, RolePrivilegeId> {
 
     List<RolePrivilege> findAllByIdRoleId(Long roleId);
@@ -15,6 +19,39 @@ public interface RolePrivilegeRepository extends JpaRepository<RolePrivilege, Ro
     List<RolePrivilege> findAllByIdPrivilegeId(Long privilegeId);
 
     boolean existsByIdRoleIdAndIdPrivilegeId(Long roleId, Long privilegeId);
+
+    /**
+     * Efficiently checks if any of the given roles has the specified privilege.
+     */
+    @Query("SELECT CASE WHEN COUNT(rp) > 0 THEN true ELSE false END " +
+           "FROM RolePrivilege rp JOIN rp.privilege p " +
+           "WHERE rp.role.id IN :roleIds AND p.code = :privilegeCode")
+    boolean existsByRoleIdInAndPrivilegeCode(
+        @Param("roleIds") Set<Long> roleIds,
+        @Param("privilegeCode") String privilegeCode
+    );
+
+    /**
+     * Checks if roles have specific resource-action permission.
+     */
+    @Query("SELECT CASE WHEN COUNT(rp) > 0 THEN true ELSE false END " +
+           "FROM RolePrivilege rp JOIN rp.privilege p " +
+           "WHERE rp.role.id IN :roleIds " +
+           "AND p.resource = :resource " +
+           "AND p.action = :action")
+    boolean existsByRoleIdInAndResourceAndAction(
+        @Param("roleIds") Set<Long> roleIds,
+        @Param("resource") String resource,
+        @Param("action") String action
+    );
+
+    /**
+     * Fetches all privileges for the given roles including privilege details.
+     */
+    @Query("SELECT rp FROM RolePrivilege rp " +
+           "JOIN FETCH rp.privilege " +
+           "WHERE rp.role.id IN :roleIds")
+    List<RolePrivilege> findByRoleIdIn(@Param("roleIds") Set<Long> roleIds);
 
     @Modifying
     @Query("delete from RolePrivilege rp where rp.id.roleId = :roleId")

--- a/sec-service/src/main/java/com/ejada/sec/repository/UserPrivilegeRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/UserPrivilegeRepository.java
@@ -3,12 +3,36 @@ package com.ejada.sec.repository;
 import com.ejada.sec.domain.UserPrivilege;
 import com.ejada.sec.domain.UserPrivilegeId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
+@Repository
 public interface UserPrivilegeRepository extends JpaRepository<UserPrivilege, UserPrivilegeId> {
 
     List<UserPrivilege> findAllByIdUserId(Long userId);
 
     boolean existsByIdUserIdAndIdPrivilegeId(Long userId, Long privilegeId);
+
+    /**
+     * Finds a user-specific privilege override by privilege code.
+     */
+    @Query("SELECT up FROM UserPrivilege up " +
+           "JOIN FETCH up.privilege p " +
+           "WHERE up.user.id = :userId AND p.code = :privilegeCode")
+    Optional<UserPrivilege> findByUserIdAndPrivilegeCode(
+        @Param("userId") Long userId,
+        @Param("privilegeCode") String privilegeCode
+    );
+
+    /**
+     * Retrieves all privilege overrides for a user with privilege details.
+     */
+    @Query("SELECT up FROM UserPrivilege up " +
+           "JOIN FETCH up.privilege " +
+           "WHERE up.user.id = :userId")
+    List<UserPrivilege> findByUserId(@Param("userId") Long userId);
 }

--- a/sec-service/src/main/java/com/ejada/sec/repository/UserRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/UserRepository.java
@@ -59,4 +59,7 @@ public interface UserRepository extends TenantAwareRepository<User, Long> {
     boolean existsByTenantIdAndUsername(UUID tenantId, String username);
 
     boolean existsByTenantIdAndEmail(UUID tenantId, String email);
+
+    @Query("SELECT DISTINCT ur.user.id FROM UserRole ur WHERE ur.role.id = :roleId")
+    List<Long> findUserIdsByRoleId(@Param("roleId") Long roleId);
 }

--- a/sec-service/src/main/java/com/ejada/sec/security/PermissionEvaluator.java
+++ b/sec-service/src/main/java/com/ejada/sec/security/PermissionEvaluator.java
@@ -1,0 +1,65 @@
+package com.ejada.sec.security;
+
+import com.ejada.sec.service.PermissionEvaluationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+/**
+ * SpEL helper that bridges Spring Security annotations with the permission service.
+ */
+@Component("permissionEvaluator")
+@RequiredArgsConstructor
+@Slf4j
+public class PermissionEvaluator {
+
+    private final PermissionEvaluationService permissionService;
+
+    public boolean hasPermission(Authentication authentication, String privilegeCode) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            log.debug("Permission check failed - unauthenticated request");
+            return false;
+        }
+
+        Long userId = extractUserId(authentication);
+        if (userId == null) {
+            log.warn("Permission check failed - userId missing in authentication token");
+            return false;
+        }
+
+        return permissionService.hasPermission(userId, privilegeCode);
+    }
+
+    public boolean hasResourcePermission(Authentication authentication, String resource, String action) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
+        }
+
+        Long userId = extractUserId(authentication);
+        if (userId == null) {
+            return false;
+        }
+
+        return permissionService.hasResourcePermission(userId, resource, action);
+    }
+
+    private Long extractUserId(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof Jwt jwt) {
+            Object userIdClaim = jwt.getClaim("userId");
+            if (userIdClaim instanceof Number number) {
+                return number.longValue();
+            }
+            if (userIdClaim instanceof String stringValue) {
+                try {
+                    return Long.parseLong(stringValue);
+                } catch (NumberFormatException ex) {
+                    log.error("Invalid userId claim format: {}", stringValue);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/security/RequiresPermission.java
+++ b/sec-service/src/main/java/com/ejada/sec/security/RequiresPermission.java
@@ -1,0 +1,26 @@
+package com.ejada.sec.security;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta-annotation that enforces a specific privilege before invoking a method.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@PreAuthorize("@permissionEvaluator.hasPermission(authentication, #permission)")
+public @interface RequiresPermission {
+
+    @AliasFor("permission")
+    String value() default "";
+
+    @AliasFor("value")
+    String permission() default "";
+}

--- a/sec-service/src/main/java/com/ejada/sec/security/RequiresResourcePermission.java
+++ b/sec-service/src/main/java/com/ejada/sec/security/RequiresResourcePermission.java
@@ -1,0 +1,23 @@
+package com.ejada.sec.security;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta-annotation that validates resource/action authorization before method execution.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@PreAuthorize("@permissionEvaluator.hasResourcePermission(authentication, #resource, #action)")
+public @interface RequiresResourcePermission {
+
+    String resource();
+
+    String action();
+}

--- a/sec-service/src/main/java/com/ejada/sec/service/PermissionEvaluationService.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/PermissionEvaluationService.java
@@ -1,0 +1,191 @@
+package com.ejada.sec.service;
+
+import com.ejada.sec.domain.RolePrivilege;
+import com.ejada.sec.domain.User;
+import com.ejada.sec.domain.UserPrivilege;
+import com.ejada.sec.domain.UserRole;
+import com.ejada.sec.repository.RolePrivilegeRepository;
+import com.ejada.sec.repository.UserPrivilegeRepository;
+import com.ejada.sec.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * High-performance permission evaluation service with multi-level caching.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PermissionEvaluationService {
+
+    private final UserRepository userRepository;
+    private final UserPrivilegeRepository userPrivilegeRepository;
+    private final RolePrivilegeRepository rolePrivilegeRepository;
+    private final CacheManager cacheManager;
+
+    @Cacheable(value = "user-permissions", key = "#userId + ':' + #privilegeCode")
+    @Transactional(readOnly = true)
+    public boolean hasPermission(Long userId, String privilegeCode) {
+        log.debug("Evaluating permission: userId={}, privilege={}", userId, privilegeCode);
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+
+        if (!user.isEnabled() || user.isLocked()) {
+            log.debug("Permission denied - user disabled or locked: {}", userId);
+            return false;
+        }
+
+        Optional<UserPrivilege> override =
+            userPrivilegeRepository.findByUserIdAndPrivilegeCode(userId, privilegeCode);
+
+        if (override.isPresent()) {
+            boolean granted = override.get().isGranted();
+            log.debug("Permission {} for user {} resolved via override: {}",
+                privilegeCode, userId, granted);
+            return granted;
+        }
+
+        Set<Long> roleIds = user.getRoles().stream()
+            .map(UserRole::getRole)
+            .filter(role -> role != null && role.getId() != null)
+            .map(role -> role.getId())
+            .collect(Collectors.toCollection(HashSet::new));
+
+        if (roleIds.isEmpty()) {
+            log.debug("Permission denied - user {} has no roles", userId);
+            return false;
+        }
+
+        boolean allowed = rolePrivilegeRepository.existsByRoleIdInAndPrivilegeCode(roleIds, privilegeCode);
+        log.debug("Permission {} for user {} resolved via roles: {}",
+            privilegeCode, userId, allowed);
+        return allowed;
+    }
+
+    @Cacheable(value = "resource-permissions", key = "#userId + ':' + #resource + ':' + #action")
+    @Transactional(readOnly = true)
+    public boolean hasResourcePermission(Long userId, String resource, String action) {
+        log.debug("Evaluating resource permission: userId={}, resource={}, action={}",
+            userId, resource, action);
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+
+        if (!user.isEnabled() || user.isLocked()) {
+            return false;
+        }
+
+        Set<Long> roleIds = user.getRoles().stream()
+            .map(UserRole::getRole)
+            .filter(role -> role != null && role.getId() != null)
+            .map(role -> role.getId())
+            .collect(Collectors.toCollection(HashSet::new));
+
+        if (roleIds.isEmpty()) {
+            return false;
+        }
+
+        return rolePrivilegeRepository.existsByRoleIdInAndResourceAndAction(roleIds, resource, action);
+    }
+
+    @Cacheable(value = "user-permission-map", key = "#userId")
+    @Transactional(readOnly = true)
+    public Map<String, Boolean> getUserPermissionMap(Long userId) {
+        log.debug("Building permission map for user {}", userId);
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+
+        if (!user.isEnabled() || user.isLocked()) {
+            log.debug("Returning empty permissions - user disabled or locked: {}", userId);
+            return Collections.emptyMap();
+        }
+
+        Map<String, Boolean> permissionMap = new HashMap<>();
+
+        Set<Long> roleIds = user.getRoles().stream()
+            .map(UserRole::getRole)
+            .filter(role -> role != null && role.getId() != null)
+            .map(role -> role.getId())
+            .collect(Collectors.toSet());
+
+        if (!roleIds.isEmpty()) {
+            List<RolePrivilege> rolePrivileges = rolePrivilegeRepository.findByRoleIdIn(roleIds);
+            rolePrivileges.forEach(rp -> permissionMap.put(rp.getPrivilege().getCode(), true));
+            log.debug("Loaded {} role privileges for user {}", rolePrivileges.size(), userId);
+        }
+
+        List<UserPrivilege> overrides = userPrivilegeRepository.findByUserId(userId);
+        overrides.forEach(up -> permissionMap.put(up.getPrivilege().getCode(), up.isGranted()));
+
+        if (!overrides.isEmpty()) {
+            log.debug("Applied {} user-specific overrides for user {}", overrides.size(), userId);
+        }
+
+        log.debug("Permission map for user {} contains {} entries", userId, permissionMap.size());
+        return permissionMap;
+    }
+
+    public void invalidateUserPermissions(Long userId) {
+        evictByPrefix("user-permissions", userId + ":");
+        evictKey("user-permission-map", userId);
+        evictByPrefix("resource-permissions", userId + ":");
+        log.info("Invalidated cached permissions for user {}", userId);
+    }
+
+    public void invalidateRolePermissions(Long roleId) {
+        List<Long> userIds = userRepository.findUserIdsByRoleId(roleId);
+        userIds.forEach(this::invalidateUserPermissions);
+        log.info("Invalidated permissions for {} users with role {}", userIds.size(), roleId);
+    }
+
+    public void invalidateAllPermissions() {
+        clearCache("user-permissions");
+        clearCache("user-permission-map");
+        clearCache("resource-permissions");
+        clearCache("role-privileges");
+        log.warn("All permission caches cleared");
+    }
+
+    private void evictKey(String cacheName, Object key) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache != null) {
+            cache.evictIfPresent(key);
+        }
+    }
+
+    private void evictByPrefix(String cacheName, String prefix) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache instanceof CaffeineCache caffeineCache) {
+            caffeineCache.getNativeCache().asMap().keySet().removeIf(key ->
+                key instanceof String str && str.startsWith(prefix)
+            );
+        } else if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    private void clearCache(String cacheName) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+}

--- a/sec-service/src/main/resources/application-prod.yaml
+++ b/sec-service/src/main/resources/application-prod.yaml
@@ -1,0 +1,6 @@
+sec:
+  permissions:
+    cache:
+      enabled: true
+      ttl-minutes: 10
+      max-size: 50000

--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -95,3 +95,8 @@ sec:
   superadmin:
     bootstrap:
       default-password: ${SEC_SUPERADMIN_DEFAULT_PASSWORD:Admin@123!}
+  permissions:
+    cache:
+      enabled: true
+      ttl-minutes: 5
+      max-size: 10000


### PR DESCRIPTION
## Summary
- add cache dependencies and caffeine-based configuration for permission data
- implement cached permission evaluation service with repository optimizations and invalidation hooks
- expose security annotations and evaluator for cached permission checks

## Testing
- `mvn -pl sec-service -am -DskipTests package` *(fails: shared starter-openapi lacks swagger model dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b1acb62c832f8532b4992edb45f7