### PR TITLE
Skip auditing actuator health requests

### DIFF
--- a/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/http/AuditWebMvcFilter.java
+++ b/shared-lib/shared-starters/starter-audit/src/main/java/com/ejada/audit/starter/http/AuditWebMvcFilter.java
@@ -170,6 +170,9 @@ public class AuditWebMvcFilter implements Filter {
     String path = req.getRequestURI();
 
     // Exclude has priority
+    if (isActuatorRequest(path)) {
+      return false;
+    }
     for (String ex : excludePaths) {
       if (matches(path, ex)) return false;
     }
@@ -179,6 +182,13 @@ public class AuditWebMvcFilter implements Filter {
       if (matches(path, inc)) return true;
     }
     return false;
+  }
+
+  private boolean isActuatorRequest(String path) {
+    if (path == null) {
+      return false;
+    }
+    return path.equals("/actuator") || path.contains("/actuator/");
   }
 
   // Simple matcher: exact, prefix (ends with '*'), or contains '**' meaning substring


### PR DESCRIPTION
## Summary
- avoid emitting audit events for actuator web endpoints by short-circuiting the audit filter

## Testing
- mvn -pl shared-lib/shared-starters/starter-audit test *(fails: missing internal dependency com.ejada:shared-common)*

------
https://chatgpt.com/codex/tasks/task_e_68e398d3cb64832f8afb29dc7331b086