### PR TITLE
Handle Docker unavailability in Postgres test support

### DIFF
--- a/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/extensions/PostgresTestExtension.java
+++ b/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/extensions/PostgresTestExtension.java
@@ -3,6 +3,8 @@ package com.ejada.testsupport.extensions;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.opentest4j.TestAbortedException;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.util.LinkedHashMap;
@@ -17,6 +19,7 @@ public class PostgresTestExtension implements BeforeAllCallback, AfterAllCallbac
 
     @Override
     public void beforeAll(ExtensionContext context) {
+        ensureDockerAvailable();
         ensureContainerStarted(context);
 
         Map<String, String> properties = new LinkedHashMap<>();
@@ -48,6 +51,14 @@ public class PostgresTestExtension implements BeforeAllCallback, AfterAllCallbac
 
     private ExtensionContext.Store getClassStore(ExtensionContext context) {
         return context.getStore(ExtensionContext.Namespace.create(PostgresTestExtension.class, context.getRequiredTestClass()));
+    }
+
+    private void ensureDockerAvailable() {
+        try {
+            DockerClientFactory.instance().client();
+        } catch (IllegalStateException ex) {
+            throw new TestAbortedException("Docker is not available for PostgresTestExtension", ex);
+        }
     }
 
     static PostgreSQLContainer<?> getContainer() {


### PR DESCRIPTION
## Summary
- abort Postgres-based JPA tests early when Docker is not available by checking Docker connectivity before starting the container

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e22019c388832fad7655a40e6ec8cc