### PR TITLE
Add database-backed route repository with refresh events

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/routes/gateway/DatabaseRouteDefinitionRepository.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/gateway/DatabaseRouteDefinitionRepository.java
@@ -1,0 +1,197 @@
+package com.ejada.gateway.routes.gateway;
+
+import com.ejada.gateway.routes.model.RouteComponent;
+import com.ejada.gateway.routes.model.RouteDefinition;
+import com.ejada.gateway.routes.model.RouteMetadata;
+import com.ejada.gateway.routes.model.RouteMetadata.BlueGreenDeployment;
+import com.ejada.gateway.routes.model.RouteMetadata.TrafficSplit;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
+import org.springframework.cloud.gateway.filter.FilterDefinition;
+import org.springframework.cloud.gateway.handler.predicate.PredicateDefinition;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@link org.springframework.cloud.gateway.route.RouteDefinitionRepository} implementation that
+ * reads active route definitions from the database and exposes them to Spring Cloud Gateway.
+ *
+ * <p>The routes are cached for a short duration to avoid hammering the database on every refresh.
+ * A {@link RefreshRoutesEvent} will invalidate the cache and trigger a reload on the next
+ * subscription.</p>
+ */
+@Component
+public class DatabaseRouteDefinitionRepository
+    implements org.springframework.cloud.gateway.route.RouteDefinitionRepository {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseRouteDefinitionRepository.class);
+  private static final Duration CACHE_TTL = Duration.ofMinutes(5);
+
+  private final com.ejada.gateway.routes.repository.RouteDefinitionRepository repository;
+  private final AtomicReference<Flux<org.springframework.cloud.gateway.route.RouteDefinition>> cachedRoutes =
+      new AtomicReference<>();
+
+  public DatabaseRouteDefinitionRepository(
+      com.ejada.gateway.routes.repository.RouteDefinitionRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  public Flux<org.springframework.cloud.gateway.route.RouteDefinition> getRouteDefinitions() {
+    Flux<org.springframework.cloud.gateway.route.RouteDefinition> cached = cachedRoutes.get();
+    if (cached != null) {
+      return cached;
+    }
+
+    Flux<org.springframework.cloud.gateway.route.RouteDefinition> loader = repository.findActiveRoutes()
+        .doOnSubscribe(subscription -> LOGGER.debug("Loading active gateway routes from database"))
+        .flatMap(route -> Mono.fromCallable(() -> toGatewayRoute(route))
+            .onErrorResume(ex -> {
+              LOGGER.warn("Skipping route {} due to conversion error", route.id(), ex);
+              return Mono.empty();
+            }))
+        .onErrorResume(ex -> {
+          LOGGER.warn("Failed to fetch route definitions from database", ex);
+          return Flux.empty();
+        })
+        .cache(CACHE_TTL);
+
+    if (cachedRoutes.compareAndSet(null, loader)) {
+      return loader;
+    }
+    return cachedRoutes.get();
+  }
+
+  @Override
+  public Mono<Void> save(Mono<org.springframework.cloud.gateway.route.RouteDefinition> route) {
+    return Mono.error(new UnsupportedOperationException(
+        "Mutations are managed via the /admin/routes API and cannot be performed directly."));
+  }
+
+  @Override
+  public Mono<Void> delete(Mono<String> routeId) {
+    return Mono.error(new UnsupportedOperationException(
+        "Mutations are managed via the /admin/routes API and cannot be performed directly."));
+  }
+
+  @EventListener(RefreshRoutesEvent.class)
+  public void handleRefreshEvent(RefreshRoutesEvent event) {
+    LOGGER.debug("Clearing cached database routes due to {}", event.getClass().getSimpleName());
+    cachedRoutes.set(null);
+  }
+
+  private org.springframework.cloud.gateway.route.RouteDefinition toGatewayRoute(RouteDefinition route) {
+    RouteDefinition resolved = route.ensureServiceUri();
+    org.springframework.cloud.gateway.route.RouteDefinition gateway =
+        new org.springframework.cloud.gateway.route.RouteDefinition();
+    gateway.setId(resolved.id().toString());
+    gateway.setUri(resolved.serviceUri());
+    gateway.setPredicates(resolved.predicates().stream()
+        .map(this::toPredicate)
+        .toList());
+    gateway.setFilters(resolved.filters().stream()
+        .map(this::toFilter)
+        .toList());
+    gateway.setMetadata(buildMetadata(resolved));
+    return gateway;
+  }
+
+  private PredicateDefinition toPredicate(RouteComponent component) {
+    PredicateDefinition predicate = new PredicateDefinition();
+    predicate.setName(component.name());
+    predicate.setArgs(new LinkedHashMap<>(component.args()));
+    return predicate;
+  }
+
+  private FilterDefinition toFilter(RouteComponent component) {
+    FilterDefinition filter = new FilterDefinition();
+    filter.setName(component.name());
+    filter.setArgs(new LinkedHashMap<>(component.args()));
+    return filter;
+  }
+
+  private Map<String, Object> buildMetadata(RouteDefinition route) {
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    metadata.put("pathPattern", route.pathPattern());
+    metadata.put("enabled", route.enabled());
+    metadata.put("version", route.version());
+    metadata.put("createdAt", route.createdAt());
+    metadata.put("updatedAt", route.updatedAt());
+
+    RouteMetadata details = route.metadata();
+    if (details != null) {
+      if (!CollectionUtils.isEmpty(details.getRequestHeaders())) {
+        metadata.put("requestHeaders", new LinkedHashMap<>(details.getRequestHeaders()));
+      }
+      if (!CollectionUtils.isEmpty(details.getMethods())) {
+        metadata.put("methods", new ArrayList<>(details.getMethods()));
+      }
+      if (details.getStripPrefix() != null) {
+        metadata.put("stripPrefix", details.getStripPrefix());
+      }
+      if (StringUtils.hasText(details.getPrefixPath())) {
+        metadata.put("prefixPath", details.getPrefixPath());
+      }
+      if (!CollectionUtils.isEmpty(details.getAttributes())) {
+        details.getAttributes().forEach(metadata::putIfAbsent);
+      }
+      Map<String, Object> blueGreen = toBlueGreen(details.getBlueGreen());
+      if (!blueGreen.isEmpty()) {
+        metadata.put("blueGreen", blueGreen);
+      }
+      List<Map<String, Object>> trafficSplits = toTrafficSplits(details.getTrafficSplits());
+      if (!trafficSplits.isEmpty()) {
+        metadata.put("trafficSplits", trafficSplits);
+      }
+    }
+    return metadata;
+  }
+
+  private Map<String, Object> toBlueGreen(BlueGreenDeployment deployment) {
+    Map<String, Object> blueGreen = new LinkedHashMap<>();
+    if (deployment == null) {
+      return blueGreen;
+    }
+    deployment.getActiveSlot().ifPresent(slot -> blueGreen.put("activeSlot", slot));
+    if (deployment.getBlueUri() != null) {
+      blueGreen.put("blueUri", deployment.getBlueUri());
+    }
+    if (deployment.getGreenUri() != null) {
+      blueGreen.put("greenUri", deployment.getGreenUri());
+    }
+    return blueGreen;
+  }
+
+  private List<Map<String, Object>> toTrafficSplits(List<TrafficSplit> splits) {
+    if (CollectionUtils.isEmpty(splits)) {
+      return List.of();
+    }
+    List<Map<String, Object>> mapped = new ArrayList<>();
+    for (TrafficSplit split : splits) {
+      if (split == null) {
+        continue;
+      }
+      Map<String, Object> entry = new LinkedHashMap<>();
+      if (StringUtils.hasText(split.getVariantId())) {
+        entry.put("variantId", split.getVariantId());
+      }
+      entry.put("percentage", split.getPercentage());
+      if (split.getServiceUri() != null) {
+        entry.put("serviceUri", split.getServiceUri());
+      }
+      mapped.add(entry);
+    }
+    return mapped;
+  }
+}

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionService.java
@@ -7,6 +7,10 @@ import com.ejada.gateway.routes.repository.RouteDefinitionRepository;
 import java.net.URI;
 import java.time.Instant;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -15,13 +19,18 @@ import reactor.core.publisher.Mono;
 @Service
 public class RouteDefinitionService {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(RouteDefinitionService.class);
+
   private final RouteDefinitionRepository repository;
   private final RouteDefinitionValidator validator;
+  private final ApplicationEventPublisher eventPublisher;
 
   public RouteDefinitionService(RouteDefinitionRepository repository,
-      RouteDefinitionValidator validator) {
+      RouteDefinitionValidator validator,
+      ApplicationEventPublisher eventPublisher) {
     this.repository = repository;
     this.validator = validator;
+    this.eventPublisher = eventPublisher;
   }
 
   public Flux<RouteDefinition> findAll() {
@@ -48,7 +57,8 @@ public class RouteDefinitionService {
   public Mono<RouteDefinition> create(RouteDefinitionRequest request, Authentication actor) {
     RouteDefinition definition = request.toDomain(null, 1, Instant.now());
     validator.validate(definition);
-    return repository.create(definition, resolveActor(actor));
+    return repository.create(definition, resolveActor(actor))
+        .doOnSuccess(route -> publishRefreshEvent("create", route));
   }
 
   public Mono<RouteDefinition> update(UUID id, RouteDefinitionRequest request, Authentication actor) {
@@ -56,12 +66,15 @@ public class RouteDefinitionService {
         .flatMap(existing -> {
           RouteDefinition candidate = request.toDomain(existing.id(), existing.version(), existing.createdAt());
           validator.validate(candidate);
-          return repository.update(candidate, resolveActor(actor));
+          return repository.update(candidate, resolveActor(actor))
+              .doOnSuccess(route -> publishRefreshEvent("update", route));
         });
   }
 
   public Mono<Void> disable(UUID id, Authentication actor) {
-    return repository.disable(id, resolveActor(actor)).then();
+    return repository.disable(id, resolveActor(actor))
+        .doOnSuccess(route -> publishRefreshEvent("disable", route))
+        .then();
   }
 
   private String resolveActor(Authentication authentication) {
@@ -69,5 +82,13 @@ public class RouteDefinitionService {
       return "system";
     }
     return authentication.getName();
+  }
+
+  private void publishRefreshEvent(String action, RouteDefinition route) {
+    if (route == null) {
+      return;
+    }
+    LOGGER.info("Publishing RefreshRoutesEvent after {} route {}", action, route.id());
+    eventPublisher.publishEvent(new RefreshRoutesEvent(this));
   }
 }

--- a/api-gateway/src/test/java/com/ejada/gateway/routes/gateway/DatabaseRouteDefinitionRepositoryTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/routes/gateway/DatabaseRouteDefinitionRepositoryTest.java
@@ -1,0 +1,105 @@
+package com.ejada.gateway.routes.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ejada.gateway.routes.model.RouteComponent;
+import com.ejada.gateway.routes.model.RouteDefinition;
+import com.ejada.gateway.routes.model.RouteMetadata;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class DatabaseRouteDefinitionRepositoryTest {
+
+  @Mock
+  private com.ejada.gateway.routes.repository.RouteDefinitionRepository routeRepository;
+
+  private DatabaseRouteDefinitionRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = new DatabaseRouteDefinitionRepository(routeRepository);
+  }
+
+  @Test
+  void mapsDomainRouteToGatewayDefinition() {
+    RouteDefinition route = buildRoute(UUID.randomUUID(), "lb://demo", Map.of("pattern", "/demo/**"));
+    RouteMetadata metadata = route.metadata();
+    metadata.setStripPrefix(1);
+    metadata.setRequestHeaders(Map.of("X-Test", "true"));
+
+    when(routeRepository.findActiveRoutes()).thenReturn(Flux.just(route));
+
+    StepVerifier.create(repository.getRouteDefinitions())
+        .assertNext(definition -> {
+          assertThat(definition.getId()).isEqualTo(route.id().toString());
+          assertThat(definition.getUri()).isEqualTo(route.serviceUri());
+          assertThat(definition.getPredicates()).hasSize(1);
+          assertThat(definition.getPredicates().get(0).getName()).isEqualTo("Path");
+          assertThat(definition.getPredicates().get(0).getArgs())
+              .containsEntry("pattern", "/demo/**");
+          assertThat(definition.getMetadata()).containsEntry("stripPrefix", 1);
+          assertThat(definition.getMetadata())
+              .hasEntrySatisfying("requestHeaders", value -> assertThat(value).isInstanceOf(Map.class));
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  void refreshEventClearsCache() {
+    RouteDefinition first = buildRoute(UUID.randomUUID(), "lb://demo", Map.of("pattern", "/first/**"));
+    RouteDefinition second = buildRoute(UUID.randomUUID(), "lb://demo", Map.of("pattern", "/second/**"));
+
+    when(routeRepository.findActiveRoutes())
+        .thenReturn(Flux.just(first))
+        .thenReturn(Flux.just(second));
+
+    StepVerifier.create(repository.getRouteDefinitions())
+        .expectNextMatches(def -> def.getId().equals(first.id().toString()))
+        .verifyComplete();
+
+    StepVerifier.create(repository.getRouteDefinitions())
+        .expectNextMatches(def -> def.getId().equals(first.id().toString()))
+        .verifyComplete();
+
+    verify(routeRepository, times(1)).findActiveRoutes();
+
+    repository.handleRefreshEvent(new RefreshRoutesEvent(this));
+
+    StepVerifier.create(repository.getRouteDefinitions())
+        .expectNextMatches(def -> def.getId().equals(second.id().toString()))
+        .verifyComplete();
+
+    verify(routeRepository, times(2)).findActiveRoutes();
+  }
+
+  private RouteDefinition buildRoute(UUID id, String uri, Map<String, String> predicateArgs) {
+    Instant now = Instant.now();
+    RouteMetadata metadata = RouteMetadata.empty();
+    return new RouteDefinition(
+        id,
+        "/demo/**",
+        URI.create(uri),
+        List.of(new RouteComponent("Path", predicateArgs)),
+        List.of(),
+        metadata,
+        true,
+        1,
+        now,
+        now);
+  }
+}

--- a/api-gateway/src/test/java/com/ejada/gateway/routes/service/RouteDefinitionServiceTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/routes/service/RouteDefinitionServiceTest.java
@@ -1,0 +1,127 @@
+package com.ejada.gateway.routes.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ejada.gateway.routes.model.RouteComponent;
+import com.ejada.gateway.routes.model.RouteDefinition;
+import com.ejada.gateway.routes.model.RouteDefinitionRequest;
+import com.ejada.gateway.routes.model.RouteMetadata;
+import com.ejada.gateway.routes.repository.RouteDefinitionRepository;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class RouteDefinitionServiceTest {
+
+  @Mock
+  private RouteDefinitionRepository repository;
+
+  @Mock
+  private RouteDefinitionValidator validator;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+
+  private RouteDefinitionService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new RouteDefinitionService(repository, validator, eventPublisher);
+    when(validator.validate(any(RouteDefinition.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  @Test
+  void createPublishesRefreshEvent() {
+    RouteDefinitionRequest request = new RouteDefinitionRequest(
+        "/api/demo/**",
+        "http://demo",
+        List.of(new RouteComponent("Path", Map.of("pattern", "/api/demo/**"))),
+        List.of(),
+        RouteMetadata.empty(),
+        true);
+
+    RouteDefinition created = buildRoute(UUID.randomUUID(), "/api/demo/**", "http://demo", 1);
+
+    when(repository.create(any(RouteDefinition.class), eq("system")))
+        .thenReturn(Mono.just(created));
+
+    StepVerifier.create(service.create(request, null))
+        .expectNext(created)
+        .verifyComplete();
+
+    verify(repository).create(any(RouteDefinition.class), eq("system"));
+    verify(eventPublisher).publishEvent(any());
+  }
+
+  @Test
+  void updatePublishesRefreshEvent() {
+    UUID id = UUID.randomUUID();
+    RouteDefinition existing = buildRoute(id, "/api/demo/**", "http://demo", 1);
+    RouteDefinition updated = buildRoute(id, "/api/demo/**", "http://demo", 2);
+
+    RouteDefinitionRequest request = new RouteDefinitionRequest(
+        "/api/demo/**",
+        "http://demo",
+        List.of(new RouteComponent("Path", Map.of("pattern", "/api/demo/**"))),
+        List.of(),
+        RouteMetadata.empty(),
+        true);
+
+    when(repository.findById(id)).thenReturn(Mono.just(existing));
+    when(repository.update(any(RouteDefinition.class), eq("system")))
+        .thenReturn(Mono.just(updated));
+
+    StepVerifier.create(service.update(id, request, null))
+        .expectNext(updated)
+        .verifyComplete();
+
+    verify(repository).update(any(RouteDefinition.class), eq("system"));
+    verify(eventPublisher).publishEvent(any());
+  }
+
+  @Test
+  void disablePublishesRefreshEvent() {
+    UUID id = UUID.randomUUID();
+    RouteDefinition disabled = buildRoute(id, "/api/demo/**", "http://demo", 2);
+
+    when(repository.disable(eq(id), eq("officer")))
+        .thenReturn(Mono.just(disabled));
+
+    StepVerifier.create(service.disable(id, new TestingAuthenticationToken("officer", "")))
+        .verifyComplete();
+
+    verify(repository).disable(eq(id), eq("officer"));
+    verify(eventPublisher).publishEvent(any());
+  }
+
+  private RouteDefinition buildRoute(UUID id, String path, String uri, int version) {
+    Instant now = Instant.now();
+    return new RouteDefinition(
+        id,
+        path,
+        URI.create(uri),
+        List.of(new RouteComponent("Path", Map.of("pattern", path))),
+        List.of(),
+        RouteMetadata.empty(),
+        true,
+        version,
+        now,
+        now);
+  }
+}


### PR DESCRIPTION
## Summary
- add a Spring Cloud Gateway `DatabaseRouteDefinitionRepository` that converts active database routes into gateway definitions with caching and refresh hooks
- publish `RefreshRoutesEvent` after route create/update/disable operations so dynamic routes reload immediately
- cover the new repository and service behaviour with unit tests

## Testing
- `mvn -pl api-gateway test` *(fails: missing internal com.ejada starter dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e4eec59bd4832fa0e30cbaad790013