### PR TITLE
Guard subscription approval IT when Docker is unavailable

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -32,7 +32,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest(classes = SubscriptionApplication.class)
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @ActiveProfiles("test")
 @EmbeddedKafka(topics = SubscriptionApprovalConsumerIT.APPROVAL_TOPIC)
 @TestPropertySource(


### PR DESCRIPTION
## Summary
- ensure the subscription approval integration test is skipped automatically when Docker is not available by enabling Testcontainers' disabledWithoutDocker flag

## Testing
- not run (private dependencies are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e248dfcaec832f8a0295786cce98fa