### PR TITLE
Fix Flyway role hierarchy migration

### DIFF
--- a/sec-service/src/main/resources/db/migration/postgresql/V7__add_role_hierarchy.sql
+++ b/sec-service/src/main/resources/db/migration/postgresql/V7__add_role_hierarchy.sql
@@ -58,8 +58,8 @@ WHERE code = 'END_USER';
 -- ============================================
 
 -- Ensure role_level has valid values
-ALTER TABLE roles 
-ADD CONSTRAINT IF NOT EXISTS ck_role_level_valid 
+ALTER TABLE roles
+ADD CONSTRAINT ck_role_level_valid
 CHECK (role_level IN (
     'PLATFORM_ADMIN', 
     'TENANT_ADMIN', 
@@ -70,8 +70,8 @@ CHECK (role_level IN (
 ));
 
 -- Prevent deletion of system roles via constraint (soft constraint)
-ALTER TABLE roles 
-ADD CONSTRAINT IF NOT EXISTS ck_system_role_protection 
+ALTER TABLE roles
+ADD CONSTRAINT ck_system_role_protection
 CHECK (is_system_role = false OR id IS NOT NULL);
 
 -- ============================================


### PR DESCRIPTION
## Summary
- remove unsupported IF NOT EXISTS clauses from role hierarchy constraint creation
- ensure Flyway migration runs without PostgreSQL syntax errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e29f13a074832fb6da017757bca2b4