### PR TITLE
Allow swagger UI paths behind prefixed routes

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SharedSecurityProps.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SharedSecurityProps.java
@@ -95,7 +95,9 @@ public class SharedSecurityProps implements BaseStarterProperties {
     private String[] permitAll = new String[]{
         "/actuator/health",
         "/v3/api-docs/**",
+        "/**/v3/api-docs/**",
         "/swagger-ui/**",
+        "/**/swagger-ui/**",
         // common public endpoints (with and without /api version prefix):
         "/auth/**", "/api/*/auth/**",
         "/login", "/register",


### PR DESCRIPTION
## Summary
- extend the default security permit-all list to cover swagger endpoints behind prefixed routes

## Testing
- mvn -pl shared-lib/shared-starters/starter-security test

------
https://chatgpt.com/codex/tasks/task_e_68e3add40910832fb8384078fd9d783f