### PR TITLE
Handle Redis cache read failures for dynamic routes

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionRepository.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionRepository.java
@@ -123,6 +123,10 @@ public class RouteDefinitionRepository {
             LOGGER.warn("Failed to decode route cache", ex);
             return Flux.empty();
           }
+        })
+        .onErrorResume(ex -> {
+          LOGGER.warn("Failed to read route cache", ex);
+          return Flux.empty();
         });
   }
 


### PR DESCRIPTION
## Summary
- ignore Redis connection failures when reading the cached route payload so dynamic routes still load from the database

## Testing
- mvn -pl api-gateway test *(fails: missing internal starter artifacts in public Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e38b911360832f90122b1a4174d2df