### PR TITLE
Allow unauthenticated access to Swagger docs via gateway

### DIFF
--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -130,6 +130,12 @@ shared:
         - /actuator/health/**
         - /actuator/info
         - /actuator/prometheus
+        - /api/**/v3/api-docs/**
+        - /api/**/swagger-ui/**
+        - /api/**/swagger-ui.html
+        - /v3/api-docs/**
+        - /swagger-ui/**
+        - /swagger-ui.html
       disable-csrf: true
       jwk-set-uri: ${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}
       issuer-uri: ${spring.security.oauth2.resourceserver.jwt.issuer-uri}
@@ -149,6 +155,12 @@ shared:
       skip-patterns:
         - /actuator/.*
         - /favicon.ico
+        - /api/**/v3/api-docs/**
+        - /api/**/swagger-ui/**
+        - /api/**/swagger-ui.html
+        - /v3/api-docs/**
+        - /swagger-ui/**
+        - /swagger-ui.html
     correlation:
       enabled: true
       header-name: X-Correlation-Id


### PR DESCRIPTION
## Summary
- allow OpenAPI and Swagger UI paths through the API Gateway without authentication
- skip tenant enforcement for documentation endpoints so docs remain browsable

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3aa9efe24832fbadb102b8096154a