### PR TITLE
Fix circular placeholder for shared schema configuration

### DIFF
--- a/shared-lib/shared-config/src/main/resources/application-shared-service.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-service.yaml
@@ -1,6 +1,6 @@
 app:
   environment: ${APP_ENVIRONMENT:dev}
-  schema: ${APP_SCHEMA:${spring.flyway.default-schema:${spring.application.name}}}
+  schema: ${APP_SCHEMA:${spring.application.name:public}}
   cache-prefix: ${APP_CACHE_PREFIX:${spring.application.name}}
   kafka:
     client-id: ${APP_KAFKA_CLIENT_ID:ejada-${spring.application.name}-${app.environment}}


### PR DESCRIPTION
## Summary
- update the shared service configuration to stop referencing `spring.flyway.default-schema` when resolving `app.schema`
- avoid the circular property placeholder resolution triggered when `app.schema` and `spring.flyway.default-schema` point to each other

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e45ddabc10832f9c4413e06124d9ed