### PR TITLE
Fix api-gateway Maven dependency resolution

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -14,6 +14,25 @@
   <name>api-gateway</name>
   <description>Spring Cloud Gateway for LMS platform reusing shared starters</description>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <version>${spring.cloud.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <properties>
     <java.version>21</java.version>
     <spring-boot.run.skip>false</spring-boot.run.skip>
@@ -187,7 +206,7 @@
     <dependency>
       <groupId>de.codecentric</groupId>
       <artifactId>chaos-monkey-spring-boot</artifactId>
-      <version>2.9.7</version>
+      <version>3.2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Summary
- import the Spring Boot and Spring Cloud BOMs directly in the api-gateway module so dependency versions resolve without relying on cached metadata
- update the Chaos Monkey test dependency to version 3.2.2, which is available from Maven Central

## Testing
- mvn -pl api-gateway -am -DskipTests verify *(fails: compilation error due to existing preview feature usage in api-gateway sources)*

------
https://chatgpt.com/codex/tasks/task_e_68e25ff55eb0832fbf348500433a4456