### PR TITLE
Guard load balancer bean when client name property missing

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/LoadBalancerConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/LoadBalancerConfiguration.java
@@ -3,6 +3,7 @@ package com.ejada.gateway.loadbalancer;
 import com.ejada.gateway.config.GatewayRoutesProperties;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.loadbalancer.annotation.LoadBalancerClients;
 import org.springframework.cloud.loadbalancer.core.ReactorServiceInstanceLoadBalancer;
 import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
@@ -49,6 +50,7 @@ public class LoadBalancerConfiguration {
     }
 
     @Bean
+    @ConditionalOnProperty(name = LoadBalancerClientFactory.PROPERTY_NAME)
     public ReactorServiceInstanceLoadBalancer reactorServiceInstanceLoadBalancer(
         LoadBalancerClientFactory clientFactory,
         LoadBalancerHealthCheckAggregator aggregator,


### PR DESCRIPTION
## Summary
- add a conditional on the tenant affinity load balancer bean so it is only created when a load-balancer client name has been set
- import ConditionalOnProperty to support the new guard

## Testing
- mvn -pl api-gateway -am -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e2fb8e26b8832f84e39b30ab4f7e54