### PR TITLE
Enable SQL schema initialization in dev profile

### DIFF
--- a/api-gateway/src/main/resources/application-dev.yaml
+++ b/api-gateway/src/main/resources/application-dev.yaml
@@ -6,6 +6,9 @@ spring:
     config:
       profile: dev
       label: develop
+  sql:
+    init:
+      mode: always
 
 gateway:
   webclient:


### PR DESCRIPTION
## Summary
- enable SQL schema initialization for the dev profile so schema.sql is applied to the gateway database

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3cab62970832f869c7bce539472b8