### PR TITLE
feat: add database backed dynamic routing to api gateway

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -99,6 +99,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-r2dbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.r2dbc</groupId>
+      <artifactId>r2dbc-postgresql</artifactId>
+      <version>0.8.13.RELEASE</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
     </dependency>

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/RouteManagementConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/RouteManagementConfiguration.java
@@ -1,0 +1,10 @@
+package com.ejada.gateway.routes;
+
+import com.ejada.gateway.routes.repository.RouteDefinitionR2dbcRepository;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+
+@Configuration
+@EnableR2dbcRepositories(basePackageClasses = RouteDefinitionR2dbcRepository.class)
+public class RouteManagementConfiguration {
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/model/RouteComponent.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/model/RouteComponent.java
@@ -1,0 +1,60 @@
+package com.ejada.gateway.routes.model;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a predicate or filter definition as stored in the database. Each component has a
+ * Spring Cloud Gateway style {@code name} and a map of arguments.
+ */
+public record RouteComponent(String name, Map<String, String> args) {
+
+  public RouteComponent {
+    String trimmed = (name == null) ? null : name.trim();
+    if (trimmed == null || trimmed.isEmpty()) {
+      throw new IllegalArgumentException("Component name must not be blank");
+    }
+    name = trimmed;
+
+    Map<String, String> safeArgs = new LinkedHashMap<>();
+    if (args != null) {
+      args.forEach((key, value) -> {
+        if (key != null && !key.isBlank() && value != null) {
+          safeArgs.put(key.trim(), value.trim());
+        }
+      });
+    }
+    args = Collections.unmodifiableMap(safeArgs);
+  }
+
+  public RouteComponent mergeArgs(Map<String, String> extraArgs) {
+    if (extraArgs == null || extraArgs.isEmpty()) {
+      return this;
+    }
+    Map<String, String> merged = new LinkedHashMap<>(args);
+    extraArgs.forEach((key, value) -> {
+      if (key != null && value != null) {
+        merged.put(key.trim(), value.trim());
+      }
+    });
+    return new RouteComponent(name, merged);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RouteComponent that)) {
+      return false;
+    }
+    return name.equalsIgnoreCase(that.name) && Objects.equals(args, that.args);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name.toLowerCase(), args);
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/model/RouteDefinition.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/model/RouteDefinition.java
@@ -1,0 +1,131 @@
+package com.ejada.gateway.routes.model;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Domain representation of a database-backed route definition.
+ */
+public record RouteDefinition(
+    UUID id,
+    String pathPattern,
+    URI serviceUri,
+    List<RouteComponent> predicates,
+    List<RouteComponent> filters,
+    RouteMetadata metadata,
+    boolean enabled,
+    int version,
+    Instant createdAt,
+    Instant updatedAt) {
+
+  public RouteDefinition {
+    predicates = sanitise(predicates);
+    filters = sanitise(filters);
+    metadata = (metadata == null) ? RouteMetadata.empty() : metadata;
+  }
+
+  private static List<RouteComponent> sanitise(List<RouteComponent> components) {
+    if (components == null || components.isEmpty()) {
+      return List.of();
+    }
+    return List.copyOf(new ArrayList<>(components));
+  }
+
+  public RouteDefinition withId(UUID newId) {
+    return new RouteDefinition(newId, pathPattern, serviceUri, predicates, filters, metadata,
+        enabled, version, createdAt, updatedAt);
+  }
+
+  public RouteDefinition withVersion(int newVersion, Instant updated) {
+    return new RouteDefinition(id, pathPattern, serviceUri, predicates, filters, metadata,
+        enabled, newVersion, createdAt, updated);
+  }
+
+  public RouteDefinition withState(boolean newEnabled, Instant updated) {
+    return new RouteDefinition(id, pathPattern, serviceUri, predicates, filters, metadata,
+        newEnabled, version, createdAt, updated);
+  }
+
+  public RouteDefinition withMetadata(RouteMetadata newMetadata) {
+    return new RouteDefinition(id, pathPattern, serviceUri, predicates, filters,
+        (newMetadata == null) ? RouteMetadata.empty() : newMetadata,
+        enabled, version, createdAt, updatedAt);
+  }
+
+  public RouteDefinition updateFrom(RouteDefinition candidate) {
+    return new RouteDefinition(
+        id,
+        candidate.pathPattern,
+        candidate.serviceUri,
+        candidate.predicates,
+        candidate.filters,
+        candidate.metadata,
+        candidate.enabled,
+        candidate.version,
+        createdAt,
+        candidate.updatedAt);
+  }
+
+  public RouteDefinition withTimestamps(Instant created, Instant updated) {
+    return new RouteDefinition(id, pathPattern, serviceUri, predicates, filters, metadata,
+        enabled, version, created, updated);
+  }
+
+  public RouteDefinition withServiceUri(URI uri) {
+    return new RouteDefinition(id, pathPattern, uri, predicates, filters, metadata,
+        enabled, version, createdAt, updatedAt);
+  }
+
+  public RouteDefinition requireId() {
+    if (id == null) {
+      throw new IllegalStateException("Route identifier has not been initialised");
+    }
+    return this;
+  }
+
+  public boolean hasTrafficSplits() {
+    return metadata != null && !metadata.getTrafficSplits().isEmpty();
+  }
+
+  public RouteDefinition ensureServiceUri() {
+    if (serviceUri != null) {
+      return this;
+    }
+    URI resolved = metadata.resolveEffectiveUri(null).orElse(null);
+    if (resolved == null) {
+      throw new IllegalStateException("Route definition " + id + " does not specify a service URI");
+    }
+    return withServiceUri(resolved);
+  }
+
+  @Override
+  public String toString() {
+    return "RouteDefinition{" +
+        "id=" + id +
+        ", pathPattern='" + pathPattern + '\'' +
+        ", serviceUri=" + serviceUri +
+        ", enabled=" + enabled +
+        ", version=" + version +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RouteDefinition that)) {
+      return false;
+    }
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/model/RouteDefinitionRequest.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/model/RouteDefinitionRequest.java
@@ -1,0 +1,34 @@
+package com.ejada.gateway.routes.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.util.StringUtils;
+
+public record RouteDefinitionRequest(
+    @NotBlank String pathPattern,
+    @NotBlank String serviceUri,
+    List<@Valid RouteComponent> predicates,
+    List<@Valid RouteComponent> filters,
+    RouteMetadata metadata,
+    boolean enabled) {
+
+  public RouteDefinition toDomain(UUID id, int version, Instant createdAt) {
+    RouteMetadata resolvedMetadata = (metadata == null) ? RouteMetadata.empty() : metadata;
+    URI uri = StringUtils.hasText(serviceUri) ? URI.create(serviceUri.trim()) : null;
+    return new RouteDefinition(
+        id,
+        pathPattern,
+        uri,
+        predicates,
+        filters,
+        resolvedMetadata,
+        enabled,
+        version,
+        createdAt,
+        Instant.now());
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/model/RouteManagementView.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/model/RouteManagementView.java
@@ -1,0 +1,18 @@
+package com.ejada.gateway.routes.model;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record RouteManagementView(
+    UUID id,
+    String pathPattern,
+    URI serviceUri,
+    boolean enabled,
+    int version,
+    Instant updatedAt,
+    RouteMetadata.BlueGreenDeployment blueGreen,
+    List<RouteMetadata.TrafficSplit> trafficSplits,
+    URI effectiveUri) {
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/model/RouteMetadata.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/model/RouteMetadata.java
@@ -1,0 +1,176 @@
+package com.ejada.gateway.routes.model;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.util.StringUtils;
+
+/**
+ * Arbitrary metadata associated with a dynamic route. Structured fields are exposed for
+ * blue/green deployments and A/B testing while unknown attributes are preserved for UI
+ * consumption.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RouteMetadata {
+
+  private BlueGreenDeployment blueGreen;
+  private final List<TrafficSplit> trafficSplits = new ArrayList<>();
+  private final Map<String, Object> attributes = new LinkedHashMap<>();
+  private Map<String, String> requestHeaders = new LinkedHashMap<>();
+  private List<String> methods = new ArrayList<>();
+  private Integer stripPrefix;
+  private String prefixPath;
+
+  public BlueGreenDeployment getBlueGreen() {
+    return blueGreen;
+  }
+
+  public void setBlueGreen(BlueGreenDeployment blueGreen) {
+    this.blueGreen = blueGreen;
+  }
+
+  public List<TrafficSplit> getTrafficSplits() {
+    return trafficSplits;
+  }
+
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  public Map<String, String> getRequestHeaders() {
+    return requestHeaders;
+  }
+
+  public void setRequestHeaders(Map<String, String> requestHeaders) {
+    this.requestHeaders = (requestHeaders == null)
+        ? new LinkedHashMap<>()
+        : new LinkedHashMap<>(requestHeaders);
+  }
+
+  public List<String> getMethods() {
+    return methods;
+  }
+
+  public void setMethods(List<String> methods) {
+    this.methods = (methods == null) ? new ArrayList<>() : new ArrayList<>(methods);
+  }
+
+  public Integer getStripPrefix() {
+    return stripPrefix;
+  }
+
+  public void setStripPrefix(Integer stripPrefix) {
+    this.stripPrefix = stripPrefix;
+  }
+
+  public String getPrefixPath() {
+    return prefixPath;
+  }
+
+  public void setPrefixPath(String prefixPath) {
+    this.prefixPath = prefixPath;
+  }
+
+  @JsonAnySetter
+  public void capture(String key, Object value) {
+    if (key == null) {
+      return;
+    }
+    attributes.put(key, value);
+  }
+
+  public Optional<URI> resolveEffectiveUri(URI defaultUri) {
+    URI candidate = defaultUri;
+    if (blueGreen != null) {
+      candidate = blueGreen.resolveActiveUri().orElse(candidate);
+    }
+    return Optional.ofNullable(candidate);
+  }
+
+  public static RouteMetadata empty() {
+    return new RouteMetadata();
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class BlueGreenDeployment {
+
+    private String activeSlot;
+    private URI blueUri;
+    private URI greenUri;
+
+    public Optional<String> getActiveSlot() {
+      return Optional.ofNullable(activeSlot).map(String::trim).filter(StringUtils::hasText);
+    }
+
+    public void setActiveSlot(String activeSlot) {
+      this.activeSlot = activeSlot;
+    }
+
+    public URI getBlueUri() {
+      return blueUri;
+    }
+
+    public void setBlueUri(URI blueUri) {
+      this.blueUri = blueUri;
+    }
+
+    public URI getGreenUri() {
+      return greenUri;
+    }
+
+    public void setGreenUri(URI greenUri) {
+      this.greenUri = greenUri;
+    }
+
+    public Optional<URI> resolveActiveUri() {
+      String slot = getActiveSlot().map(String::toLowerCase).orElse("blue");
+      if (Objects.equals(slot, "blue")) {
+        return Optional.ofNullable(blueUri);
+      }
+      if (Objects.equals(slot, "green")) {
+        return Optional.ofNullable(greenUri);
+      }
+      return Optional.empty();
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class TrafficSplit {
+
+    private String variantId;
+    private int percentage;
+    private URI serviceUri;
+
+    public String getVariantId() {
+      return variantId;
+    }
+
+    public void setVariantId(String variantId) {
+      this.variantId = variantId;
+    }
+
+    public int getPercentage() {
+      return percentage;
+    }
+
+    public void setPercentage(int percentage) {
+      this.percentage = percentage;
+    }
+
+    public URI getServiceUri() {
+      return serviceUri;
+    }
+
+    public void setServiceUri(URI serviceUri) {
+      this.serviceUri = serviceUri;
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionAuditEntity.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionAuditEntity.java
@@ -1,0 +1,87 @@
+package com.ejada.gateway.routes.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("route_definition_audit")
+public class RouteDefinitionAuditEntity {
+
+  @Id
+  @Column("audit_id")
+  private UUID auditId;
+
+  @Column("route_id")
+  private UUID routeId;
+
+  @Column("change_type")
+  private String changeType;
+
+  private String payload;
+
+  @Column("changed_by")
+  private String changedBy;
+
+  @Column("changed_at")
+  private Instant changedAt;
+
+  private int version;
+
+  public UUID getAuditId() {
+    return auditId;
+  }
+
+  public void setAuditId(UUID auditId) {
+    this.auditId = auditId;
+  }
+
+  public UUID getRouteId() {
+    return routeId;
+  }
+
+  public void setRouteId(UUID routeId) {
+    this.routeId = routeId;
+  }
+
+  public String getChangeType() {
+    return changeType;
+  }
+
+  public void setChangeType(String changeType) {
+    this.changeType = changeType;
+  }
+
+  public String getPayload() {
+    return payload;
+  }
+
+  public void setPayload(String payload) {
+    this.payload = payload;
+  }
+
+  public String getChangedBy() {
+    return changedBy;
+  }
+
+  public void setChangedBy(String changedBy) {
+    this.changedBy = changedBy;
+  }
+
+  public Instant getChangedAt() {
+    return changedAt;
+  }
+
+  public void setChangedAt(Instant changedAt) {
+    this.changedAt = changedAt;
+  }
+
+  public int getVersion() {
+    return version;
+  }
+
+  public void setVersion(int version) {
+    this.version = version;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionAuditR2dbcRepository.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionAuditR2dbcRepository.java
@@ -1,0 +1,8 @@
+package com.ejada.gateway.routes.repository;
+
+import java.util.UUID;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+public interface RouteDefinitionAuditR2dbcRepository
+    extends ReactiveCrudRepository<RouteDefinitionAuditEntity, UUID> {
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionEntity.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionEntity.java
@@ -1,0 +1,116 @@
+package com.ejada.gateway.routes.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("route_definitions")
+public class RouteDefinitionEntity {
+
+  @Id
+  private UUID id;
+
+  @Column("path_pattern")
+  private String pathPattern;
+
+  @Column("service_uri")
+  private String serviceUri;
+
+  private String predicates;
+
+  private String filters;
+
+  private String metadata;
+
+  private boolean enabled;
+
+  private int version;
+
+  @Column("created_at")
+  private Instant createdAt;
+
+  @Column("updated_at")
+  private Instant updatedAt;
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getPathPattern() {
+    return pathPattern;
+  }
+
+  public void setPathPattern(String pathPattern) {
+    this.pathPattern = pathPattern;
+  }
+
+  public String getServiceUri() {
+    return serviceUri;
+  }
+
+  public void setServiceUri(String serviceUri) {
+    this.serviceUri = serviceUri;
+  }
+
+  public String getPredicates() {
+    return predicates;
+  }
+
+  public void setPredicates(String predicates) {
+    this.predicates = predicates;
+  }
+
+  public String getFilters() {
+    return filters;
+  }
+
+  public void setFilters(String filters) {
+    this.filters = filters;
+  }
+
+  public String getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(String metadata) {
+    this.metadata = metadata;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public int getVersion() {
+    return version;
+  }
+
+  public void setVersion(int version) {
+    this.version = version;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(Instant createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(Instant updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionMapper.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionMapper.java
@@ -1,0 +1,154 @@
+package com.ejada.gateway.routes.repository;
+
+import com.ejada.gateway.routes.model.RouteComponent;
+import com.ejada.gateway.routes.model.RouteDefinition;
+import com.ejada.gateway.routes.model.RouteMetadata;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class RouteDefinitionMapper {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RouteDefinitionMapper.class);
+
+  private static final TypeReference<List<RouteComponent>> COMPONENT_LIST =
+      new TypeReference<>() {
+      };
+
+  private final ObjectMapper objectMapper;
+
+  public RouteDefinitionMapper(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public RouteDefinition toDomain(RouteDefinitionEntity entity) {
+    if (entity == null) {
+      return null;
+    }
+    try {
+      List<RouteComponent> predicates = readComponents(entity.getPredicates());
+      List<RouteComponent> filters = readComponents(entity.getFilters());
+      RouteMetadata metadata = readMetadata(entity.getMetadata());
+      URI uri = StringUtils.hasText(entity.getServiceUri()) ? URI.create(entity.getServiceUri()) : null;
+      return new RouteDefinition(
+          entity.getId(),
+          entity.getPathPattern(),
+          uri,
+          predicates,
+          filters,
+          metadata,
+          entity.isEnabled(),
+          entity.getVersion(),
+          entity.getCreatedAt(),
+          entity.getUpdatedAt());
+    } catch (Exception ex) {
+      throw new IllegalStateException("Failed to map route entity " + entity.getId(), ex);
+    }
+  }
+
+  public RouteDefinitionEntity toEntity(RouteDefinition definition) {
+    RouteDefinitionEntity entity = new RouteDefinitionEntity();
+    entity.setId(definition.id());
+    entity.setPathPattern(definition.pathPattern());
+    entity.setServiceUri(definition.serviceUri() != null ? definition.serviceUri().toString() : null);
+    entity.setPredicates(writeComponents(definition.predicates()));
+    entity.setFilters(writeComponents(definition.filters()));
+    entity.setMetadata(writeMetadata(definition.metadata()));
+    entity.setEnabled(definition.enabled());
+    entity.setVersion(definition.version());
+    entity.setCreatedAt(definition.createdAt());
+    entity.setUpdatedAt(definition.updatedAt());
+    return entity;
+  }
+
+  public List<RouteDefinition> decodeList(String payload) {
+    if (!StringUtils.hasText(payload)) {
+      return List.of();
+    }
+    try {
+      return objectMapper.readValue(payload, new TypeReference<List<RouteDefinition>>() {
+      });
+    } catch (Exception ex) {
+      throw new IllegalStateException("Failed to decode cached route definitions", ex);
+    }
+  }
+
+  public String encodeList(List<RouteDefinition> routes) {
+    try {
+      return objectMapper.writeValueAsString(routes);
+    } catch (Exception ex) {
+      throw new UncheckedIOException("Unable to serialise route definitions", new java.io.IOException(ex));
+    }
+  }
+
+  private RouteMetadata readMetadata(String payload) {
+    if (!StringUtils.hasText(payload)) {
+      return RouteMetadata.empty();
+    }
+    try {
+      return objectMapper.readValue(payload, RouteMetadata.class);
+    } catch (Exception ex) {
+      LOGGER.warn("Failed to parse route metadata: {}", payload, ex);
+      return RouteMetadata.empty();
+    }
+  }
+
+  private List<RouteComponent> readComponents(String payload) {
+    if (!StringUtils.hasText(payload)) {
+      return List.of();
+    }
+    try {
+      return objectMapper.readValue(payload, COMPONENT_LIST);
+    } catch (Exception ex) {
+      LOGGER.warn("Failed to parse route components: {}", payload, ex);
+      return List.of();
+    }
+  }
+
+  private String writeComponents(List<RouteComponent> components) {
+    try {
+      return objectMapper.writeValueAsString((components == null) ? Collections.emptyList() : components);
+    } catch (Exception ex) {
+      throw new IllegalStateException("Failed to encode route components", ex);
+    }
+  }
+
+  private String writeMetadata(RouteMetadata metadata) {
+    try {
+      return objectMapper.writeValueAsString(metadata == null ? RouteMetadata.empty() : metadata);
+    } catch (Exception ex) {
+      throw new IllegalStateException("Failed to encode route metadata", ex);
+    }
+  }
+
+  public RouteDefinitionAuditEntity toAuditEntity(RouteDefinition route, String changeType,
+      String changedBy) {
+    RouteDefinitionAuditEntity audit = new RouteDefinitionAuditEntity();
+    audit.setAuditId(UUID.randomUUID());
+    audit.setRouteId(route.id());
+    audit.setChangeType(changeType);
+    audit.setChangedBy(changedBy);
+    audit.setChangedAt(Instant.now());
+    audit.setVersion(route.version());
+    audit.setPayload(writeAuditPayload(route));
+    return audit;
+  }
+
+  private String writeAuditPayload(RouteDefinition route) {
+    try {
+      return objectMapper.writeValueAsString(route);
+    } catch (Exception ex) {
+      throw new IllegalStateException("Failed to encode audit payload", ex);
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionR2dbcRepository.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionR2dbcRepository.java
@@ -1,0 +1,11 @@
+package com.ejada.gateway.routes.repository;
+
+import java.util.UUID;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+
+public interface RouteDefinitionR2dbcRepository
+    extends ReactiveCrudRepository<RouteDefinitionEntity, UUID> {
+
+  Flux<RouteDefinitionEntity> findAllByEnabledTrue();
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionRepository.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionRepository.java
@@ -1,0 +1,157 @@
+package com.ejada.gateway.routes.repository;
+
+import com.ejada.gateway.routes.model.RouteDefinition;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Repository
+public class RouteDefinitionRepository {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RouteDefinitionRepository.class);
+  private static final String ACTIVE_ROUTES_CACHE_KEY = "gateway:routes:active";
+
+  private final RouteDefinitionR2dbcRepository routeStore;
+  private final RouteDefinitionAuditR2dbcRepository auditStore;
+  private final RouteDefinitionMapper mapper;
+  private final ReactiveStringRedisTemplate redisTemplate;
+
+  public RouteDefinitionRepository(
+      RouteDefinitionR2dbcRepository routeStore,
+      RouteDefinitionAuditR2dbcRepository auditStore,
+      RouteDefinitionMapper mapper,
+      ReactiveStringRedisTemplate redisTemplate) {
+    this.routeStore = routeStore;
+    this.auditStore = auditStore;
+    this.mapper = mapper;
+    this.redisTemplate = redisTemplate;
+  }
+
+  public Flux<RouteDefinition> findAll() {
+    return routeStore.findAll().map(mapper::toDomain);
+  }
+
+  public Mono<RouteDefinition> findById(UUID id) {
+    return routeStore.findById(id)
+        .switchIfEmpty(Mono.error(new RouteNotFoundException(id)))
+        .map(mapper::toDomain);
+  }
+
+  public Flux<RouteDefinition> findActiveRoutes() {
+    return readCache()
+        .switchIfEmpty(loadAndCacheActiveRoutes());
+  }
+
+  @Transactional
+  public Mono<RouteDefinition> create(RouteDefinition definition, String actor) {
+    Instant now = Instant.now();
+    RouteDefinition initialised = definition
+        .withId(definition.id() == null ? UUID.randomUUID() : definition.id())
+        .withVersion(Math.max(1, definition.version()), now)
+        .withTimestamps(now, now);
+    RouteDefinitionEntity entity = mapper.toEntity(initialised);
+    return routeStore.save(entity)
+        .map(mapper::toDomain)
+        .flatMap(saved -> audit("CREATE", saved, actor).thenReturn(saved))
+        .flatMap(saved -> evictCache().thenReturn(saved));
+  }
+
+  @Transactional
+  public Mono<RouteDefinition> update(RouteDefinition definition, String actor) {
+    UUID id = definition.requireId().id();
+    return routeStore.findById(id)
+        .switchIfEmpty(Mono.error(new RouteNotFoundException(id)))
+        .map(mapper::toDomain)
+        .flatMap(existing -> {
+          Instant now = Instant.now();
+          RouteDefinition updated = definition
+              .withVersion(existing.version() + 1, now)
+              .withTimestamps(existing.createdAt(), now);
+          return routeStore.save(mapper.toEntity(updated))
+              .map(mapper::toDomain)
+              .flatMap(saved -> audit("UPDATE", saved, actor).thenReturn(saved));
+        })
+        .flatMap(saved -> evictCache().thenReturn(saved));
+  }
+
+  @Transactional
+  public Mono<RouteDefinition> disable(UUID id, String actor) {
+    return routeStore.findById(id)
+        .switchIfEmpty(Mono.error(new RouteNotFoundException(id)))
+        .map(mapper::toDomain)
+        .flatMap(existing -> {
+          Instant now = Instant.now();
+          RouteDefinition disabled = existing
+              .withState(false, now)
+              .withVersion(existing.version() + 1, now);
+          RouteDefinitionEntity entity = mapper.toEntity(disabled);
+          return routeStore.save(entity)
+              .map(mapper::toDomain)
+              .flatMap(saved -> audit("DISABLE", saved, actor).thenReturn(saved));
+        })
+        .flatMap(saved -> evictCache().thenReturn(saved));
+  }
+
+  private Mono<Void> evictCache() {
+    return redisTemplate.delete(ACTIVE_ROUTES_CACHE_KEY)
+        .onErrorResume(ex -> {
+          LOGGER.warn("Failed to evict route cache", ex);
+          return Mono.empty();
+        })
+        .then();
+  }
+
+  private Flux<RouteDefinition> readCache() {
+    return redisTemplate.opsForValue().get(ACTIVE_ROUTES_CACHE_KEY)
+        .flatMapMany(payload -> {
+          if (!StringUtils.hasText(payload)) {
+            return Flux.empty();
+          }
+          try {
+            List<RouteDefinition> cached = mapper.decodeList(payload);
+            return Flux.fromIterable(cached);
+          } catch (Exception ex) {
+            LOGGER.warn("Failed to decode route cache", ex);
+            return Flux.empty();
+          }
+        });
+  }
+
+  private Flux<RouteDefinition> loadAndCacheActiveRoutes() {
+    return routeStore.findAllByEnabledTrue()
+        .map(mapper::toDomain)
+        .collectList()
+        .flatMapMany(list -> cacheActiveRoutes(list).thenMany(Flux.fromIterable(list)));
+  }
+
+  private Mono<Void> cacheActiveRoutes(List<RouteDefinition> routes) {
+    if (routes.isEmpty()) {
+      return redisTemplate.delete(ACTIVE_ROUTES_CACHE_KEY).then();
+    }
+    String payload = mapper.encodeList(routes);
+    return redisTemplate.opsForValue().set(ACTIVE_ROUTES_CACHE_KEY, payload)
+        .onErrorResume(DataAccessException.class, ex -> {
+          LOGGER.warn("Failed to write route cache", ex);
+          return Mono.just(Boolean.FALSE);
+        })
+        .then();
+  }
+
+  private Mono<Void> audit(String changeType, RouteDefinition route, String actor) {
+    return auditStore.save(mapper.toAuditEntity(route, changeType, actor))
+        .then()
+        .onErrorResume(ex -> {
+          LOGGER.warn("Failed to persist audit entry for route {}", route.id(), ex);
+          return Mono.empty();
+        });
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteNotFoundException.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteNotFoundException.java
@@ -1,0 +1,10 @@
+package com.ejada.gateway.routes.repository;
+
+import java.util.UUID;
+
+public class RouteNotFoundException extends RuntimeException {
+
+  public RouteNotFoundException(UUID id) {
+    super("Route definition " + id + " not found");
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/service/DatabaseRouteDefinitionProvider.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/service/DatabaseRouteDefinitionProvider.java
@@ -1,0 +1,31 @@
+package com.ejada.gateway.routes.service;
+
+import com.ejada.gateway.config.GatewayRouteDefinitionProvider;
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import com.ejada.gateway.routes.repository.RouteDefinitionRepository;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+@Component
+public class DatabaseRouteDefinitionProvider implements GatewayRouteDefinitionProvider {
+
+  private final RouteDefinitionRepository repository;
+  private final RouteDefinitionConverter converter;
+
+  public DatabaseRouteDefinitionProvider(RouteDefinitionRepository repository,
+      RouteDefinitionConverter converter) {
+    this.repository = repository;
+    this.converter = converter;
+  }
+
+  @Override
+  public Flux<GatewayRoutesProperties.ServiceRoute> loadRoutes() {
+    return repository.findActiveRoutes()
+        .flatMapIterable(converter::toServiceRoutes);
+  }
+
+  @Override
+  public String getProviderName() {
+    return "DatabaseRouteDefinitionProvider";
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionConverter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionConverter.java
@@ -1,0 +1,169 @@
+package com.ejada.gateway.routes.service;
+
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import com.ejada.gateway.routes.model.RouteComponent;
+import com.ejada.gateway.routes.model.RouteDefinition;
+import com.ejada.gateway.routes.model.RouteMetadata;
+import com.ejada.gateway.routes.model.RouteMetadata.TrafficSplit;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class RouteDefinitionConverter {
+
+  public List<GatewayRoutesProperties.ServiceRoute> toServiceRoutes(RouteDefinition definition) {
+    RouteDefinition resolved = definition.ensureServiceUri();
+    URI baseUri = resolved.metadata().resolveEffectiveUri(resolved.serviceUri()).orElse(resolved.serviceUri());
+    List<GatewayRoutesProperties.ServiceRoute> routes = new ArrayList<>();
+    if (resolved.hasTrafficSplits()) {
+      String group = resolved.id().toString();
+      for (TrafficSplit split : resolved.metadata().getTrafficSplits()) {
+        GatewayRoutesProperties.ServiceRoute route = createBaseRoute(resolved, split.getServiceUri() != null
+            ? split.getServiceUri()
+            : baseUri);
+        route.setId(group + "-" + normaliseVariant(split.getVariantId()));
+        route.getWeight().setEnabled(true);
+        route.getWeight().setGroup(group);
+        route.getWeight().setValue(split.getPercentage());
+        routes.add(route);
+      }
+    } else {
+      GatewayRoutesProperties.ServiceRoute route = createBaseRoute(resolved, baseUri);
+      route.setId(resolved.id().toString());
+      routes.add(route);
+    }
+    return routes;
+  }
+
+  private GatewayRoutesProperties.ServiceRoute createBaseRoute(RouteDefinition definition, URI uri) {
+    GatewayRoutesProperties.ServiceRoute route = new GatewayRoutesProperties.ServiceRoute();
+    route.setUri(uri);
+    applyPathPatterns(definition, route);
+    applyPredicates(definition.predicates(), route);
+    applyFilters(definition.filters(), route);
+    applyMetadata(definition.metadata(), route);
+    return route;
+  }
+
+  private void applyPathPatterns(RouteDefinition definition, GatewayRoutesProperties.ServiceRoute route) {
+    List<String> patterns = new ArrayList<>();
+    if (StringUtils.hasText(definition.pathPattern())) {
+      patterns.addAll(splitPatterns(definition.pathPattern()));
+    }
+    route.setPaths(patterns);
+  }
+
+  private void applyMetadata(RouteMetadata metadata, GatewayRoutesProperties.ServiceRoute route) {
+    if (metadata == null) {
+      return;
+    }
+    if (!metadata.getMethods().isEmpty()) {
+      route.setMethods(metadata.getMethods());
+    }
+    if (metadata.getStripPrefix() != null) {
+      route.setStripPrefix(metadata.getStripPrefix());
+    }
+    if (StringUtils.hasText(metadata.getPrefixPath())) {
+      route.setPrefixPath(metadata.getPrefixPath());
+    }
+    if (!metadata.getRequestHeaders().isEmpty()) {
+      route.setRequestHeaders(metadata.getRequestHeaders());
+    }
+  }
+
+  private void applyPredicates(List<RouteComponent> predicates, GatewayRoutesProperties.ServiceRoute route) {
+    if (predicates == null) {
+      return;
+    }
+    for (RouteComponent predicate : predicates) {
+      String name = predicate.name().toLowerCase(Locale.ROOT);
+      Map<String, String> args = predicate.args();
+      if ("path".equals(name)) {
+        List<String> patterns = args.values().stream()
+            .filter(StringUtils::hasText)
+            .flatMap(value -> splitPatterns(value).stream())
+            .collect(Collectors.toCollection(ArrayList::new));
+        if (!patterns.isEmpty()) {
+          route.getPaths().addAll(patterns);
+        }
+      } else if ("method".equals(name)) {
+        List<String> methods = args.values().stream()
+            .filter(StringUtils::hasText)
+            .map(value -> value.trim().toUpperCase(Locale.ROOT))
+            .toList();
+        if (!methods.isEmpty()) {
+          List<String> merged = new ArrayList<>(route.getMethods());
+          merged.addAll(methods);
+          route.setMethods(merged);
+        }
+      }
+    }
+  }
+
+  private void applyFilters(List<RouteComponent> filters, GatewayRoutesProperties.ServiceRoute route) {
+    if (filters == null) {
+      return;
+    }
+    for (RouteComponent filter : filters) {
+      Map<String, String> args = filter.args();
+      switch (filter.name().toLowerCase(Locale.ROOT)) {
+        case "stripprefix" -> {
+          String parts = resolveFirst(args);
+          if (StringUtils.hasText(parts)) {
+            route.setStripPrefix(Integer.parseInt(parts));
+          }
+        }
+        case "prefixpath" -> {
+          String prefix = resolveFirst(args);
+          if (StringUtils.hasText(prefix)) {
+            route.setPrefixPath(prefix);
+          }
+        }
+        case "addrequestheader" -> {
+          String headerName = args.getOrDefault("name", args.get("_genkey_0"));
+          String headerValue = args.getOrDefault("value", args.get("_genkey_1"));
+          if (StringUtils.hasText(headerName) && StringUtils.hasText(headerValue)) {
+            Map<String, String> headers = new LinkedHashMap<>(route.getRequestHeaders());
+            headers.put(headerName, headerValue);
+            route.setRequestHeaders(headers);
+          }
+        }
+        default -> {
+          // unsupported filter types are ignored for runtime registration but retained for UI
+        }
+      }
+    }
+  }
+
+  private String resolveFirst(Map<String, String> args) {
+    if (args == null || args.isEmpty()) {
+      return null;
+    }
+    return args.values().iterator().next();
+  }
+
+  private List<String> splitPatterns(String value) {
+    String[] tokens = value.split(",");
+    List<String> result = new ArrayList<>();
+    for (String token : tokens) {
+      if (StringUtils.hasText(token)) {
+        result.add(token.trim());
+      }
+    }
+    return result;
+  }
+
+  private String normaliseVariant(String value) {
+    if (!StringUtils.hasText(value)) {
+      return "variant";
+    }
+    return value.trim().toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", "-");
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionService.java
@@ -1,0 +1,73 @@
+package com.ejada.gateway.routes.service;
+
+import com.ejada.gateway.routes.model.RouteDefinition;
+import com.ejada.gateway.routes.model.RouteDefinitionRequest;
+import com.ejada.gateway.routes.model.RouteManagementView;
+import com.ejada.gateway.routes.repository.RouteDefinitionRepository;
+import java.net.URI;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class RouteDefinitionService {
+
+  private final RouteDefinitionRepository repository;
+  private final RouteDefinitionValidator validator;
+
+  public RouteDefinitionService(RouteDefinitionRepository repository,
+      RouteDefinitionValidator validator) {
+    this.repository = repository;
+    this.validator = validator;
+  }
+
+  public Flux<RouteDefinition> findAll() {
+    return repository.findAll();
+  }
+
+  public Flux<RouteManagementView> fetchManagementView() {
+    return repository.findAll()
+        .map(route -> {
+          URI effective = route.metadata().resolveEffectiveUri(route.serviceUri()).orElse(route.serviceUri());
+          return new RouteManagementView(
+              route.id(),
+              route.pathPattern(),
+              route.serviceUri(),
+              route.enabled(),
+              route.version(),
+              route.updatedAt(),
+              route.metadata().getBlueGreen(),
+              route.metadata().getTrafficSplits(),
+              effective);
+        });
+  }
+
+  public Mono<RouteDefinition> create(RouteDefinitionRequest request, Authentication actor) {
+    RouteDefinition definition = request.toDomain(null, 1, Instant.now());
+    validator.validate(definition);
+    return repository.create(definition, resolveActor(actor));
+  }
+
+  public Mono<RouteDefinition> update(UUID id, RouteDefinitionRequest request, Authentication actor) {
+    return repository.findById(id)
+        .flatMap(existing -> {
+          RouteDefinition candidate = request.toDomain(existing.id(), existing.version(), existing.createdAt());
+          validator.validate(candidate);
+          return repository.update(candidate, resolveActor(actor));
+        });
+  }
+
+  public Mono<Void> disable(UUID id, Authentication actor) {
+    return repository.disable(id, resolveActor(actor)).then();
+  }
+
+  private String resolveActor(Authentication authentication) {
+    if (authentication == null) {
+      return "system";
+    }
+    return authentication.getName();
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionValidator.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionValidator.java
@@ -1,0 +1,65 @@
+package com.ejada.gateway.routes.service;
+
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import com.ejada.gateway.routes.model.RouteDefinition;
+import com.ejada.gateway.routes.model.RouteMetadata;
+import com.ejada.gateway.routes.model.RouteMetadata.TrafficSplit;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+@Component
+public class RouteDefinitionValidator {
+
+  private final RouteDefinitionConverter converter;
+
+  public RouteDefinitionValidator(RouteDefinitionConverter converter) {
+    this.converter = converter;
+  }
+
+  public RouteDefinition validate(RouteDefinition definition) {
+    if (definition == null) {
+      throw new RouteValidationException("Route definition must not be null");
+    }
+    if (!StringUtils.hasText(definition.pathPattern())) {
+      throw new RouteValidationException("Path pattern is required");
+    }
+    if (definition.serviceUri() == null && definition.metadata().resolveEffectiveUri(null).isEmpty()) {
+      throw new RouteValidationException("Service URI or active blue/green URI is required");
+    }
+    validateTrafficSplits(definition.metadata());
+    List<GatewayRoutesProperties.ServiceRoute> serviceRoutes = converter.toServiceRoutes(definition);
+    for (GatewayRoutesProperties.ServiceRoute serviceRoute : serviceRoutes) {
+      serviceRoute.applyDefaults(new GatewayRoutesProperties.RouteDefaults());
+      serviceRoute.validate(serviceRoute.getId());
+    }
+    return definition;
+  }
+
+  private void validateTrafficSplits(RouteMetadata metadata) {
+    if (metadata == null || CollectionUtils.isEmpty(metadata.getTrafficSplits())) {
+      return;
+    }
+    int total = 0;
+    for (TrafficSplit split : metadata.getTrafficSplits()) {
+      if (split.getPercentage() <= 0) {
+        throw new RouteValidationException("Traffic split percentages must be positive");
+      }
+      if (split.getServiceUri() == null && metadata.resolveEffectiveUri(null).isEmpty()) {
+        throw new RouteValidationException("Traffic split requires service URI override when base URI missing");
+      }
+      total += split.getPercentage();
+    }
+    if (total != 100) {
+      throw new RouteValidationException("Traffic split percentages must total 100 but were " + total);
+    }
+  }
+
+  public static class RouteValidationException extends RuntimeException {
+
+    public RouteValidationException(String message) {
+      super(message);
+    }
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/web/RouteAdminController.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/web/RouteAdminController.java
@@ -1,0 +1,72 @@
+package com.ejada.gateway.routes.web;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.gateway.routes.model.RouteDefinition;
+import com.ejada.gateway.routes.model.RouteDefinitionRequest;
+import com.ejada.gateway.routes.model.RouteManagementView;
+import com.ejada.gateway.routes.service.RouteDefinitionService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/admin/routes")
+public class RouteAdminController {
+
+  private final RouteDefinitionService routeService;
+
+  public RouteAdminController(RouteDefinitionService routeService) {
+    this.routeService = routeService;
+  }
+
+  @GetMapping
+  @PreAuthorize("hasRole('EJADA_OFFICER')")
+  public Mono<BaseResponse<java.util.List<RouteDefinition>>> listRoutes() {
+    return routeService.findAll()
+        .collectList()
+        .map(routes -> BaseResponse.success("Route definitions", routes));
+  }
+
+  @GetMapping("/ui")
+  @PreAuthorize("hasRole('EJADA_OFFICER')")
+  public Mono<BaseResponse<java.util.List<RouteManagementView>>> uiSummary() {
+    return routeService.fetchManagementView()
+        .collectList()
+        .map(views -> BaseResponse.success("Route overview", views));
+  }
+
+  @PostMapping
+  @PreAuthorize("hasRole('EJADA_OFFICER')")
+  public Mono<BaseResponse<RouteDefinition>> createRoute(@Valid @RequestBody RouteDefinitionRequest request,
+      Authentication authentication) {
+    return routeService.create(request, authentication)
+        .map(route -> BaseResponse.success("Route created", route));
+  }
+
+  @PutMapping("/{id}")
+  @PreAuthorize("hasRole('EJADA_OFFICER')")
+  public Mono<BaseResponse<RouteDefinition>> updateRoute(@PathVariable("id") UUID id,
+      @Valid @RequestBody RouteDefinitionRequest request,
+      Authentication authentication) {
+    return routeService.update(id, request, authentication)
+        .map(route -> BaseResponse.success("Route updated", route));
+  }
+
+  @DeleteMapping("/{id}")
+  @PreAuthorize("hasRole('EJADA_OFFICER')")
+  public Mono<BaseResponse<Void>> disableRoute(@PathVariable("id") UUID id,
+      Authentication authentication) {
+    return routeService.disable(id, authentication)
+        .thenReturn(BaseResponse.success("Route disabled", null));
+  }
+}

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -27,6 +27,14 @@ spring:
       username: ${SPRING_CLOUD_CONFIG_USERNAME:}
       password: ${SPRING_CLOUD_CONFIG_PASSWORD:}
       fail-fast: true
+  r2dbc:
+    url: ${SPRING_R2DBC_URL:}
+    username: ${SPRING_R2DBC_USERNAME:}
+    password: ${SPRING_R2DBC_PASSWORD:}
+  sql:
+    init:
+      mode: ${SPRING_SQL_INIT_MODE:never}
+      schema-locations: classpath:schema.sql
     compatibility-verifier:
       enabled: false
     gateway:

--- a/api-gateway/src/main/resources/schema.sql
+++ b/api-gateway/src/main/resources/schema.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS route_definitions (
+    id UUID PRIMARY KEY,
+    path_pattern TEXT NOT NULL,
+    service_uri TEXT NOT NULL,
+    predicates JSONB NOT NULL DEFAULT '[]'::jsonb,
+    filters JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    version INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS route_definition_audit (
+    audit_id UUID PRIMARY KEY,
+    route_id UUID NOT NULL,
+    change_type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    changed_by TEXT,
+    changed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version INTEGER NOT NULL,
+    CONSTRAINT fk_route_definition
+      FOREIGN KEY(route_id) REFERENCES route_definitions(id)
+);


### PR DESCRIPTION
## Summary
- add R2DBC persistence and Redis caching for route definitions with audit logging
- expose secure admin APIs for managing dynamic routes and UI friendly summaries
- load enabled routes into the gateway via a database-backed provider supporting blue/green and traffic splits

## Testing
- `mvn -pl api-gateway -am test` *(fails: Byte Buddy agent jar download is corrupted in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b268378c832f81f9efa6d9ebbcc1