### PR TITLE
Add toggle to disable gateway cache Kafka listeners

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/cache/CacheInvalidationListener.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/cache/CacheInvalidationListener.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -16,6 +17,7 @@ import org.springframework.util.StringUtils;
  * catalog or tenant data changes.
  */
 @Component
+@ConditionalOnExpression("${gateway.cache.enabled:true} && ${gateway.cache.kafka.enabled:true}")
 public class CacheInvalidationListener {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CacheInvalidationListener.class);

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayCacheProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayCacheProperties.java
@@ -144,6 +144,8 @@ public class GatewayCacheProperties {
 
     private String groupId = "gateway-cache";
 
+    private boolean enabled = true;
+
     public String getGroupId() {
       return groupId;
     }
@@ -152,6 +154,14 @@ public class GatewayCacheProperties {
       if (StringUtils.hasText(groupId)) {
         this.groupId = groupId.trim();
       }
+    }
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
     }
   }
 

--- a/api-gateway/src/test/java/com/ejada/gateway/ApiGatewayApplicationTests.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/ApiGatewayApplicationTests.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.TestPropertySource;
     "gateway.routes.test.id=test-route",
     "gateway.routes.test.uri=http://example.org",
     "gateway.routes.test.paths[0]=/test/**",
+    "gateway.cache.kafka.enabled=false",
     "shared.ratelimit.enabled=false",
     "spring.autoconfigure.exclude=com.ejada.shared_starter_ratelimit.RateLimitAutoConfiguration"
 })


### PR DESCRIPTION
## Summary
- gate the cache invalidation listener on both the cache and Kafka enablement flags to avoid unwanted listener startup
- expose a `gateway.cache.kafka.enabled` property so environments without Kafka can disable the listener cleanly
- update the gateway context load test to turn off the Kafka listener and prevent accidental broker connections during testing

## Testing
- `mvn -pl api-gateway test` *(fails: missing shared artifacts such as com.ejada:starter-kafka)*

------
https://chatgpt.com/codex/tasks/task_e_68e241b3ff28832f9e01aee87cdb45d5