### PR TITLE
Fix gateway security tests for Spring 6 builders

### DIFF
--- a/api-gateway/src/test/java/com/ejada/gateway/security/ApiKeyAuthenticationFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/security/ApiKeyAuthenticationFilterTest.java
@@ -93,7 +93,7 @@ class ApiKeyAuthenticationFilterTest {
     StepVerifier.create(filter.filter(exchange, chain)).verifyComplete();
 
     assertThat(exchange.getRequest().getHeaders().getFirst(HeaderNames.X_TENANT_ID)).isEqualTo("tenant-a");
-    assertThat(exchange.getAttribute(GatewayRequestAttributes.TENANT_ID)).isEqualTo("tenant-a");
+    assertThat((String) exchange.getAttribute(GatewayRequestAttributes.TENANT_ID)).isEqualTo("tenant-a");
     assertThat(authenticationRef.get()).isInstanceOf(ApiKeyAuthenticationToken.class);
     double validated = meterRegistry.get("gateway.security.api_key_validated").counter().count();
     assertThat(validated).isEqualTo(1.0d);

--- a/api-gateway/src/test/java/com/ejada/gateway/security/RequestSignatureValidationFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/security/RequestSignatureValidationFilterTest.java
@@ -19,6 +19,7 @@ import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -73,7 +74,7 @@ class RequestSignatureValidationFilterTest {
     MockServerHttpRequest request = MockServerHttpRequest.post("/secure")
         .header(HeaderNames.X_TENANT_ID, "tenant-a")
         .header("X-Signature", hmac("POST\n/secure\n\n" + body))
-        .bodyValue(body);
+        .body(BodyInserters.fromValue(body));
     MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
     java.util.concurrent.atomic.AtomicReference<String> captured = new java.util.concurrent.atomic.AtomicReference<>();
@@ -94,7 +95,7 @@ class RequestSignatureValidationFilterTest {
   void rejectsWhenSignatureMissing() {
     MockServerHttpRequest request = MockServerHttpRequest.post("/secure")
         .header(HeaderNames.X_TENANT_ID, "tenant-a")
-        .bodyValue("");
+        .body(BodyInserters.fromValue(""));
     MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
     WebFilterChain chain = webExchange -> Mono.empty();
@@ -110,7 +111,7 @@ class RequestSignatureValidationFilterTest {
     MockServerHttpRequest request = MockServerHttpRequest.post("/secure")
         .header(HeaderNames.X_TENANT_ID, "tenant-a")
         .header("X-Signature", "deadbeef")
-        .bodyValue("");
+        .body(BodyInserters.fromValue(""));
     MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
     WebFilterChain chain = webExchange -> Mono.empty();


### PR DESCRIPTION
## Summary
- cast the tenant attribute lookup in `ApiKeyAuthenticationFilterTest` to avoid AssertJ predicate overload ambiguity
- replace deprecated `bodyValue` usage with `BodyInserters.fromValue` in the signature validation tests for compatibility with Spring 6 builders

## Testing
- `mvn -pl api-gateway test -DskipITs` *(fails: missing internal com.ejada starter artifacts in Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e2771f75ac832fa7f185415cf77096