### PR TITLE
Handle blank environment profile when tagging metrics

### DIFF
--- a/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/metrics/CommonTagsCustomizer.java
+++ b/shared-lib/shared-starters/starter-actuator/src/main/java/com/ejada/actuator/starter/metrics/CommonTagsCustomizer.java
@@ -5,6 +5,7 @@ import com.ejada.actuator.starter.config.SharedActuatorProperties;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 
 public class CommonTagsCustomizer implements MeterRegistryCustomizer<MeterRegistry> {
 
@@ -24,7 +25,8 @@ public class CommonTagsCustomizer implements MeterRegistryCustomizer<MeterRegist
       tags.add("application"); tags.add(env.getProperty("spring.application.name", "app"));
     }
     if (common.isEnvironmentEnabled()) {
-      tags.add("env"); tags.add(env.getProperty("ENV", env.getProperty("SPRING_PROFILES_ACTIVE", "default")));
+      tags.add("env");
+      tags.add(resolveEnvironmentTag());
     }
     if (common.isRegionEnabled()) {
       tags.add("region"); tags.add(env.getProperty("REGION", "unknown"));
@@ -35,5 +37,13 @@ public class CommonTagsCustomizer implements MeterRegistryCustomizer<MeterRegist
     if (!tags.isEmpty()) {
       registry.config().commonTags(tags.toArray(String[]::new));
     }
+  }
+
+  private String resolveEnvironmentTag() {
+    var environment = env.getProperty("ENV");
+    if (!StringUtils.hasText(environment)) {
+      environment = env.getProperty("SPRING_PROFILES_ACTIVE");
+    }
+    return StringUtils.hasText(environment) ? environment : "default";
   }
 }


### PR DESCRIPTION
## Summary
- ensure the common metrics "env" tag falls back to "default" when ENV and SPRING_PROFILES_ACTIVE are blank

## Testing
- mvn -pl shared-lib/shared-starters/starter-actuator test -DskipITs

------
https://chatgpt.com/codex/tasks/task_e_68e29ecc01b4832fb86affb104b110ac