### PR TITLE
Ensure public schema is created for gateway routes

### DIFF
--- a/api-gateway/src/main/resources/schema.sql
+++ b/api-gateway/src/main/resources/schema.sql
@@ -1,3 +1,5 @@
+CREATE SCHEMA IF NOT EXISTS public;
+
 CREATE TABLE IF NOT EXISTS public.route_definitions (
     id UUID PRIMARY KEY,
     path_pattern TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- add explicit creation of the public schema before creating gateway route tables

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e45e242304832f80a634ad919ae840