### PR TITLE
Allow Swagger UI through gateway in dev config

### DIFF
--- a/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
@@ -197,7 +197,12 @@ shared:
       secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
     resource-server:
       enabled: true
-      permit-all: []
+      permit-all:
+        - "/actuator/health"
+        - "/v3/api-docs/**"
+        - "/swagger-ui/**"
+        - "/api/*/v3/api-docs/**"
+        - "/api/*/swagger-ui/**"
       disable-csrf: false
     stateless: true
     roles-claim: roles

--- a/shared-lib/shared-config/src/main/resources/application-shared-platform-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-platform-dev.yaml
@@ -58,6 +58,10 @@ shared:
       enabled: true
       permit-all:
         - "/actuator/health"
+        - "/v3/api-docs/**"
+        - "/swagger-ui/**"
+        - "/api/*/v3/api-docs/**"
+        - "/api/*/swagger-ui/**"
       disable-csrf: false
     stateless: true
     roles-claim: roles


### PR DESCRIPTION
## Summary
- add default permit-all patterns for Swagger UI and OpenAPI docs in shared dev configurations so the gateway won't require authentication for those paths

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e38c08d8d8832f87d740c58d2c5095