### PR TITLE
Make config server fail-fast optional

### DIFF
--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -26,7 +26,7 @@ spring:
       label: ${SPRING_CLOUD_CONFIG_LABEL:main}
       username: ${SPRING_CLOUD_CONFIG_USERNAME:}
       password: ${SPRING_CLOUD_CONFIG_PASSWORD:}
-      fail-fast: true
+      fail-fast: ${SPRING_CLOUD_CONFIG_FAIL_FAST:false}
   r2dbc:
     url: ${SPRING_R2DBC_URL:}
     username: ${SPRING_R2DBC_USERNAME:}


### PR DESCRIPTION
## Summary
- allow overriding the Spring Cloud Config fail-fast flag via environment variable, defaulting to false so the gateway can start without the config server

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a7f990a8832f98ccadc66a28821f