### PR TITLE
Add reflective constructor overloads for KafkaSink

### DIFF
--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/core/dispatch/sinks/KafkaSink.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/core/dispatch/sinks/KafkaSink.java
@@ -6,6 +6,8 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
 
@@ -14,15 +16,54 @@ public class KafkaSink implements Sink {
   private final String topic;
 
   public KafkaSink(String bootstrapServers, String topic, String acks, String compression, int timeoutMs) {
-    Properties p = new Properties();
-    p.put("bootstrap.servers", bootstrapServers);
-    p.put("acks", acks);
-    p.put("compression.type", compression);
-    p.put("enable.idempotence", "true");
-    p.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-    p.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-    this.producer = new KafkaProducer<>(p);
+    this(bootstrapServers, topic, buildOverrides(acks, compression, timeoutMs));
+  }
+
+  public KafkaSink(String bootstrapServers, String topic, Map<String, ?> overrides) {
+    this(new KafkaProducer<>(buildProperties(bootstrapServers, overrides)), topic);
+  }
+
+  public KafkaSink(String bootstrapServers, String topic) {
+    this(bootstrapServers, topic, Map.of());
+  }
+
+  private KafkaSink(KafkaProducer<String, String> producer, String topic) {
+    this.producer = producer;
     this.topic = topic;
+  }
+
+  private static Properties buildProperties(String bootstrapServers, Map<String, ?> overrides) {
+    Properties properties = new Properties();
+    properties.put("bootstrap.servers", bootstrapServers);
+    properties.put("acks", "all");
+    properties.put("compression.type", "zstd");
+    properties.put("enable.idempotence", "true");
+    properties.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    properties.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+    if (overrides != null) {
+      overrides.forEach((key, value) -> {
+        if (key != null && value != null) {
+          properties.put(key, String.valueOf(value));
+        }
+      });
+    }
+
+    return properties;
+  }
+
+  private static Map<String, Object> buildOverrides(String acks, String compression, int timeoutMs) {
+    Map<String, Object> overrides = new HashMap<>();
+    if (acks != null && !acks.isBlank()) {
+      overrides.put("acks", acks);
+    }
+    if (compression != null && !compression.isBlank()) {
+      overrides.put("compression.type", compression);
+    }
+    if (timeoutMs > 0) {
+      overrides.put("delivery.timeout.ms", timeoutMs);
+    }
+    return overrides;
   }
 
   @Override public void send(AuditEvent event) throws Exception {


### PR DESCRIPTION
## Summary
- add constructor overloads to KafkaSink so AuditAutoConfiguration can resolve expected reflective signatures
- centralize Kafka producer property initialization and override handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e7761b3c832f9bba95a726667f71