### PR TITLE
Fix KafkaTemplate send usage in SubscriptionApprovalConsumerIT

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -122,7 +122,6 @@ class SubscriptionApprovalConsumerIT {
                 .executeInTransaction(operations -> {
                     operations
                             .send(APPROVAL_TOPIC, message.requestId().toString(), message)
-                            .completable()
                             .get(10, TimeUnit.SECONDS);
                     return null;
                 });


### PR DESCRIPTION
## Summary
- update SubscriptionApprovalConsumerIT to call `CompletableFuture#get` directly after sending the message via `KafkaTemplate`

## Testing
- mvn -pl tenant-platform/subscription-service -am test -DskipITs *(fails: shared-common tests abort because `net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar` is missing in the local Maven repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e2722946c8832f99bd2a3ff4061290