### PR TITLE
Fix RequestSignatureValidationFilterTest body creation

### DIFF
--- a/api-gateway/src/test/java/com/ejada/gateway/security/RequestSignatureValidationFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/security/RequestSignatureValidationFilterTest.java
@@ -19,7 +19,6 @@ import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
-import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -74,7 +73,7 @@ class RequestSignatureValidationFilterTest {
     MockServerHttpRequest request = MockServerHttpRequest.post("/secure")
         .header(HeaderNames.X_TENANT_ID, "tenant-a")
         .header("X-Signature", hmac("POST\n/secure\n\n" + body))
-        .body(BodyInserters.fromValue(body));
+        .body(body);
     MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
     java.util.concurrent.atomic.AtomicReference<String> captured = new java.util.concurrent.atomic.AtomicReference<>();
@@ -95,7 +94,7 @@ class RequestSignatureValidationFilterTest {
   void rejectsWhenSignatureMissing() {
     MockServerHttpRequest request = MockServerHttpRequest.post("/secure")
         .header(HeaderNames.X_TENANT_ID, "tenant-a")
-        .body(BodyInserters.fromValue(""));
+        .body("");
     MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
     WebFilterChain chain = webExchange -> Mono.empty();
@@ -111,7 +110,7 @@ class RequestSignatureValidationFilterTest {
     MockServerHttpRequest request = MockServerHttpRequest.post("/secure")
         .header(HeaderNames.X_TENANT_ID, "tenant-a")
         .header("X-Signature", "deadbeef")
-        .body(BodyInserters.fromValue(""));
+        .body("");
     MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
     WebFilterChain chain = webExchange -> Mono.empty();


### PR DESCRIPTION
## Summary
- replace usage of `BodyInserters` in `RequestSignatureValidationFilterTest` with the `MockServerHttpRequest` string body builder overload
- drop the now-unused `BodyInserters` import

## Testing
- `mvn -pl api-gateway test -DskipITs` *(fails: missing internal com.ejada starter artifacts in Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e278d97558832fb84606c23ce5ab6a