### PR TITLE
Align gateway with Spring Cloud 2024 APIs

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -70,6 +70,10 @@
       <artifactId>spring-cloud-starter-config</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-loadbalancer</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.ulisesbocchio</groupId>
       <artifactId>jasypt-spring-boot-starter</artifactId>
     </dependency>
@@ -142,6 +146,10 @@
     <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-observability</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-tracing</artifactId>
     </dependency>
 
     <dependency>

--- a/api-gateway/src/main/java/com/ejada/gateway/admin/GatewayReadinessIndicator.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/admin/GatewayReadinessIndicator.java
@@ -3,7 +3,6 @@ package com.ejada.gateway.admin;
 import com.ejada.gateway.admin.model.AdminServiceSnapshot;
 import com.ejada.gateway.admin.model.AdminServiceState;
 import com.ejada.gateway.admin.model.DetailedHealthStatus;
-import org.springframework.boot.actuate.autoconfigure.health.Readiness;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.ReactiveHealthIndicator;
 import org.springframework.stereotype.Component;
@@ -13,7 +12,6 @@ import reactor.core.publisher.Mono;
  * Contributes readiness information by validating critical gateway dependencies.
  */
 @Component
-@Readiness
 public class GatewayReadinessIndicator implements ReactiveHealthIndicator {
 
   private final AdminAggregationService adminAggregationService;

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRateLimitProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayRateLimitProperties.java
@@ -99,7 +99,7 @@ public class GatewayRateLimitProperties {
       }
       if (parts.length == 2 && StringUtils.hasText(parts[1])) {
         try {
-          window = DurationStyle.detectAndParse(parts[1].trim(), DurationStyle.SUFFIX);
+          window = DurationStyle.detectAndParse(parts[1].trim());
         } catch (Exception ignored) {
           window = DEFAULT_WINDOW;
         }

--- a/api-gateway/src/main/java/com/ejada/gateway/fallback/BillingFallbackQueue.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/fallback/BillingFallbackQueue.java
@@ -56,7 +56,8 @@ public class BillingFallbackQueue {
   public Mono<String> enqueue(String tenantId, ServerHttpRequest request) {
     Map<String, Object> payload = new LinkedHashMap<>();
     payload.put("tenantId", StringUtils.hasText(tenantId) ? tenantId : "unknown");
-    payload.put("method", request.getMethodValue());
+    String method = request.getMethod() != null ? request.getMethod().name() : "UNKNOWN";
+    payload.put("method", method);
     URI uri = request.getURI();
     payload.put("path", uri.getPath());
     payload.put("query", uri.getQuery());

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/GatewayAccessLogFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/GatewayAccessLogFilter.java
@@ -10,11 +10,13 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.gateway.route.Route;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.core.Ordered;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
@@ -86,7 +88,10 @@ public class GatewayAccessLogFilter implements WebFilter, Ordered {
     payload.put("timestamp", Instant.now().toString());
     payload.put("correlationId", resolveCorrelationId(exchange));
     payload.put("tenantId", trimToNull(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID)));
-    payload.put("method", exchange.getRequest().getMethodValue());
+    String method = Optional.ofNullable(exchange.getRequest().getMethod())
+        .map(HttpMethod::name)
+        .orElse("UNKNOWN");
+    payload.put("method", method);
     payload.put("path", exchange.getRequest().getPath().value());
     payload.put("statusCode", exchange.getResponse().getStatusCode() != null
         ? exchange.getResponse().getStatusCode().value()

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/GatewayMetricsFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/GatewayMetricsFilter.java
@@ -9,6 +9,7 @@ import org.springframework.cloud.gateway.route.Route;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
@@ -46,7 +47,7 @@ public class GatewayMetricsFilter implements WebFilter, Ordered {
   }
 
   private void recordMetrics(ServerWebExchange exchange, Timer.Sample sample, long durationNanos) {
-    HttpStatus status = exchange.getResponse().getStatusCode();
+    HttpStatusCode status = exchange.getResponse().getStatusCode();
     int statusCode = status != null ? status.value() : HttpStatus.OK.value();
     String tenant = trimToDefault(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID));
     meterRegistry.counter("gateway.requests.by_tenant",

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/RequestBodyTransformationGatewayFilterFactory.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/RequestBodyTransformationGatewayFilterFactory.java
@@ -102,10 +102,11 @@ public class RequestBodyTransformationGatewayFilterFactory {
             if (shouldTransformBody && readable > 0) {
               transformed = requestBodyTransformer.transform(effectiveRouteId, bodyBytes);
             }
+            byte[] finalTransformed = transformed;
 
             DataBufferFactory bufferFactory = mutatedExchange.getResponse().bufferFactory();
             Flux<DataBuffer> newBody = Flux.defer(() -> {
-              DataBuffer newBuffer = bufferFactory.wrap(transformed);
+              DataBuffer newBuffer = bufferFactory.wrap(finalTransformed);
               return Mono.just(newBuffer);
             });
 

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/LoadBalancerConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/LoadBalancerConfiguration.java
@@ -3,7 +3,7 @@ package com.ejada.gateway.loadbalancer;
 import com.ejada.gateway.config.GatewayRoutesProperties;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.client.loadbalancer.LoadBalancerClientFactory;
+import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
 import org.springframework.cloud.loadbalancer.annotation.LoadBalancerClients;
 import org.springframework.cloud.loadbalancer.core.ReactorServiceInstanceLoadBalancer;
 import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
@@ -11,6 +11,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.core.env.Environment;
 
 /**
  * Central configuration that replaces the default round-robin load balancer with the
@@ -49,8 +50,9 @@ public class LoadBalancerConfiguration {
       LoadBalancerHealthCheckAggregator aggregator,
       GatewayRoutesProperties routesProperties,
       WebSocketStickTable stickTable,
-      @Value("${spring.cloud.loadbalancer.zone:}") String localZone) {
-    String serviceId = clientFactory.getName();
+      @Value("${spring.cloud.loadbalancer.zone:}") String localZone,
+      Environment environment) {
+    String serviceId = LoadBalancerClientFactory.getName(environment);
     ObjectProvider<ServiceInstanceListSupplier> provider = clientFactory
         .getLazyProvider(serviceId, ServiceInstanceListSupplier.class);
     return new TenantAffinityLoadBalancer(serviceId, provider, aggregator, routesProperties, stickTable, localZone);

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/TenantAffinityLoadBalancer.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/TenantAffinityLoadBalancer.java
@@ -23,6 +23,7 @@ import org.springframework.cloud.client.loadbalancer.Request;
 import org.springframework.cloud.client.loadbalancer.RequestData;
 import org.springframework.cloud.client.loadbalancer.RequestDataContext;
 import org.springframework.cloud.client.loadbalancer.Response;
+import org.springframework.cloud.gateway.route.Route;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.cloud.loadbalancer.core.ReactorServiceInstanceLoadBalancer;
 import org.springframework.cloud.loadbalancer.core.RoundRobinLoadBalancer;
@@ -140,8 +141,11 @@ public class TenantAffinityLoadBalancer implements ReactorServiceInstanceLoadBal
     if (requestData == null) {
       return null;
     }
-    Object attr = requestData.getAttributes().get(ServerWebExchangeUtils.GATEWAY_ROUTE_ID_ATTR);
-    if (attr instanceof String text && StringUtils.hasText(text)) {
+    Object routeAttr = requestData.getAttributes().get(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+    if (routeAttr instanceof Route route) {
+      return route.getId();
+    }
+    if (routeAttr instanceof String text && StringUtils.hasText(text)) {
       return text;
     }
     return null;
@@ -262,14 +266,6 @@ public class TenantAffinityLoadBalancer implements ReactorServiceInstanceLoadBal
   }
 
   private record WeightedInstance(ServiceInstance instance, LoadBalancerHealthCheckAggregator.InstanceState state) {
-
-    ServiceInstance instance() {
-      return instance;
-    }
-
-    LoadBalancerHealthCheckAggregator.InstanceState state() {
-      return state;
-    }
 
     String instanceKey() {
       return state.getInstanceId();

--- a/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
@@ -318,7 +318,10 @@ return {tostring(allowed), tostring(totalRemaining), tostring(resetTimestamp), t
       if (Math.abs(now - timestamp) > INTERNAL_REQUEST_MAX_SKEW_SECONDS) {
         return false;
       }
-      String payload = timestampPart + ":" + exchange.getRequest().getMethodValue() + ":"
+      String method = exchange.getRequest().getMethod() != null
+          ? exchange.getRequest().getMethod().name()
+          : "UNKNOWN";
+      String payload = timestampPart + ":" + method + ":"
           + exchange.getRequest().getPath().value();
       Mac mac = Mac.getInstance("HmacSHA256");
       mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));

--- a/api-gateway/src/main/java/com/ejada/gateway/security/ApiKeyAuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/security/ApiKeyAuthenticationFilter.java
@@ -81,7 +81,8 @@ public class ApiKeyAuthenticationFilter implements WebFilter, Ordered {
         .switchIfEmpty(Mono.defer(() -> {
           LOGGER.debug("API key not found for redis key {}", redisKey);
           metrics.incrementBlocked("api_key", null);
-          return reject(exchange, HttpStatus.UNAUTHORIZED, "ERR_API_KEY_INVALID", "Invalid API key");
+          return reject(exchange, HttpStatus.UNAUTHORIZED, "ERR_API_KEY_INVALID", "Invalid API key")
+              .then(Mono.empty());
         }))
         .flatMap(record -> validateAndAuthenticate(record, apiKey, exchange, chain));
   }

--- a/api-gateway/src/main/java/com/ejada/gateway/subscription/SubscriptionCacheService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/subscription/SubscriptionCacheService.java
@@ -118,14 +118,18 @@ public class SubscriptionCacheService {
 
   public Mono<SubscriptionRecord> fetchAndCache(String tenantId) {
     String key = cacheKey(tenantId);
-    return fetch(tenantId).flatMap(record -> cache(key, record).thenReturn(record));
+    return fetch(tenantId).flatMap(record -> cacheByKey(key, record).thenReturn(record));
   }
 
-  public Mono<Void> cache(String tenantId, SubscriptionRecord record) {
-    return cache(cacheKey(tenantId), record);
+  public Mono<Void> cacheTenant(String tenantId, SubscriptionRecord record) {
+    return cacheByKey(cacheKey(tenantId), record);
   }
 
   public Mono<Void> cache(String cacheKey, SubscriptionRecord record) {
+    return cacheByKey(cacheKey, record);
+  }
+
+  private Mono<Void> cacheByKey(String cacheKey, SubscriptionRecord record) {
     try {
       String value = objectMapper.writeValueAsString(record);
       Duration ttl = Optional.ofNullable(properties.getCacheTtl())

--- a/api-gateway/src/main/java/com/ejada/gateway/transformation/RequestBodyTransformer.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/transformation/RequestBodyTransformer.java
@@ -52,8 +52,7 @@ public class RequestBodyTransformer {
       return original;
     }
   }
-}
-
   private static final Configuration BASE_CONFIGURATION = Configuration.defaultConfiguration()
-      .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL, Option.SUPPRESS_EXCEPTIONS, Option.CREATE_PATH);
+      .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL, Option.SUPPRESS_EXCEPTIONS);
+}
 

--- a/api-gateway/src/main/java/com/ejada/gateway/transformation/TransformationRuleCache.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/transformation/TransformationRuleCache.java
@@ -5,9 +5,7 @@ import com.ejada.gateway.config.GatewayTransformationProperties.RequestTransform
 import com.ejada.gateway.config.GatewayTransformationProperties.RouteTransformation;
 import com.ejada.gateway.config.GatewayTransformationProperties.RequestRule;
 import com.ejada.gateway.config.GatewayTransformationProperties.RequestOperation;
-import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -66,10 +64,10 @@ public class TransformationRuleCache {
 
   private CompiledRequestRule compileRule(RequestRule rule) {
     try {
-      JsonPath path = JsonPath.using(BASE_CONFIGURATION).compile(rule.getJsonPath());
+      JsonPath path = JsonPath.compile(rule.getJsonPath());
       JsonPath target = null;
       if (rule.getOperation() == RequestOperation.RENAME && rule.getTargetPath() != null) {
-        target = JsonPath.using(BASE_CONFIGURATION).compile(rule.getTargetPath());
+        target = JsonPath.compile(rule.getTargetPath());
       }
       return new CompiledRequestRule(rule, path, target);
     } catch (Exception ex) {
@@ -81,7 +79,4 @@ public class TransformationRuleCache {
   private record CachedRequestRules(long version, List<CompiledRequestRule> rules) {
   }
 }
-
-  private static final Configuration BASE_CONFIGURATION = Configuration.defaultConfiguration()
-      .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL, Option.SUPPRESS_EXCEPTIONS, Option.CREATE_PATH);
 

--- a/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionMappingResolver.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionMappingResolver.java
@@ -17,7 +17,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.UriTemplate;
-import org.springframework.web.util.pattern.PathContainer;
+import org.springframework.http.server.PathContainer;
 import org.springframework.web.util.pattern.PathPattern;
 import org.springframework.web.util.pattern.PathPattern.PathMatchInfo;
 import org.springframework.web.util.pattern.PathPatternParser;


### PR DESCRIPTION
## Summary
- add the Spring Cloud load balancer and Micrometer tracing dependencies and refresh the JsonPath-based request transformation utilities for the latest library APIs
- adapt the gateway load balancer, caching, and resilience helpers to the updated Spring Cloud LoadBalancer and Resilience4j contracts
- modernize HTTP method, status, and readiness handling across filters and fallback controllers to match Spring Boot 3.5 changes

## Testing
- mvn -pl api-gateway -am -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68e268ac85b0832f83d55a36f970790a