### PR TITLE
Align Spring Cloud Contract versions and update Redis testcontainers dependency

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -164,9 +164,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>redis</artifactId>
-      <version>1.19.3</version>
+      <groupId>com.redis</groupId>
+      <artifactId>testcontainers-redis</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -220,7 +219,7 @@
       <plugin>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-contract-maven-plugin</artifactId>
-        <version>4.0.4</version>
+        <version>${spring.cloud.contract.version}</version>
         <extensions>true</extensions>
         <configuration>
           <baseClassForTests>com.ejada.gateway.contract.ContractBaseTest</baseClassForTests>

--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -51,6 +51,8 @@
     <jacoco.coverage.minimum>0.00</jacoco.coverage.minimum>
                 <!-- if any module uses Boot plugin -->
     <spring.boot.version>3.5.5</spring.boot.version>
+    <spring.cloud.version>2024.0.2</spring.cloud.version>
+    <spring.cloud.contract.version>4.2.2</spring.cloud.contract.version>
     <spring-boot.run.skip>true</spring-boot.run.skip>
     <flyway.version>11.8.2</flyway.version>
     <mockito.inline.version>5.2.0</mockito.inline.version>

--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -16,6 +16,7 @@
     <!-- Platforms -->
     <spring.boot.version>3.5.5</spring.boot.version>
     <spring.cloud.version>2024.0.2</spring.cloud.version> <!-- 2024.0.3 is not on Central -->
+    <spring.cloud.contract.version>4.2.2</spring.cloud.contract.version>
 
     <!-- Observability & testing infrastructure -->
     <otel.version>1.45.0</otel.version>
@@ -83,6 +84,16 @@
         <version>${spring.cloud.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-contract-verifier</artifactId>
+        <version>${spring.cloud.contract.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-contract-wiremock</artifactId>
+        <version>${spring.cloud.contract.version}</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
## Summary
- add shared properties for Spring Cloud and Spring Cloud Contract versions in the shared library configuration
- import Spring Cloud Contract verifier and wiremock artifacts at version 4.2.2 through the shared BOM
- switch api-gateway to the com.redis testcontainers module and reference the shared Spring Cloud Contract plugin version

## Testing
- mvn -pl shared-lib/shared-bom dependency:resolve -DskipTests

------
https://chatgpt.com/codex/tasks/task_e_68e24a0a06f8832fa7206c4f6b460fd7