### PR TITLE
Suppress SpotBugs EI_EXPOSE_REP2 warnings for Spring-managed dependencies

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/MarketplaceCallbackOrchestrator.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/MarketplaceCallbackOrchestrator.java
@@ -81,8 +81,11 @@ public class MarketplaceCallbackOrchestrator {
     @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring manages dependency scope")
     private final ApprovalWorkflowService approvalWorkflowService;
     private final NotificationReplayService notificationReplayService;
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring manages dependency scope")
     private final NotificationAuditService notificationAuditService;
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring manages dependency scope")
     private final SubscriptionOutboxService subscriptionOutboxService;
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring manages dependency scope")
     private final IdempotentRequestService idempotentRequestService;
 
     @Transactional

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/IdempotentRequestService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/IdempotentRequestService.java
@@ -4,6 +4,7 @@ import com.ejada.common.marketplace.token.TokenHashing;
 import com.ejada.subscription.model.IdempotentRequest;
 import com.ejada.subscription.repository.IdempotentRequestRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class IdempotentRequestService {
 
     private final IdempotentRequestRepository idempotentRequestRepository;
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring manages dependency scope")
     private final ObjectMapper objectMapper;
     private final NewTransactionExecutor newTransactionExecutor;
 

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/NotificationAuditService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/NotificationAuditService.java
@@ -4,6 +4,7 @@ import com.ejada.common.marketplace.token.TokenHashing;
 import com.ejada.subscription.model.InboundNotificationAudit;
 import com.ejada.subscription.repository.InboundNotificationAuditRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public class NotificationAuditService {
 
     private final InboundNotificationAuditRepository auditRepository;
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring manages dependency scope")
     private final ObjectMapper objectMapper;
     private final NewTransactionExecutor newTransactionExecutor;
 

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/SubscriptionOutboxService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/acl/service/SubscriptionOutboxService.java
@@ -3,6 +3,7 @@ package com.ejada.subscription.acl.service;
 import com.ejada.subscription.model.OutboxEvent;
 import com.ejada.subscription.repository.OutboxEventRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
 public class SubscriptionOutboxService {
 
     private final OutboxEventRepository outboxRepository;
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring manages dependency scope")
     private final ObjectMapper objectMapper;
 
     public void emit(final String aggregate, final String id, final String type, final java.util.Map<String, ?> payload) {


### PR DESCRIPTION
## Summary
- suppress EI_EXPOSE_REP2 warnings on Spring-managed collaborators in `MarketplaceCallbackOrchestrator`
- add SpotBugs suppressions for injected `ObjectMapper` dependencies in ACL services to avoid false positives

## Testing
- `mvn -pl subscription-service spotbugs:check` *(fails: requires private shared-bom and dependency versions unavailable in open environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e4f9b614832fa781d99031b7c999