### PR TITLE
Fix load balancer bean initialization in API gateway

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/LoadBalancerConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/LoadBalancerConfiguration.java
@@ -3,23 +3,24 @@ package com.ejada.gateway.loadbalancer;
 import com.ejada.gateway.config.GatewayRoutesProperties;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
 import org.springframework.cloud.loadbalancer.annotation.LoadBalancerClients;
 import org.springframework.cloud.loadbalancer.core.ReactorServiceInstanceLoadBalancer;
 import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 
 /**
  * Central configuration that replaces the default round-robin load balancer with the
  * {@link TenantAffinityLoadBalancer} and ensures service instances are enriched with dynamic
  * weighting metadata.
  */
-@Configuration
-@LoadBalancerClients
+@Configuration(proxyBeanMethods = false)
+@LoadBalancerClients(defaultConfiguration = LoadBalancerConfiguration.TenantAffinityLoadBalancerClientConfiguration.class)
 public class LoadBalancerConfiguration {
 
   @Bean
@@ -33,28 +34,36 @@ public class LoadBalancerConfiguration {
     return new WebSocketStickTable(ttl);
   }
 
-  @Bean
-  @Primary
-  public ServiceInstanceListSupplier serviceInstanceListSupplier(ConfigurableApplicationContext context,
-      LoadBalancerHealthCheckAggregator aggregator) {
-    ServiceInstanceListSupplier delegate = ServiceInstanceListSupplier.builder()
-        .withDiscoveryClient()
-        .withCaching()
-        .build(context);
-    return new WeightedServiceInstanceListSupplier(delegate, aggregator);
-  }
+  @Configuration(proxyBeanMethods = false)
+  static class TenantAffinityLoadBalancerClientConfiguration {
 
-  @Bean
-  public ReactorServiceInstanceLoadBalancer reactorServiceInstanceLoadBalancer(
-      LoadBalancerClientFactory clientFactory,
-      LoadBalancerHealthCheckAggregator aggregator,
-      GatewayRoutesProperties routesProperties,
-      WebSocketStickTable stickTable,
-      @Value("${spring.cloud.loadbalancer.zone:}") String localZone,
-      Environment environment) {
-    String serviceId = LoadBalancerClientFactory.getName(environment);
-    ObjectProvider<ServiceInstanceListSupplier> provider = clientFactory
-        .getLazyProvider(serviceId, ServiceInstanceListSupplier.class);
-    return new TenantAffinityLoadBalancer(serviceId, provider, aggregator, routesProperties, stickTable, localZone);
+    @Bean
+    @Primary
+    public ServiceInstanceListSupplier serviceInstanceListSupplier(ConfigurableApplicationContext context,
+        LoadBalancerHealthCheckAggregator aggregator) {
+      ServiceInstanceListSupplier delegate = ServiceInstanceListSupplier.builder()
+          .withDiscoveryClient()
+          .withCaching()
+          .build(context);
+      return new WeightedServiceInstanceListSupplier(delegate, aggregator);
+    }
+
+    @Bean
+    public ReactorServiceInstanceLoadBalancer reactorServiceInstanceLoadBalancer(
+        LoadBalancerClientFactory clientFactory,
+        LoadBalancerHealthCheckAggregator aggregator,
+        GatewayRoutesProperties routesProperties,
+        WebSocketStickTable stickTable,
+        @Value("${spring.cloud.loadbalancer.zone:}") String localZone,
+        Environment environment) {
+      String serviceId = LoadBalancerClientFactory.getName(environment);
+      if (!StringUtils.hasText(serviceId)) {
+        throw new IllegalStateException(
+            "No load-balancer client name configured; ensure requests use 'lb://<serviceId>' URIs.");
+      }
+      ObjectProvider<ServiceInstanceListSupplier> provider = clientFactory
+          .getLazyProvider(serviceId, ServiceInstanceListSupplier.class);
+      return new TenantAffinityLoadBalancer(serviceId, provider, aggregator, routesProperties, stickTable, localZone);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- scope the custom tenant affinity load-balancer beans to Spring Cloud LoadBalancer client contexts
- guard against missing load-balancer client names to avoid startup failures when the gateway context is created

## Testing
- mvn -pl api-gateway -am -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68e2f8a89e2c832f9c2554b854ef6bc7