### PR TITLE
Configure security repository tests with postgres support

### DIFF
--- a/sec-service/src/test/java/com/ejada/sec/repository/UserRepositoryTenantIsolationTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/repository/UserRepositoryTenantIsolationTest.java
@@ -3,11 +3,16 @@ package com.ejada.sec.repository;
 import com.ejada.common.context.ContextManager;
 import com.ejada.common.exception.ValidationException;
 import com.ejada.sec.domain.User;
+import com.ejada.testsupport.extensions.PostgresTestExtension;
+import com.ejada.testsupport.extensions.SecuritySchemaExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,6 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ExtendWith({PostgresTestExtension.class, SecuritySchemaExtension.class})
+@Testcontainers(disabledWithoutDocker = true)
 class UserRepositoryTenantIsolationTest {
 
     @Autowired

--- a/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/extensions/SecuritySchemaExtension.java
+++ b/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/extensions/SecuritySchemaExtension.java
@@ -1,0 +1,44 @@
+package com.ejada.testsupport.extensions;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class SecuritySchemaExtension implements BeforeAllCallback, AfterAllCallback {
+
+    private static final String DEFAULT_SCHEMA = "security";
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("spring.jpa.properties.hibernate.default_schema", DEFAULT_SCHEMA);
+        properties.put("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces", "true");
+        properties.put("spring.jpa.properties.hibernate.format_sql", "true");
+        properties.put("spring.flyway.enabled", "true");
+        properties.put("spring.flyway.schemas", "public," + DEFAULT_SCHEMA);
+        properties.put("spring.flyway.default-schema", DEFAULT_SCHEMA);
+        properties.put("spring.flyway.locations", "classpath:db/migration/common,classpath:db/migration/{vendor}");
+
+        Map<String, String> previousValues = SystemPropertyExtensionSupport.apply(properties);
+        getClassStore(context).put(PropertiesHolder.KEY, new PropertiesHolder(previousValues));
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        PropertiesHolder holder = getClassStore(context).remove(PropertiesHolder.KEY, PropertiesHolder.class);
+        if (holder != null) {
+            SystemPropertyExtensionSupport.restore(holder.previousValues());
+        }
+    }
+
+    private ExtensionContext.Store getClassStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(SecuritySchemaExtension.class, context.getRequiredTestClass()));
+    }
+
+    private record PropertiesHolder(Map<String, String> previousValues) {
+        private static final String KEY = "security-schema-properties";
+    }
+}

--- a/shared-lib/shared-test-support/src/test/java/com/ejada/testsupport/extensions/SecuritySchemaExtensionTest.java
+++ b/shared-lib/shared-test-support/src/test/java/com/ejada/testsupport/extensions/SecuritySchemaExtensionTest.java
@@ -1,0 +1,21 @@
+package com.ejada.testsupport.extensions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SecuritySchemaExtension.class)
+class SecuritySchemaExtensionTest {
+
+    @Test
+    void configuresSecuritySchemaAndFlyway() {
+        assertThat(System.getProperty("spring.jpa.properties.hibernate.default_schema")).isEqualTo("security");
+        assertThat(System.getProperty("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces")).isEqualTo("true");
+        assertThat(System.getProperty("spring.jpa.properties.hibernate.format_sql")).isEqualTo("true");
+        assertThat(System.getProperty("spring.flyway.enabled")).isEqualTo("true");
+        assertThat(System.getProperty("spring.flyway.schemas")).isEqualTo("public,security");
+        assertThat(System.getProperty("spring.flyway.default-schema")).isEqualTo("security");
+        assertThat(System.getProperty("spring.flyway.locations")).isEqualTo("classpath:db/migration/common,classpath:db/migration/{vendor}");
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable SecuritySchemaExtension to configure security schema Flyway properties for tests
- apply Postgres test container and security schema extensions to UserRepositoryTenantIsolationTest so it uses the containerised Postgres database
- cover the new extension with a focused unit test

## Testing
- mvn -pl shared-lib/shared-test-support test *(fails: missing com.ejada:shared-common 1.0.0 dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b5d938ec832fae535c2cc391c077