### PR TITLE
Stop auditing actuator health endpoints by default

### DIFF
--- a/shared-lib/shared-starters/starter-audit/README.md
+++ b/shared-lib/shared-starters/starter-audit/README.md
@@ -28,3 +28,9 @@ Annotate methods:
 @Audited(action = AuditAction.CREATE, entity = "Customer", entityIdExpr = "#result.id")
 public Customer createCustomer(CreateCustomerReq req) { ... }
 ```
+
+### HTTP request auditing
+
+The servlet filter ships with sensible defaults so that liveness endpoints (for example
+`/actuator/health`) are not persisted to the audit store. Use `shared.audit.web.exclude-paths`
+to override or extend the default list when integrating in your service configuration.

--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/config/AuditProperties.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/config/AuditProperties.java
@@ -34,7 +34,14 @@ public class AuditProperties {
     private boolean includeHeaders = false;
     private boolean trackBodies = false;
     private List<String> includePaths = new ArrayList<>();
-    private List<String> excludePaths = new ArrayList<>();
+    private List<String> excludePaths = new ArrayList<>(List.of(
+        "/actuator/**",
+        "**/actuator/**",
+        "/health",
+        "/health/**",
+        "**/health",
+        "**/health/**"
+    ));
     public boolean isEnabled() { return enabled; }
     public void setEnabled(boolean enabled) { this.enabled = enabled; }
     public boolean isIncludeHeaders() { return includeHeaders; }


### PR DESCRIPTION
## Summary
- default the audit web filter to ignore actuator and health endpoints so health checks no longer create audit rows
- document the new defaults and how to customize them in the starter-audit README

## Testing
- `mvn -pl shared-lib/shared-starters/starter-audit -am test` *(fails: surefire forked VM exited before running tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e397576c40832f93430c18b6b5f040