### PR TITLE
Centralize schema configuration across services

### DIFF
--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -177,8 +177,6 @@ shared:
     jwt-security: false
 
 app:
-  schema: security
-  cache-prefix: security
   kafka:
     client-id: ejada-security-dev
   subscription-approval:

--- a/sec-service/src/main/resources/application-qa.yaml
+++ b/sec-service/src/main/resources/application-qa.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:ejada}?currentSchema=security}"
+    url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:ejada}?currentSchema=${app.schema}}"
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
@@ -20,7 +20,7 @@ spring:
     properties:
       hibernate:
         ddl-auto: none
-        default_schema: security
+        default_schema: ${app.schema}
         hbm2ddl.create_namespaces: true
         format_sql: true
         jdbc.time_zone: UTC
@@ -28,8 +28,8 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: security
-    default-schema: security
+    schemas: ${app.schema}
+    default-schema: ${app.schema}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
     client-id: ejada-security-qa
@@ -175,7 +175,7 @@ app:
     sinks:
       db:
         enabled: true
-        schema: security
+        schema: ${app.schema}
         table: audit_logs
       kafka:
         enabled: true

--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -8,8 +8,8 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
-    schemas: security
-    default-schema: security
+    schemas: ${app.schema}
+    default-schema: ${app.schema}
 server:
   port: 8080
   shutdown: graceful
@@ -70,7 +70,7 @@ shared:
     sinks:
       db:
         enabled: true
-        schema: security
+        schema: ${app.schema}
         table: audit_logs
       kafka:
         enabled: true
@@ -92,6 +92,10 @@ shared:
       password-expiry-days: 90
       min-active-admins: 1
       max-failed-attempts: 5
+
+app:
+  schema: security
+  cache-prefix: security
 
 sec:
   superadmin:

--- a/setup-service/src/main/resources/application-dev.yaml
+++ b/setup-service/src/main/resources/application-dev.yaml
@@ -18,8 +18,6 @@ spring:
         enabled: ${AWS_SECRETS_MANAGER_ENABLED:false}
 
 app:
-  schema: setup
-  cache-prefix: setup
   kafka:
     client-id: ejada-setup-dev
   jpa:

--- a/setup-service/src/main/resources/application-local.yaml
+++ b/setup-service/src/main/resources/application-local.yaml
@@ -4,8 +4,6 @@ spring:
       - optional:classpath:application-shared-platform-dev.yaml
 
 app:
-  schema: setup
-  cache-prefix: setup
   kafka:
     client-id: ejada-setup-dev
   jpa:

--- a/setup-service/src/main/resources/application-qa.yaml
+++ b/setup-service/src/main/resources/application-qa.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:ejada}?currentSchema=setup}"
+    url: "${DB_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:ejada}?currentSchema=${app.schema}}"
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
@@ -20,7 +20,7 @@ spring:
     properties:
       hibernate:
         ddl-auto: none
-        default_schema: setup
+        default_schema: ${app.schema}
         hbm2ddl.create_namespaces: true
         format_sql: true
       jdbc:
@@ -29,8 +29,8 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: setup
-    default-schema: setup
+    schemas: ${app.schema}
+    default-schema: ${app.schema}
   kafka:
     bootstrap-servers: kafka:9092
     client-id: ejada-setup-qa
@@ -157,7 +157,7 @@ shared:
     sinks:
       db:
         enabled: true
-        schema: setup
+        schema: ${app.schema}
         table: audit_logs
       kafka:
         enabled: true

--- a/setup-service/src/main/resources/application.yaml
+++ b/setup-service/src/main/resources/application.yaml
@@ -8,8 +8,12 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
-    schemas: setup
-    default-schema: setup
+    schemas: ${app.schema}
+    default-schema: ${app.schema}
+
+app:
+  schema: setup
+  cache-prefix: setup
 server:
   port: 8080
   shutdown: graceful

--- a/shared-lib/shared-config/src/main/resources/application-shared-tenant-qa.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-tenant-qa.yaml
@@ -5,7 +5,6 @@ spring:
 app:
   environment: qa
   service-code: tenant
-  schema: tenant
   cache-prefix: ejada
   kafka:
     client-id: ${app.kafka-client-id:ejada-${app.service-code}-${app.environment}}

--- a/tenant-platform/analytics-service/src/main/resources/application.yml
+++ b/tenant-platform/analytics-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:lms}?currentSchema=tenant_usage}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:lms}?currentSchema=${app.schema}}
     username: ${SPRING_DATASOURCE_USERNAME:postgres}
     password: ${SPRING_DATASOURCE_PASSWORD:postgres}
     driver-class-name: org.postgresql.Driver
@@ -19,7 +19,7 @@ spring:
       ddl-auto: none
     properties:
       hibernate:
-        default_schema: tenant_usage
+        default_schema: ${app.schema}
         hbm2ddl:
           create_namespaces: true
         format_sql: true
@@ -29,8 +29,8 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: tenant
-    default-schema: tenant_usage
+    schemas: ${app.schema}
+    default-schema: ${app.schema}
   cache:
     type: redis
   data:

--- a/tenant-platform/billing-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-dev.yaml
@@ -20,8 +20,6 @@ shared:
     enable-role-check: false
 
 app:
-  schema: billing
-  cache-prefix: billing
   kafka:
     client-id: ejada-billing-dev
   billing:

--- a/tenant-platform/billing-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application-qa.yaml
@@ -4,7 +4,6 @@ spring:
 
 app:
   service-code: billing
-  schema: billing
 
 management:
   endpoints:

--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -8,8 +8,12 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
-    default-schema: billing
-    schemas: billing
+    default-schema: ${app.schema}
+    schemas: ${app.schema}
+
+app:
+  schema: billing
+  cache-prefix: billing
 
 server:
   port: 8080

--- a/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
@@ -17,8 +17,6 @@ shared:
     jwt-security: false
 
 app:
-  schema: catalog
-  cache-prefix: catalog
   kafka:
     client-id: ejada-catalog-dev
   jpa:

--- a/tenant-platform/catalog-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-qa.yaml
@@ -4,7 +4,6 @@ spring:
 
 app:
   service-code: catalog
-  schema: catalog
   tenant-provisioning:
     topic: tenant.provisioning
     consumer-group: catalog-tenant-provisioning

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -8,8 +8,12 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
-    default-schema: catalog
-    schemas: catalog
+    default-schema: ${app.schema}
+    schemas: ${app.schema}
+
+app:
+  schema: catalog
+  cache-prefix: catalog
 
 server:
   port: 8080

--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -3,8 +3,6 @@ spring:
     import: optional:classpath:application-shared-platform-dev.yaml
 
 app:
-  schema: subscription
-  cache-prefix: subscription
   kafka:
     client-id: ejada-subscription-dev
   subscription-approval:

--- a/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
@@ -4,7 +4,6 @@ spring:
 
 app:
   service-code: subscription
-  schema: subscription
   subscription-approval:
     topic: tenant.subscription-approvals
     approval-role: ejada-officer

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -8,8 +8,12 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
-    default-schema: subscription
-    schemas: subscription
+    default-schema: ${app.schema}
+    schemas: ${app.schema}
+
+app:
+  schema: subscription
+  cache-prefix: subscription
 
 server:
   port: 8080

--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -17,8 +17,6 @@ shared:
     jwt-security: false
 
 app:
-  schema: tenant
-  cache-prefix: tenant
   kafka:
     client-id: ejada-tenant-dev
   subscription-approval:

--- a/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
@@ -4,7 +4,6 @@ spring:
 
 app:
   service-code: tenant
-  schema: tenant
   subscription-approval:
     topic: tenant.subscription-approvals
     approval-role: ejada-officer

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -8,8 +8,12 @@ spring:
   flyway:
     baseline-on-migrate: true
     baseline-version: 0
-    schemas: tenant
-    default-schema: tenant
+    schemas: ${app.schema}
+    default-schema: ${app.schema}
+
+app:
+  schema: tenant
+  cache-prefix: tenant
 server:
   port: 8080
   shutdown: graceful


### PR DESCRIPTION
## Summary
- derive each service's Flyway schema from the shared `app.schema` property and define the schema/cache defaults in the base configs
- remove redundant schema overrides from the dev/qa/local profiles now that the defaults live in the common `application` files
- update QA/service configuration snippets to reference `${app.schema}` instead of hard-coded schema names and drop the tenant QA shared schema override

## Testing
- not run (missing required internal Maven artifacts)

------
https://chatgpt.com/codex/tasks/task_e_68e3d7fc2830832f8533f73c70c23e42