### PR TITLE
Fix entrypoint script creation in Dockerfile

### DIFF
--- a/Dockerfile.spring-service
+++ b/Dockerfile.spring-service
@@ -25,7 +25,7 @@ RUN set -eux; \
     [ -n "${BOOT_JAR}" ]; \
     mv "${BOOT_JAR}" app.jar; \
     find . -maxdepth 1 -name "${ARTIFACT_NAME}-*-plain.jar" -exec rm -f {} \;; \
-    cat <<'EOF' > /entrypoint.sh; \
+    cat <<'EOF' > /entrypoint.sh
 #!/bin/sh
 set -e
 
@@ -53,8 +53,9 @@ fi
 
 exec java $JAVA_OPTS -jar /app/app.jar
 EOF
-    chmod +x /entrypoint.sh; \
-    chown -R ${APP_USER}:${APP_GROUP} /app
+
+RUN chmod +x /entrypoint.sh \
+    && chown -R ${APP_USER}:${APP_GROUP} /app
 
 USER ${APP_USER}
 


### PR DESCRIPTION
## Summary
- ensure the entrypoint script heredoc is written without prematurely ending the RUN command
- move the chmod/chown operations into a dedicated RUN instruction to avoid Podman parsing issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b910baf0832f9456bf9480b7e8aa