### PR TITLE
Ensure gateway route schema is initialized on startup

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/RouteSchemaInitializer.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/RouteSchemaInitializer.java
@@ -1,0 +1,83 @@
+package com.ejada.gateway.config;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Component;
+import org.springframework.util.FileCopyUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Ensures the gateway route schema exists when the application starts. This is necessary because
+ * the gateway relies solely on an R2DBC connection and does not benefit from Spring's traditional
+ * JDBC schema initialisation.
+ */
+@Component
+public class RouteSchemaInitializer implements ApplicationRunner {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RouteSchemaInitializer.class);
+  private static final Duration INITIALISATION_TIMEOUT = Duration.ofSeconds(30);
+
+  private final DatabaseClient databaseClient;
+  private final ResourceLoader resourceLoader;
+
+  public RouteSchemaInitializer(DatabaseClient databaseClient, ResourceLoader resourceLoader) {
+    this.databaseClient = databaseClient;
+    this.resourceLoader = resourceLoader;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) throws Exception {
+    Resource schema = resourceLoader.getResource("classpath:schema.sql");
+    if (!schema.exists()) {
+      LOGGER.warn(
+          "No schema.sql found on the classpath; gateway route tables will not be initialised automatically");
+      return;
+    }
+
+    List<String> statements = loadStatements(schema);
+    if (statements.isEmpty()) {
+      LOGGER.debug("Route schema resource {} did not contain executable statements", schema);
+      return;
+    }
+
+    LOGGER.info("Ensuring gateway route schema is present using {}", schema);
+    Flux.fromIterable(statements)
+        .concatMap(this::executeStatement)
+        .then()
+        .block(INITIALISATION_TIMEOUT);
+  }
+
+  private Mono<Void> executeStatement(String sql) {
+    return databaseClient
+        .sql(sql)
+        .fetch()
+        .rowsUpdated()
+        .doOnError(error -> LOGGER.error("Failed to execute route schema statement: {}", sql, error))
+        .onErrorResume(error -> Mono.empty())
+        .then();
+  }
+
+  private List<String> loadStatements(Resource schema) throws IOException {
+    try (InputStreamReader reader =
+        new InputStreamReader(schema.getInputStream(), StandardCharsets.UTF_8)) {
+      String content = FileCopyUtils.copyToString(reader);
+      return Arrays.stream(content.split(";"))
+          .map(String::trim)
+          .filter(statement -> !statement.isEmpty())
+          .collect(Collectors.toList());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a startup initializer that reads the bundled schema.sql and executes its statements through the reactive DatabaseClient so the route tables are present even when only R2DBC is configured
- log success and failures to simplify diagnosing schema creation issues

## Testing
- `mvn -pl api-gateway -am test` *(fails: Error opening zip file or JAR manifest missing : /root/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cbeb4834832f94fe4ac5575afced