### PR TITLE
Fix SubscriptionApprovalConsumerIT embedded Kafka configuration

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -35,7 +35,11 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 @ActiveProfiles("test")
 @EmbeddedKafka(topics = SubscriptionApprovalConsumerIT.APPROVAL_TOPIC)
-@TestPropertySource(properties = "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}")
+@TestPropertySource(
+        properties = {
+            "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+            "shared.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}"
+        })
 class SubscriptionApprovalConsumerIT {
 
     static final String APPROVAL_TOPIC = "subscription-approvals-it";


### PR DESCRIPTION
## Summary
- point the shared Kafka bootstrap configuration used by the subscription approval integration test to the embedded Kafka broker so the context starts successfully

## Testing
- mvn -pl . -am -Dtest= -Dit.test=SubscriptionApprovalConsumerIT verify *(fails: repository lacks internal shared-bom artifacts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e23bc26b14832f90aef58c93cfdc9f