### PR TITLE
Handle already committed gateway responses

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/context/ReactiveRequestContextFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/ReactiveRequestContextFilter.java
@@ -226,6 +226,10 @@ public class ReactiveRequestContextFilter implements WebFilter {
       LOGGER.warn("Tenant resolution error [{}]", code);
     }
     ServerHttpResponse response = exchange.getResponse();
+    if (response.isCommitted()) {
+      LOGGER.debug("Response already committed, skipping tenant rejection for {}", exchange.getRequest().getPath());
+      return Mono.empty();
+    }
     response.setStatusCode(HttpStatus.valueOf(status));
     response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
     BaseResponse<Void> body = BaseResponse.error(code, message);

--- a/api-gateway/src/main/java/com/ejada/gateway/context/TenantExtractionGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/TenantExtractionGatewayFilter.java
@@ -177,6 +177,10 @@ public class TenantExtractionGatewayFilter implements WebFilter {
   private Mono<Void> reject(ServerWebExchange exchange, String rawValue) {
     LOGGER.warn("Rejecting request due to invalid tenant identifier: {}", rawValue);
     var response = exchange.getResponse();
+    if (response.isCommitted()) {
+      LOGGER.debug("Response already committed, skipping tenant rejection for {}", exchange.getRequest().getPath());
+      return Mono.empty();
+    }
     response.setStatusCode(HttpStatus.BAD_REQUEST);
     response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
     BaseResponse<Void> body = BaseResponse.error("ERR_INVALID_TENANT", "Invalid " + HeaderNames.X_TENANT_ID);

--- a/api-gateway/src/main/java/com/ejada/gateway/filter/SubscriptionValidationGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/SubscriptionValidationGatewayFilter.java
@@ -301,6 +301,10 @@ public class SubscriptionValidationGatewayFilter implements GlobalFilter, Ordere
   }
 
   private Mono<Void> reject(ServerWebExchange exchange, SubscriptionDecision decision) {
+    if (exchange.getResponse().isCommitted()) {
+      LOGGER.debug("Response already committed, skipping subscription rejection for {}", exchange.getRequest().getPath());
+      return Mono.empty();
+    }
     exchange.getResponse().setStatusCode(decision.status());
     exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
     BaseResponse<Object> body = BaseResponse.<Object>builder()

--- a/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
@@ -471,6 +471,10 @@ return {tostring(allowed), tostring(totalRemaining), tostring(resetTimestamp), t
   private Mono<Void> reject(ServerWebExchange exchange) {
     LOGGER.debug("Rate limit exceeded for request to {}", exchange.getRequest().getPath());
     var response = exchange.getResponse();
+    if (response.isCommitted()) {
+      LOGGER.debug("Response already committed, skipping rate limit rejection for {}", exchange.getRequest().getPath());
+      return Mono.empty();
+    }
     response.setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
     response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
     BaseResponse<Void> body = BaseResponse.error("ERR_RATE_LIMIT", "Rate limit exceeded");

--- a/api-gateway/src/main/java/com/ejada/gateway/security/ApiKeyAuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/security/ApiKeyAuthenticationFilter.java
@@ -147,6 +147,10 @@ public class ApiKeyAuthenticationFilter implements WebFilter, Ordered {
 
   private Mono<Void> reject(ServerWebExchange exchange, HttpStatus status, String code, String message) {
     var response = exchange.getResponse();
+    if (response.isCommitted()) {
+      LOGGER.debug("Response already committed, skipping API key rejection for {}", exchange.getRequest().getPath());
+      return Mono.empty();
+    }
     response.setStatusCode(status);
     response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
     BaseResponse<Void> body = BaseResponse.error(code, message);

--- a/api-gateway/src/main/java/com/ejada/gateway/security/IpFilteringGatewayFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/security/IpFilteringGatewayFilter.java
@@ -113,6 +113,10 @@ public class IpFilteringGatewayFilter implements GlobalFilter, Ordered {
 
   private Mono<Void> reject(ServerWebExchange exchange, String code, String message, HttpStatus status) {
     var response = exchange.getResponse();
+    if (response.isCommitted()) {
+      LOGGER.debug("Response already committed, skipping IP filter rejection for {}", exchange.getRequest().getPath());
+      return Mono.empty();
+    }
     response.setStatusCode(status);
     response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
     BaseResponse<Void> body = BaseResponse.error(code, message);

--- a/api-gateway/src/main/java/com/ejada/gateway/security/RequestSignatureValidationFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/security/RequestSignatureValidationFilter.java
@@ -178,6 +178,10 @@ public class RequestSignatureValidationFilter implements WebFilter, Ordered {
 
   private Mono<Void> reject(ServerWebExchange exchange, HttpStatus status, String code, String message) {
     var response = exchange.getResponse();
+    if (response.isCommitted()) {
+      LOGGER.debug("Response already committed, skipping request signature rejection for {}", exchange.getRequest().getPath());
+      return Mono.empty();
+    }
     response.setStatusCode(status);
     response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
     BaseResponse<Void> body = BaseResponse.error(code, message);


### PR DESCRIPTION
## Summary
- add guard clauses across gateway rejection filters to skip writing responses when Reactor Netty has already committed the exchange
- log when the exchange is already committed to aid diagnostics and prevent duplicate error payload attempts

## Testing
- mvn -pl shared-lib clean install -DskipTests
- mvn -pl api-gateway test *(fails: missing shared starter artifacts in local Maven repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d4fef388832fa1b9221d7015dae7