### PR TITLE
test: add Kafka test extension for localhost bootstrap port

### DIFF
--- a/docs/kafka-troubleshooting.md
+++ b/docs/kafka-troubleshooting.md
@@ -1,0 +1,48 @@
+# Kafka Troubleshooting – Controller fails to send `UpdateMetadataRequest`
+
+The platform's local Kafka broker can refuse metadata updates when the
+controller connects over an unexpected listener. In that case the broker
+accepts a socket connection, immediately closes it, and the controller logs
+messages similar to:
+
+```
+[RequestSendThread controllerId=0] Controller 0 epoch 1 fails to send request (type: UpdateMetadataRequest ... type=UNKNOWN ... ) to broker localhost:53413 (id: 0 rack: null). Reconnecting to broker.
+```
+
+This loop normally happens when the broker advertises an address that does
+not match how the controller (or other services) can reach it. The Docker
+Compose file publishes two listeners: one that other containers use and one
+that the host machine uses for local testing. 【F:docker-compose.yml†L61-L73】
+
+## Fix
+
+1. **Keep the container listener untouched.**
+   The `PLAINTEXT://kafka:9092` advertised listener is how every service in
+   the compose network (including the controller) reaches the broker.
+   Changing it to `localhost` (or another host name that only resolves on the
+   host OS) will cause the controller handshake to fail. 【F:docker-compose.yml†L69-L73】
+
+2. **Only customise the host-mapped listener when necessary.**
+   If you need to change the port that developers use from the host machine,
+   update the `PLAINTEXT_HOST://localhost:29092` entry while keeping the
+   `localhost` host name. This listener is never used by other containers, so
+   altering it will not break the controller connection. 【F:docker-compose.yml†L69-L73】
+
+3. **Reset local Kafka data after configuration changes.**
+   Once the advertised listeners have been fixed, wipe the existing broker
+   data to discard corrupted metadata that might still reference the old
+   endpoints:
+
+   ```bash
+   docker compose down
+   docker volume rm newLms_kafkadata
+   docker compose up --build kafka
+   ```
+
+   The `kafkadata` named volume stores metadata and log segments. Removing it
+   ensures the broker starts cleanly with the corrected listener configuration.
+   Adjust the volume name if your Docker Compose project name differs.
+   【F:docker-compose.yml†L85-L86】
+
+Following these steps keeps the controller and broker in sync and prevents the
+rapid connect/disconnect cycle triggered by `UpdateMetadataRequest` failures.

--- a/shared-lib/shared-test-support/pom.xml
+++ b/shared-lib/shared-test-support/pom.xml
@@ -44,10 +44,10 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>
-   <dependency>
-    <groupId>com.redis</groupId>
-    <artifactId>testcontainers-redis</artifactId>
-  </dependency> 
+    <dependency>
+      <groupId>com.redis</groupId>
+      <artifactId>testcontainers-redis</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>

--- a/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/extensions/KafkaTestExtension.java
+++ b/shared-lib/shared-test-support/src/main/java/com/ejada/testsupport/extensions/KafkaTestExtension.java
@@ -1,0 +1,104 @@
+package com.ejada.testsupport.extensions;
+
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.Ports;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.opentest4j.TestAbortedException;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class KafkaTestExtension implements BeforeAllCallback, AfterAllCallback {
+
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create(KafkaTestExtension.class);
+
+    private static final DockerImageName KAFKA_IMAGE = DockerImageName.parse("apache/kafka:3.7.0");
+    private static final String BOOTSTRAP_SERVERS = "localhost:29092";
+
+    @SuppressWarnings("resource")
+    private static final KafkaContainer KAFKA = new KafkaContainer(KAFKA_IMAGE)
+            .withCreateContainerCmdModifier(cmd -> {
+                HostConfig hostConfig = cmd.getHostConfig();
+                if (hostConfig == null) {
+                    hostConfig = new HostConfig();
+                    cmd.withHostConfig(hostConfig);
+                }
+                Ports portBindings = hostConfig.getPortBindings();
+                if (portBindings == null) {
+                    portBindings = new Ports();
+                }
+                portBindings.bind(ExposedPort.tcp(9092), Ports.Binding.bindPort(29092));
+                hostConfig.withPortBindings(portBindings);
+            });
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        ensureDockerAvailable();
+        ensureContainerStarted(context);
+
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("spring.kafka.bootstrap-servers", BOOTSTRAP_SERVERS);
+        properties.put("shared.kafka.bootstrap-servers", BOOTSTRAP_SERVERS);
+
+        Map<String, String> previousValues = SystemPropertyExtensionSupport.apply(properties);
+        getClassStore(context).put(PropertiesHolder.KEY, new PropertiesHolder(previousValues));
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        PropertiesHolder holder = getClassStore(context).remove(PropertiesHolder.KEY, PropertiesHolder.class);
+        if (holder != null) {
+            SystemPropertyExtensionSupport.restore(holder.previousValues());
+        }
+    }
+
+    private void ensureContainerStarted(ExtensionContext context) {
+        ExtensionContext.Store rootStore = context.getRoot().getStore(NAMESPACE);
+        rootStore.getOrComputeIfAbsent("kafka", key -> {
+            if (!KAFKA.isRunning()) {
+                KAFKA.start();
+                verifyFixedBootstrapPort();
+            }
+            return (ExtensionContext.Store.CloseableResource) KAFKA::stop;
+        });
+    }
+
+    private void verifyFixedBootstrapPort() {
+        Integer mappedPort = KAFKA.getMappedPort(9092);
+        if (mappedPort == null || mappedPort != 29092) {
+            throw new IllegalStateException(
+                    "Kafka container did not expose port 29092; actual mapped port was " + mappedPort);
+        }
+    }
+
+    private ExtensionContext.Store getClassStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(KafkaTestExtension.class, context.getRequiredTestClass()));
+    }
+
+    private void ensureDockerAvailable() {
+        try {
+            DockerClientFactory.instance().client();
+        } catch (IllegalStateException ex) {
+            throw new TestAbortedException("Docker is not available for KafkaTestExtension", ex);
+        }
+    }
+
+    public static boolean isRunning() {
+        return KAFKA.isRunning();
+    }
+
+    public static String getBootstrapServers() {
+        return BOOTSTRAP_SERVERS;
+    }
+
+    private record PropertiesHolder(Map<String, String> previousValues) {
+        private static final String KEY = "kafka-properties";
+    }
+}

--- a/shared-lib/shared-test-support/src/test/java/com/ejada/testsupport/extensions/KafkaTestExtensionTest.java
+++ b/shared-lib/shared-test-support/src/test/java/com/ejada/testsupport/extensions/KafkaTestExtensionTest.java
@@ -1,0 +1,21 @@
+package com.ejada.testsupport.extensions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(KafkaTestExtension.class)
+@Testcontainers(disabledWithoutDocker = true)
+class KafkaTestExtensionTest {
+
+    @Test
+    void startsKafkaAndSetsBootstrapServers() {
+        assertThat(KafkaTestExtension.isRunning()).isTrue();
+        assertThat(System.getProperty("spring.kafka.bootstrap-servers"))
+                .isEqualTo(KafkaTestExtension.getBootstrapServers());
+        assertThat(System.getProperty("shared.kafka.bootstrap-servers"))
+                .isEqualTo(KafkaTestExtension.getBootstrapServers());
+    }
+}


### PR DESCRIPTION
## Summary
- restore the shared docker compose Kafka listener mappings so the runtime stack is unchanged
- add a `KafkaTestExtension` in shared test support that provisions a Kafka container bound to `localhost:29092` for tests
- cover the extension with a lightweight verification test while keeping the module dependencies tidy

## Testing
- mvn -pl shared-lib/shared-test-support -am -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e248128bb0832fa09662f4011be529