### PR TITLE
Fix entrypoint script setup in service Dockerfiles

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -17,7 +17,7 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -type f \( -name 'api-gateway-*-plain.jar' -o -name 'api-gateway-*-stubs.jar' -o -name 'api-gateway-*.jar.original' \) -delete; \
-    cat <<'EOF' > /entrypoint.sh; \
+    cat <<'EOF' > /entrypoint.sh
 #!/bin/sh
 set -e
 
@@ -45,8 +45,9 @@ fi
 
 exec java $JAVA_OPTS -jar /app/app.jar
 EOF
-    chmod +x /entrypoint.sh; \
-    chown -R appuser:appgroup /app
+
+RUN chmod +x /entrypoint.sh
+RUN chown -R appuser:appgroup /app
 
 USER appuser
 

--- a/sec-service/Dockerfile
+++ b/sec-service/Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'sec-service-*-plain.jar' -delete; \
-    cat <<'EOF' > /entrypoint.sh; \
+    cat <<'EOF' > /entrypoint.sh
 #!/bin/sh
 set -e
 
@@ -44,8 +44,9 @@ fi
 
 exec java $JAVA_OPTS -jar /app/app.jar
 EOF
-    chmod +x /entrypoint.sh; \
-    chown -R appuser:appgroup /app
+
+RUN chmod +x /entrypoint.sh
+RUN chown -R appuser:appgroup /app
 
 USER appuser
 

--- a/setup-service/Dockerfile
+++ b/setup-service/Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'setup-service-*-plain.jar' -delete; \
-    cat <<'EOF' > /entrypoint.sh; \
+    cat <<'EOF' > /entrypoint.sh
 #!/bin/sh
 set -e
 
@@ -44,8 +44,9 @@ fi
 
 exec java $JAVA_OPTS -jar /app/app.jar
 EOF
-    chmod +x /entrypoint.sh; \
-    chown -R appuser:appgroup /app
+
+RUN chmod +x /entrypoint.sh
+RUN chown -R appuser:appgroup /app
 
 USER appuser
 

--- a/tenant-platform/analytics-service/Dockerfile
+++ b/tenant-platform/analytics-service/Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'analytics-service-*-plain.jar' -delete; \
-    cat <<'EOF' > /entrypoint.sh; \
+    cat <<'EOF' > /entrypoint.sh
 #!/bin/sh
 set -e
 
@@ -44,8 +44,9 @@ fi
 
 exec java $JAVA_OPTS -jar /app/app.jar
 EOF
-    chmod +x /entrypoint.sh; \
-    chown -R appuser:appgroup /app
+
+RUN chmod +x /entrypoint.sh
+RUN chown -R appuser:appgroup /app
 
 USER appuser
 

--- a/tenant-platform/billing-service/Dockerfile
+++ b/tenant-platform/billing-service/Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'billing-service-*-plain.jar' -delete; \
-    cat <<'EOF' > /entrypoint.sh; \
+    cat <<'EOF' > /entrypoint.sh
 #!/bin/sh
 set -e
 
@@ -44,8 +44,9 @@ fi
 
 exec java $JAVA_OPTS -jar /app/app.jar
 EOF
-    chmod +x /entrypoint.sh; \
-    chown -R appuser:appgroup /app
+
+RUN chmod +x /entrypoint.sh
+RUN chown -R appuser:appgroup /app
 
 USER appuser
 

--- a/tenant-platform/catalog-service/Dockerfile
+++ b/tenant-platform/catalog-service/Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'catalog-service-*-plain.jar' -delete; \
-    cat <<'EOF' > /entrypoint.sh; \
+    cat <<'EOF' > /entrypoint.sh
 #!/bin/sh
 set -e
 
@@ -44,8 +44,9 @@ fi
 
 exec java $JAVA_OPTS -jar /app/app.jar
 EOF
-    chmod +x /entrypoint.sh; \
-    chown -R appuser:appgroup /app
+
+RUN chmod +x /entrypoint.sh
+RUN chown -R appuser:appgroup /app
 
 USER appuser
 

--- a/tenant-platform/subscription-service/Dockerfile
+++ b/tenant-platform/subscription-service/Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'subscription-service-*-plain.jar' -delete; \
-    cat <<'EOF' > /entrypoint.sh; \
+    cat <<'EOF' > /entrypoint.sh
 #!/bin/sh
 set -e
 
@@ -44,8 +44,9 @@ fi
 
 exec java $JAVA_OPTS -jar /app/app.jar
 EOF
-    chmod +x /entrypoint.sh; \
-    chown -R appuser:appgroup /app
+
+RUN chmod +x /entrypoint.sh
+RUN chown -R appuser:appgroup /app
 
 USER appuser
 

--- a/tenant-platform/tenant-service/Dockerfile
+++ b/tenant-platform/tenant-service/Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux; \
     [ -n "$BOOT_JAR" ]; \
     mv "$BOOT_JAR" app.jar; \
     find . -maxdepth 1 -name 'tenant-service-*-plain.jar' -delete; \
-    cat <<'EOF' > /entrypoint.sh; \
+    cat <<'EOF' > /entrypoint.sh
 #!/bin/sh
 set -e
 
@@ -44,8 +44,9 @@ fi
 
 exec java $JAVA_OPTS -jar /app/app.jar
 EOF
-    chmod +x /entrypoint.sh; \
-    chown -R appuser:appgroup /app
+
+RUN chmod +x /entrypoint.sh
+RUN chown -R appuser:appgroup /app
 
 USER appuser
 


### PR DESCRIPTION
## Summary
- ensure each service Dockerfile finishes the heredoc entrypoint creation within the RUN statement
- move the chmod and chown commands into dedicated RUN instructions to avoid Podman build failures

## Testing
- not run (infrastructure change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3c7c305e4832f8e549f5bde2270ef