### PR TITLE
Fix Flyway schema init for subscription approval consumer IT

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -63,6 +63,7 @@ class SubscriptionApprovalConsumerIT {
                 () -> "classpath:db/migration/postgresql,classpath:db/testdata/subscription");
         registry.add("spring.flyway.schemas", () -> "subscription");
         registry.add("spring.flyway.default-schema", () -> "subscription");
+        registry.add("spring.flyway.create-schemas", () -> "true");
         registry.add("spring.kafka.consumer.auto-offset-reset", () -> "earliest");
         registry.add(
                 "spring.kafka.producer.value-serializer",


### PR DESCRIPTION
## Summary
- ensure the approval consumer integration test enables Flyway schema creation so migrations can run against the Postgres container

## Testing
- not run (local Maven dependency resolution failed)


------
https://chatgpt.com/codex/tasks/task_e_68e241cd5a70832fbe88155e3bbfd053