### PR TITLE
Fix gateway config server defaults and fallback wiring

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/fallback/BillingFallbackQueue.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/fallback/BillingFallbackQueue.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -31,6 +32,7 @@ public class BillingFallbackQueue {
   private final ObjectMapper objectMapper;
   private final String queueKey;
 
+  @Autowired
   public BillingFallbackQueue(ReactiveStringRedisTemplate redisTemplate,
       @Qualifier("jacksonObjectMapper") ObjectProvider<ObjectMapper> primaryObjectMapper,
       ObjectProvider<ObjectMapper> fallbackObjectMapper) {

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ server:
 spring:
   # Import remote configuration first, allowing local overrides via active profiles.
   config:
-    import: optional:configserver:${spring.cloud.config.uri:${SPRING_CLOUD_CONFIG_URI:http://localhost:8888}}
+    import: optional:configserver:${spring.cloud.config.uri:${SPRING_CLOUD_CONFIG_URI:http://config-server:8888}}
   application:
     name: api-gateway
   main:
@@ -21,7 +21,7 @@ spring:
           issuer-uri: ${GATEWAY_ISSUER_URI:}
   cloud:
     config:
-      uri: ${SPRING_CLOUD_CONFIG_URI:http://localhost:8888}
+      uri: ${SPRING_CLOUD_CONFIG_URI:http://config-server:8888}
       profile: ${SPRING_CLOUD_CONFIG_PROFILE:${SPRING_PROFILES_ACTIVE:local}}
       label: ${SPRING_CLOUD_CONFIG_LABEL:main}
       username: ${SPRING_CLOUD_CONFIG_USERNAME:}


### PR DESCRIPTION
## Summary
- point the gateway's default Config Server URI to the config-server service for container environments
- mark the BillingFallbackQueue injection constructor with @Autowired so Spring can instantiate the bean

## Testing
- mvn -pl api-gateway -am test *(fails: Error opening zip file or JAR manifest missing : /root/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68e2dec76588832fad1cdfee0e7cc693