### PR TITLE
Provide default dev crypto key for setup service

### DIFF
--- a/setup-service/src/main/resources/application-dev.yaml
+++ b/setup-service/src/main/resources/application-dev.yaml
@@ -190,7 +190,7 @@ shared:
     in-memory:
       activeKid: ${CRYPTO_ACTIVE_KID:local-dev-key}
       keys:
-        ${CRYPTO_ACTIVE_KID:local-dev-key}: ${CRYPTO_LOCAL_DEV_KEY:?set CRYPTO_LOCAL_DEV_KEY via Vault or Secrets Manager}
+        ${CRYPTO_ACTIVE_KID:local-dev-key}: ${CRYPTO_LOCAL_DEV_KEY:4J8bfqUaEqzJCQakoJPM3w==}
     vault:
       endpoint: ${VAULT_URI:}
       transitPath: ${VAULT_TRANSIT_PATH:transit}


### PR DESCRIPTION
## Summary
- add a default in-memory encryption key for the dev profile so the setup service can start without external secret configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b21f6448832f9f7cfad3c5d7a059