### PR TITLE
Reduce API Gateway dev startup overhead

### DIFF
--- a/api-gateway/src/main/resources/application-dev.yaml
+++ b/api-gateway/src/main/resources/application-dev.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    lazy-initialization: true
   config:
     activate:
       on-profile: dev
@@ -6,6 +8,8 @@ spring:
     config:
       profile: dev
       label: develop
+  jpa:
+    open-in-view: false
   sql:
     init:
       mode: always
@@ -39,3 +43,9 @@ app:
 jasypt:
   encryptor:
     fail-on-missing-password: false
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false


### PR DESCRIPTION
## Summary
- enable lazy bean initialisation and disable open-in-view for the dev profile to cut startup work
- disable springdoc API docs and Swagger UI in dev to avoid unnecessary boot-time processing

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3cc551408832fbbbb2423445044b0