### PR TITLE
Align Spring Boot version with Spring Cloud release

### DIFF
--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -50,7 +50,7 @@
     <findsecbugs.version>1.13.0</findsecbugs.version>
     <jacoco.coverage.minimum>0.00</jacoco.coverage.minimum>
                 <!-- if any module uses Boot plugin -->
-    <spring.boot.version>3.5.5</spring.boot.version>
+    <spring.boot.version>3.4.4</spring.boot.version>
     <spring.cloud.version>2024.0.2</spring.cloud.version>
     <spring.cloud.contract.version>4.2.2</spring.cloud.contract.version>
     <spring-boot.run.skip>true</spring-boot.run.skip>


### PR DESCRIPTION
## Summary
- align the shared parent Spring Boot version with the Spring Cloud 2024.0.2 release train to satisfy the compatibility verifier

## Testing
- mvn -pl api-gateway -am test *(fails: network unreachable while downloading net.bytebuddy:byte-buddy-agent:1.17.7)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fda79698832fb1e1be220cf09d50