### PR TITLE
Fix chmod step to use RUN instruction in Spring service Dockerfile

### DIFF
--- a/Dockerfile.spring-service
+++ b/Dockerfile.spring-service
@@ -54,8 +54,8 @@ fi
 exec java $JAVA_OPTS -jar /app/app.jar
 EOF
 
-RUN chmod +x /entrypoint.sh \
-    && chown -R ${APP_USER}:${APP_GROUP} /app
+RUN chmod +x /entrypoint.sh
+RUN chown -R ${APP_USER}:${APP_GROUP} /app
 
 USER ${APP_USER}
 


### PR DESCRIPTION
## Summary
- split the chmod/chown step in the Spring service Dockerfile into explicit RUN instructions
- ensure the container build no longer hits the "Unknown instruction: CHMOD" error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c55b8c00832fa1e95d823a3d9726