### PR TITLE
feat: enable kubernetes-native service discovery for gateway

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -74,6 +74,14 @@
       <artifactId>spring-cloud-starter-loadbalancer</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-kubernetes-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-kubernetes-client-loadbalancer</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>

--- a/api-gateway/src/main/java/com/ejada/gateway/config/GatewayKubernetesDiscoveryProperties.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/GatewayKubernetesDiscoveryProperties.java
@@ -1,0 +1,201 @@
+package com.ejada.gateway.config;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Kubernetes-based service discovery.
+ *
+ * <p>The properties control how pod metadata is projected into Spring Cloud LoadBalancer
+ * so the custom tenant-aware load balancer can make informed, health-aware routing
+ * decisions. The defaults favor a single-namespace deployment that relies on standard
+ * Kubernetes labels (such as {@code topology.kubernetes.io/zone}) and optional
+ * annotations for custom rollout and health information.</p>
+ */
+@ConfigurationProperties(prefix = "gateway.kubernetes.discovery")
+public class GatewayKubernetesDiscoveryProperties {
+
+  /** Enables the Kubernetes discovery enhancements. */
+  private boolean enabled = true;
+
+  /** Overrides the namespace used when looking up pods (defaults to client namespace). */
+  private String namespace;
+
+  /** How long pod metadata is cached before refreshing from the Kubernetes API. */
+  private Duration metadataTtl = Duration.ofSeconds(30);
+
+  /**
+   * Default response time (in milliseconds) used when pods do not expose a custom metric
+   * via annotations.
+   */
+  private Duration defaultResponseTime = Duration.ofMillis(250);
+
+  /** Primary pod label used to determine the pod's zone / topology. */
+  private String zoneLabel = "topology.kubernetes.io/zone";
+
+  /** Fallback pod labels used to determine the pod's zone / topology. */
+  private List<String> zoneLabelFallbacks = new ArrayList<>(List.of(
+      "failure-domain.beta.kubernetes.io/zone"));
+
+  /** Service instance metadata keys that may already contain zone information. */
+  private List<String> serviceZoneMetadataKeys = new ArrayList<>(List.of(
+      "spring-cloud-loadbalancer-zone",
+      "zone",
+      "zoneId",
+      "zone-id"));
+
+  /** Pod annotation that optionally provides a rollout/deployment phase indicator. */
+  private String rolloutAnnotation = "gateway.lb/rollout-phase";
+
+  /** Pod label that optionally provides a rollout/deployment phase indicator. */
+  private String rolloutLabel = "deployment.ejada.com/phase";
+
+  /** Pod annotation providing a pre-computed health score for the instance. */
+  private String healthScoreAnnotation = "gateway.lb/health-score";
+
+  /** Pod annotation providing an observed average response time in milliseconds. */
+  private String responseTimeAnnotation = "gateway.lb/avg-response-time-ms";
+
+  /**
+   * Pod annotation that can explicitly advertise availability state (e.g. draining,
+   * out-of-service). When absent, readiness is used.
+   */
+  private String availabilityAnnotation = "gateway.lb/availability";
+
+  /** Metadata keys that may contain the Kubernetes namespace for the instance. */
+  private List<String> namespaceMetadataKeys = new ArrayList<>(List.of(
+      "k8s_namespace",
+      "kubernetes_namespace",
+      "spring.cloud.kubernetes.namespace",
+      "namespace"));
+
+  /** Metadata keys that may contain the Kubernetes pod name for the instance. */
+  private List<String> podNameMetadataKeys = new ArrayList<>(List.of(
+      "k8s_pod_name",
+      "podName",
+      "pod_name",
+      "kubernetes.io/pod-name"));
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public void setNamespace(String namespace) {
+    this.namespace = namespace;
+  }
+
+  public Duration getMetadataTtl() {
+    return metadataTtl;
+  }
+
+  public void setMetadataTtl(Duration metadataTtl) {
+    this.metadataTtl = metadataTtl;
+  }
+
+  public Duration getDefaultResponseTime() {
+    return defaultResponseTime;
+  }
+
+  public void setDefaultResponseTime(Duration defaultResponseTime) {
+    this.defaultResponseTime = defaultResponseTime;
+  }
+
+  public String getZoneLabel() {
+    return zoneLabel;
+  }
+
+  public void setZoneLabel(String zoneLabel) {
+    this.zoneLabel = zoneLabel;
+  }
+
+  public List<String> getZoneLabelFallbacks() {
+    return zoneLabelFallbacks;
+  }
+
+  public void setZoneLabelFallbacks(List<String> zoneLabelFallbacks) {
+    this.zoneLabelFallbacks = zoneLabelFallbacks != null
+        ? new ArrayList<>(zoneLabelFallbacks)
+        : new ArrayList<>();
+  }
+
+  public List<String> getServiceZoneMetadataKeys() {
+    return serviceZoneMetadataKeys;
+  }
+
+  public void setServiceZoneMetadataKeys(List<String> serviceZoneMetadataKeys) {
+    this.serviceZoneMetadataKeys = serviceZoneMetadataKeys != null
+        ? new ArrayList<>(serviceZoneMetadataKeys)
+        : new ArrayList<>();
+  }
+
+  public String getRolloutAnnotation() {
+    return rolloutAnnotation;
+  }
+
+  public void setRolloutAnnotation(String rolloutAnnotation) {
+    this.rolloutAnnotation = rolloutAnnotation;
+  }
+
+  public String getRolloutLabel() {
+    return rolloutLabel;
+  }
+
+  public void setRolloutLabel(String rolloutLabel) {
+    this.rolloutLabel = rolloutLabel;
+  }
+
+  public String getHealthScoreAnnotation() {
+    return healthScoreAnnotation;
+  }
+
+  public void setHealthScoreAnnotation(String healthScoreAnnotation) {
+    this.healthScoreAnnotation = healthScoreAnnotation;
+  }
+
+  public String getResponseTimeAnnotation() {
+    return responseTimeAnnotation;
+  }
+
+  public void setResponseTimeAnnotation(String responseTimeAnnotation) {
+    this.responseTimeAnnotation = responseTimeAnnotation;
+  }
+
+  public String getAvailabilityAnnotation() {
+    return availabilityAnnotation;
+  }
+
+  public void setAvailabilityAnnotation(String availabilityAnnotation) {
+    this.availabilityAnnotation = availabilityAnnotation;
+  }
+
+  public List<String> getNamespaceMetadataKeys() {
+    return namespaceMetadataKeys;
+  }
+
+  public void setNamespaceMetadataKeys(List<String> namespaceMetadataKeys) {
+    this.namespaceMetadataKeys = namespaceMetadataKeys != null
+        ? new ArrayList<>(namespaceMetadataKeys)
+        : new ArrayList<>();
+  }
+
+  public List<String> getPodNameMetadataKeys() {
+    return podNameMetadataKeys;
+  }
+
+  public void setPodNameMetadataKeys(List<String> podNameMetadataKeys) {
+    this.podNameMetadataKeys = podNameMetadataKeys != null
+        ? new ArrayList<>(podNameMetadataKeys)
+        : new ArrayList<>();
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/Fabric8KubernetesPodMetadataProvider.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/Fabric8KubernetesPodMetadataProvider.java
@@ -1,0 +1,225 @@
+package com.ejada.gateway.loadbalancer;
+
+import com.ejada.gateway.config.GatewayKubernetesDiscoveryProperties;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodCondition;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link KubernetesPodMetadataProvider} backed by the Fabric8
+ * {@link KubernetesClient}. The provider looks up pods by name or IP address and
+ * projects relevant labels/annotations into {@link KubernetesPodMetadata} so the
+ * load balancer can honour pod readiness, rollout state and zone topology.
+ */
+public class Fabric8KubernetesPodMetadataProvider implements KubernetesPodMetadataProvider {
+
+  private static final Log LOG = LogFactory.getLog(Fabric8KubernetesPodMetadataProvider.class);
+
+  private final KubernetesClient client;
+  private final GatewayKubernetesDiscoveryProperties properties;
+
+  public Fabric8KubernetesPodMetadataProvider(KubernetesClient client,
+      GatewayKubernetesDiscoveryProperties properties) {
+    this.client = client;
+    this.properties = properties;
+  }
+
+  @Override
+  public Optional<KubernetesPodMetadata> resolve(ServiceInstance instance) {
+    if (!properties.isEnabled() || instance == null) {
+      return Optional.empty();
+    }
+    String namespace = resolveNamespace(instance);
+    if (!StringUtils.hasText(namespace)) {
+      return Optional.empty();
+    }
+    Pod pod = locatePod(instance, namespace);
+    if (pod == null) {
+      return Optional.empty();
+    }
+    return Optional.of(extractMetadata(namespace, pod, instance));
+  }
+
+  private String resolveNamespace(ServiceInstance instance) {
+    if (StringUtils.hasText(properties.getNamespace())) {
+      return properties.getNamespace();
+    }
+    for (String key : properties.getNamespaceMetadataKeys()) {
+      String value = instance.getMetadata().get(key);
+      if (StringUtils.hasText(value)) {
+        return value.trim();
+      }
+    }
+    String clientNamespace = client.getConfiguration() != null ? client.getConfiguration().getNamespace() : null;
+    if (StringUtils.hasText(clientNamespace)) {
+      return clientNamespace;
+    }
+    return "default";
+  }
+
+  private Pod locatePod(ServiceInstance instance, String namespace) {
+    try {
+      String podName = resolvePodName(instance);
+      if (StringUtils.hasText(podName)) {
+        Pod pod = client.pods().inNamespace(namespace).withName(podName).get();
+        if (pod != null) {
+          return pod;
+        }
+      }
+      String ip = instance.getHost();
+      if (!StringUtils.hasText(ip)) {
+        return null;
+      }
+      PodList podList = client.pods().inNamespace(namespace)
+          .withField("status.podIP", ip)
+          .list(1, TimeUnit.SECONDS);
+      if (podList == null || CollectionUtils.isEmpty(podList.getItems())) {
+        return null;
+      }
+      return podList.getItems().get(0);
+    } catch (KubernetesClientException ex) {
+      LOG.warn("Failed to resolve pod metadata from Kubernetes API", ex);
+      return null;
+    }
+  }
+
+  private String resolvePodName(ServiceInstance instance) {
+    for (String key : properties.getPodNameMetadataKeys()) {
+      String value = instance.getMetadata().get(key);
+      if (StringUtils.hasText(value)) {
+        return value.trim();
+      }
+    }
+    String instanceId = instance.getInstanceId();
+    if (StringUtils.hasText(instanceId)) {
+      return instanceId;
+    }
+    return null;
+  }
+
+  private KubernetesPodMetadata extractMetadata(String namespace, Pod pod, ServiceInstance instance) {
+    Map<String, String> annotations = safeMap(pod.getMetadata() != null ? pod.getMetadata().getAnnotations() : null);
+    Map<String, String> labels = safeMap(pod.getMetadata() != null ? pod.getMetadata().getLabels() : null);
+
+    String availability = resolveAvailability(pod, annotations);
+    Double healthScore = resolveDouble(annotations, properties.getHealthScoreAnnotation(),
+        "health-score", availabilityUp(availability) ? 1.0d : 0.0d);
+    Double responseTime = resolveDouble(annotations, properties.getResponseTimeAnnotation(),
+        "avg-response-time-ms", properties.getDefaultResponseTime().toMillis());
+    String zone = resolveZone(labels, instance.getMetadata());
+    String rollout = resolveRollout(annotations, labels);
+
+    Map<String, String> additional = Map.of();
+    return new KubernetesPodMetadata(namespace, availability, healthScore, responseTime, zone, rollout, additional);
+  }
+
+  private Map<String, String> safeMap(Map<String, String> map) {
+    return map != null ? map : Map.of();
+  }
+
+  private String resolveAvailability(Pod pod, Map<String, String> annotations) {
+    String override = annotations.get(properties.getAvailabilityAnnotation());
+    if (StringUtils.hasText(override)) {
+      return override.trim();
+    }
+    if (pod.getStatus() != null && pod.getStatus().getConditions() != null) {
+      for (PodCondition condition : pod.getStatus().getConditions()) {
+        if ("Ready".equalsIgnoreCase(condition.getType())) {
+          return Boolean.parseBoolean(condition.getStatus()) ? "UP" : "DOWN";
+        }
+      }
+    }
+    return "UNKNOWN";
+  }
+
+  private boolean availabilityUp(String availability) {
+    if (!StringUtils.hasText(availability)) {
+      return false;
+    }
+    String normalized = availability.trim().toUpperCase(Locale.ROOT);
+    return switch (normalized) {
+      case "UP", "READY", "AVAILABLE" -> true;
+      case "UNKNOWN" -> true;
+      default -> false;
+    };
+  }
+
+  private Double resolveDouble(Map<String, String> source, String primaryKey, String legacyKey, double fallback) {
+    List<String> candidates = new ArrayList<>();
+    if (StringUtils.hasText(primaryKey)) {
+      candidates.add(primaryKey);
+    }
+    if (StringUtils.hasText(legacyKey)) {
+      candidates.add(legacyKey);
+    }
+    for (String key : candidates) {
+      if (!StringUtils.hasText(key)) {
+        continue;
+      }
+      String value = source.get(key);
+      if (!StringUtils.hasText(value)) {
+        continue;
+      }
+      try {
+        return Double.parseDouble(value.trim());
+      } catch (NumberFormatException ignored) {
+        // ignore and continue searching
+      }
+    }
+    return fallback;
+  }
+
+  private String resolveZone(Map<String, String> labels, Map<String, String> instanceMetadata) {
+    if (instanceMetadata != null) {
+      for (String key : properties.getServiceZoneMetadataKeys()) {
+        String value = instanceMetadata.get(key);
+        if (StringUtils.hasText(value)) {
+          return value.trim();
+        }
+      }
+    }
+    if (labels != null) {
+      String direct = labels.get(properties.getZoneLabel());
+      if (StringUtils.hasText(direct)) {
+        return direct.trim();
+      }
+      for (String fallbackKey : properties.getZoneLabelFallbacks()) {
+        String value = labels.get(fallbackKey);
+        if (StringUtils.hasText(value)) {
+          return value.trim();
+        }
+      }
+    }
+    return null;
+  }
+
+  private String resolveRollout(Map<String, String> annotations, Map<String, String> labels) {
+    if (annotations != null && StringUtils.hasText(properties.getRolloutAnnotation())) {
+      String value = annotations.get(properties.getRolloutAnnotation());
+      if (StringUtils.hasText(value)) {
+        return value.trim();
+      }
+    }
+    if (labels != null && StringUtils.hasText(properties.getRolloutLabel())) {
+      String value = labels.get(properties.getRolloutLabel());
+      if (StringUtils.hasText(value)) {
+        return value.trim();
+      }
+    }
+    return null;
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/KubernetesPodMetadata.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/KubernetesPodMetadata.java
@@ -1,0 +1,22 @@
+package com.ejada.gateway.loadbalancer;
+
+import java.util.Map;
+
+/**
+ * Normalised metadata extracted from a Kubernetes pod that is relevant to the
+ * gateway's health-aware load-balancing decisions.
+ */
+public record KubernetesPodMetadata(
+    String namespace,
+    String availability,
+    Double healthScore,
+    Double responseTimeMs,
+    String zone,
+    String rolloutPhase,
+    Map<String, String> additionalMetadata) {
+
+  public KubernetesPodMetadata {
+    additionalMetadata = additionalMetadata == null ? Map.of() : Map.copyOf(additionalMetadata);
+  }
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/KubernetesPodMetadataProvider.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/KubernetesPodMetadataProvider.java
@@ -1,0 +1,16 @@
+package com.ejada.gateway.loadbalancer;
+
+import java.util.Optional;
+import org.springframework.cloud.client.ServiceInstance;
+
+/**
+ * Strategy interface that resolves {@link KubernetesPodMetadata} for a given
+ * {@link ServiceInstance}. The default implementation uses the Fabric8
+ * {@code KubernetesClient}, but the abstraction keeps the
+ * {@link KubernetesServiceInstanceMetadataSupplier} testable.
+ */
+public interface KubernetesPodMetadataProvider {
+
+  Optional<KubernetesPodMetadata> resolve(ServiceInstance instance);
+}
+

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/KubernetesServiceInstanceMetadataSupplier.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/KubernetesServiceInstanceMetadataSupplier.java
@@ -1,0 +1,179 @@
+package com.ejada.gateway.loadbalancer;
+
+import com.ejada.gateway.config.GatewayKubernetesDiscoveryProperties;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.Request;
+import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
+
+/**
+ * Decorates a {@link ServiceInstanceListSupplier} with Kubernetes pod metadata so that the
+ * {@link TenantAffinityLoadBalancer} can make health-aware routing decisions when running
+ * inside Kubernetes. The decorator keeps a lightweight cache of pod metadata to avoid
+ * repeatedly hitting the Kubernetes API.
+ */
+public class KubernetesServiceInstanceMetadataSupplier implements ServiceInstanceListSupplier {
+
+  private final ServiceInstanceListSupplier delegate;
+  private final KubernetesPodMetadataProvider metadataProvider;
+  private final GatewayKubernetesDiscoveryProperties properties;
+  private final ConcurrentMap<String, CachedMetadata> cache = new ConcurrentHashMap<>();
+
+  public KubernetesServiceInstanceMetadataSupplier(ServiceInstanceListSupplier delegate,
+      KubernetesPodMetadataProvider metadataProvider,
+      GatewayKubernetesDiscoveryProperties properties) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+    this.metadataProvider = Objects.requireNonNull(metadataProvider, "metadataProvider");
+    this.properties = Objects.requireNonNull(properties, "properties");
+  }
+
+  @Override
+  public Flux<List<ServiceInstance>> get() {
+    return delegate.get().map(this::enrichInstances);
+  }
+
+  @Override
+  public Flux<List<ServiceInstance>> get(Request request) {
+    return delegate.get(request).map(this::enrichInstances);
+  }
+
+  @Override
+  public String getServiceId() {
+    return delegate.getServiceId();
+  }
+
+  private List<ServiceInstance> enrichInstances(List<ServiceInstance> instances) {
+    if (!properties.isEnabled() || instances == null || instances.isEmpty()) {
+      return instances;
+    }
+    List<ServiceInstance> enriched = new ArrayList<>(instances.size());
+    for (ServiceInstance instance : instances) {
+      enriched.add(enrichInstance(instance));
+    }
+    return enriched;
+  }
+
+  private ServiceInstance enrichInstance(ServiceInstance instance) {
+    KubernetesPodMetadata metadata = resolveMetadata(instance);
+    if (metadata == null) {
+      return instance;
+    }
+    Map<String, String> merged = new LinkedHashMap<>(instance.getMetadata());
+    if (StringUtils.hasText(metadata.availability())) {
+      merged.putIfAbsent("availability", metadata.availability());
+      merged.put("status", metadata.availability());
+    }
+    if (metadata.healthScore() != null) {
+      merged.put("healthScore", Double.toString(metadata.healthScore()));
+    }
+    if (metadata.responseTimeMs() != null) {
+      merged.put("avgResponseTimeMs", Double.toString(metadata.responseTimeMs()));
+    }
+    if (StringUtils.hasText(metadata.zone())) {
+      merged.put("zone", metadata.zone());
+      merged.put("spring-cloud-loadbalancer-zone", metadata.zone());
+    }
+    if (StringUtils.hasText(metadata.rolloutPhase())) {
+      merged.put("rolloutPhase", metadata.rolloutPhase());
+    }
+    if (StringUtils.hasText(metadata.namespace())) {
+      merged.putIfAbsent("k8s_namespace", metadata.namespace());
+    }
+    metadata.additionalMetadata().forEach(merged::putIfAbsent);
+    return new ImmutableServiceInstance(instance, merged);
+  }
+
+  private KubernetesPodMetadata resolveMetadata(ServiceInstance instance) {
+    String cacheKey = cacheKey(instance);
+    CachedMetadata cached = cache.get(cacheKey);
+    if (cached != null && !cached.isExpired()) {
+      return cached.metadata();
+    }
+    Optional<KubernetesPodMetadata> resolved = metadataProvider.resolve(instance);
+    if (resolved.isEmpty()) {
+      cache.remove(cacheKey);
+      return null;
+    }
+    KubernetesPodMetadata metadata = resolved.get();
+    Duration ttl = properties.getMetadataTtl();
+    Instant expiresAt = (ttl == null || ttl.isZero() || ttl.isNegative())
+        ? null
+        : Instant.now().plus(ttl);
+    cache.put(cacheKey, new CachedMetadata(metadata, expiresAt));
+    return metadata;
+  }
+
+  private String cacheKey(ServiceInstance instance) {
+    return instance.getServiceId() + "|" + instance.getHost() + "|" + instance.getPort();
+  }
+
+  private record CachedMetadata(KubernetesPodMetadata metadata, Instant expiresAt) {
+
+    boolean isExpired() {
+      return expiresAt != null && Instant.now().isAfter(expiresAt);
+    }
+  }
+
+  private static final class ImmutableServiceInstance implements ServiceInstance {
+
+    private final ServiceInstance delegate;
+    private final Map<String, String> metadata;
+
+    private ImmutableServiceInstance(ServiceInstance delegate, Map<String, String> metadata) {
+      this.delegate = delegate;
+      this.metadata = Map.copyOf(metadata);
+    }
+
+    @Override
+    public String getInstanceId() {
+      return delegate.getInstanceId();
+    }
+
+    @Override
+    public String getServiceId() {
+      return delegate.getServiceId();
+    }
+
+    @Override
+    public String getHost() {
+      return delegate.getHost();
+    }
+
+    @Override
+    public int getPort() {
+      return delegate.getPort();
+    }
+
+    @Override
+    public boolean isSecure() {
+      return delegate.isSecure();
+    }
+
+    @Override
+    public java.net.URI getUri() {
+      return delegate.getUri();
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+      return metadata;
+    }
+
+    @Override
+    public String getScheme() {
+      return delegate.getScheme();
+    }
+  }
+}
+

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -96,6 +96,21 @@ spring:
         add-service-instance-cookie: true
         cookie-name: LMS-AFFINITY
     kubernetes:
+      enabled: ${SPRING_CLOUD_KUBERNETES_ENABLED:false}
+      discovery:
+        enabled: ${SPRING_CLOUD_KUBERNETES_DISCOVERY_ENABLED:${spring.cloud.kubernetes.enabled}}
+        all-namespaces: false
+        include-not-ready-addresses: false
+        wait-cache-ready: true
+        cache-loading-timeout-seconds: 30
+        namespaces:
+          - ${SPRING_CLOUD_KUBERNETES_DISCOVERY_NAMESPACE:${KUBERNETES_NAMESPACE:}}
+        metadata:
+          add-pod-labels: true
+          add-pod-annotations: true
+      loadbalancer:
+        enabled: ${SPRING_CLOUD_KUBERNETES_LOADBALANCER_ENABLED:${spring.cloud.kubernetes.enabled}}
+        mode: POD
       reload:
         enabled: true
         mode: event

--- a/api-gateway/src/test/java/com/ejada/gateway/loadbalancer/KubernetesServiceInstanceMetadataSupplierTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/loadbalancer/KubernetesServiceInstanceMetadataSupplierTest.java
@@ -1,0 +1,112 @@
+package com.ejada.gateway.loadbalancer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ejada.gateway.config.GatewayKubernetesDiscoveryProperties;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.Request;
+import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import reactor.core.publisher.Flux;
+
+class KubernetesServiceInstanceMetadataSupplierTest {
+
+  @Test
+  void enrichesInstancesWithKubernetesMetadata() {
+    GatewayKubernetesDiscoveryProperties properties = new GatewayKubernetesDiscoveryProperties();
+    properties.setEnabled(true);
+    properties.setMetadataTtl(Duration.ofSeconds(60));
+
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("k8s_namespace", "lms");
+    ServiceInstance instance = new DefaultServiceInstance("tenant-service-1", "tenant-service",
+        "10.0.0.5", 8080, false, metadata);
+
+    KubernetesPodMetadata podMetadata = new KubernetesPodMetadata(
+        "lms",
+        "UP",
+        0.9d,
+        150d,
+        "me-south-1a",
+        "canary",
+        Map.of("custom", "value"));
+
+    AtomicInteger invocationCounter = new AtomicInteger();
+    KubernetesPodMetadataProvider provider = svc -> {
+      invocationCounter.incrementAndGet();
+      return Optional.of(podMetadata);
+    };
+
+    ServiceInstanceListSupplier delegate = new StaticServiceInstanceListSupplier("tenant-service", List.of(instance));
+    KubernetesServiceInstanceMetadataSupplier supplier = new KubernetesServiceInstanceMetadataSupplier(delegate, provider,
+        properties);
+
+    List<ServiceInstance> enriched = supplier.get().blockFirst();
+    assertThat(enriched).singleElement().satisfies(enrichedInstance -> {
+      assertThat(enrichedInstance.getMetadata()).containsEntry("status", "UP");
+      assertThat(enrichedInstance.getMetadata()).containsEntry("zone", "me-south-1a");
+      assertThat(enrichedInstance.getMetadata()).containsEntry("spring-cloud-loadbalancer-zone", "me-south-1a");
+      assertThat(enrichedInstance.getMetadata()).containsEntry("rolloutPhase", "canary");
+      assertThat(enrichedInstance.getMetadata()).containsEntry("healthScore", "0.9");
+      assertThat(enrichedInstance.getMetadata()).containsEntry("avgResponseTimeMs", "150.0");
+      assertThat(enrichedInstance.getMetadata()).containsEntry("custom", "value");
+    });
+
+    // Resolve again to ensure metadata is cached and provider is not invoked repeatedly.
+    supplier.get().blockFirst();
+    assertThat(invocationCounter).hasValue(1);
+  }
+
+  @Test
+  void returnsOriginalInstanceWhenMetadataUnavailable() {
+    GatewayKubernetesDiscoveryProperties properties = new GatewayKubernetesDiscoveryProperties();
+    properties.setEnabled(true);
+    properties.setMetadataTtl(Duration.ofSeconds(10));
+
+    ServiceInstance instance = new DefaultServiceInstance("tenant-service-1", "tenant-service",
+        "10.0.0.5", 8080, false, Map.of());
+
+    KubernetesPodMetadataProvider provider = svc -> Optional.empty();
+
+    ServiceInstanceListSupplier delegate = new StaticServiceInstanceListSupplier("tenant-service", List.of(instance));
+    KubernetesServiceInstanceMetadataSupplier supplier = new KubernetesServiceInstanceMetadataSupplier(delegate, provider,
+        properties);
+
+    List<ServiceInstance> enriched = supplier.get().blockFirst();
+    assertThat(enriched).singleElement().isSameAs(instance);
+  }
+
+  private static final class StaticServiceInstanceListSupplier implements ServiceInstanceListSupplier {
+
+    private final String serviceId;
+    private final List<ServiceInstance> instances;
+
+    private StaticServiceInstanceListSupplier(String serviceId, List<ServiceInstance> instances) {
+      this.serviceId = serviceId;
+      this.instances = List.copyOf(instances);
+    }
+
+    @Override
+    public Flux<List<ServiceInstance>> get() {
+      return Flux.just(instances);
+    }
+
+    @Override
+    public Flux<List<ServiceInstance>> get(Request request) {
+      return get();
+    }
+
+    @Override
+    public String getServiceId() {
+      return serviceId;
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Spring Cloud Kubernetes discovery/load-balancer starters and configuration properties to drive pod-aware routing
- enrich service instances with Kubernetes pod metadata for health, zone, and rollout awareness before the tenant-affinity load balancer executes
- document the Kubernetes discovery toggle and cover the new supplier logic with unit tests

## Testing
- `mvn -pl api-gateway test` *(fails: missing internal com.ejada starter artifacts in the build image)*

------
https://chatgpt.com/codex/tasks/task_e_68e4da90a900832f859428ff837963a9