### PR TITLE
Ensure Jasypt encryption works with required crypto provider

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -77,6 +77,10 @@
       <groupId>com.github.ulisesbocchio</groupId>
       <artifactId>jasypt-spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+    </dependency>
 
     <!-- Shared starters & libraries -->
     <dependency>

--- a/shared-lib/shared-bom/pom.xml
+++ b/shared-lib/shared-bom/pom.xml
@@ -44,6 +44,7 @@
 
     <!-- Security / resilience -->
     <jjwt.version>0.13.0</jjwt.version> <!-- per jjwt install guide -->
+    <bouncycastle.version>1.78.1</bouncycastle.version>
     <resilience4j.version>2.2.0</resilience4j.version>
     <bucket4j.version>8.14.0</bucket4j.version>
 
@@ -232,6 +233,11 @@
         <groupId>com.github.ulisesbocchio</groupId>
         <artifactId>jasypt-spring-boot-starter</artifactId>
         <version>${jasypt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
## Summary
- add the BouncyCastle provider to the shared BOM and api-gateway module so Jasypt can load the AES-256 encryptor
- ensures the gateway starts even when the external Config Server is unavailable and encrypted properties are still present

## Testing
- mvn -pl api-gateway -am -DskipTests package


------
https://chatgpt.com/codex/tasks/task_e_68e2b2314834832fb62d0ada2de64506