### PR TITLE
Enhance API key security controls

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityConfiguration.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityConfiguration.java
@@ -2,6 +2,7 @@ package com.ejada.gateway.config;
 
 import com.ejada.gateway.authorization.TenantAuthorizationManager;
 import com.ejada.gateway.config.GatewayRateLimitProperties;
+import com.ejada.gateway.config.GatewayRoutesProperties;
 import com.ejada.gateway.security.ApiKeyAuthenticationFilter;
 import com.ejada.gateway.security.GatewaySecurityMetrics;
 import com.ejada.gateway.security.GatewayTokenIntrospectionService;
@@ -136,9 +137,10 @@ public class GatewaySecurityConfiguration {
       ReactiveStringRedisTemplate redisTemplate,
       GatewaySecurityMetrics metrics,
       GatewaySecurityProperties properties,
+      GatewayRoutesProperties routesProperties,
       @Qualifier("jacksonObjectMapper") ObjectProvider<ObjectMapper> primaryObjectMapper,
       ObjectProvider<ObjectMapper> fallbackObjectMapper) {
-    return new ApiKeyAuthenticationFilter(redisTemplate, metrics, properties, primaryObjectMapper, fallbackObjectMapper);
+    return new ApiKeyAuthenticationFilter(redisTemplate, metrics, properties, routesProperties, primaryObjectMapper, fallbackObjectMapper);
   }
 
   @Bean

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewaySecurityProperties.java
@@ -189,6 +189,10 @@ public class GatewaySecurityProperties {
 
     private boolean enabled = true;
     private String keyPrefix = "gateway:api-key:";
+    private final Encryption encryption = new Encryption();
+    private final Rotation rotation = new Rotation();
+    private final ScopeEnforcement scopeEnforcement = new ScopeEnforcement();
+    private final Audit audit = new Audit();
 
     public boolean isEnabled() {
       return enabled;
@@ -210,6 +214,175 @@ public class GatewaySecurityProperties {
 
     public String redisKey(String apiKey) {
       return keyPrefix + apiKey;
+    }
+
+    public Encryption getEncryption() {
+      return encryption;
+    }
+
+    public Rotation getRotation() {
+      return rotation;
+    }
+
+    public ScopeEnforcement getScopeEnforcement() {
+      return scopeEnforcement;
+    }
+
+    public Audit getAudit() {
+      return audit;
+    }
+  }
+
+  public enum EncryptionAlgorithm {
+    AES_256_GCM("AES-256-GCM", "AES/GCM/NoPadding");
+
+    private final String id;
+    private final String transformation;
+
+    EncryptionAlgorithm(String id, String transformation) {
+      this.id = id;
+      this.transformation = transformation;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getTransformation() {
+      return transformation;
+    }
+
+    public static EncryptionAlgorithm from(String value) {
+      if (!StringUtils.hasText(value)) {
+        return null;
+      }
+      for (EncryptionAlgorithm candidate : values()) {
+        if (candidate.id.equalsIgnoreCase(value) || candidate.name().equalsIgnoreCase(value)) {
+          return candidate;
+        }
+      }
+      return null;
+    }
+  }
+
+  public static class Encryption {
+
+    private boolean enabled = false;
+    private EncryptionAlgorithm algorithm = EncryptionAlgorithm.AES_256_GCM;
+    private String keyId = "default";
+    private String keyValue;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public EncryptionAlgorithm getAlgorithm() {
+      return algorithm;
+    }
+
+    public void setAlgorithm(EncryptionAlgorithm algorithm) {
+      this.algorithm = (algorithm == null) ? EncryptionAlgorithm.AES_256_GCM : algorithm;
+    }
+
+    public void setAlgorithm(String algorithm) {
+      EncryptionAlgorithm resolved = EncryptionAlgorithm.from(algorithm);
+      if (resolved != null) {
+        this.algorithm = resolved;
+      }
+    }
+
+    public String getKeyId() {
+      return keyId;
+    }
+
+    public void setKeyId(String keyId) {
+      if (StringUtils.hasText(keyId)) {
+        this.keyId = keyId.trim();
+      }
+    }
+
+    public String getKeyValue() {
+      return keyValue;
+    }
+
+    public void setKeyValue(String keyValue) {
+      if (!StringUtils.hasText(keyValue)) {
+        this.keyValue = null;
+        return;
+      }
+      this.keyValue = keyValue.trim();
+    }
+  }
+
+  public static class Rotation {
+
+    private boolean enabled = false;
+    private long maxAgeDays = 90;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public long getMaxAgeDays() {
+      return maxAgeDays;
+    }
+
+    public void setMaxAgeDays(long maxAgeDays) {
+      if (maxAgeDays > 0) {
+        this.maxAgeDays = maxAgeDays;
+      }
+    }
+  }
+
+  public static class ScopeEnforcement {
+
+    private boolean enabled = false;
+    private boolean requireExactMatch = false;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public boolean isRequireExactMatch() {
+      return requireExactMatch;
+    }
+
+    public void setRequireExactMatch(boolean requireExactMatch) {
+      this.requireExactMatch = requireExactMatch;
+    }
+  }
+
+  public static class Audit {
+
+    private boolean logUsage = false;
+    private boolean trackLastUsed = false;
+
+    public boolean isLogUsage() {
+      return logUsage;
+    }
+
+    public void setLogUsage(boolean logUsage) {
+      this.logUsage = logUsage;
+    }
+
+    public boolean isTrackLastUsed() {
+      return trackLastUsed;
+    }
+
+    public void setTrackLastUsed(boolean trackLastUsed) {
+      this.trackLastUsed = trackLastUsed;
     }
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/security/ApiKeyAuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/security/ApiKeyAuthenticationFilter.java
@@ -2,16 +2,33 @@ package com.ejada.gateway.security;
 
 import com.ejada.common.constants.HeaderNames;
 import com.ejada.common.dto.BaseResponse;
+import com.ejada.gateway.config.GatewayRoutesProperties;
+import com.ejada.gateway.config.GatewayRoutesProperties.ServiceRoute;
 import com.ejada.gateway.config.GatewaySecurityProperties;
+import com.ejada.gateway.config.GatewaySecurityProperties.EncryptionAlgorithm;
 import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.ejada.gateway.security.GatewaySecurityMetrics;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -19,6 +36,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -27,6 +45,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
@@ -40,21 +60,31 @@ import reactor.core.publisher.Mono;
 public class ApiKeyAuthenticationFilter implements WebFilter, Ordered {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ApiKeyAuthenticationFilter.class);
+  private static final int GCM_TAG_LENGTH = 128;
+  private static final int GCM_IV_LENGTH = 12;
 
   private final ReactiveStringRedisTemplate redisTemplate;
   private final ObjectMapper objectMapper;
   private final GatewaySecurityProperties properties;
   private final GatewaySecurityMetrics metrics;
+  private final GatewayRoutesProperties routesProperties;
+  private final PathMatcher pathMatcher = new AntPathMatcher();
+  private final SecureRandom secureRandom = new SecureRandom();
+
+  private volatile SecretKey cachedSecretKey;
+  private volatile String cachedKeyValue;
 
   public ApiKeyAuthenticationFilter(
       ReactiveStringRedisTemplate redisTemplate,
       GatewaySecurityMetrics metrics,
       GatewaySecurityProperties properties,
+      GatewayRoutesProperties routesProperties,
       @Qualifier("jacksonObjectMapper") ObjectProvider<ObjectMapper> primaryObjectMapper,
       ObjectProvider<ObjectMapper> fallbackObjectMapper) {
     this.redisTemplate = Objects.requireNonNull(redisTemplate, "redisTemplate");
     this.properties = Objects.requireNonNull(properties, "properties");
     this.metrics = Objects.requireNonNull(metrics, "metrics");
+    this.routesProperties = Objects.requireNonNull(routesProperties, "routesProperties");
     ObjectMapper mapper = (primaryObjectMapper != null) ? primaryObjectMapper.getIfAvailable() : null;
     if (mapper == null) {
       mapper = (fallbackObjectMapper != null) ? fallbackObjectMapper.getIfAvailable() : null;
@@ -75,10 +105,11 @@ public class ApiKeyAuthenticationFilter implements WebFilter, Ordered {
 
     String redisKey = properties.getApiKey().redisKey(apiKey);
     return redisTemplate.opsForValue().get(redisKey)
-        .flatMap(json -> Mono.fromCallable(() -> objectMapper.readValue(json, ApiKeyRecord.class))
+        .flatMap(payload -> decodeRecord(payload)
             .onErrorResume(ex -> {
-              LOGGER.warn("Failed to decode API key payload", ex);
-              return Mono.empty();
+              LOGGER.warn("Failed to decode API key payload for key {}", redisKey, ex);
+              metrics.incrementBlocked("api_key_decode", null);
+              return reject(exchange, HttpStatus.UNAUTHORIZED, "ERR_API_KEY_INVALID", "Invalid API key");
             }))
         .switchIfEmpty(Mono.defer(() -> {
           LOGGER.debug("API key not found for redis key {}", redisKey);
@@ -86,7 +117,7 @@ public class ApiKeyAuthenticationFilter implements WebFilter, Ordered {
           return reject(exchange, HttpStatus.UNAUTHORIZED, "ERR_API_KEY_INVALID", "Invalid API key")
               .then(Mono.empty());
         }))
-        .flatMap(record -> validateAndAuthenticate(record, apiKey, exchange, chain));
+        .flatMap(decoded -> validateAndAuthenticate(decoded, apiKey, redisKey, exchange, chain));
   }
 
   @Override
@@ -94,35 +125,115 @@ public class ApiKeyAuthenticationFilter implements WebFilter, Ordered {
     return Ordered.HIGHEST_PRECEDENCE + 1;
   }
 
-  private Mono<Void> validateAndAuthenticate(ApiKeyRecord record, String apiKey,
+  private Mono<DecodedApiKeyRecord> decodeRecord(String raw) {
+    return Mono.fromCallable(() -> {
+      JsonNode tree = objectMapper.readTree(raw);
+      if (tree.hasNonNull("ciphertext")) {
+        EncryptedPayload payload = objectMapper.treeToValue(tree, EncryptedPayload.class);
+        ApiKeyRecord record = decrypt(payload);
+        return DecodedApiKeyRecord.encrypted(record, payload.keyId());
+      }
+      PlainStoredApiKeyRecord stored = objectMapper.treeToValue(tree, PlainStoredApiKeyRecord.class);
+      return DecodedApiKeyRecord.plain(stored.toRecord());
+    });
+  }
+
+  private Mono<Void> validateAndAuthenticate(DecodedApiKeyRecord decoded, String apiKey, String redisKey,
       ServerWebExchange exchange, WebFilterChain chain) {
-    if (!StringUtils.hasText(record.tenantId())) {
+    ApiKeyRecord record = decoded.record();
+    Instant now = Instant.now();
+    if (!StringUtils.hasText(record.getTenantId())) {
       metrics.incrementBlocked("api_key", null);
       return reject(exchange, HttpStatus.UNAUTHORIZED, "ERR_API_KEY_INVALID", "API key is not bound to a tenant");
     }
-    if (record.expiresAt() != null && record.expiresAt().isBefore(Instant.now())) {
-      metrics.incrementBlocked("api_key_expired", record.tenantId());
+    if (record.getExpiresAt() != null && record.getExpiresAt().isBefore(now)) {
+      metrics.incrementBlocked("api_key_expired", record.getTenantId());
       return reject(exchange, HttpStatus.UNAUTHORIZED, "ERR_API_KEY_EXPIRED", "API key has expired");
     }
 
-    Collection<GrantedAuthority> authorities = authorities(record.scopes());
-    ApiKeyAuthenticationToken authentication = new ApiKeyAuthenticationToken(apiKey, record.tenantId(), authorities);
+    GatewaySecurityProperties.ApiKey.Rotation rotation = properties.getApiKey().getRotation();
+    if (rotation.isEnabled()) {
+      Instant rotatedAt = record.getRotatedAt();
+      if (rotatedAt == null) {
+        metrics.incrementBlocked("api_key_rotation_missing", record.getTenantId());
+        return reject(exchange, HttpStatus.UNAUTHORIZED, "ERR_API_KEY_ROTATION_REQUIRED", "API key rotation metadata missing");
+      }
+      Duration maxAge = Duration.ofDays(Math.max(1, rotation.getMaxAgeDays()));
+      if (rotatedAt.plus(maxAge).isBefore(now)) {
+        metrics.incrementBlocked("api_key_rotation_expired", record.getTenantId());
+        return reject(exchange, HttpStatus.UNAUTHORIZED, "ERR_API_KEY_ROTATED", "API key rotation window exceeded");
+      }
+    }
 
-    metrics.incrementApiKeyValidated(record.tenantId());
+    ScopeRequirements requirements = resolveScopeRequirements(exchange);
+    if (!requirements.scopes().isEmpty()) {
+      Set<String> granted = normaliseScopes(record.getScopes());
+      Set<String> required = normaliseScopes(requirements.scopes());
+      boolean requireExact = properties.getApiKey().getScopeEnforcement().isRequireExactMatch();
+      boolean authorised = requireExact ? granted.equals(required) : granted.containsAll(required);
+      if (!authorised) {
+        metrics.incrementBlocked("api_key_scope", record.getTenantId());
+        String message = requireExact
+            ? "API key scopes do not exactly match route requirements"
+            : "API key missing required scopes";
+        return reject(exchange, HttpStatus.FORBIDDEN, "ERR_API_KEY_SCOPE", message);
+      }
+    }
 
-    ServerHttpRequest mutatedRequest = mutateRequest(exchange.getRequest(), record.tenantId());
+    Collection<GrantedAuthority> authorities = authorities(record.getScopes());
+    ApiKeyAuthenticationToken authentication = new ApiKeyAuthenticationToken(apiKey, record.getTenantId(), authorities);
+
+    metrics.incrementApiKeyValidated(record.getTenantId());
+
+    ServerHttpRequest mutatedRequest = mutateRequest(exchange.getRequest(), record.getTenantId());
     ServerWebExchange mutatedExchange = exchange.mutate()
         .request(mutatedRequest)
         .build();
-    mutatedExchange.getAttributes().put(GatewayRequestAttributes.TENANT_ID, record.tenantId());
-    mutatedExchange.getAttributes().put(HeaderNames.X_TENANT_ID, record.tenantId());
+    mutatedExchange.getAttributes().put(GatewayRequestAttributes.TENANT_ID, record.getTenantId());
+    mutatedExchange.getAttributes().put(HeaderNames.X_TENANT_ID, record.getTenantId());
 
-    return chain.filter(mutatedExchange)
+    Mono<Void> audit = auditUsage(decoded, redisKey, record, exchange)
+        .onErrorResume(ex -> {
+          LOGGER.warn("Failed to audit API key usage for tenant {}", record.getTenantId(), ex);
+          return Mono.empty();
+        });
+
+    return audit.then(chain.filter(mutatedExchange)
         .contextWrite(ctx -> ctx
-            .put(GatewayRequestAttributes.TENANT_ID, record.tenantId())
-            .put(HeaderNames.X_TENANT_ID, record.tenantId())
+            .put(GatewayRequestAttributes.TENANT_ID, record.getTenantId())
+            .put(HeaderNames.X_TENANT_ID, record.getTenantId())
             .put(SecurityContext.class, new SecurityContextImpl(authentication)))
-        .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
+        .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication)));
+  }
+
+  private Mono<Void> auditUsage(DecodedApiKeyRecord decoded, String redisKey, ApiKeyRecord record,
+      ServerWebExchange exchange) {
+    GatewaySecurityProperties.ApiKey.Audit audit = properties.getApiKey().getAudit();
+    if (!audit.isLogUsage() && !audit.isTrackLastUsed()) {
+      return Mono.empty();
+    }
+    Instant now = Instant.now();
+    ScopeRequirements requirements = resolveScopeRequirements(exchange);
+    if (audit.isLogUsage()) {
+      LOGGER.info("API key usage: tenant={}, path={}, routes={}, keyId={}",
+          record.getTenantId(), exchange.getRequest().getPath(),
+          String.join(",", requirements.routeIds()), decoded.keyId().orElse("n/a"));
+    }
+    if (!audit.isTrackLastUsed()) {
+      return Mono.empty();
+    }
+    Instant previous = record.getLastUsedAt();
+    if (previous != null && !previous.isBefore(now.minusSeconds(1))) {
+      return Mono.empty();
+    }
+    record.setLastUsedAt(now);
+    return Mono.fromCallable(() -> serializeRecord(record, decoded.encrypted()))
+        .flatMap(serialized -> {
+          if (!StringUtils.hasText(serialized)) {
+            return Mono.empty();
+          }
+          return redisTemplate.opsForValue().set(redisKey, serialized).then();
+        });
   }
 
   private ServerHttpRequest mutateRequest(ServerHttpRequest request, String tenantId) {
@@ -163,6 +274,148 @@ public class ApiKeyAuthenticationFilter implements WebFilter, Ordered {
     return response.writeWith(Mono.just(response.bufferFactory().wrap(payload)));
   }
 
+  private ScopeRequirements resolveScopeRequirements(ServerWebExchange exchange) {
+    GatewaySecurityProperties.ApiKey.ScopeEnforcement enforcement = properties.getApiKey().getScopeEnforcement();
+    if (!enforcement.isEnabled()) {
+      return ScopeRequirements.empty();
+    }
+    String path = exchange.getRequest().getURI().getPath();
+    HttpMethod method = exchange.getRequest().getMethod();
+    Set<String> scopes = new LinkedHashSet<>();
+    Set<String> routeIds = new LinkedHashSet<>();
+    for (ServiceRoute route : routesProperties.getRoutes().values()) {
+      if (route == null || route.getRequiredScopes().isEmpty()) {
+        continue;
+      }
+      if (!methodMatches(route, method)) {
+        continue;
+      }
+      if (!pathMatches(route, path)) {
+        continue;
+      }
+      scopes.addAll(route.getRequiredScopes());
+      if (StringUtils.hasText(route.getId())) {
+        routeIds.add(route.getId());
+      }
+    }
+    return scopes.isEmpty() ? ScopeRequirements.empty() : new ScopeRequirements(scopes, routeIds);
+  }
+
+  private boolean methodMatches(ServiceRoute route, HttpMethod method) {
+    if (route.getMethods() == null || route.getMethods().isEmpty()) {
+      return true;
+    }
+    if (method == null) {
+      return false;
+    }
+    String current = method.name().toUpperCase(Locale.ROOT);
+    return route.getMethods().stream()
+        .filter(StringUtils::hasText)
+        .map(value -> value.trim().toUpperCase(Locale.ROOT))
+        .anyMatch(current::equals);
+  }
+
+  private boolean pathMatches(ServiceRoute route, String path) {
+    if (route.getPaths() == null || route.getPaths().isEmpty()) {
+      return false;
+    }
+    for (String pattern : route.getPaths()) {
+      if (StringUtils.hasText(pattern) && pathMatcher.match(pattern, path)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Set<String> normaliseScopes(Collection<String> scopes) {
+    if (scopes == null || scopes.isEmpty()) {
+      return Set.of();
+    }
+    return scopes.stream()
+        .filter(StringUtils::hasText)
+        .map(String::trim)
+        .map(scope -> scope.startsWith("SCOPE_") ? scope.substring("SCOPE_".length()) : scope)
+        .map(value -> value.toLowerCase(Locale.ROOT))
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private ApiKeyRecord decrypt(EncryptedPayload payload) throws GeneralSecurityException, JsonProcessingException {
+    if (!StringUtils.hasText(payload.ciphertext()) || !StringUtils.hasText(payload.iv())) {
+      throw new IllegalArgumentException("Encrypted payload missing ciphertext or IV");
+    }
+    EncryptionAlgorithm algorithm = Optional.ofNullable(payload.algorithm())
+        .map(EncryptionAlgorithm::from)
+        .orElse(properties.getApiKey().getEncryption().getAlgorithm());
+    if (algorithm != EncryptionAlgorithm.AES_256_GCM) {
+      throw new IllegalStateException("Unsupported API key encryption algorithm: " + payload.algorithm());
+    }
+    SecretKey key = resolveEncryptionKey();
+    byte[] iv = Base64.getDecoder().decode(payload.iv());
+    byte[] ciphertext = Base64.getDecoder().decode(payload.ciphertext());
+    Cipher cipher = Cipher.getInstance(algorithm.getTransformation());
+    cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+    byte[] plaintext = cipher.doFinal(ciphertext);
+    PlainStoredApiKeyRecord stored = objectMapper.readValue(plaintext, PlainStoredApiKeyRecord.class);
+    return stored.toRecord();
+  }
+
+  private String serializeRecord(ApiKeyRecord record, boolean wasEncrypted)
+      throws GeneralSecurityException, JsonProcessingException {
+    GatewaySecurityProperties.ApiKey.Encryption encryption = properties.getApiKey().getEncryption();
+    boolean shouldEncrypt = encryption.isEnabled() && resolveEncryptionKeyOptional().isPresent();
+    if (wasEncrypted) {
+      shouldEncrypt = true;
+    }
+    if (shouldEncrypt) {
+      EncryptionAlgorithm algorithm = encryption.getAlgorithm();
+      EncryptedPayload payload = encrypt(record, algorithm, encryption.getKeyId());
+      return objectMapper.writeValueAsString(payload);
+    }
+    PlainStoredApiKeyRecord stored = PlainStoredApiKeyRecord.from(record);
+    return objectMapper.writeValueAsString(stored);
+  }
+
+  private EncryptedPayload encrypt(ApiKeyRecord record, EncryptionAlgorithm algorithm, String keyId)
+      throws GeneralSecurityException, JsonProcessingException {
+    SecretKey key = resolveEncryptionKey();
+    byte[] iv = new byte[GCM_IV_LENGTH];
+    secureRandom.nextBytes(iv);
+    Cipher cipher = Cipher.getInstance(algorithm.getTransformation());
+    cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+    byte[] plaintext = objectMapper.writeValueAsBytes(PlainStoredApiKeyRecord.from(record));
+    byte[] ciphertext = cipher.doFinal(plaintext);
+    return new EncryptedPayload(
+        Base64.getEncoder().encodeToString(ciphertext),
+        Base64.getEncoder().encodeToString(iv),
+        algorithm.getId(),
+        keyId);
+  }
+
+  private SecretKey resolveEncryptionKey() {
+    return resolveEncryptionKeyOptional()
+        .orElseThrow(() -> new IllegalStateException("API key encryption key is not configured"));
+  }
+
+  private Optional<SecretKey> resolveEncryptionKeyOptional() {
+    GatewaySecurityProperties.ApiKey.Encryption encryption = properties.getApiKey().getEncryption();
+    String keyValue = encryption.getKeyValue();
+    if (!StringUtils.hasText(keyValue)) {
+      return Optional.empty();
+    }
+    SecretKey cached = this.cachedSecretKey;
+    if (cached != null && keyValue.equals(this.cachedKeyValue)) {
+      return Optional.of(cached);
+    }
+    byte[] decoded = Base64.getDecoder().decode(keyValue);
+    if (!(decoded.length == 16 || decoded.length == 24 || decoded.length == 32)) {
+      throw new IllegalStateException("API key encryption key must be 128, 192 or 256 bits");
+    }
+    SecretKey secretKey = new SecretKeySpec(decoded, "AES");
+    this.cachedSecretKey = secretKey;
+    this.cachedKeyValue = keyValue;
+    return Optional.of(secretKey);
+  }
+
   private static String trimToNull(String value) {
     if (!StringUtils.hasText(value)) {
       return null;
@@ -171,6 +424,109 @@ public class ApiKeyAuthenticationFilter implements WebFilter, Ordered {
     return trimmed.isEmpty() ? null : trimmed;
   }
 
-  private record ApiKeyRecord(String tenantId, Set<String> scopes, Instant expiresAt) {
+  private record DecodedApiKeyRecord(ApiKeyRecord record, boolean encrypted, Optional<String> keyId) {
+
+    static DecodedApiKeyRecord plain(ApiKeyRecord record) {
+      return new DecodedApiKeyRecord(record, false, Optional.empty());
+    }
+
+    static DecodedApiKeyRecord encrypted(ApiKeyRecord record, String keyId) {
+      return new DecodedApiKeyRecord(record, true, Optional.ofNullable(keyId));
+    }
+  }
+
+  private record EncryptedPayload(String ciphertext, String iv, String algorithm, String keyId) {
+  }
+
+  private static final class PlainStoredApiKeyRecord {
+
+    private String tenantId;
+    private Set<String> scopes;
+    private Instant expiresAt;
+    private Instant rotatedAt;
+    private Instant lastUsedAt;
+
+    ApiKeyRecord toRecord() {
+      ApiKeyRecord record = new ApiKeyRecord();
+      record.setTenantId(tenantId);
+      record.setScopes(scopes);
+      record.setExpiresAt(expiresAt);
+      record.setRotatedAt(rotatedAt);
+      record.setLastUsedAt(lastUsedAt);
+      return record;
+    }
+
+    static PlainStoredApiKeyRecord from(ApiKeyRecord record) {
+      PlainStoredApiKeyRecord stored = new PlainStoredApiKeyRecord();
+      stored.tenantId = record.getTenantId();
+      stored.scopes = (record.getScopes() == null) ? Set.of() : new LinkedHashSet<>(record.getScopes());
+      stored.expiresAt = record.getExpiresAt();
+      stored.rotatedAt = record.getRotatedAt();
+      stored.lastUsedAt = record.getLastUsedAt();
+      return stored;
+    }
+  }
+
+  private static final class ApiKeyRecord {
+
+    private String tenantId;
+    private Set<String> scopes = Set.of();
+    private Instant expiresAt;
+    private Instant rotatedAt;
+    private Instant lastUsedAt;
+
+    String getTenantId() {
+      return tenantId;
+    }
+
+    void setTenantId(String tenantId) {
+      this.tenantId = tenantId;
+    }
+
+    Set<String> getScopes() {
+      return (scopes == null) ? Set.of() : scopes;
+    }
+
+    void setScopes(Collection<String> scopes) {
+      if (scopes == null || scopes.isEmpty()) {
+        this.scopes = Set.of();
+        return;
+      }
+      this.scopes = scopes.stream()
+          .filter(Objects::nonNull)
+          .map(String::trim)
+          .filter(StringUtils::hasText)
+          .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    Instant getExpiresAt() {
+      return expiresAt;
+    }
+
+    void setExpiresAt(Instant expiresAt) {
+      this.expiresAt = expiresAt;
+    }
+
+    Instant getRotatedAt() {
+      return rotatedAt;
+    }
+
+    void setRotatedAt(Instant rotatedAt) {
+      this.rotatedAt = rotatedAt;
+    }
+
+    Instant getLastUsedAt() {
+      return lastUsedAt;
+    }
+
+    void setLastUsedAt(Instant lastUsedAt) {
+      this.lastUsedAt = lastUsedAt;
+    }
+  }
+
+  private record ScopeRequirements(Set<String> scopes, Set<String> routeIds) {
+    static ScopeRequirements empty() {
+      return new ScopeRequirements(Set.of(), Set.of());
+    }
   }
 }

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -376,6 +376,22 @@ gateway:
         - /public/**
         - /actuator/**
         - /auth/**
+    api-key:
+      enabled: true
+      encryption:
+        enabled: true
+        algorithm: AES-256-GCM
+        key-id: default
+        key-value: ${GATEWAY_API_KEY_ENCRYPTION_KEY:}
+      rotation:
+        enabled: true
+        max-age-days: 90
+      scope-enforcement:
+        enabled: true
+        require-exact-match: false
+      audit:
+        log-usage: true
+        track-last-used: true
     token-cache:
       enabled: false
       ttl: 15m

--- a/api-gateway/src/test/java/com/ejada/gateway/security/ApiKeyAuthenticationFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/security/ApiKeyAuthenticationFilterTest.java
@@ -3,14 +3,23 @@ package com.ejada.gateway.security;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ejada.common.constants.HeaderNames;
+import com.ejada.gateway.config.GatewayRoutesProperties;
 import com.ejada.gateway.config.GatewaySecurityProperties;
+import com.ejada.gateway.config.GatewaySecurityProperties.EncryptionAlgorithm;
 import com.ejada.gateway.context.GatewayRequestAttributes;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.security.SecureRandom;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +49,10 @@ class ApiKeyAuthenticationFilterTest {
   private ApiKeyAuthenticationFilter filter;
   private SimpleMeterRegistry meterRegistry;
   private ObjectMapper objectMapper;
+  private GatewaySecurityProperties properties;
+  private GatewayRoutesProperties routesProperties;
+  private byte[] encryptionKey;
+  private final SecureRandom secureRandom = new SecureRandom();
 
   @BeforeEach
   void setUp() {
@@ -52,9 +65,12 @@ class ApiKeyAuthenticationFilterTest {
     this.objectMapper = new ObjectMapper().findAndRegisterModules();
     this.meterRegistry = new SimpleMeterRegistry();
     GatewaySecurityMetrics metrics = new GatewaySecurityMetrics(meterRegistry);
-    GatewaySecurityProperties properties = new GatewaySecurityProperties();
-    properties.getApiKey().setEnabled(true);
-    this.filter = new ApiKeyAuthenticationFilter(redisTemplate, metrics, properties, TestObjectProviders.of(objectMapper), TestObjectProviders.of(objectMapper));
+    this.properties = new GatewaySecurityProperties();
+    this.routesProperties = new GatewayRoutesProperties();
+    configureRoutes();
+    configureSecurity();
+    this.filter = new ApiKeyAuthenticationFilter(redisTemplate, metrics, properties, routesProperties,
+        TestObjectProviders.of(objectMapper), TestObjectProviders.of(objectMapper));
   }
 
   @AfterEach
@@ -69,12 +85,12 @@ class ApiKeyAuthenticationFilterTest {
 
   @Test
   void authenticatesValidApiKeyAndPopulatesContext() throws Exception {
-    Instant expiresAt = Instant.now().plusSeconds(120);
-    String value = objectMapper.writeValueAsString(Map.of(
+    Instant now = Instant.now();
+    storeEncryptedRecord("test-key", Map.of(
         "tenantId", "tenant-a",
         "scopes", List.of("read"),
-        "expiresAt", expiresAt.toString()));
-    redisTemplate.opsForValue().set("gateway:api-key:test-key", value).block();
+        "expiresAt", now.plusSeconds(120).toString(),
+        "rotatedAt", now.toString()));
 
     MockServerHttpRequest request = MockServerHttpRequest.get("/secure")
         .header(HeaderNames.API_KEY, "test-key")
@@ -97,6 +113,51 @@ class ApiKeyAuthenticationFilterTest {
     assertThat(authenticationRef.get()).isInstanceOf(ApiKeyAuthenticationToken.class);
     double validated = meterRegistry.get("gateway.security.api_key_validated").counter().count();
     assertThat(validated).isEqualTo(1.0d);
+
+    Map<String, Object> stored = decryptRecord(redisTemplate.opsForValue().get("gateway:api-key:test-key").block());
+    assertThat(stored.get("lastUsedAt")).isNotNull();
+  }
+
+  @Test
+  void rejectsApiKeyWhenRequiredScopeMissing() throws Exception {
+    Instant now = Instant.now();
+    storeEncryptedRecord("missing-scope", Map.of(
+        "tenantId", "tenant-b",
+        "scopes", List.of("write"),
+        "expiresAt", now.plusSeconds(60).toString(),
+        "rotatedAt", now.toString()));
+
+    MockServerHttpRequest request = MockServerHttpRequest.get("/secure")
+        .header(HeaderNames.API_KEY, "missing-scope")
+        .build();
+    MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+    StepVerifier.create(filter.filter(exchange, webExchange -> Mono.empty())).verifyComplete();
+
+    assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    String body = exchange.getResponse().getBodyAsString().block();
+    assertThat(body).contains("ERR_API_KEY_SCOPE");
+  }
+
+  @Test
+  void rejectsApiKeyWhenRotationExpired() throws Exception {
+    Instant now = Instant.now();
+    storeEncryptedRecord("expired-rotation", Map.of(
+        "tenantId", "tenant-c",
+        "scopes", List.of("read"),
+        "expiresAt", now.plusSeconds(60).toString(),
+        "rotatedAt", now.minusSeconds(91L * 24 * 3600).toString()));
+
+    MockServerHttpRequest request = MockServerHttpRequest.get("/secure")
+        .header(HeaderNames.API_KEY, "expired-rotation")
+        .build();
+    MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+    StepVerifier.create(filter.filter(exchange, webExchange -> Mono.empty())).verifyComplete();
+
+    assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    String body = exchange.getResponse().getBodyAsString().block();
+    assertThat(body).contains("ERR_API_KEY_ROTATED");
   }
 
   @Test
@@ -106,15 +167,66 @@ class ApiKeyAuthenticationFilterTest {
         .build();
     MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
-    WebFilterChain chain = webExchange -> Mono.empty();
-
-    StepVerifier.create(filter.filter(exchange, chain)).verifyComplete();
+    StepVerifier.create(filter.filter(exchange, webExchange -> Mono.empty())).verifyComplete();
 
     assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
     String body = exchange.getResponse().getBodyAsString().block();
     assertThat(body).contains("ERR_API_KEY_INVALID");
     double blocked = meterRegistry.get("gateway.security.blocked").counter().count();
     assertThat(blocked).isEqualTo(1.0d);
+  }
+
+  private void configureRoutes() {
+    GatewayRoutesProperties.ServiceRoute route = new GatewayRoutesProperties.ServiceRoute();
+    route.setId("test-route");
+    route.setPaths(List.of("/secure"));
+    route.setMethods(List.of("GET"));
+    route.setRequiredScopes(List.of("read"));
+    routesProperties.getRoutes().put("test-route", route);
+  }
+
+  private void configureSecurity() {
+    GatewaySecurityProperties.ApiKey apiKey = properties.getApiKey();
+    apiKey.setEnabled(true);
+    apiKey.getRotation().setEnabled(true);
+    apiKey.getRotation().setMaxAgeDays(90);
+    apiKey.getScopeEnforcement().setEnabled(true);
+    apiKey.getAudit().setLogUsage(true);
+    apiKey.getAudit().setTrackLastUsed(true);
+    apiKey.getEncryption().setEnabled(true);
+    apiKey.getEncryption().setAlgorithm(EncryptionAlgorithm.AES_256_GCM);
+    this.encryptionKey = new byte[32];
+    secureRandom.nextBytes(this.encryptionKey);
+    apiKey.getEncryption().setKeyValue(Base64.getEncoder().encodeToString(encryptionKey));
+    apiKey.getEncryption().setKeyId("unit-test");
+  }
+
+  private void storeEncryptedRecord(String apiKey, Map<String, Object> record) throws Exception {
+    byte[] plaintext = objectMapper.writeValueAsBytes(record);
+    byte[] iv = new byte[12];
+    secureRandom.nextBytes(iv);
+    Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+    cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(encryptionKey, "AES"), new GCMParameterSpec(128, iv));
+    byte[] ciphertext = cipher.doFinal(plaintext);
+    String payload = objectMapper.writeValueAsString(Map.of(
+        "ciphertext", Base64.getEncoder().encodeToString(ciphertext),
+        "iv", Base64.getEncoder().encodeToString(iv),
+        "algorithm", properties.getApiKey().getEncryption().getAlgorithm().getId(),
+        "keyId", properties.getApiKey().getEncryption().getKeyId()));
+    redisTemplate.opsForValue().set(properties.getApiKey().redisKey(apiKey), payload).block();
+  }
+
+  private Map<String, Object> decryptRecord(String payload) throws Exception {
+    JsonNode node = objectMapper.readTree(payload);
+    if (node.hasNonNull("ciphertext")) {
+      byte[] ciphertext = Base64.getDecoder().decode(node.get("ciphertext").asText());
+      byte[] iv = Base64.getDecoder().decode(node.get("iv").asText());
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(encryptionKey, "AES"), new GCMParameterSpec(128, iv));
+      byte[] plaintext = cipher.doFinal(ciphertext);
+      return objectMapper.readValue(plaintext, new TypeReference<Map<String, Object>>() {});
+    }
+    return objectMapper.readValue(payload, new TypeReference<Map<String, Object>>() {});
   }
 
   private void flushRedis() {


### PR DESCRIPTION
## Summary
- add API key encryption, rotation, scope enforcement, and audit configuration options to gateway security properties and configuration
- update the API key authentication filter to decrypt encrypted records, enforce rotation timelines and scope requirements, and audit usage updates in Redis
- surface required scopes on routes, propagate metadata, and refresh tests/application config for encrypted records and new enforcement paths

## Testing
- mvn -pl api-gateway test *(fails: missing internal com.ejada starter dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d99c4b64832f9948d4de4299d94f