### PR TITLE
Enhance gateway error responses with diagnostic metadata

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseResponse.java
@@ -71,6 +71,19 @@ public class BaseResponse<T> {
         return build(ApiStatus.ERROR, code, message, null);
     }
 
+    /**
+     * Create an error response with additional diagnostic payload.
+     *
+     * @param code    business or technical error code
+     * @param message human-readable description of the error
+     * @param data    optional payload containing structured diagnostic details
+     * @param <T>     type of the diagnostic payload
+     * @return a new BaseResponse with status ERROR
+     */
+    public static <T> BaseResponse<T> error(String code, String message, T data) {
+        return build(ApiStatus.ERROR, code, message, data);
+    }
+
     public static <T> BaseResponse<T> warning(String code, String message, T data) {
         return build(ApiStatus.WARNING, code, message, data);
     }

--- a/shared-lib/shared-common/src/test/java/com/ejada/common/dto/BaseResponseTest.java
+++ b/shared-lib/shared-common/src/test/java/com/ejada/common/dto/BaseResponseTest.java
@@ -72,6 +72,20 @@ class BaseResponseTest {
     }
 
     @Test
+    void errorFactoryIncludesDiagnosticPayload() {
+        BaseResponse<java.util.Map<String, Object>> response = BaseResponse.error(
+                "ERR_TEST",
+                "Something went wrong",
+                java.util.Map.of("correlationId", "corr-1"));
+
+        assertEquals(ApiStatus.ERROR, response.getStatus());
+        assertEquals("ERR_TEST", response.getCode());
+        assertEquals("Something went wrong", response.getMessage());
+        assertNotNull(response.getData());
+        assertEquals("corr-1", response.getData().get("correlationId"));
+    }
+
+    @Test
     void tenantIdDefaultsFromContext() {
         try (ContextManager.Tenant.Scope ignore = ContextManager.Tenant.openScope("tenantA")) {
             BaseResponse<Void> r = new BaseResponse<>();


### PR DESCRIPTION
## Summary
- enrich the reactive gateway error handler with actionable diagnostics, including correlation and tenant identifiers, and improve fallback messaging
- add an overloaded `BaseResponse.error` factory that accepts diagnostic payloads and cover it with unit tests
- update existing gateway handler tests to assert the new metadata structure and add coverage for the enhanced fallback path

## Testing
- mvn -pl shared-lib/shared-common test *(fails: unable to download net.bytebuddy:byte-buddy-agent:1.17.7 due to "Error opening zip file or JAR manifest missing")*

------
https://chatgpt.com/codex/tasks/task_e_68e4eeb45b78832fa521c3887b4fa9be