### PR TITLE
Configure gateway load balancer client name

### DIFF
--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -73,6 +73,8 @@ spring:
           enabled: false
       routes: []
     loadbalancer:
+      client:
+        name: ${SPRING_CLOUD_LOADBALANCER_CLIENT_NAME:${spring.application.name}}
       retry:
         enabled: true
       sticky-session:


### PR DESCRIPTION
## Summary
- configure the gateway load balancer client name so the load balancer bean has a service ID by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2fbd2ed48832f87e4c3043c1a9a0f