### PR TITLE
Refactor callback orchestrator into focused services

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/MarketplaceCallbackEndpoints.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/MarketplaceCallbackEndpoints.java
@@ -1,0 +1,9 @@
+package com.ejada.subscription.acl;
+
+public final class MarketplaceCallbackEndpoints {
+
+    public static final String NOTIFICATION = "RECEIVE_NOTIFICATION";
+    public static final String UPDATE = "RECEIVE_UPDATE";
+
+    private MarketplaceCallbackEndpoints() {}
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/IdempotentRequestService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/IdempotentRequestService.java
@@ -1,0 +1,53 @@
+package com.ejada.subscription.acl.service;
+
+import com.ejada.common.marketplace.token.TokenHashing;
+import com.ejada.subscription.model.IdempotentRequest;
+import com.ejada.subscription.repository.IdempotentRequestRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class IdempotentRequestService {
+
+    private final IdempotentRequestRepository idempotentRequestRepository;
+    private final ObjectMapper objectMapper;
+    private final NewTransactionExecutor newTransactionExecutor;
+
+    public void record(final java.util.UUID rqUid, final String endpoint, final Object payload) {
+        if (rqUid == null) {
+            return;
+        }
+        newTransactionExecutor.run(
+                () -> {
+                    if (idempotentRequestRepository.existsByIdempotencyKey(rqUid)) {
+                        return;
+                    }
+                    IdempotentRequest request = new IdempotentRequest();
+                    request.setIdempotencyKey(rqUid);
+                    request.setEndpoint(endpoint);
+                    request.setRequestHash(TokenHashing.sha256(writeJson(payload)));
+                    try {
+                        idempotentRequestRepository.save(request);
+                    } catch (Exception ex) {
+                        log.warn(
+                                "Failed to persist idempotent request {} for endpoint {}",
+                                rqUid,
+                                endpoint,
+                                ex);
+                    }
+                },
+                "persist idempotent request");
+    }
+
+    private String writeJson(final Object payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (Exception e) {
+            return "{\"error\":\"serialize\"}";
+        }
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/NewTransactionExecutor.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/NewTransactionExecutor.java
@@ -1,0 +1,41 @@
+package com.ejada.subscription.acl.service;
+
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NewTransactionExecutor {
+
+    private final PlatformTransactionManager transactionManager;
+
+    public <T> T execute(Supplier<T> supplier, String description) {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        try {
+            return template.execute(status -> supplier.get());
+        } catch (RuntimeException txEx) {
+            log.error("{}", description, txEx);
+            throw txEx;
+        }
+    }
+
+    public void run(Runnable task, String description) {
+        try {
+            execute(
+                    () -> {
+                        task.run();
+                        return null;
+                    },
+                    description);
+        } catch (RuntimeException ignored) {
+            // already logged inside execute
+        }
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/NotificationAuditService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/NotificationAuditService.java
@@ -1,0 +1,75 @@
+package com.ejada.subscription.acl.service;
+
+import com.ejada.common.marketplace.token.TokenHashing;
+import com.ejada.subscription.model.InboundNotificationAudit;
+import com.ejada.subscription.repository.InboundNotificationAuditRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.interceptor.TransactionAspectSupport;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationAuditService {
+
+    private final InboundNotificationAuditRepository auditRepository;
+    private final ObjectMapper objectMapper;
+    private final NewTransactionExecutor newTransactionExecutor;
+
+    public InboundNotificationAudit recordInboundAudit(
+            final java.util.UUID rqUid, final String token, final Object payload, final String endpoint) {
+        final String tokenHash = token == null ? null : TokenHashing.sha256(token);
+        final String payloadJson = payload == null ? null : writeJson(payload);
+
+        return newTransactionExecutor.execute(
+                () ->
+                        auditRepository
+                                .findByRqUidAndEndpoint(rqUid, endpoint)
+                                .orElseGet(
+                                        () -> {
+                                            InboundNotificationAudit audit = new InboundNotificationAudit();
+                                            audit.setRqUid(rqUid);
+                                            audit.setEndpoint(endpoint);
+                                            audit.setTokenHash(tokenHash);
+                                            audit.setPayload(payloadJson);
+                                            try {
+                                                return auditRepository.save(audit);
+                                            } catch (org.springframework.dao.DataIntegrityViolationException ex) {
+                                                return auditRepository
+                                                        .findByRqUidAndEndpoint(rqUid, endpoint)
+                                                        .orElseThrow(() -> ex);
+                                            }
+                                        }),
+                "persist inbound notification audit");
+    }
+
+    public void markSuccess(final Long auditId, final String code, final String desc, final String detailsJson) {
+        newTransactionExecutor.run(
+                () -> auditRepository.markProcessed(auditId, code, desc, detailsJson),
+                "mark inbound audit success");
+    }
+
+    public void markFailure(final Long auditId, final String code, final String desc, final String detailsJson) {
+        newTransactionExecutor.run(
+                () -> auditRepository.markProcessed(auditId, code, desc, detailsJson),
+                "mark inbound audit failure");
+    }
+
+    public void markRollbackOnlyIfActive() {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
+        }
+    }
+
+    private String writeJson(final Object payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (Exception e) {
+            log.warn("Failed to serialize payload for audit", e);
+            return "{\"error\":\"serialize\"}";
+        }
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/NotificationReplayService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/NotificationReplayService.java
@@ -1,0 +1,60 @@
+package com.ejada.subscription.acl.service;
+
+import com.ejada.common.dto.ServiceResult;
+import com.ejada.common.marketplace.subscription.dto.ReceiveSubscriptionNotificationRq;
+import com.ejada.common.marketplace.subscription.dto.ReceiveSubscriptionNotificationRs;
+import com.ejada.subscription.acl.MarketplaceCallbackEndpoints;
+import com.ejada.subscription.mapper.SubscriptionEnvironmentIdentifierMapper;
+import com.ejada.subscription.model.SubscriptionEnvironmentIdentifier;
+import com.ejada.subscription.repository.InboundNotificationAuditRepository;
+import com.ejada.subscription.repository.SubscriptionEnvironmentIdentifierRepository;
+import com.ejada.subscription.repository.SubscriptionRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationReplayService {
+
+    private final InboundNotificationAuditRepository auditRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionEnvironmentIdentifierRepository envIdentifierRepository;
+    private final SubscriptionEnvironmentIdentifierMapper envIdentifierMapper;
+
+    private final Map<UUID, ServiceResult<ReceiveSubscriptionNotificationRs>> processedCache =
+            new ConcurrentHashMap<>();
+
+    public ServiceResult<ReceiveSubscriptionNotificationRs> replayNotificationIfProcessed(
+            final UUID rqUid, final ReceiveSubscriptionNotificationRq rq) {
+        if (rqUid == null || rq == null || rq.subscriptionInfo() == null) {
+            return null;
+        }
+
+        return processedCache.computeIfAbsent(
+                rqUid,
+                key ->
+                        auditRepository
+                                .findByRqUidAndEndpoint(key, MarketplaceCallbackEndpoints.NOTIFICATION)
+                                .filter(audit -> Boolean.TRUE.equals(audit.getProcessed()))
+                                .map(audit -> {
+                                    var info = rq.subscriptionInfo();
+                                    var maybeSub =
+                                            subscriptionRepository.findByExtSubscriptionIdAndExtCustomerId(
+                                                    info.subscriptionId(), info.customerId());
+                                    List<SubscriptionEnvironmentIdentifier> ids = maybeSub
+                                            .map(sub ->
+                                                    envIdentifierRepository.findBySubscriptionSubscriptionId(
+                                                            sub.getSubscriptionId()))
+                                            .orElseGet(List::of);
+                                    ReceiveSubscriptionNotificationRs rs =
+                                            new ReceiveSubscriptionNotificationRs(
+                                                    Boolean.TRUE, envIdentifierMapper.toDtoList(ids));
+                                    return ServiceResult.ok(rs);
+                                })
+                                .orElse(null));
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/SubscriptionOutboxService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/SubscriptionOutboxService.java
@@ -1,0 +1,39 @@
+package com.ejada.subscription.acl.service;
+
+import com.ejada.subscription.model.OutboxEvent;
+import com.ejada.subscription.repository.OutboxEventRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubscriptionOutboxService {
+
+    private final OutboxEventRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+
+    public void emit(final String aggregate, final String id, final String type, final java.util.Map<String, ?> payload) {
+        try {
+            OutboxEvent ev = new OutboxEvent();
+            ev.setAggregateType(aggregate);
+            ev.setAggregateId(id);
+            ev.setEventType(type);
+            ev.setPayload(writeJson(payload));
+            outboxRepository.save(ev);
+        } catch (Exception e) {
+            log.warn("Outbox emit failed: {} {} - {}", type, id, e.toString());
+            log.debug("Outbox emit failure details", e);
+        }
+    }
+
+    private String writeJson(final java.util.Map<String, ?> payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (Exception e) {
+            return "{\"error\":\"serialize\"}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract dedicated services for audits, notification replay, idempotent requests, outbox publishing, and transaction helpers
- simplify `MarketplaceCallbackOrchestrator` to delegate cross-cutting concerns to the new services
- update unit tests to mock the new collaborators and assert the revised orchestration behaviour

## Testing
- `mvn -q -DskipITs test` *(fails: missing internal BOM/dependency versions in shared POMs)*

------
https://chatgpt.com/codex/tasks/task_e_68e29e253dc0832fbb24e548d4f3408a