### PR TITLE
Add multi-channel OTP infrastructure

### DIFF
--- a/sec-service/pom.xml
+++ b/sec-service/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>spring-boot-starter-data-redis</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-mail</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
     </dependency>
@@ -101,6 +105,10 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-security</artifactId>
     </dependency>
@@ -136,6 +144,12 @@
     <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>shared-lib-crypto</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.twilio.sdk</groupId>
+      <artifactId>twilio</artifactId>
+      <version>9.14.1</version>
+      <optional>true</optional>
     </dependency>
       <!-- covered by starter-openapi -->
     <dependency>

--- a/sec-service/src/main/java/com/ejada/sec/domain/MfaMethod.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/MfaMethod.java
@@ -1,0 +1,48 @@
+package com.ejada.sec.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Supported MFA methods with notification channels.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum MfaMethod {
+    /**
+     * Time-based OTP via authenticator app (Google Authenticator, Authy).
+     */
+    TOTP("Authenticator App", false),
+
+    /**
+     * OTP sent via email.
+     */
+    EMAIL("Email Verification", true),
+
+    /**
+     * OTP sent via SMS.
+     */
+    SMS("SMS Verification", true),
+
+    /**
+     * OTP printed to console (DEVELOPMENT ONLY).
+     */
+    CONSOLE("Console Output (Dev)", true);
+
+    private final String description;
+    private final boolean requiresOtpGeneration;
+
+    /**
+     * Checks if this method requires OTP code generation and delivery.
+     */
+    public boolean isOtpBased() {
+        return requiresOtpGeneration;
+    }
+
+    /**
+     * Checks if this method is allowed in production.
+     */
+    public boolean isProductionSafe() {
+        return this != CONSOLE;
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/domain/OtpCode.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/OtpCode.java
@@ -1,0 +1,117 @@
+package com.ejada.sec.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+/**
+ * Stores generated OTP codes with expiration.
+ * Used for EMAIL, SMS, and CONSOLE MFA methods.
+ */
+@Entity
+@Table(name = "otp_codes",
+       indexes = {
+           @Index(name = "ix_otp_user", columnList = "user_id"),
+           @Index(name = "ix_otp_code", columnList = "code_hash"),
+           @Index(name = "ix_otp_expires", columnList = "expires_at")
+       })
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OtpCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * User this OTP belongs to.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /**
+     * Hashed OTP code (never store plain text).
+     */
+    @Column(name = "code_hash", nullable = false, length = 255)
+    private String codeHash;
+
+    /**
+     * Method this OTP was sent via.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mfa_method", nullable = false, length = 20)
+    private MfaMethod method;
+
+    /**
+     * When OTP was generated.
+     */
+    @Column(name = "generated_at", nullable = false)
+    @Builder.Default
+    private Instant generatedAt = Instant.now();
+
+    /**
+     * When OTP expires (typically 5 minutes).
+     */
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    /**
+     * When OTP was used (null if not used yet).
+     */
+    @Column(name = "used_at")
+    private Instant usedAt;
+
+    /**
+     * Failed validation attempts for this OTP.
+     */
+    @Column(name = "failed_attempts")
+    @Builder.Default
+    private Integer failedAttempts = 0;
+
+    /**
+     * Delivery details (email address, phone number, etc).
+     */
+    @Column(name = "sent_to", length = 255)
+    private String sentTo;
+
+    /**
+     * Whether OTP was successfully delivered.
+     */
+    @Column(name = "delivered")
+    @Builder.Default
+    private Boolean delivered = false;
+
+    /**
+     * Delivery error message if failed.
+     */
+    @Column(name = "delivery_error", length = 500)
+    private String deliveryError;
+
+    /**
+     * Checks if OTP is still valid (not expired, not used).
+     */
+    public boolean isValid() {
+        return usedAt == null
+            && expiresAt.isAfter(Instant.now())
+            && Boolean.TRUE.equals(delivered);
+    }
+
+    /**
+     * Marks OTP as used.
+     */
+    public void markAsUsed() {
+        this.usedAt = Instant.now();
+    }
+
+    /**
+     * Increments failed attempts.
+     */
+    public void incrementFailedAttempts() {
+        this.failedAttempts++;
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/domain/User.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/User.java
@@ -35,6 +35,9 @@ public class User extends AuditableEntity {
     @Column(nullable = false, length = 255)
     private String email;
 
+    @Column(name = "phone_number", length = 32)
+    private String phoneNumber;
+
     @Column(name = "password_hash", nullable = false, length = 255)
     private String passwordHash;
 

--- a/sec-service/src/main/java/com/ejada/sec/notification/ConsoleNotificationChannel.java
+++ b/sec-service/src/main/java/com/ejada/sec/notification/ConsoleNotificationChannel.java
@@ -1,0 +1,55 @@
+package com.ejada.sec.notification;
+
+import com.ejada.sec.domain.MfaMethod;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Console-based OTP delivery for DEVELOPMENT ONLY.
+ * Prints OTP codes to console/logs for easy testing.
+ *
+ * WARNING: Never enable this in production!
+ */
+@Component
+@Profile({"dev", "local", "test"})
+@Slf4j
+public class ConsoleNotificationChannel implements NotificationChannel {
+
+    @Value("${sec.mfa.console.enabled:true}")
+    private boolean enabled;
+
+    @Override
+    public NotificationResult send(String recipient, String otpCode, int expiryMinutes) {
+        if (!enabled) {
+            return NotificationResult.failure("Console notification disabled");
+        }
+
+        String border = "═".repeat(70);
+
+        log.info("\n");
+        log.info(border);
+        log.info("║  🔐 MFA VERIFICATION CODE (DEVELOPMENT MODE)");
+        log.info("║");
+        log.info("║  Recipient: {}", recipient);
+        log.info("║  OTP Code:  {}", otpCode);
+        log.info("║  Valid for: {} minutes", expiryMinutes);
+        log.info("║");
+        log.info("║  ⚠️  This is DEVELOPMENT mode - code printed to console");
+        log.info(border);
+        log.info("\n");
+
+        return NotificationResult.success("OTP printed to console");
+    }
+
+    @Override
+    public MfaMethod getSupportedMethod() {
+        return MfaMethod.CONSOLE;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/notification/EmailNotificationChannel.java
+++ b/sec-service/src/main/java/com/ejada/sec/notification/EmailNotificationChannel.java
@@ -1,0 +1,81 @@
+package com.ejada.sec.notification;
+
+import com.ejada.sec.domain.MfaMethod;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+/**
+ * Email-based OTP delivery using Spring Mail.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EmailNotificationChannel implements NotificationChannel {
+
+    private final JavaMailSender mailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    @Value("${sec.mfa.email.enabled:true}")
+    private boolean enabled;
+
+    @Value("${sec.mfa.email.from:noreply@yourcompany.com}")
+    private String fromEmail;
+
+    @Value("${sec.mfa.email.subject:Your Verification Code}")
+    private String subject;
+
+    @Override
+    public NotificationResult send(String recipient, String otpCode, int expiryMinutes) {
+        if (!enabled) {
+            return NotificationResult.failure("Email notification disabled");
+        }
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setFrom(fromEmail);
+            helper.setTo(recipient);
+            helper.setSubject(subject);
+
+            String htmlContent = generateEmailContent(otpCode, expiryMinutes);
+            helper.setText(htmlContent, true);
+
+            mailSender.send(message);
+
+            log.info("OTP email sent successfully to: {}", recipient);
+            return NotificationResult.success("OTP sent to email");
+
+        } catch (MessagingException e) {
+            log.error("Failed to send OTP email to: {}", recipient, e);
+            return NotificationResult.failure("Email sending failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public MfaMethod getSupportedMethod() {
+        return MfaMethod.EMAIL;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    private String generateEmailContent(String otpCode, int expiryMinutes) {
+        Context context = new Context();
+        context.setVariable("otpCode", otpCode);
+        context.setVariable("expiryMinutes", expiryMinutes);
+        context.setVariable("year", java.time.Year.now().getValue());
+
+        return templateEngine.process("email/otp-code", context);
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/notification/NotificationChannel.java
+++ b/sec-service/src/main/java/com/ejada/sec/notification/NotificationChannel.java
@@ -1,0 +1,29 @@
+package com.ejada.sec.notification;
+
+import com.ejada.sec.domain.MfaMethod;
+
+/**
+ * Interface for OTP notification delivery channels.
+ */
+public interface NotificationChannel {
+
+    /**
+     * Sends OTP code to the recipient.
+     *
+     * @param recipient email address, phone number, or user identifier
+     * @param otpCode the 6-digit OTP code
+     * @param expiryMinutes how long the code is valid
+     * @return result of sending notification
+     */
+    NotificationResult send(String recipient, String otpCode, int expiryMinutes);
+
+    /**
+     * Gets the MFA method this channel supports.
+     */
+    MfaMethod getSupportedMethod();
+
+    /**
+     * Checks if this channel is enabled in current environment.
+     */
+    boolean isEnabled();
+}

--- a/sec-service/src/main/java/com/ejada/sec/notification/NotificationResult.java
+++ b/sec-service/src/main/java/com/ejada/sec/notification/NotificationResult.java
@@ -1,0 +1,26 @@
+package com.ejada.sec.notification;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationResult {
+    private boolean success;
+    private String message;
+    private String errorDetails;
+
+    public static NotificationResult success(String message) {
+        return NotificationResult.builder()
+            .success(true)
+            .message(message)
+            .build();
+    }
+
+    public static NotificationResult failure(String errorDetails) {
+        return NotificationResult.builder()
+            .success(false)
+            .errorDetails(errorDetails)
+            .build();
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/notification/SmsNotificationChannel.java
+++ b/sec-service/src/main/java/com/ejada/sec/notification/SmsNotificationChannel.java
@@ -1,0 +1,79 @@
+package com.ejada.sec.notification;
+
+import com.ejada.sec.domain.MfaMethod;
+import com.twilio.Twilio;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.type.PhoneNumber;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.stereotype.Component;
+
+/**
+ * SMS-based OTP delivery using Twilio.
+ * Only enabled if Twilio is on classpath and configured.
+ */
+@Component
+@ConditionalOnClass(Twilio.class)
+@Slf4j
+public class SmsNotificationChannel implements NotificationChannel {
+
+    @Value("${sec.mfa.sms.enabled:false}")
+    private boolean enabled;
+
+    @Value("${sec.mfa.sms.twilio.account-sid:}")
+    private String accountSid;
+
+    @Value("${sec.mfa.sms.twilio.auth-token:}")
+    private String authToken;
+
+    @Value("${sec.mfa.sms.twilio.from-number:}")
+    private String fromNumber;
+
+    @PostConstruct
+    public void init() {
+        if (enabled && accountSid != null && !accountSid.isBlank() && authToken != null && !authToken.isBlank()) {
+            Twilio.init(accountSid, authToken);
+            log.info("Twilio SMS channel initialized");
+        }
+    }
+
+    @Override
+    public NotificationResult send(String recipient, String otpCode, int expiryMinutes) {
+        if (!enabled) {
+            return NotificationResult.failure("SMS notification disabled");
+        }
+
+        try {
+            String messageBody = String.format(
+                "Your verification code is: %s\n\nValid for %d minutes.\n\nIf you didn't request this, please ignore.",
+                otpCode, expiryMinutes
+            );
+
+            Message message = Message.creator(
+                new PhoneNumber(recipient),
+                new PhoneNumber(fromNumber),
+                messageBody
+            ).create();
+
+            log.info("OTP SMS sent successfully to: {} (SID: {})", recipient, message.getSid());
+
+            return NotificationResult.success("OTP sent via SMS");
+
+        } catch (Exception e) {
+            log.error("Failed to send OTP SMS to: {}", recipient, e);
+            return NotificationResult.failure("SMS sending failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public MfaMethod getSupportedMethod() {
+        return MfaMethod.SMS;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/repository/OtpCodeRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/OtpCodeRepository.java
@@ -1,0 +1,33 @@
+package com.ejada.sec.repository;
+
+import com.ejada.sec.domain.OtpCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+public interface OtpCodeRepository extends JpaRepository<OtpCode, Long> {
+
+    /**
+     * Finds active (unused, not expired) OTPs for user.
+     */
+    @Query("SELECT o FROM OtpCode o " +
+           "WHERE o.user.id = :userId " +
+           "AND o.usedAt IS NULL " +
+           "AND o.expiresAt > :now " +
+           "AND o.delivered = true " +
+           "ORDER BY o.generatedAt DESC")
+    List<OtpCode> findActiveOtpsByUserId(
+        @Param("userId") Long userId,
+        @Param("now") Instant now
+    );
+
+    /**
+     * Deletes expired OTPs.
+     */
+    void deleteByExpiresAtBefore(Instant cutoff);
+}

--- a/sec-service/src/main/java/com/ejada/sec/service/OtpService.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/OtpService.java
@@ -1,0 +1,30 @@
+package com.ejada.sec.service;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.sec.domain.MfaMethod;
+
+public interface OtpService {
+
+    /**
+     * Generates and sends OTP code via specified method.
+     *
+     * @param userId user ID
+     * @param method delivery method (EMAIL, SMS, CONSOLE)
+     * @return response with success/failure status
+     */
+    BaseResponse<Void> generateAndSendOtp(Long userId, MfaMethod method);
+
+    /**
+     * Validates OTP code entered by user.
+     *
+     * @param userId user ID
+     * @param otpCode 6-digit OTP code
+     * @return true if valid
+     */
+    boolean validateOtp(Long userId, String otpCode);
+
+    /**
+     * Invalidates all active OTPs for user.
+     */
+    void invalidateUserOtps(Long userId);
+}

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/OtpServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/OtpServiceImpl.java
@@ -1,0 +1,178 @@
+package com.ejada.sec.service.impl;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.crypto.password.PasswordHasher;
+import com.ejada.sec.domain.MfaMethod;
+import com.ejada.sec.domain.OtpCode;
+import com.ejada.sec.domain.User;
+import com.ejada.sec.notification.NotificationChannel;
+import com.ejada.sec.notification.NotificationResult;
+import com.ejada.sec.repository.OtpCodeRepository;
+import com.ejada.sec.repository.UserRepository;
+import com.ejada.sec.service.OtpService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OtpServiceImpl implements OtpService {
+
+    private final OtpCodeRepository otpCodeRepository;
+    private final UserRepository userRepository;
+    private final List<NotificationChannel> notificationChannels;
+
+    @Value("${sec.mfa.otp.length:6}")
+    private int otpLength;
+
+    @Value("${sec.mfa.otp.expiry-minutes:5}")
+    private int otpExpiryMinutes;
+
+    @Value("${sec.mfa.otp.max-attempts:3}")
+    private int maxAttempts;
+
+    private final SecureRandom random = new SecureRandom();
+
+    @Override
+    @Transactional
+    public BaseResponse<Void> generateAndSendOtp(Long userId, MfaMethod method) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new NoSuchElementException("User not found"));
+
+        if (!method.isOtpBased()) {
+            return BaseResponse.error("INVALID_METHOD",
+                "Method does not support OTP: " + method);
+        }
+
+        NotificationChannel channel = getNotificationChannel(method);
+        if (channel == null || !channel.isEnabled()) {
+            return BaseResponse.error("CHANNEL_DISABLED",
+                "Notification channel not available: " + method);
+        }
+
+        invalidateUserOtps(userId);
+
+        String otpCode = generateOtpCode();
+        String otpHash = PasswordHasher.bcrypt(otpCode);
+
+        String recipient = getRecipient(user, method);
+        if (recipient == null || recipient.isBlank()) {
+            return BaseResponse.error("NO_RECIPIENT",
+                "No recipient configured for method: " + method);
+        }
+
+        NotificationResult result = channel.send(recipient, otpCode, otpExpiryMinutes);
+
+        OtpCode otp = OtpCode.builder()
+            .user(user)
+            .codeHash(otpHash)
+            .method(method)
+            .generatedAt(Instant.now())
+            .expiresAt(Instant.now().plus(otpExpiryMinutes, ChronoUnit.MINUTES))
+            .sentTo(recipient)
+            .delivered(result.isSuccess())
+            .deliveryError(result.getErrorDetails())
+            .build();
+
+        otpCodeRepository.save(otp);
+
+        if (!result.isSuccess()) {
+            log.error("Failed to send OTP to {} via {}: {}",
+                recipient, method, result.getErrorDetails());
+            return BaseResponse.error("SEND_FAILED",
+                "Failed to send OTP: " + result.getErrorDetails());
+        }
+
+        log.info("OTP generated and sent to user {} via {}", userId, method);
+        return BaseResponse.success("OTP sent successfully", null);
+    }
+
+    @Override
+    @Transactional
+    public boolean validateOtp(Long userId, String otpCode) {
+        userRepository.findById(userId)
+            .orElseThrow(() -> new NoSuchElementException("User not found"));
+
+        List<OtpCode> activeOtps = otpCodeRepository.findActiveOtpsByUserId(
+            userId, Instant.now());
+
+        if (activeOtps.isEmpty()) {
+            log.warn("No active OTP found for user: {}", userId);
+            return false;
+        }
+
+        boolean valid = false;
+
+        for (OtpCode otp : activeOtps) {
+            if (PasswordHasher.matchesBcrypt(otpCode, otp.getCodeHash())) {
+                otp.markAsUsed();
+                otpCodeRepository.save(otp);
+                valid = true;
+                break;
+            }
+
+            otp.incrementFailedAttempts();
+            if (otp.getFailedAttempts() >= maxAttempts) {
+                otp.markAsUsed();
+                log.warn("OTP invalidated due to {} failed attempts for user: {}",
+                    maxAttempts, userId);
+            }
+            otpCodeRepository.save(otp);
+        }
+
+        if (!valid) {
+            log.warn("Invalid OTP code for user: {}", userId);
+        }
+
+        return valid;
+    }
+
+    @Override
+    @Transactional
+    public void invalidateUserOtps(Long userId) {
+        List<OtpCode> activeOtps = otpCodeRepository.findActiveOtpsByUserId(
+            userId, Instant.now());
+
+        activeOtps.forEach(OtpCode::markAsUsed);
+        otpCodeRepository.saveAll(activeOtps);
+
+        log.debug("Invalidated {} active OTPs for user: {}", activeOtps.size(), userId);
+    }
+
+    private String generateOtpCode() {
+        int bound = (int) Math.pow(10, otpLength);
+        int code = random.nextInt(bound);
+        return String.format("%0" + otpLength + "d", code);
+    }
+
+    private NotificationChannel getNotificationChannel(MfaMethod method) {
+        Map<MfaMethod, NotificationChannel> channelMap = notificationChannels.stream()
+            .collect(Collectors.toMap(
+                NotificationChannel::getSupportedMethod,
+                Function.identity(),
+                (existing, replacement) -> existing
+            ));
+
+        return channelMap.get(method);
+    }
+
+    private String getRecipient(User user, MfaMethod method) {
+        return switch (method) {
+            case EMAIL, CONSOLE -> user.getEmail();
+            case SMS -> user.getPhoneNumber();
+            default -> null;
+        };
+    }
+}

--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -54,6 +54,9 @@ spring:
     redis:
       repositories:
         enabled: false
+  mail:
+    host: localhost
+    port: 1025
 
 management:
   endpoints:
@@ -249,3 +252,16 @@ logging:
     org.springframework.cache.interceptor.CacheAspectSupport: ERROR
 
 debug: false
+
+sec:
+  mfa:
+    otp:
+      length: 6
+      expiry-minutes: 5
+      max-attempts: 3
+    console:
+      enabled: true
+    email:
+      enabled: false
+    sms:
+      enabled: false

--- a/sec-service/src/main/resources/application-prod.yaml
+++ b/sec-service/src/main/resources/application-prod.yaml
@@ -4,3 +4,33 @@ sec:
       enabled: true
       ttl-minutes: 10
       max-size: 50000
+  mfa:
+    otp:
+      length: 6
+      expiry-minutes: 5
+      max-attempts: 3
+    console:
+      enabled: false
+    email:
+      enabled: true
+      from: noreply@yourcompany.com
+      subject: Your Verification Code
+    sms:
+      enabled: true
+      twilio:
+        account-sid: ${TWILIO_ACCOUNT_SID}
+        auth-token: ${TWILIO_AUTH_TOKEN}
+        from-number: ${TWILIO_FROM_NUMBER}
+
+spring:
+  mail:
+    host: ${SMTP_HOST}
+    port: ${SMTP_PORT:587}
+    username: ${SMTP_USERNAME}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true

--- a/sec-service/src/main/resources/db/migration/postgresql/V10__add_otp_codes.sql
+++ b/sec-service/src/main/resources/db/migration/postgresql/V10__add_otp_codes.sql
@@ -1,0 +1,67 @@
+-- ============================================
+-- V10: OTP Codes Table for Multi-Channel MFA
+-- ============================================
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS phone_number VARCHAR(32);
+
+CREATE TABLE IF NOT EXISTS otp_codes (
+    id                BIGSERIAL PRIMARY KEY,
+    user_id           BIGINT       NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    code_hash         VARCHAR(255) NOT NULL,
+    mfa_method        VARCHAR(20)  NOT NULL,
+    generated_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    expires_at        TIMESTAMPTZ  NOT NULL,
+    used_at           TIMESTAMPTZ,
+    failed_attempts   INTEGER      NOT NULL DEFAULT 0,
+    sent_to           VARCHAR(255),
+    delivered         BOOLEAN      NOT NULL DEFAULT false,
+    delivery_error    VARCHAR(500),
+
+    CONSTRAINT ck_otp_method_valid CHECK (
+        mfa_method IN ('EMAIL', 'SMS', 'CONSOLE')
+    ),
+    CONSTRAINT ck_otp_expires_after_generated CHECK (
+        expires_at > generated_at
+    )
+);
+
+CREATE INDEX ix_otp_user ON otp_codes(user_id);
+CREATE INDEX ix_otp_code ON otp_codes(code_hash);
+CREATE INDEX ix_otp_expires ON otp_codes(expires_at);
+
+-- Auto-cleanup of expired OTPs (run hourly)
+CREATE OR REPLACE FUNCTION cleanup_expired_otps()
+RETURNS INTEGER AS $$
+DECLARE
+    deleted_count INTEGER;
+BEGIN
+    DELETE FROM otp_codes
+    WHERE expires_at < NOW() - INTERVAL '1 hour';
+
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- View: Active OTPs
+CREATE OR REPLACE VIEW active_otps AS
+SELECT 
+    id,
+    user_id,
+    mfa_method,
+    generated_at,
+    expires_at,
+    sent_to,
+    delivered,
+    EXTRACT(EPOCH FROM (expires_at - NOW())) AS seconds_until_expiry
+FROM otp_codes
+WHERE used_at IS NULL
+  AND expires_at > NOW()
+ORDER BY generated_at DESC;
+
+COMMENT ON TABLE otp_codes IS 
+'Stores generated OTP codes for email/SMS/console MFA methods';
+
+COMMENT ON COLUMN otp_codes.code_hash IS 
+'Bcrypt hash of the 6-digit OTP code - never store plain text';

--- a/sec-service/src/main/resources/templates/email/otp-code.html
+++ b/sec-service/src/main/resources/templates/email/otp-code.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Your Verification Code</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f4; padding: 20px;">
+        <tr>
+            <td align="center">
+                <table width="600" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                    <!-- Header -->
+                    <tr>
+                        <td style="background-color: #4F46E5; padding: 30px; text-align: center;">
+                            <h1 style="margin: 0; color: #ffffff; font-size: 24px;">🔐 Verification Code</h1>
+                        </td>
+                    </tr>
+                    
+                    <!-- Content -->
+                    <tr>
+                        <td style="padding: 40px 30px;">
+                            <p style="margin: 0 0 20px; font-size: 16px; color: #333333;">
+                                Your verification code is:
+                            </p>
+                            
+                            <!-- OTP Code Box -->
+                            <div style="background-color: #F3F4F6; border: 2px dashed #4F46E5; border-radius: 8px; padding: 20px; text-align: center; margin: 20px 0;">
+                                <div style="font-size: 36px; font-weight: bold; color: #4F46E5; letter-spacing: 8px;">
+                                    <span th:text="${otpCode}">123456</span>
+                                </div>
+                            </div>
+                            
+                            <p style="margin: 20px 0 0; font-size: 14px; color: #666666;">
+                                This code will expire in <strong th:text="${expiryMinutes}">5</strong> minutes.
+                            </p>
+                            
+                            <p style="margin: 20px 0 0; font-size: 14px; color: #666666;">
+                                If you didn't request this code, please ignore this email.
+                            </p>
+                        </td>
+                    </tr>
+                    
+                    <!-- Footer -->
+                    <tr>
+                        <td style="background-color: #F9FAFB; padding: 20px 30px; text-align: center; border-top: 1px solid #E5E7EB;">
+                            <p style="margin: 0; font-size: 12px; color: #9CA3AF;">
+                                &copy; <span th:text="${year}">2024</span> Your Company. All rights reserved.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mail, Thymeleaf, and Twilio dependencies to enable new OTP delivery channels
- introduce OTP domain model, repository, notification channel implementations, and service logic
- add database migration, email template, and environment configuration for multi-channel MFA support

## Testing
- `mvn -pl sec-service -am test` *(fails: missing swagger dependencies in shared starter due to repository resolution issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b5cf8da8832fa5b6de246f20ca98