### PR TITLE
Rebrand LMS references to Ejada SaaS Products Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Learning Management System Platform
+# Ejada SaaS Products Framework
 
-The **newLms** repository hosts the multi-tenant Learning Management System. It is built from
+The **newLms** repository hosts the multi-tenant Ejada SaaS Products Framework. It is built from
 Spring Boot microservices that share a common set of starters for security, observability,
 resilience, and Redis integration. An API Gateway fronts every service to provide a single edge
 entry point with authentication, tenant enforcement, subscription validation, and rate limiting.
@@ -9,7 +9,7 @@ entry point with authentication, tenant enforcement, subscription validation, an
 
 | Module | Description |
 | ------ | ----------- |
-| `shared-lib` | Reusable LMS starters (security, core, observability, rate limiting, config) shared by all services. |
+| `shared-lib` | Reusable framework starters (security, core, observability, rate limiting, config) shared by all services. |
 | `tenant-platform` | Aggregator Maven project for the domain services (`tenant`, `catalog`, `subscription`, `billing`, `analytics`). |
 | `setup-service` | Platform bootstrap service for tenant provisioning, catalog metadata, and reference data. |
 | `sec-service` | Security service responsible for IAM, audit, and policy management. |
@@ -65,7 +65,7 @@ and application services.
    docker compose -f docker/tools/docker-compose.yml up -d
    ```
 
-2. Build and start the LMS microservices and gateway:
+2. Build and start the framework microservices and gateway:
 
    ```bash
    docker compose -f docker/services/docker-compose.yml up --build

--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -1,6 +1,6 @@
-# LMS API Gateway
+# Ejada SaaS Products Framework API Gateway
 
-Enterprise-ready Spring Cloud Gateway that fronts the LMS microservices. It reuses the shared LMS starters (security, observability, redis, kafka) and enforces multi-tenant policies at the edge.
+Enterprise-ready Spring Cloud Gateway that fronts the Ejada SaaS Products Framework microservices. It reuses the shared framework starters (security, observability, redis, kafka) and enforces multi-tenant policies at the edge.
 
 ## Key Capabilities
 

--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>api-gateway</artifactId>
   <name>api-gateway</name>
-  <description>Spring Cloud Gateway for LMS platform reusing shared starters</description>
+  <description>Spring Cloud Gateway for the Ejada SaaS Products Framework reusing shared starters</description>
 
   <dependencyManagement>
     <dependencies>

--- a/api-gateway/src/main/java/com/ejada/gateway/ApiGatewayApplication.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ApiGatewayApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
 
 /**
- * Entry point for the LMS API Gateway.
+ * Entry point for the Ejada SaaS Products Framework API Gateway.
  */
 @SpringBootApplication
 public class ApiGatewayApplication {

--- a/docs/api-gateway-enhancement-plan.md
+++ b/docs/api-gateway-enhancement-plan.md
@@ -1,6 +1,6 @@
 # API Gateway Enhancement Plan
 
-This document describes the incremental steps required to harden, scale, and operationalize the Learning Management System (LMS) API Gateway. The plan assumes a Spring Boot 3.5.x / Spring Cloud Gateway 2024.x stack running on Kubernetes (GKE) and reuses the shared LMS starters (security, observability, core, redis, kafka).
+This document describes the incremental steps required to harden, scale, and operationalize the Ejada SaaS Products Framework API Gateway. The plan assumes a Spring Boot 3.5.x / Spring Cloud Gateway 2024.x stack running on Kubernetes (GKE) and reuses the shared framework starters (security, observability, core, redis, kafka).
 
 > **Goal**: deliver a production-grade edge service with security, resilience, observability, and dynamic multi-tenant routing baked in.
 
@@ -68,7 +68,7 @@ graph LR
 ### 2.1 JWT & OIDC Strategy
 1. **Rotate to asymmetric signing** – configure shared security starter to prefer RS256/ES256 keys sourced from the IdP JWK set.
 2. **Support multiple issuers** – load trusted issuers (internal IAM + external partners) through configuration; fallback to OIDC discovery when a token issuer is unknown.
-3. **Tenant-aware claims** – map `tenant_id`, `sub`, `scope`, and custom LMS roles into the `Authentication` object via a custom converter.
+3. **Tenant-aware claims** – map `tenant_id`, `sub`, `scope`, and custom framework roles into the `Authentication` object via a custom converter.
 4. **mTLS for partner channels** – optionally enforce client certificates for partner route groups.
 
 #### Key Snippet – `GatewaySecurityConfiguration`

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <packaging>pom</packaging>
 
   <name>newLms platform</name>
-  <description>Aggregator project to build the LMS platform modules together.</description>
+  <description>Aggregator project to build the Ejada SaaS Products Framework modules together.</description>
 
   <modules>
     <module>shared-lib</module>

--- a/tenant-platform/README.md
+++ b/tenant-platform/README.md
@@ -1,6 +1,6 @@
 # Tenant Platform
 
-Combined platform containing shared tenant components and Ejada microservices.
+Combined platform containing shared tenant components and Ejada SaaS Products Framework microservices.
 
 ## Structure
 

--- a/tenant-platform/catalog-service/README.md
+++ b/tenant-platform/catalog-service/README.md
@@ -1,6 +1,6 @@
 # Catalog Service – Addon Module
 
-This Spring Boot microservice manages addons for the multi-tenant LMS platform. It provides REST endpoints to create, update, retrieve, list, and soft-delete addons. The service uses Postgres and Redis, integrated with shared-lib starters.
+This Spring Boot microservice manages addons for the multi-tenant Ejada SaaS Products Framework. It provides REST endpoints to create, update, retrieve, list, and soft-delete addons. The service uses Postgres and Redis, integrated with shared-lib starters.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- update repository and module documentation to reference the Ejada SaaS Products Framework instead of the legacy LMS branding
- align build metadata and gateway comments with the new framework name for clarity

## Testing
- not run (documentation and metadata updates only)

------
https://chatgpt.com/codex/tasks/task_e_68e4ec6fb3fc832fb754e03c0427d2b5