### PR TITLE
Override Kotlin coroutines BOM version

### DIFF
--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -17,6 +17,9 @@
     <spring.boot.version>3.5.5</spring.boot.version>
     <spring.cloud.version>2024.0.2</spring.cloud.version> <!-- 2024.0.3 is not on Central -->
     <spring.cloud.contract.version>4.2.2</spring.cloud.contract.version>
+    <!-- Override Kotlin coroutines BOM version to avoid fetching the
+         corrupted 1.6.4 descriptor that some mirrors serve as HTML -->
+    <kotlinx-coroutines.version>1.8.1</kotlinx-coroutines.version>
 
     <!-- Observability & testing infrastructure -->
     <otel.version>1.45.0</otel.version>


### PR DESCRIPTION
## Summary
- pin the kotlinx-coroutines BOM to 1.8.1 in the shared BOM to avoid mirrors serving the corrupted 1.6.4 descriptor

## Testing
- mvn -pl shared-lib/shared-bom help:evaluate -Dexpression=kotlinx-coroutines.version -DforceStdout

------
https://chatgpt.com/codex/tasks/task_e_68e2b160fd14832fb77421433be609e3