### PR TITLE
Support legacy JWT secret property

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/JwtDecoderAutoConfigurationTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/JwtDecoderAutoConfigurationTest.java
@@ -60,6 +60,22 @@ class JwtDecoderAutoConfigurationTest {
         });
   }
 
+  @Test
+  void legacyJwtSecretPropertyIsBackwardsCompatible() {
+    contextRunner.withPropertyValues("shared.security.jwt.secret=" + BASE64_SECRET)
+        .run(context -> {
+          assertThat(context).hasNotFailed();
+          JwtDecoder decoder = context.getBean(JwtDecoder.class);
+          try {
+            String token = createHs256Token(BASE64_SECRET, "legacy-user");
+            Jwt jwt = decoder.decode(token);
+            assertThat(jwt.getSubject()).isEqualTo("legacy-user");
+          } catch (JOSEException e) {
+            fail("Failed to create test token", e);
+          }
+        });
+  }
+
   private static String createHs256Token(String base64Secret, String subject) throws JOSEException {
     byte[] keyBytes = Base64.getDecoder().decode(base64Secret);
     JWSSigner signer = new MACSigner(keyBytes);


### PR DESCRIPTION
## Summary
- populate the hs256 secret from the legacy `shared.security.jwt.secret` so contexts keep starting without the new property
- cover the compatibility path with a JwtDecoder auto-configuration test

## Testing
- mvn -pl shared-lib/shared-starters/starter-security -am test
- mvn -pl setup-service -am test

------
https://chatgpt.com/codex/tasks/task_e_68e2b7cc4850832f8a1ed0ff9abc0070