### PR TITLE
Disable Redis repository scanning in API Gateway

### DIFF
--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -10,6 +10,10 @@ spring:
     name: api-gateway
   main:
     web-application-type: reactive
+  data:
+    redis:
+      repositories:
+        enabled: false
   autoconfigure:
     exclude:
       - com.ejada.shared_starter_ratelimit.RateLimitAutoConfiguration


### PR DESCRIPTION
## Summary
- disable automatic Spring Data Redis repository scanning to avoid misidentifying R2DBC repositories as Redis candidates

## Testing
- `mvn -pl api-gateway test` *(fails: missing internal com.ejada starter artifacts in Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a006b8bc832fb75a024278c2355d