### PR TITLE
Allow API gateway to start without Jasypt password in dev

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/MultiTenantJasyptConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/MultiTenantJasyptConfiguration.java
@@ -27,10 +27,17 @@ public class MultiTenantJasyptConfiguration {
   @ConditionalOnMissingBean(name = "jasyptStringEncryptor")
   public StringEncryptor jasyptStringEncryptor(TenantJasyptProperties properties) {
     if (!StringUtils.hasText(properties.getPassword())) {
-      throw new IllegalStateException(
-          "Jasypt encryption password is not configured. "
-              + "Set the JASYPT_ENCRYPTOR_PASSWORD environment variable or the "
-              + "jasypt.encryptor.password property before starting the API Gateway.");
+      if (properties.isFailOnMissingPassword()) {
+        throw new IllegalStateException(
+            "Jasypt encryption password is not configured. "
+                + "Set the JASYPT_ENCRYPTOR_PASSWORD environment variable or the "
+                + "jasypt.encryptor.password property before starting the API Gateway.");
+      }
+
+      LOGGER.warn(
+          "Jasypt encryption password is not configured; falling back to a no-op encryptor. "
+              + "Do not use this configuration in production environments.");
+      return new NoOpStringEncryptor();
     }
 
     LOGGER.info("Initialising Jasypt encryptor with algorithm '{}' and pool size {}", properties.getAlgorithm(),

--- a/api-gateway/src/main/java/com/ejada/gateway/config/NoOpStringEncryptor.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/NoOpStringEncryptor.java
@@ -1,0 +1,24 @@
+package com.ejada.gateway.config;
+
+import org.jasypt.encryption.StringEncryptor;
+
+/**
+ * Minimal {@link StringEncryptor} implementation that simply echoes values back to callers.
+ *
+ * <p>This is intended for development scenarios where encrypted secrets are not required. The
+ * encryptor should never be used in production because it does not provide any confidentiality for
+ * stored values.</p>
+ */
+final class NoOpStringEncryptor implements StringEncryptor {
+
+  @Override
+  public String encrypt(String message) {
+    return message;
+  }
+
+  @Override
+  public String decrypt(String encryptedMessage) {
+    return encryptedMessage;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/TenantJasyptProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/TenantJasyptProperties.java
@@ -28,6 +28,8 @@ public class TenantJasyptProperties {
 
   private String stringOutputType = "base64";
 
+  private boolean failOnMissingPassword = true;
+
   public String getPassword() {
     return password;
   }
@@ -90,6 +92,14 @@ public class TenantJasyptProperties {
 
   public void setStringOutputType(String stringOutputType) {
     this.stringOutputType = stringOutputType;
+  }
+
+  public boolean isFailOnMissingPassword() {
+    return failOnMissingPassword;
+  }
+
+  public void setFailOnMissingPassword(boolean failOnMissingPassword) {
+    this.failOnMissingPassword = failOnMissingPassword;
   }
 }
 

--- a/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -74,6 +74,12 @@
       "name": "jasypt.encryptor.string-output-type",
       "type": "java.lang.String",
       "description": "Encoding applied to decrypted strings (for example base64)."
+    },
+    {
+      "name": "jasypt.encryptor.fail-on-missing-password",
+      "type": "java.lang.Boolean",
+      "description": "Whether the gateway should fail fast when the Jasypt password is missing.",
+      "defaultValue": true
     }
   ]
 }

--- a/api-gateway/src/main/resources/application-dev.yaml
+++ b/api-gateway/src/main/resources/application-dev.yaml
@@ -32,3 +32,7 @@ shared:
 
 app:
   env: dev
+
+jasypt:
+  encryptor:
+    fail-on-missing-password: false

--- a/api-gateway/src/main/resources/application-local.yaml
+++ b/api-gateway/src/main/resources/application-local.yaml
@@ -27,3 +27,7 @@ shared:
 
 app:
   env: local
+
+jasypt:
+  encryptor:
+    fail-on-missing-password: false

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -419,6 +419,7 @@ jasypt:
     salt-generator-classname: org.jasypt.salt.RandomSaltGenerator
     iv-generator-classname: org.jasypt.iv.RandomIvGenerator
     string-output-type: base64
+    fail-on-missing-password: ${JASYPT_ENCRYPTOR_FAIL_ON_MISSING_PASSWORD:true}
     property:
       prefix: ENC(
       suffix: )

--- a/api-gateway/src/test/java/com/ejada/gateway/config/MultiTenantJasyptConfigurationTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/config/MultiTenantJasyptConfigurationTest.java
@@ -1,0 +1,38 @@
+package com.ejada.gateway.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.junit.jupiter.api.Test;
+
+class MultiTenantJasyptConfigurationTest {
+
+  private final MultiTenantJasyptConfiguration configuration = new MultiTenantJasyptConfiguration();
+
+  @Test
+  void jasyptStringEncryptorThrowsWhenPasswordMissingAndFailFastEnabled() {
+    TenantJasyptProperties properties = new TenantJasyptProperties();
+    properties.setFailOnMissingPassword(true);
+
+    assertThatThrownBy(() -> configuration.jasyptStringEncryptor(properties))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Jasypt encryption password is not configured");
+  }
+
+  @Test
+  void jasyptStringEncryptorFallsBackToNoOpEncryptorWhenDisabled() {
+    TenantJasyptProperties properties = new TenantJasyptProperties();
+    properties.setFailOnMissingPassword(false);
+
+    StringEncryptor encryptor = configuration.jasyptStringEncryptor(properties);
+
+    assertThat(encryptor.encrypt("secret"))
+        .as("encrypt should act as a no-op when the password is missing")
+        .isEqualTo("secret");
+    assertThat(encryptor.decrypt("cipher"))
+        .as("decrypt should act as a no-op when the password is missing")
+        .isEqualTo("cipher");
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a no-op Jasypt encryptor fallback that is used when the password is absent and fail fast is disabled
- expose a configurable `fail-on-missing-password` flag with documentation and defaults for dev/local profiles
- cover the new configuration path with a unit test

## Testing
- mvn -pl api-gateway test *(fails: missing internal starter artifacts such as com.ejada:starter-security:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e5fd250c832f9a35847f22aba6b9