### PR TITLE
Fix API gateway Docker image to ignore stub jar

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -13,10 +13,10 @@ WORKDIR /app
 COPY target/*.jar ./
 
 RUN set -eux; \
-    BOOT_JAR=$(find . -maxdepth 1 -name 'api-gateway-*.jar' ! -name '*-plain.jar' | head -n 1); \
+    BOOT_JAR=$(find . -maxdepth 1 -type f -name 'api-gateway-*.jar' ! -name '*-plain.jar' ! -name '*-stubs.jar' ! -name '*.original' | sort | head -n 1); \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
-    find . -maxdepth 1 -name 'api-gateway-*-plain.jar' -delete; \
+    find . -maxdepth 1 -type f \( -name 'api-gateway-*-plain.jar' -o -name 'api-gateway-*-stubs.jar' -o -name 'api-gateway-*.jar.original' \) -delete; \
     chown -R appuser:appgroup /app
 
 USER appuser


### PR DESCRIPTION
## Summary
- ensure the API gateway Docker image only packages the executable Spring Boot jar
- remove generated stub/plain/original jars so the container always runs the correct artifact

## Testing
- mvn -pl api-gateway -am clean package -DskipTests

------
https://chatgpt.com/codex/tasks/task_e_68e29f630f10832f81d97fc8956ecb14