### PR TITLE
Prevent starter duplication and expose env injection in containers

### DIFF
--- a/Dockerfile.spring-service
+++ b/Dockerfile.spring-service
@@ -25,10 +25,39 @@ RUN set -eux; \
     [ -n "${BOOT_JAR}" ]; \
     mv "${BOOT_JAR}" app.jar; \
     find . -maxdepth 1 -name "${ARTIFACT_NAME}-*-plain.jar" -exec rm -f {} \;; \
+    cat <<'EOF' > /entrypoint.sh; \
+#!/bin/sh
+set -e
+
+if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
+  export SPRING_PROFILES_ACTIVE=dev
+  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+else
+  echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -z "${SPRING_DATASOURCE_URL:-}" ]; then
+  export SPRING_DATASOURCE_URL="${DATABASE_URL}"
+  echo "Mapped DATABASE_URL -> SPRING_DATASOURCE_URL"
+fi
+
+if [ -n "${KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+  if [ -z "${SPRING_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SPRING_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  if [ -z "${SHARED_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SHARED_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  echo "Using Kafka bootstrap servers from environment"
+fi
+
+exec java $JAVA_OPTS -jar /app/app.jar
+EOF
+    chmod +x /entrypoint.sh; \
     chown -R ${APP_USER}:${APP_GROUP} /app
 
 USER ${APP_USER}
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -17,10 +17,39 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -type f \( -name 'api-gateway-*-plain.jar' -o -name 'api-gateway-*-stubs.jar' -o -name 'api-gateway-*.jar.original' \) -delete; \
+    cat <<'EOF' > /entrypoint.sh; \
+#!/bin/sh
+set -e
+
+if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
+  export SPRING_PROFILES_ACTIVE=dev
+  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+else
+  echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -z "${SPRING_DATASOURCE_URL:-}" ]; then
+  export SPRING_DATASOURCE_URL="${DATABASE_URL}"
+  echo "Mapped DATABASE_URL -> SPRING_DATASOURCE_URL"
+fi
+
+if [ -n "${KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+  if [ -z "${SPRING_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SPRING_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  if [ -z "${SHARED_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SHARED_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  echo "Using Kafka bootstrap servers from environment"
+fi
+
+exec java $JAVA_OPTS -jar /app/app.jar
+EOF
+    chmod +x /entrypoint.sh; \
     chown -R appuser:appgroup /app
 
 USER appuser
 
 EXPOSE 8000
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/sec-service/Dockerfile
+++ b/sec-service/Dockerfile
@@ -16,10 +16,39 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'sec-service-*-plain.jar' -delete; \
+    cat <<'EOF' > /entrypoint.sh; \
+#!/bin/sh
+set -e
+
+if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
+  export SPRING_PROFILES_ACTIVE=dev
+  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+else
+  echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -z "${SPRING_DATASOURCE_URL:-}" ]; then
+  export SPRING_DATASOURCE_URL="${DATABASE_URL}"
+  echo "Mapped DATABASE_URL -> SPRING_DATASOURCE_URL"
+fi
+
+if [ -n "${KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+  if [ -z "${SPRING_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SPRING_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  if [ -z "${SHARED_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SHARED_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  echo "Using Kafka bootstrap servers from environment"
+fi
+
+exec java $JAVA_OPTS -jar /app/app.jar
+EOF
+    chmod +x /entrypoint.sh; \
     chown -R appuser:appgroup /app
 
 USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/setup-service/Dockerfile
+++ b/setup-service/Dockerfile
@@ -16,10 +16,39 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'setup-service-*-plain.jar' -delete; \
+    cat <<'EOF' > /entrypoint.sh; \
+#!/bin/sh
+set -e
+
+if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
+  export SPRING_PROFILES_ACTIVE=dev
+  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+else
+  echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -z "${SPRING_DATASOURCE_URL:-}" ]; then
+  export SPRING_DATASOURCE_URL="${DATABASE_URL}"
+  echo "Mapped DATABASE_URL -> SPRING_DATASOURCE_URL"
+fi
+
+if [ -n "${KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+  if [ -z "${SPRING_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SPRING_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  if [ -z "${SHARED_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SHARED_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  echo "Using Kafka bootstrap servers from environment"
+fi
+
+exec java $JAVA_OPTS -jar /app/app.jar
+EOF
+    chmod +x /entrypoint.sh; \
     chown -R appuser:appgroup /app
 
 USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/shared-lib/shared-starters/starter-kafka/src/main/resources/application.yml
+++ b/shared-lib/shared-starters/starter-kafka/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+
+shared:
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:${SHARED_KAFKA_BOOTSTRAP_SERVERS:kafka:9092}}
+    env: ${APP_ENV:${SPRING_PROFILES_ACTIVE:dev}}

--- a/shared-lib/shared-starters/starter-redis/src/main/resources/application.yml
+++ b/shared-lib/shared-starters/starter-redis/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+
+shared:
+  redis:
+    url: ${SHARED_REDIS_URL:${REDIS_URL:}}
+    host: ${SHARED_REDIS_HOST:${REDIS_HOST:redis}}
+    port: ${SHARED_REDIS_PORT:${REDIS_PORT:6379}}
+    password: ${SHARED_REDIS_PASSWORD:${REDIS_PASSWORD:}}
+    timeout: ${SHARED_REDIS_TIMEOUT:5s}
+    key-prefix: ${SHARED_REDIS_KEY_PREFIX:shared}
+    default-ttl: ${SHARED_REDIS_DEFAULT_TTL:10m}

--- a/shared-lib/shared-starters/starter-security/src/main/resources/application.yml
+++ b/shared-lib/shared-starters/starter-security/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+
+shared:
+  security:
+    mode: ${SHARED_SECURITY_MODE:hs256}
+    hs256:
+      secret: ${SHARED_SECURITY_HS256_SECRET:change-me}
+    resource-server:
+      enabled: ${SHARED_SECURITY_RESOURCE_SERVER_ENABLED:true}
+    roles-claim: ${SHARED_SECURITY_ROLES_CLAIM:roles}
+    scope-claim: ${SHARED_SECURITY_SCOPE_CLAIM:scope}

--- a/tenant-platform/analytics-service/Dockerfile
+++ b/tenant-platform/analytics-service/Dockerfile
@@ -16,10 +16,39 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'analytics-service-*-plain.jar' -delete; \
+    cat <<'EOF' > /entrypoint.sh; \
+#!/bin/sh
+set -e
+
+if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
+  export SPRING_PROFILES_ACTIVE=dev
+  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+else
+  echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -z "${SPRING_DATASOURCE_URL:-}" ]; then
+  export SPRING_DATASOURCE_URL="${DATABASE_URL}"
+  echo "Mapped DATABASE_URL -> SPRING_DATASOURCE_URL"
+fi
+
+if [ -n "${KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+  if [ -z "${SPRING_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SPRING_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  if [ -z "${SHARED_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SHARED_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  echo "Using Kafka bootstrap servers from environment"
+fi
+
+exec java $JAVA_OPTS -jar /app/app.jar
+EOF
+    chmod +x /entrypoint.sh; \
     chown -R appuser:appgroup /app
 
 USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tenant-platform/billing-service/Dockerfile
+++ b/tenant-platform/billing-service/Dockerfile
@@ -16,10 +16,39 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'billing-service-*-plain.jar' -delete; \
+    cat <<'EOF' > /entrypoint.sh; \
+#!/bin/sh
+set -e
+
+if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
+  export SPRING_PROFILES_ACTIVE=dev
+  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+else
+  echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -z "${SPRING_DATASOURCE_URL:-}" ]; then
+  export SPRING_DATASOURCE_URL="${DATABASE_URL}"
+  echo "Mapped DATABASE_URL -> SPRING_DATASOURCE_URL"
+fi
+
+if [ -n "${KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+  if [ -z "${SPRING_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SPRING_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  if [ -z "${SHARED_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SHARED_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  echo "Using Kafka bootstrap servers from environment"
+fi
+
+exec java $JAVA_OPTS -jar /app/app.jar
+EOF
+    chmod +x /entrypoint.sh; \
     chown -R appuser:appgroup /app
 
 USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tenant-platform/catalog-service/Dockerfile
+++ b/tenant-platform/catalog-service/Dockerfile
@@ -16,10 +16,39 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'catalog-service-*-plain.jar' -delete; \
+    cat <<'EOF' > /entrypoint.sh; \
+#!/bin/sh
+set -e
+
+if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
+  export SPRING_PROFILES_ACTIVE=dev
+  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+else
+  echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -z "${SPRING_DATASOURCE_URL:-}" ]; then
+  export SPRING_DATASOURCE_URL="${DATABASE_URL}"
+  echo "Mapped DATABASE_URL -> SPRING_DATASOURCE_URL"
+fi
+
+if [ -n "${KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+  if [ -z "${SPRING_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SPRING_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  if [ -z "${SHARED_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SHARED_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  echo "Using Kafka bootstrap servers from environment"
+fi
+
+exec java $JAVA_OPTS -jar /app/app.jar
+EOF
+    chmod +x /entrypoint.sh; \
     chown -R appuser:appgroup /app
 
 USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tenant-platform/subscription-service/Dockerfile
+++ b/tenant-platform/subscription-service/Dockerfile
@@ -16,10 +16,39 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'subscription-service-*-plain.jar' -delete; \
+    cat <<'EOF' > /entrypoint.sh; \
+#!/bin/sh
+set -e
+
+if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
+  export SPRING_PROFILES_ACTIVE=dev
+  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+else
+  echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -z "${SPRING_DATASOURCE_URL:-}" ]; then
+  export SPRING_DATASOURCE_URL="${DATABASE_URL}"
+  echo "Mapped DATABASE_URL -> SPRING_DATASOURCE_URL"
+fi
+
+if [ -n "${KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+  if [ -z "${SPRING_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SPRING_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  if [ -z "${SHARED_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SHARED_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  echo "Using Kafka bootstrap servers from environment"
+fi
+
+exec java $JAVA_OPTS -jar /app/app.jar
+EOF
+    chmod +x /entrypoint.sh; \
     chown -R appuser:appgroup /app
 
 USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tenant-platform/tenant-service/Dockerfile
+++ b/tenant-platform/tenant-service/Dockerfile
@@ -16,10 +16,39 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'tenant-service-*-plain.jar' -delete; \
+    cat <<'EOF' > /entrypoint.sh; \
+#!/bin/sh
+set -e
+
+if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
+  export SPRING_PROFILES_ACTIVE=dev
+  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+else
+  echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -z "${SPRING_DATASOURCE_URL:-}" ]; then
+  export SPRING_DATASOURCE_URL="${DATABASE_URL}"
+  echo "Mapped DATABASE_URL -> SPRING_DATASOURCE_URL"
+fi
+
+if [ -n "${KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+  if [ -z "${SPRING_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SPRING_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  if [ -z "${SHARED_KAFKA_BOOTSTRAP_SERVERS:-}" ]; then
+    export SHARED_KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS}"
+  fi
+  echo "Using Kafka bootstrap servers from environment"
+fi
+
+exec java $JAVA_OPTS -jar /app/app.jar
+EOF
+    chmod +x /entrypoint.sh; \
     chown -R appuser:appgroup /app
 
 USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- add starter-level application.yml defaults that exclude overlapping Kafka/Redis/Security Boot auto-config and source key values from environment variables
- generate a lightweight entrypoint script in every Spring service Dockerfile to echo and map SPRING_PROFILES_ACTIVE, DATABASE_URL, and KAFKA_BOOTSTRAP_SERVERS before launching the jar

## Testing
- mvn -pl shared-lib/shared-starters/starter-kafka,shared-lib/shared-starters/starter-redis,shared-lib/shared-starters/starter-security -am -DskipITs test *(fails: corrupted ~/.m2 byte-buddy-agent 1.17.7)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ac0018d8832f8cd2442fde89f1bb