### PR TITLE
Configure HS256 secret for analytics service

### DIFF
--- a/tenant-platform/analytics-service/src/main/resources/application.yml
+++ b/tenant-platform/analytics-service/src/main/resources/application.yml
@@ -54,6 +54,9 @@ management:
 
 shared:
   security:
+    mode: ${SHARED_SECURITY_MODE:hs256}
+    hs256:
+      secret: ${SHARED_SECURITY_HS256_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
     resource-server:
       enabled: false
     jwt:


### PR DESCRIPTION
## Summary
- set explicit HS256 configuration for the analytics service dev profile
- provide default secret values via environment overrides to satisfy security starter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a87fb218832f9e1c6c11b872dfd5