### PR TITLE
Fix dependency convergence for api-gateway module

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -30,6 +30,16 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>2.27.0</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.15.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Summary
- align the api-gateway dependency management with explicit versions for `error_prone_annotations` and `commons-io`
- ensure Maven enforcer no longer flags convergence issues when building the gateway module

## Testing
- `mvn -pl api-gateway -am clean verify` *(fails: local Maven repository produced a corrupt net.bytebuddy byte-buddy-agent 1.17.7 download that prevents Surefire from starting)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e8e434a0832f9ee7178bd1695185