### PR TITLE
Fix transactional send in SubscriptionApprovalConsumerIT

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -118,7 +118,14 @@ class SubscriptionApprovalConsumerIT {
                 OffsetDateTime.now(),
                 null);
 
-        kafkaTemplate.send(APPROVAL_TOPIC, message.requestId().toString(), message).get(10, TimeUnit.SECONDS);
+        kafkaTemplate
+                .executeInTransaction(operations -> {
+                    operations
+                            .send(APPROVAL_TOPIC, message.requestId().toString(), message)
+                            .completable()
+                            .get(10, TimeUnit.SECONDS);
+                    return null;
+                });
 
         assertThat(latch.await(15, TimeUnit.SECONDS)).as("listener should publish provisioning payload").isTrue();
 


### PR DESCRIPTION
## Summary
- execute the KafkaTemplate send inside a transaction in SubscriptionApprovalConsumerIT so that transactional producers are handled correctly

## Testing
- not run (tests require extensive multi-module Maven build and were skipped in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e26e76e378832fa39b9ddd5b2e8202