### PR TITLE
Handle database errors when loading dynamic gateway routes

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionRepository.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteDefinitionRepository.java
@@ -134,7 +134,11 @@ public class RouteDefinitionRepository {
     return routeStore.findAllByEnabledTrue()
         .map(mapper::toDomain)
         .collectList()
-        .flatMapMany(list -> cacheActiveRoutes(list).thenMany(Flux.fromIterable(list)));
+        .flatMapMany(list -> cacheActiveRoutes(list).thenMany(Flux.fromIterable(list)))
+        .onErrorResume(ex -> {
+          LOGGER.warn("Failed to load active routes from database", ex);
+          return Flux.empty();
+        });
   }
 
   private Mono<Void> cacheActiveRoutes(List<RouteDefinition> routes) {


### PR DESCRIPTION
## Summary
- guard the dynamic route loader against database failures so an empty route list is returned instead of aborting the refresh

## Testing
- mvn -pl api-gateway -am -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e3a0c3757c832f826cef466990cc21