### PR TITLE
Remove public schema references from Flyway configurations

### DIFF
--- a/sec-service/pom.xml
+++ b/sec-service/pom.xml
@@ -21,7 +21,7 @@
         <java.version>21</java.version>
         <spring-boot.run.skip>false</spring-boot.run.skip>
         <qa.flyway.vendor>postgresql</qa.flyway.vendor>
-        <qa.flyway.schemas>public,security</qa.flyway.schemas>
+        <qa.flyway.schemas>security</qa.flyway.schemas>
         <qa.flyway.defaultSchema>security</qa.flyway.defaultSchema>
         <qa.flyway.locations>classpath:db/migration/common,classpath:db/migration/${qa.flyway.vendor}</qa.flyway.locations>
         <qa.flyway.url>jdbc:postgresql://localhost:5432/ejada</qa.flyway.url>

--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -29,7 +29,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,security
+    schemas: security
     default-schema: security
 
   kafka:

--- a/sec-service/src/main/resources/application-qa.yaml
+++ b/sec-service/src/main/resources/application-qa.yaml
@@ -28,7 +28,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,security
+    schemas: security
     default-schema: security
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}

--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -6,7 +6,7 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
-    schemas: public,security
+    schemas: security
     default-schema: security
 server:
   port: 8080

--- a/setup-service/pom.xml
+++ b/setup-service/pom.xml
@@ -17,7 +17,7 @@
     <java.version>21</java.version>
     <spring-boot.run.skip>false</spring-boot.run.skip>
     <qa.flyway.vendor>postgresql</qa.flyway.vendor>
-    <qa.flyway.schemas>public,setup</qa.flyway.schemas>
+    <qa.flyway.schemas>setup</qa.flyway.schemas>
     <qa.flyway.defaultSchema>setup</qa.flyway.defaultSchema>
     <qa.flyway.locations>classpath:db/migration/common,classpath:db/migration/${qa.flyway.vendor}</qa.flyway.locations>
     <qa.flyway.url>jdbc:postgresql://localhost:5432/ejada</qa.flyway.url>

--- a/setup-service/src/main/resources/application-dev.yaml
+++ b/setup-service/src/main/resources/application-dev.yaml
@@ -44,7 +44,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,setup
+    schemas: setup
     default-schema: setup
 
   kafka:

--- a/setup-service/src/main/resources/application-local.yaml
+++ b/setup-service/src/main/resources/application-local.yaml
@@ -27,7 +27,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,setup
+    schemas: setup
     default-schema: setup
 
   kafka:

--- a/setup-service/src/main/resources/application-qa.yaml
+++ b/setup-service/src/main/resources/application-qa.yaml
@@ -29,7 +29,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,setup
+    schemas: setup
     default-schema: setup
   kafka:
     bootstrap-servers: kafka:9092

--- a/setup-service/src/main/resources/application.yaml
+++ b/setup-service/src/main/resources/application.yaml
@@ -6,7 +6,7 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
-    schemas: public,setup
+    schemas: setup
     default-schema: setup
 server:
   port: 8080

--- a/shared-lib/shared-config/src/main/resources/application-shared-tenant-qa.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-tenant-qa.yaml
@@ -32,7 +32,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,${app.schema}
+    schemas: ${app.schema}
     default-schema: ${app.schema}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}

--- a/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/extensions/SecuritySchemaExtension.java
+++ b/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/extensions/SecuritySchemaExtension.java
@@ -18,7 +18,7 @@ public class SecuritySchemaExtension implements BeforeAllCallback, AfterAllCallb
         properties.put("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces", "true");
         properties.put("spring.jpa.properties.hibernate.format_sql", "true");
         properties.put("spring.flyway.enabled", "true");
-        properties.put("spring.flyway.schemas", "public," + DEFAULT_SCHEMA);
+        properties.put("spring.flyway.schemas", DEFAULT_SCHEMA);
         properties.put("spring.flyway.default-schema", DEFAULT_SCHEMA);
         properties.put("spring.flyway.locations", "classpath:db/migration/common,classpath:db/migration/{vendor}");
 

--- a/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/extensions/SetupSchemaExtension.java
+++ b/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/extensions/SetupSchemaExtension.java
@@ -18,7 +18,7 @@ public class SetupSchemaExtension implements BeforeAllCallback, AfterAllCallback
         properties.put("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces", "true");
         properties.put("spring.jpa.properties.hibernate.format_sql", "true");
         properties.put("spring.flyway.enabled", "true");
-        properties.put("spring.flyway.schemas", "public," + DEFAULT_SCHEMA);
+        properties.put("spring.flyway.schemas", DEFAULT_SCHEMA);
         properties.put("spring.flyway.default-schema", DEFAULT_SCHEMA);
         properties.put("spring.flyway.locations", "classpath:db/migration/common,classpath:db/migration/{vendor}");
 

--- a/shared-lib/shared-test-support/src/test/java/com/ejada/testsupport/extensions/SecuritySchemaExtensionTest.java
+++ b/shared-lib/shared-test-support/src/test/java/com/ejada/testsupport/extensions/SecuritySchemaExtensionTest.java
@@ -14,7 +14,7 @@ class SecuritySchemaExtensionTest {
         assertThat(System.getProperty("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces")).isEqualTo("true");
         assertThat(System.getProperty("spring.jpa.properties.hibernate.format_sql")).isEqualTo("true");
         assertThat(System.getProperty("spring.flyway.enabled")).isEqualTo("true");
-        assertThat(System.getProperty("spring.flyway.schemas")).isEqualTo("public,security");
+        assertThat(System.getProperty("spring.flyway.schemas")).isEqualTo("security");
         assertThat(System.getProperty("spring.flyway.default-schema")).isEqualTo("security");
         assertThat(System.getProperty("spring.flyway.locations")).isEqualTo("classpath:db/migration/common,classpath:db/migration/{vendor}");
     }

--- a/shared-lib/shared-test-support/src/test/java/com/ejada/testsupport/extensions/SetupSchemaExtensionTest.java
+++ b/shared-lib/shared-test-support/src/test/java/com/ejada/testsupport/extensions/SetupSchemaExtensionTest.java
@@ -14,7 +14,7 @@ class SetupSchemaExtensionTest {
         assertThat(System.getProperty("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces")).isEqualTo("true");
         assertThat(System.getProperty("spring.jpa.properties.hibernate.format_sql")).isEqualTo("true");
         assertThat(System.getProperty("spring.flyway.enabled")).isEqualTo("true");
-        assertThat(System.getProperty("spring.flyway.schemas")).isEqualTo("public,setup");
+        assertThat(System.getProperty("spring.flyway.schemas")).isEqualTo("setup");
         assertThat(System.getProperty("spring.flyway.default-schema")).isEqualTo("setup");
         assertThat(System.getProperty("spring.flyway.locations")).isEqualTo("classpath:db/migration/common,classpath:db/migration/{vendor}");
     }

--- a/tenant-platform/billing-service/pom.xml
+++ b/tenant-platform/billing-service/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <java.version>21</java.version>
     <qa.flyway.vendor>postgresql</qa.flyway.vendor>
-    <qa.flyway.schemas>public,billing</qa.flyway.schemas>
+    <qa.flyway.schemas>billing</qa.flyway.schemas>
     <qa.flyway.defaultSchema>billing</qa.flyway.defaultSchema>
     <qa.flyway.locations>classpath:db/migration/common,classpath:db/migration/${qa.flyway.vendor}</qa.flyway.locations>
     <qa.flyway.url>jdbc:postgresql://localhost:5432/ejada</qa.flyway.url>

--- a/tenant-platform/catalog-service/pom.xml
+++ b/tenant-platform/catalog-service/pom.xml
@@ -18,7 +18,7 @@
     <java.version>21</java.version>
     <spring-boot.run.skip>false</spring-boot.run.skip>
     <qa.flyway.vendor>postgresql</qa.flyway.vendor>
-    <qa.flyway.schemas>public,catalog</qa.flyway.schemas>
+    <qa.flyway.schemas>catalog</qa.flyway.schemas>
     <qa.flyway.defaultSchema>catalog</qa.flyway.defaultSchema>
     <qa.flyway.locations>classpath:db/migration/common,classpath:db/migration/${qa.flyway.vendor}</qa.flyway.locations>
     <qa.flyway.url>jdbc:postgresql://localhost:5432/ejada</qa.flyway.url>

--- a/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
@@ -30,7 +30,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,catalog
+    schemas: catalog
     default-schema: catalog
 
   kafka:

--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <java.version>21</java.version>
     <qa.flyway.vendor>postgresql</qa.flyway.vendor>
-    <qa.flyway.schemas>public,subscription</qa.flyway.schemas>
+    <qa.flyway.schemas>subscription</qa.flyway.schemas>
     <qa.flyway.defaultSchema>subscription</qa.flyway.defaultSchema>
     <qa.flyway.locations>classpath:db/migration/common,classpath:db/migration/${qa.flyway.vendor}</qa.flyway.locations>
     <qa.flyway.url>jdbc:postgresql://localhost:5432/ejada</qa.flyway.url>

--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -30,7 +30,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,subscription
+    schemas: subscription
     default-schema: subscription
 
   kafka:

--- a/tenant-platform/tenant-service/pom.xml
+++ b/tenant-platform/tenant-service/pom.xml
@@ -18,7 +18,7 @@
     <java.version>21</java.version>
     <spring-boot.run.skip>false</spring-boot.run.skip>
     <qa.flyway.vendor>postgresql</qa.flyway.vendor>
-    <qa.flyway.schemas>public,tenant</qa.flyway.schemas>
+    <qa.flyway.schemas>tenant</qa.flyway.schemas>
     <qa.flyway.defaultSchema>tenant</qa.flyway.defaultSchema>
     <qa.flyway.locations>classpath:db/migration/common,classpath:db/migration/${qa.flyway.vendor}</qa.flyway.locations>
     <qa.flyway.url>jdbc:postgresql://localhost:5432/ejada</qa.flyway.url>

--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -30,7 +30,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,tenant
+    schemas: tenant
     default-schema: tenant
 
   kafka:

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -6,7 +6,7 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
-    schemas: public,tenant
+    schemas: tenant
     default-schema: tenant
 server:
   port: 8080


### PR DESCRIPTION
## Summary
- remove the `public` schema from Flyway schema lists across service modules
- update shared configuration and test utilities to align with service-specific schemas

## Testing
- mvn -pl shared-lib/shared-test-support test *(fails: missing dependency com.ejada:shared-common:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e2421f35a0832fa9784a22f1c19591