### PR TITLE
Configure strong Jasypt encryptor for API gateway

### DIFF
--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -24,6 +24,7 @@ All configuration lives in [`src/main/resources/application.yaml`](src/main/reso
 - `shared.security` – JWT/OIDC configuration and CORS policy.
 - `resilience4j.*` – circuit breaker/retry/bulkhead defaults.
 - `spring.cloud.gateway.*` – HTTP client tuning, rate limiting, metrics.
+- `jasypt.encryptor.*` – password and cipher settings for decrypting secrets served by the Config Server.
 
 A configuration reload (Spring Cloud Config or Kubernetes ConfigMap) triggers the [`GatewayRoutesRefresher`](src/main/java/com/ejada/gateway/config/GatewayRoutesRefresher.java) which publishes a `RefreshRoutesEvent` and reloads dynamic routes without downtime.
 
@@ -38,6 +39,21 @@ mvn -pl api-gateway test
 ```
 
 Enable debug logging by exporting `LOGGING_LEVEL_COM_EJADA_GATEWAY=DEBUG`.
+
+### Decrypting Secure Configuration
+
+Encrypted values retrieved from Spring Cloud Config (or environment-specific YAML files) rely on
+Jasypt. Provide the encryption password through the `JASYPT_ENCRYPTOR_PASSWORD` environment variable
+before starting the gateway:
+
+```bash
+export JASYPT_ENCRYPTOR_PASSWORD="local-dev-secret"
+mvn -pl api-gateway spring-boot:run -Dspring-boot.run.profiles=local
+```
+
+The default encryptor uses `PBEWITHHMACSHA512ANDAES_256` with a random IV and salt generator. Override
+any of the `jasypt.encryptor.*` settings if you need to align with a cloud KMS strategy or
+per-tenant key rotation.
 
 ## Building the Container
 

--- a/api-gateway/src/main/java/com/ejada/gateway/config/MultiTenantJasyptConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/MultiTenantJasyptConfiguration.java
@@ -1,0 +1,61 @@
+package com.ejada.gateway.config;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+/**
+ * Customises the Jasypt encryptor so that multi-tenant deployments can rely on
+ * a strong, pooled cipher configuration. The encryptor intentionally fails fast
+ * when the password is missing to avoid silently booting without the ability to
+ * decrypt shared secrets.
+ */
+@Configuration
+@EnableConfigurationProperties(TenantJasyptProperties.class)
+public class MultiTenantJasyptConfiguration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MultiTenantJasyptConfiguration.class);
+
+  @Bean(name = "jasyptStringEncryptor")
+  @ConditionalOnMissingBean(name = "jasyptStringEncryptor")
+  public StringEncryptor jasyptStringEncryptor(TenantJasyptProperties properties) {
+    if (!StringUtils.hasText(properties.getPassword())) {
+      throw new IllegalStateException(
+          "Jasypt encryption password is not configured. "
+              + "Set the JASYPT_ENCRYPTOR_PASSWORD environment variable or the "
+              + "jasypt.encryptor.password property before starting the API Gateway.");
+    }
+
+    LOGGER.info("Initialising Jasypt encryptor with algorithm '{}' and pool size {}", properties.getAlgorithm(),
+        properties.getPoolSize());
+
+    PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+    encryptor.setConfig(createConfig(properties));
+    return encryptor;
+  }
+
+  private SimpleStringPBEConfig createConfig(TenantJasyptProperties properties) {
+    SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+    config.setPassword(properties.getPassword());
+    config.setAlgorithm(properties.getAlgorithm());
+    config.setKeyObtentionIterations(Integer.toString(properties.getKeyObtentionIterations()));
+    config.setPoolSize(Integer.toString(properties.getPoolSize()));
+
+    if (StringUtils.hasText(properties.getProviderName())) {
+      config.setProviderName(properties.getProviderName());
+    }
+
+    config.setSaltGeneratorClassName(properties.getSaltGeneratorClassname());
+    config.setIvGeneratorClassName(properties.getIvGeneratorClassname());
+    config.setStringOutputType(properties.getStringOutputType());
+    return config;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/TenantJasyptProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/TenantJasyptProperties.java
@@ -1,0 +1,95 @@
+package com.ejada.gateway.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the Jasypt encryptor used by the API gateway.
+ *
+ * <p>The properties are intentionally opinionated to enforce a strong default
+ * algorithm while still allowing overrides through {@code application.yaml} or
+ * environment variables.</p>
+ */
+@ConfigurationProperties(prefix = "jasypt.encryptor")
+public class TenantJasyptProperties {
+
+  private String password;
+
+  private String algorithm = "PBEWITHHMACSHA512ANDAES_256";
+
+  private int keyObtentionIterations = 1000;
+
+  private int poolSize = 1;
+
+  private String providerName = "SunJCE";
+
+  private String saltGeneratorClassname = "org.jasypt.salt.RandomSaltGenerator";
+
+  private String ivGeneratorClassname = "org.jasypt.iv.RandomIvGenerator";
+
+  private String stringOutputType = "base64";
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public String getAlgorithm() {
+    return algorithm;
+  }
+
+  public void setAlgorithm(String algorithm) {
+    this.algorithm = algorithm;
+  }
+
+  public int getKeyObtentionIterations() {
+    return keyObtentionIterations;
+  }
+
+  public void setKeyObtentionIterations(int keyObtentionIterations) {
+    this.keyObtentionIterations = keyObtentionIterations;
+  }
+
+  public int getPoolSize() {
+    return poolSize;
+  }
+
+  public void setPoolSize(int poolSize) {
+    this.poolSize = poolSize;
+  }
+
+  public String getProviderName() {
+    return providerName;
+  }
+
+  public void setProviderName(String providerName) {
+    this.providerName = providerName;
+  }
+
+  public String getSaltGeneratorClassname() {
+    return saltGeneratorClassname;
+  }
+
+  public void setSaltGeneratorClassname(String saltGeneratorClassname) {
+    this.saltGeneratorClassname = saltGeneratorClassname;
+  }
+
+  public String getIvGeneratorClassname() {
+    return ivGeneratorClassname;
+  }
+
+  public void setIvGeneratorClassname(String ivGeneratorClassname) {
+    this.ivGeneratorClassname = ivGeneratorClassname;
+  }
+
+  public String getStringOutputType() {
+    return stringOutputType;
+  }
+
+  public void setStringOutputType(String stringOutputType) {
+    this.stringOutputType = stringOutputType;
+  }
+}
+

--- a/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -39,6 +39,41 @@
       "name": "jasypt.encryptor.password",
       "type": "java.lang.String",
       "description": "Password used by Jasypt to decrypt ENC(...) values provided by the Config Server."
+    },
+    {
+      "name": "jasypt.encryptor.algorithm",
+      "type": "java.lang.String",
+      "description": "Encryption algorithm applied to secrets decrypted by the API gateway."
+    },
+    {
+      "name": "jasypt.encryptor.key-obtention-iterations",
+      "type": "java.lang.Integer",
+      "description": "Number of key stretching iterations applied by the encryptor."
+    },
+    {
+      "name": "jasypt.encryptor.pool-size",
+      "type": "java.lang.Integer",
+      "description": "Size of the encryptor pool used to decrypt secrets concurrently."
+    },
+    {
+      "name": "jasypt.encryptor.provider-name",
+      "type": "java.lang.String",
+      "description": "Security provider used when initialising the encryptor (for example SunJCE)."
+    },
+    {
+      "name": "jasypt.encryptor.salt-generator-classname",
+      "type": "java.lang.String",
+      "description": "Fully qualified class name of the salt generator implementation."
+    },
+    {
+      "name": "jasypt.encryptor.iv-generator-classname",
+      "type": "java.lang.String",
+      "description": "Fully qualified class name of the IV generator implementation."
+    },
+    {
+      "name": "jasypt.encryptor.string-output-type",
+      "type": "java.lang.String",
+      "description": "Encoding applied to decrypted strings (for example base64)."
     }
   ]
 }

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -411,8 +411,14 @@ app:
 # Encryption support for secrets served by the Config Server (ENC(...) syntax).
 jasypt:
   encryptor:
-    password: ${JASYPT_ENCRYPTOR_PASSWORD:changeit}
-    algorithm: PBEWithHmacSHA512AndAES_256
+    password: ${JASYPT_ENCRYPTOR_PASSWORD:}
+    algorithm: PBEWITHHMACSHA512ANDAES_256
+    key-obtention-iterations: 1000
+    pool-size: 1
+    provider-name: SunJCE
+    salt-generator-classname: org.jasypt.salt.RandomSaltGenerator
+    iv-generator-classname: org.jasypt.iv.RandomIvGenerator
+    string-output-type: base64
     property:
       prefix: ENC(
       suffix: )

--- a/api-gateway/src/test/resources/application.yaml
+++ b/api-gateway/src/test/resources/application.yaml
@@ -1,0 +1,3 @@
+jasypt:
+  encryptor:
+    password: test-secret


### PR DESCRIPTION
## Summary
- add a dedicated Jasypt encryptor configuration with strong defaults and a fail-fast password check for the API Gateway
- surface the new encryptor options in configuration metadata, documentation, and test resources
- require the JASYPT_ENCRYPTOR_PASSWORD environment variable (or property) while keeping tests wired with a deterministic secret

## Testing
- mvn -pl api-gateway test *(fails: missing dependency com.ejada:starter-observability:1.0.0 in Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b8d0ccb4832fa636c4b63f10af09