### PR TITLE
Use H2 for repository tenant isolation tests

### DIFF
--- a/sec-service/pom.xml
+++ b/sec-service/pom.xml
@@ -161,6 +161,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>shared-test-support</artifactId>
       <scope>test</scope>

--- a/sec-service/src/test/java/com/ejada/sec/repository/UserRepositoryTenantIsolationTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/repository/UserRepositoryTenantIsolationTest.java
@@ -3,16 +3,13 @@ package com.ejada.sec.repository;
 import com.ejada.common.context.ContextManager;
 import com.ejada.common.exception.ValidationException;
 import com.ejada.sec.domain.User;
-import com.ejada.testsupport.extensions.PostgresTestExtension;
-import com.ejada.testsupport.extensions.SecuritySchemaExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,9 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ExtendWith({PostgresTestExtension.class, SecuritySchemaExtension.class})
-@Testcontainers(disabledWithoutDocker = true)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
 class UserRepositoryTenantIsolationTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- switch UserRepositoryTenantIsolationTest to run against an embedded H2 database with Flyway disabled for the slice
- add the H2 test dependency so the embedded database is available during JPA tests

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68e221d607a0832faf3907e7d9be3dbe