### PR TITLE
Align reactive context keys with gateway propagation

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/context/ReactiveRequestContextFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/context/ReactiveRequestContextFilter.java
@@ -113,9 +113,11 @@ public class ReactiveRequestContextFilter implements WebFilter {
     Context updated = context;
     if (state.getCorrelationId() != null) {
       updated = updated.put(HeaderNames.CORRELATION_ID, state.getCorrelationId());
+      updated = updated.put(GatewayRequestAttributes.CORRELATION_ID, state.getCorrelationId());
     }
     if (state.getTenant() != null) {
       updated = updated.put(HeaderNames.X_TENANT_ID, state.getTenant());
+      updated = updated.put(GatewayRequestAttributes.TENANT_ID, state.getTenant());
     }
     if (state.getUserId() != null) {
       updated = updated.put(HeaderNames.USER_ID, state.getUserId());

--- a/api-gateway/src/test/java/com/ejada/gateway/context/ReactiveRequestContextFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/context/ReactiveRequestContextFilterTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ejada.common.constants.HeaderNames;
 import com.ejada.common.context.ContextManager;
+import com.ejada.gateway.context.GatewayRequestAttributes;
 import com.ejada.starter_core.config.CoreAutoConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
@@ -59,6 +60,8 @@ class ReactiveRequestContextFilterTest {
         assertThat(contextRef.get()).isNotNull();
         assertThat((String) contextRef.get().get(HeaderNames.CORRELATION_ID)).isEqualTo("corr-123");
         assertThat((String) contextRef.get().get(HeaderNames.X_TENANT_ID)).isEqualTo("tenant-1");
+        assertThat((String) contextRef.get().get(GatewayRequestAttributes.CORRELATION_ID)).isEqualTo("corr-123");
+        assertThat((String) contextRef.get().get(GatewayRequestAttributes.TENANT_ID)).isEqualTo("tenant-1");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add gateway attribute keys to the Reactor context produced by `ReactiveRequestContextFilter`
- extend the filter test to verify both header-based and gateway attribute keys are present

## Testing
- `mvn -pl api-gateway test -DskipITs` *(fails: missing internal starter artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d51d6904832fa9da5e40f74a00cf