### PR TITLE
Fix shared default schema fallback to avoid duplicate schema creation

### DIFF
--- a/shared-lib/shared-config/src/main/resources/application-shared-service.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-service.yaml
@@ -1,6 +1,6 @@
 app:
   environment: ${APP_ENVIRONMENT:dev}
-  schema: ${APP_SCHEMA:${spring.application.name}}
+  schema: ${APP_SCHEMA:${spring.flyway.default-schema:${spring.application.name}}}
   cache-prefix: ${APP_CACHE_PREFIX:${spring.application.name}}
   kafka:
     client-id: ${APP_KAFKA_CLIENT_ID:ejada-${spring.application.name}-${app.environment}}


### PR DESCRIPTION
## Summary
- ensure the shared service configuration defaults the application schema to the Flyway default schema when available to prevent duplicate schema creation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d450d9c0832fa5b21d636afb9db6