### PR TITLE
Enable buffering application startup across shared configs

### DIFF
--- a/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    application-startup: buffering
   datasource:
     url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:ejada}?currentSchema=setup}"
     username: ${DB_USERNAME:postgres}

--- a/shared-lib/shared-config/src/main/resources/application-shared-platform-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-platform-dev.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    application-startup: buffering
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
     consumer:

--- a/shared-lib/shared-config/src/main/resources/application-shared-tenant-qa.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-tenant-qa.yaml
@@ -4,6 +4,8 @@ app:
   schema: tenant
 
 spring:
+  main:
+    application-startup: buffering
   datasource:
     url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:ejada}?currentSchema=${app.schema}}"
     username: ${DB_USERNAME}


### PR DESCRIPTION
## Summary
- set `spring.main.application-startup=buffering` in shared configuration profiles so Spring Boot wires the BufferingApplicationStartup
- ensures services that import the shared config can expose the actuator startup endpoint when enabled

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2ac71a9a8832f8376945b41c9793f