### PR TITLE
Fix SpotBugs exposure warnings in analytics service

### DIFF
--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/dto/CostForecastResponse.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/dto/CostForecastResponse.java
@@ -8,13 +8,37 @@ public record CostForecastResponse(
     List<FeatureForecastDto> features,
     OffsetDateTimeRange forecastWindow) {
 
+  public CostForecastResponse(
+      Long tenantId, List<FeatureForecastDto> features, OffsetDateTimeRange forecastWindow) {
+    this.tenantId = tenantId;
+    this.features = features == null ? List.of() : List.copyOf(features);
+    this.forecastWindow = forecastWindow;
+  }
+
   public record FeatureForecastDto(
       String featureKey,
       BigDecimal currentUsage,
       BigDecimal forecastedUsage,
       BigDecimal planLimit,
       boolean overageRisk,
-      List<String> recommendations) {}
+      List<String> recommendations) {
+
+    public FeatureForecastDto(
+        String featureKey,
+        BigDecimal currentUsage,
+        BigDecimal forecastedUsage,
+        BigDecimal planLimit,
+        boolean overageRisk,
+        List<String> recommendations) {
+      this.featureKey = featureKey;
+      this.currentUsage = currentUsage;
+      this.forecastedUsage = forecastedUsage;
+      this.planLimit = planLimit;
+      this.overageRisk = overageRisk;
+      this.recommendations =
+          recommendations == null ? List.of() : List.copyOf(recommendations);
+    }
+  }
 
   public record OffsetDateTimeRange(java.time.OffsetDateTime start, java.time.OffsetDateTime end) {}
 }

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/dto/FeatureAdoptionResponse.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/dto/FeatureAdoptionResponse.java
@@ -4,5 +4,16 @@ import java.util.List;
 
 public record FeatureAdoptionResponse(Long tenantId, List<FeatureTrendDto> features) {
 
-  public record FeatureTrendDto(String featureKey, List<UsageTrendPointDto> trend) {}
+  public FeatureAdoptionResponse(Long tenantId, List<FeatureTrendDto> features) {
+    this.tenantId = tenantId;
+    this.features = features == null ? List.of() : List.copyOf(features);
+  }
+
+  public record FeatureTrendDto(String featureKey, List<UsageTrendPointDto> trend) {
+
+    public FeatureTrendDto(String featureKey, List<UsageTrendPointDto> trend) {
+      this.featureKey = featureKey;
+      this.trend = trend == null ? List.of() : List.copyOf(trend);
+    }
+  }
 }

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/dto/FeatureUsageSummaryDto.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/dto/FeatureUsageSummaryDto.java
@@ -12,4 +12,27 @@ public record FeatureUsageSummaryDto(
     BigDecimal forecastedUsage,
     boolean predictedOverage,
     List<String> costRecommendations,
-    List<PeakUsageWindowDto> peakUsageWindows) {}
+    List<PeakUsageWindowDto> peakUsageWindows) {
+
+  public FeatureUsageSummaryDto(
+      String featureKey,
+      BigDecimal totalUsage,
+      Long eventCount,
+      BigDecimal planLimit,
+      BigDecimal utilizationPercentage,
+      BigDecimal forecastedUsage,
+      boolean predictedOverage,
+      List<String> costRecommendations,
+      List<PeakUsageWindowDto> peakUsageWindows) {
+    this.featureKey = featureKey;
+    this.totalUsage = totalUsage;
+    this.eventCount = eventCount;
+    this.planLimit = planLimit;
+    this.utilizationPercentage = utilizationPercentage;
+    this.forecastedUsage = forecastedUsage;
+    this.predictedOverage = predictedOverage;
+    this.costRecommendations =
+        costRecommendations == null ? List.of() : List.copyOf(costRecommendations);
+    this.peakUsageWindows = peakUsageWindows == null ? List.of() : List.copyOf(peakUsageWindows);
+  }
+}

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/dto/UsageSummaryResponse.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/dto/UsageSummaryResponse.java
@@ -8,4 +8,18 @@ public record UsageSummaryResponse(
     AnalyticsPeriod period,
     OffsetDateTime periodStart,
     OffsetDateTime periodEnd,
-    List<FeatureUsageSummaryDto> features) {}
+    List<FeatureUsageSummaryDto> features) {
+
+  public UsageSummaryResponse(
+      Long tenantId,
+      AnalyticsPeriod period,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd,
+      List<FeatureUsageSummaryDto> features) {
+    this.tenantId = tenantId;
+    this.period = period;
+    this.periodStart = periodStart;
+    this.periodEnd = periodEnd;
+    this.features = features == null ? List.of() : List.copyOf(features);
+  }
+}

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/model/FeatureUsageDailyView.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/model/FeatureUsageDailyView.java
@@ -25,7 +25,10 @@ public class FeatureUsageDailyView {
   private BigDecimal planLimit;
 
   public FeatureUsageDailyViewId getId() {
-    return id;
+    if (id == null) {
+      return null;
+    }
+    return new FeatureUsageDailyViewId(id.getTenantId(), id.getFeatureKey(), id.getUsageDay());
   }
 
   public Long getEventCount() {

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/model/FeatureUsageDailyViewId.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/model/FeatureUsageDailyViewId.java
@@ -9,6 +9,8 @@ import java.util.Objects;
 @Embeddable
 public class FeatureUsageDailyViewId implements Serializable {
 
+  private static final long serialVersionUID = 1L;
+
   @Column(name = "tenant_id")
   private Long tenantId;
 

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/model/PeakUsageHourViewId.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/model/PeakUsageHourViewId.java
@@ -9,6 +9,8 @@ import java.util.Objects;
 @Embeddable
 public class PeakUsageHourViewId implements Serializable {
 
+  private static final long serialVersionUID = 1L;
+
   @Column(name = "tenant_id")
   private Long tenantId;
 

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/model/UsageSummaryView.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/model/UsageSummaryView.java
@@ -28,7 +28,10 @@ public class UsageSummaryView {
   private OffsetDateTime lastEventAt;
 
   public UsageSummaryViewId getId() {
-    return id;
+    if (id == null) {
+      return null;
+    }
+    return new UsageSummaryViewId(id.getTenantId(), id.getFeatureKey(), id.getUsagePeriod());
   }
 
   public Long getEventCount() {

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/model/UsageSummaryViewId.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/model/UsageSummaryViewId.java
@@ -9,6 +9,8 @@ import java.util.Objects;
 @Embeddable
 public class UsageSummaryViewId implements Serializable {
 
+  private static final long serialVersionUID = 1L;
+
   @Column(name = "tenant_id")
   private Long tenantId;
 

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/scheduler/MaterializedViewRefresher.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/scheduler/MaterializedViewRefresher.java
@@ -1,5 +1,6 @@
 package com.ejada.analytics.scheduler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.annotation.PostConstruct;
 import java.util.List;
 
@@ -25,6 +26,9 @@ public class MaterializedViewRefresher {
   private final JdbcTemplate jdbcTemplate;
   private final String cronExpression;
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "JdbcTemplate is a managed Spring bean and is safe to retain")
   public MaterializedViewRefresher(
       JdbcTemplate jdbcTemplate, @Value("${app.analytics.refresh-cron}") String cronExpression) {
     this.jdbcTemplate = jdbcTemplate;


### PR DESCRIPTION
## Summary
- add defensive copies to analytics DTOs to prevent exposing mutable lists
- return defensive copies of embedded ids and add serialVersionUID fields for view identifiers
- suppress SpotBugs warning for Spring-managed JdbcTemplate dependency

## Testing
- `mvn -pl tenant-platform/analytics-service -am -DskipTests compile`


------
https://chatgpt.com/codex/tasks/task_e_68e2ea68c4a4832f988b1e20e123a59d