### PR TITLE
Align Kafka client version with Spring Boot

### DIFF
--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -33,7 +33,7 @@
     <!-- Messaging / schema -->
     <avro.version>1.11.3</avro.version>
     <confluent.version>7.6.1</confluent.version>
-    <kafka.clients.version>3.7.1</kafka.clients.version>
+    <kafka.clients.version>3.9.0</kafka.clients.version>
 
     <!-- Serialization -->
     <jackson.version>2.19.2</jackson.version>


### PR DESCRIPTION
## Summary
- align the managed `kafka-clients` dependency with Spring Boot's version so Embedded Kafka can load the expected classes

## Testing
- mvn -pl tenant-platform/subscription-service -am test *(fails: multiple upstream repositories return HTML instead of POMs, corrupting local cache)*

------
https://chatgpt.com/codex/tasks/task_e_68e222c55f64832f9d0beac32a8563b8