### PR TITLE
Enable lazy bean initialization to improve service startup time

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ curl http://localhost:8000/actuator/health
 ## Configuration Notes
 
 - The gateway port is configurable with the `SERVER_PORT` environment variable (defaults to `8000`).
+- Spring Boot lazy initialization is enabled by default across services to reduce container warm-up times; set
+  `SPRING_MAIN_LAZY_INITIALIZATION=false` when eager bean creation is preferred (for example, in production load tests).
 - Each microservice disables its own resource server and trusts authentication performed by the
   gateway (`shared.security.resource-server.enabled=false`).
 - Redis is required for rate limiting and subscription cache validation. Configure `REDIS_HOST`

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -9,6 +9,7 @@ spring:
   application:
     name: api-gateway
   main:
+    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
     web-application-type: reactive
   autoconfigure:
     exclude:

--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: security-service
+  main:
+    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:

--- a/setup-service/src/main/resources/application.yaml
+++ b/setup-service/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: setup-service
+  main:
+    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:

--- a/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
@@ -1,5 +1,6 @@
 spring:
   main:
+    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
     application-startup: buffering
   datasource:
     url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:ejada}?currentSchema=setup}"

--- a/shared-lib/shared-config/src/main/resources/application-shared-platform-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-platform-dev.yaml
@@ -1,5 +1,6 @@
 spring:
   main:
+    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
     application-startup: buffering
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}

--- a/shared-lib/shared-config/src/main/resources/application-shared-tenant-qa.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-tenant-qa.yaml
@@ -5,6 +5,7 @@ app:
 
 spring:
   main:
+    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
     application-startup: buffering
   datasource:
     url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:ejada}?currentSchema=${app.schema}}"

--- a/tenant-platform/analytics-service/src/main/resources/application.yml
+++ b/tenant-platform/analytics-service/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: analytics-service
+  main:
+    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
   datasource:

--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: billing-service
+  main:
+    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: catalog-service
+  main:
+    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: subscription-service
+  main:
+    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: tenant-service
+  main:
+    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
   flyway:


### PR DESCRIPTION
## Summary
- enable Spring Boot lazy initialization across the gateway and domain services so beans load on demand and cut startup time
- propagate the lazy initialization default into the shared dev/qa configuration bundles and document how to override it when eager startup is required

## Testing
- `mvn -pl shared-lib/shared-config test` *(fails: missing com.ejada:shared-test-support:1.0.0 dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e39fc21c4c832fa5acbd5e66f45dc6