### PR TITLE
Replace broken Jasypt starter with direct core dependency

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -74,8 +74,9 @@
       <artifactId>spring-cloud-starter-loadbalancer</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.ulisesbocchio</groupId>
-      <artifactId>jasypt-spring-boot-starter</artifactId>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt</artifactId>
+      <version>1.9.3</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
## Summary
- replace the problematic `jasypt-spring-boot-starter` dependency with the core `org.jasypt:jasypt` library so the gateway can compile again

## Testing
- mvn -pl api-gateway -am clean package -DskipTests

------
https://chatgpt.com/codex/tasks/task_e_68e2be7a1c9c832fbc87f3b12a2dde93