### PR TITLE
Ensure gateway route schema initialises before route loading

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/routes/service/DatabaseRouteDefinitionProvider.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/service/DatabaseRouteDefinitionProvider.java
@@ -3,10 +3,12 @@ package com.ejada.gateway.routes.service;
 import com.ejada.gateway.config.GatewayRouteDefinitionProvider;
 import com.ejada.gateway.config.GatewayRoutesProperties;
 import com.ejada.gateway.routes.repository.RouteDefinitionRepository;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 
 @Component
+@DependsOn("gatewayRouteSchemaInitializer")
 public class DatabaseRouteDefinitionProvider implements GatewayRouteDefinitionProvider {
 
   private final RouteDefinitionRepository repository;


### PR DESCRIPTION
## Summary
- initialise the gateway route schema during bean creation to guarantee tables exist before dynamic routes load
- gate the database-backed route provider on the schema initialiser so startup ordering is predictable

## Testing
- `mvn -pl api-gateway -am test` *(fails: Error opening zip file or JAR manifest missing : /root/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cf21434c832f8a4042063855d01d