### PR TITLE
Add bounded cache for processed notification replay

### DIFF
--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
     <!-- DB & Migrations -->
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- replace the unbounded processed notification map with a bounded Caffeine cache and TTL
- cache Optional results to avoid redundant lookups while still expiring stale entries
- add the Caffeine dependency to the subscription service module

## Testing
- mvn -pl tenant-platform/subscription-service test *(fails: missing internal com.ejada dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a18ddd4c832f89dc5a846968714f