### PR TITLE
feat(gateway): improve startup diagnostics and defer infrastructure

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -74,6 +74,10 @@
       <artifactId>spring-cloud-starter-loadbalancer</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jasypt</groupId>
       <artifactId>jasypt</artifactId>
       <version>1.9.3</version>
@@ -134,16 +138,6 @@
       <groupId>io.r2dbc</groupId>
       <artifactId>r2dbc-postgresql</artifactId>
       <version>0.8.13.RELEASE</version>
-    </dependency>
-    <dependency>
-      <groupId>io.r2dbc</groupId>
-      <artifactId>r2dbc-h2</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/api-gateway/src/main/java/com/ejada/gateway/ApiGatewayApplication.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ApiGatewayApplication.java
@@ -2,6 +2,7 @@ package com.ejada.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
 
 /**
  * Entry point for the LMS API Gateway.
@@ -10,6 +11,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class ApiGatewayApplication {
 
   public static void main(String[] args) {
-    SpringApplication.run(ApiGatewayApplication.class, args);
+    SpringApplication application = new SpringApplication(ApiGatewayApplication.class);
+    BufferingApplicationStartup applicationStartup = new BufferingApplicationStartup(2048);
+    applicationStartup.startRecording();
+    application.setApplicationStartup(applicationStartup);
+    application.run(args);
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/cache/CacheInvalidationListener.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/cache/CacheInvalidationListener.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -17,6 +18,7 @@ import org.springframework.util.StringUtils;
  * catalog or tenant data changes.
  */
 @Component
+@Lazy(false)
 @ConditionalOnExpression("${gateway.cache.enabled:true} && ${gateway.cache.kafka.enabled:true}")
 public class CacheInvalidationListener {
 

--- a/api-gateway/src/main/java/com/ejada/gateway/config/DeferredInfrastructureInitializer.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/DeferredInfrastructureInitializer.java
@@ -1,0 +1,71 @@
+package com.ejada.gateway.config;
+
+import java.time.Duration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+
+/**
+ * Defers the initialisation of infrastructure connections that should only begin once the
+ * application is ready to handle traffic.
+ */
+@Component
+@Lazy(false)
+public class DeferredInfrastructureInitializer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DeferredInfrastructureInitializer.class);
+
+  private final ObjectProvider<KafkaListenerEndpointRegistry> kafkaRegistryProvider;
+  private final ObjectProvider<ReactiveStringRedisTemplate> redisTemplateProvider;
+
+  public DeferredInfrastructureInitializer(ObjectProvider<KafkaListenerEndpointRegistry> kafkaRegistryProvider,
+      ObjectProvider<ReactiveStringRedisTemplate> redisTemplateProvider) {
+    this.kafkaRegistryProvider = kafkaRegistryProvider;
+    this.redisTemplateProvider = redisTemplateProvider;
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void onApplicationReady() {
+    startKafkaListeners();
+    warmRedisConnection();
+  }
+
+  private void startKafkaListeners() {
+    KafkaListenerEndpointRegistry registry = kafkaRegistryProvider.getIfAvailable();
+    if (registry == null) {
+      LOGGER.debug("KafkaListenerEndpointRegistry not available; skipping deferred startup");
+      return;
+    }
+    if (registry.isRunning()) {
+      LOGGER.debug("Kafka listener containers already running; no deferred startup required");
+      return;
+    }
+    registry.start();
+    LOGGER.info("Started {} Kafka listener containers after ApplicationReadyEvent",
+        registry.getListenerContainers().size());
+  }
+
+  private void warmRedisConnection() {
+    ReactiveStringRedisTemplate redisTemplate = redisTemplateProvider.getIfAvailable();
+    if (redisTemplate == null || redisTemplate.getConnectionFactory() == null) {
+      LOGGER.debug("ReactiveStringRedisTemplate not available; skipping Redis warm-up");
+      return;
+    }
+    try (ReactiveRedisConnection connection = redisTemplate.getConnectionFactory().getReactiveConnection()) {
+      connection.ping().block(Duration.ofSeconds(2));
+      LOGGER.info("Verified Redis connectivity after ApplicationReadyEvent");
+    } catch (Exception ex) {
+      LOGGER.warn("Redis connectivity warm-up failed after ApplicationReadyEvent", ex);
+    }
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/config/R2dbcFallbackConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/R2dbcFallbackConfiguration.java
@@ -20,15 +20,14 @@ public class R2dbcFallbackConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(R2dbcFallbackConfiguration.class);
 
-  private static final String FALLBACK_URL =
-      "r2dbc:h2:mem:///gateway-routes?options=DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
+  private static final String FALLBACK_URL = "r2dbc:postgresql://postgres:5432/lms";
 
   @Bean
   @ConditionalOnMissingBean(ConnectionFactory.class)
   public ConnectionFactory inMemoryGatewayConnectionFactory() {
     LOGGER.warn(
-        "spring.r2dbc.url is not configured; falling back to an in-memory H2 database at {}. "
-            + "Provide SPRING_R2DBC_URL (or spring.r2dbc.url) to connect to a persistent store.",
+        "spring.r2dbc.url is not configured; falling back to default PostgreSQL connection {}. "
+            + "Provide SPRING_R2DBC_URL (or spring.r2dbc.url) to target the correct database.",
         FALLBACK_URL);
     return ConnectionFactories.get(FALLBACK_URL);
   }

--- a/api-gateway/src/main/java/com/ejada/gateway/config/StartupTimelineLogger.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/StartupTimelineLogger.java
@@ -1,0 +1,111 @@
+package com.ejada.gateway.config;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
+import org.springframework.boot.context.metrics.buffering.StartupTimeline;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import org.springframework.core.metrics.StartupStep;
+
+/**
+ * Emits a concise summary of the startup timeline once the application is ready so we can
+ * understand which beans and auto-configurations completed after the
+ * {@code "Starting ApiGatewayApplication"} log entry.
+ */
+@Component
+@Lazy(false)
+public class StartupTimelineLogger implements ApplicationListener<ApplicationReadyEvent> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StartupTimelineLogger.class);
+
+  @Override
+  public void onApplicationEvent(ApplicationReadyEvent event) {
+    if (!LOGGER.isInfoEnabled()) {
+      return;
+    }
+
+    if (!(event.getApplicationContext().getApplicationStartup() instanceof BufferingApplicationStartup buffering)) {
+      LOGGER.debug("ApplicationStartup does not support buffering; startup timeline logging skipped");
+      return;
+    }
+
+    StartupTimeline timeline = buffering.drainBufferedTimeline();
+    List<StartupTimeline.TimelineEvent> sortedEvents = timeline.getEvents().stream()
+        .sorted(Comparator.comparing(StartupTimeline.TimelineEvent::getStartTime))
+        .collect(Collectors.toList());
+
+    if (sortedEvents.isEmpty()) {
+      LOGGER.info("Spring Boot startup timeline did not record any steps");
+      return;
+    }
+
+    Instant end = sortedEvents.get(sortedEvents.size() - 1).getEndTime();
+    Duration total = Duration.between(timeline.getStartTime(), end);
+    LOGGER.info("Spring Boot startup captured {} steps over {} ms", sortedEvents.size(), total.toMillis());
+
+    sortedEvents.stream()
+        .filter(eventStep -> shouldLog(eventStep.getStartupStep()))
+        .forEach(eventStep -> logStep(eventStep));
+  }
+
+  private void logStep(StartupTimeline.TimelineEvent event) {
+    StartupStep step = event.getStartupStep();
+    String stepName = step.getName();
+    Duration duration = event.getDuration();
+    if (stepName.startsWith("spring.boot.autoconfigure")) {
+      String autoConfiguration = tagValue(step, "className");
+      LOGGER.info("  Auto-configuration {} completed in {} ms",
+          (autoConfiguration != null) ? autoConfiguration : stepName,
+          duration.toMillis());
+      return;
+    }
+
+    if (stepName.startsWith("spring.beans.")) {
+      String beanName = tagValue(step, "beanName");
+      String beanType = tagValue(step, "beanType");
+      if (beanType != null) {
+        LOGGER.info("  Bean {} [{}] initialised in {} ms",
+            (beanName != null) ? beanName : "<unknown>",
+            beanType,
+            duration.toMillis());
+      } else {
+        LOGGER.info("  Bean {} initialised in {} ms", (beanName != null) ? beanName : stepName, duration.toMillis());
+      }
+    }
+  }
+
+  private boolean shouldLog(StartupStep step) {
+    String name = step.getName();
+    if (name.startsWith("spring.boot.autoconfigure")) {
+      return true;
+    }
+    if (name.startsWith("spring.beans.")) {
+      String beanType = tagValue(step, "beanType");
+      return beanType != null
+          && (beanType.startsWith("com.ejada.gateway")
+              || beanType.startsWith("org.springframework.kafka")
+              || beanType.startsWith("org.springframework.data.redis"));
+    }
+    return false;
+  }
+
+  private String tagValue(StartupStep step, String tagName) {
+    for (StartupStep.Tag tag : step.getTags()) {
+      if (tagName.equals(tag.getKey())) {
+        return tag.getValue();
+      }
+    }
+    return null;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionConverter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionConverter.java
@@ -154,10 +154,24 @@ public class RouteDefinitionConverter {
     List<String> result = new ArrayList<>();
     for (String token : tokens) {
       if (StringUtils.hasText(token)) {
-        result.add(token.trim());
+        String candidate = token.trim();
+        if (!isExcluded(candidate)) {
+          result.add(candidate);
+        }
       }
     }
     return result;
+  }
+
+  private boolean isExcluded(String pattern) {
+    if (!StringUtils.hasText(pattern)) {
+      return true;
+    }
+    String candidate = pattern.trim();
+    if (candidate.startsWith("/actuator")) {
+      return true;
+    }
+    return "/health".equals(candidate) || candidate.startsWith("/health/");
   }
 
   private String normaliseVariant(String value) {

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -8,9 +8,13 @@ spring:
     import: optional:configserver:${spring.cloud.config.uri:${SPRING_CLOUD_CONFIG_URI:http://config-server:8888}}
   application:
     name: api-gateway
+    admin:
+      enabled: true
   main:
-    lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
+    lazy-initialization: true
     web-application-type: reactive
+  boot:
+    startup: info
   data:
     redis:
       repositories:
@@ -24,6 +28,10 @@ spring:
         jwt:
           jwk-set-uri: ${GATEWAY_JWK_SET_URI:}
           issuer-uri: ${GATEWAY_ISSUER_URI:}
+  kafka:
+    listener:
+      concurrency: 2
+      auto-startup: false
   cloud:
     config:
       enabled: ${SPRING_CLOUD_CONFIG_ENABLED:true}


### PR DESCRIPTION
## Summary
- record Spring Boot startup timelines by enabling buffered startup and logging auto-configuration and bean initialization durations
- defer Kafka listener startup and proactively verify Redis connectivity on `ApplicationReadyEvent`
- enforce PostgreSQL R2DBC fallback, add Caffeine cache support, enable lazy initialization/startup logging/admin metrics, adjust Kafka listener settings, and skip actuator paths during route scanning

## Testing
- `mvn -pl api-gateway -am -DskipTests package` *(aborted after prolonged dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68e3aa23c67c832fb4f758ff8e61573f