### PR TITLE
Improve billing consumption diagnostics

### DIFF
--- a/tenant-platform/billing-service/src/test/java/com/ejada/billing/service/impl/ConsumptionServiceImplTest.java
+++ b/tenant-platform/billing-service/src/test/java/com/ejada/billing/service/impl/ConsumptionServiceImplTest.java
@@ -84,8 +84,8 @@ class ConsumptionServiceImplTest {
 
     assertThat(result.success()).isFalse();
     assertThat(result.statusCode()).isEqualTo("EINT000");
-    assertThat(result.statusDetails()).contains("Unexpected Error");
-    assertThat(result.debugId()).isNotBlank();
+    assertThat(result.statusDetails()).contains("Unexpected Error", "Diagnostic Key: usage-event:2");
+    assertThat(result.debugId()).isEqualTo("usage-event:2");
 
     verify(eventMapper).build(eq(rqUid), any(), any(), eq(11L), eq("EINT000"), eq("Unexpected Error"), any());
     verify(eventRepository, times(1)).save(auditEvent);


### PR DESCRIPTION
## Summary
- return the persisted usage-event identifier as the debug key when tracking consumption fails
- centralize JSON serialization fallback handling for usage event payloads and details

## Testing
- `mvn -pl tenant-platform/billing-service test -Dtest=ConsumptionServiceImplTest` *(fails: repository references internal artifacts that are not published to Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a1b694c0832f8ff04cc554af36e5