### PR TITLE
Add fallback in-memory R2DBC configuration

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -135,6 +135,16 @@
       <artifactId>r2dbc-postgresql</artifactId>
       <version>0.8.13.RELEASE</version>
     </dependency>
+    <dependency>
+      <groupId>io.r2dbc</groupId>
+      <artifactId>r2dbc-h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.cloud</groupId>

--- a/api-gateway/src/main/java/com/ejada/gateway/config/R2dbcFallbackConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/R2dbcFallbackConfiguration.java
@@ -1,0 +1,35 @@
+package com.ejada.gateway.config;
+
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides an in-memory R2DBC {@link ConnectionFactory} when no external database configuration
+ * is supplied. This allows the gateway to start for local development scenarios even when the
+ * Config Server is unavailable.
+ */
+@Configuration
+@ConditionalOnClass(ConnectionFactory.class)
+public class R2dbcFallbackConfiguration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(R2dbcFallbackConfiguration.class);
+
+  private static final String FALLBACK_URL =
+      "r2dbc:h2:mem:///gateway-routes?options=DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
+
+  @Bean
+  @ConditionalOnMissingBean(ConnectionFactory.class)
+  public ConnectionFactory inMemoryGatewayConnectionFactory() {
+    LOGGER.warn(
+        "spring.r2dbc.url is not configured; falling back to an in-memory H2 database at {}. "
+            + "Provide SPRING_R2DBC_URL (or spring.r2dbc.url) to connect to a persistent store.",
+        FALLBACK_URL);
+    return ConnectionFactories.get(FALLBACK_URL);
+  }
+}


### PR DESCRIPTION
## Summary
- add runtime dependencies for in-memory H2 so the gateway can start without an external R2DBC URL
- introduce a conditional configuration that registers an in-memory R2DBC ConnectionFactory when none is present

## Testing
- not run (repository build downloads many artifacts and was interrupted to avoid excessive runtime)


------
https://chatgpt.com/codex/tasks/task_e_68e2e0e8b5c8832f984c3e0f09c4b29f