### PR TITLE
Align subscription schema configuration defaults

### DIFF
--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -3,8 +3,6 @@ spring:
     import: optional:classpath:application-shared-platform-dev.yaml
 
 app:
-  schema: subscription
-  cache-prefix: subscription
   kafka:
     client-id: ejada-subscription-dev
   subscription-approval:

--- a/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
@@ -4,7 +4,6 @@ spring:
 
 app:
   service-code: subscription
-  schema: subscription
   subscription-approval:
     topic: tenant.subscription-approvals
     approval-role: ejada-officer

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -8,8 +8,12 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
-    default-schema: subscription
-    schemas: subscription
+    default-schema: ${app.schema}
+    schemas: ${app.schema}
+
+app:
+  schema: subscription
+  cache-prefix: subscription
 
 server:
   port: 8080


### PR DESCRIPTION
## Summary
- drive the default Flyway schema from the shared `app.schema` setting
- declare the `subscription` schema and cache prefix once in the base application config
- remove redundant schema overrides from the dev and QA profiles

## Testing
- not run (missing internal Maven artifacts)


------
https://chatgpt.com/codex/tasks/task_e_68e3d7fc2830832f8533f73c70c23e42