### PR TITLE
Fix duplicate Flyway schema declarations in dev config

### DIFF
--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -30,8 +30,6 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,security
-    default-schema: security
   kafka:
     client-id: ejada-security-dev
     consumer:

--- a/setup-service/src/main/resources/application-dev.yaml
+++ b/setup-service/src/main/resources/application-dev.yaml
@@ -30,8 +30,6 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,setup
-    default-schema: setup
   kafka:
     client-id: ejada-setup-dev
     consumer:

--- a/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application-dev.yaml
@@ -29,8 +29,6 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,catalog
-    default-schema: catalog
   kafka:
     client-id: ejada-catalog-dev
     consumer:

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -7,7 +7,9 @@ spring:
     baseline-on-migrate: true
     baseline-version: 0
     default-schema: catalog
-    schemas: catalog
+    schemas:
+      - public
+      - catalog
 
 server:
   port: 8080

--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -29,8 +29,6 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,subscription
-    default-schema: subscription
   kafka:
     client-id: ejada-subscription-dev
     consumer:

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -7,7 +7,9 @@ spring:
     baseline-on-migrate: true
     baseline-version: 0
     default-schema: subscription
-    schemas: subscription
+    schemas:
+      - public
+      - subscription
 
 server:
   port: 8080

--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -29,8 +29,6 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
-    schemas: public,tenant
-    default-schema: tenant
   kafka:
     client-id: ejada-tenant-dev
     consumer:


### PR DESCRIPTION
## Summary
- remove redundant Flyway schema/default-schema overrides from dev profiles for catalog, subscription, security, setup, and tenant services
- define the combined public and service schemas once in the base catalog and subscription application configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4daf1bbcc832fadb6e97e8f7e0f02