### PR TITLE
Fix swagger routing for setup-service

### DIFF
--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -435,7 +435,7 @@ gateway:
       uri: lb://setup-service
       paths:
         - /api/setup/**
-      strip-prefix: 1
+      strip-prefix: 2
       prefix-path: /core
 
 # Application metadata that surfaces through /actuator/info and diagnostics endpoints.


### PR DESCRIPTION
## Summary
- ensure the API gateway forwards /api/setup requests to the setup service without duplicating the context path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4d4e46a34832fbfbae38d0ebc4cec