### PR TITLE
Add tenant validation guardrails to service security

### DIFF
--- a/sec-service/src/main/resources/application-dev.yaml
+++ b/sec-service/src/main/resources/application-dev.yaml
@@ -148,12 +148,16 @@ shared:
       secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
     resource-server:
       enabled: true
+      verify-tenant-claim: true
       permit-all:
         - "/actuator/health"
         - "/api/v1/auth/**"
       disable-csrf: false
       csrf-ignore:
         - "/api/v1/auth/**"
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     stateless: true
     roles-claim: roles
     tenant-claim: tenant

--- a/sec-service/src/main/resources/application-qa.yaml
+++ b/sec-service/src/main/resources/application-qa.yaml
@@ -222,6 +222,7 @@ app:
       secret: ${JWT_SECRET}
     resource-server:
       enabled: true
+      verify-tenant-claim: true
       permit-all:
         - "/api/auth/**"
         - "/v3/api-docs/**"
@@ -232,7 +233,10 @@ app:
         - "/api/auth/**"
         - "/v3/api-docs/**"
         - "/swagger-ui/**"
-      stateless: true
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
+    stateless: true
     roles-claim: roles
     tenant-claim: tenant
     enable-role-check: true

--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -83,7 +83,11 @@ shared:
   security:
     enable-role-check: true
     resource-server:
-      enabled: false
+      enabled: true
+      verify-tenant-claim: true
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     jwt:
       secret: ${SHARED_SECURITY_JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
       token-period: 15m

--- a/setup-service/src/main/resources/application-local.yaml
+++ b/setup-service/src/main/resources/application-local.yaml
@@ -31,9 +31,13 @@ shared:
       secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
     resource-server:
       enabled: true
+      verify-tenant-claim: true
       permit-all:
         - "/**"
       disable-csrf: false
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     stateless: true
     roles-claim: roles
     tenant-claim: tenant

--- a/setup-service/src/main/resources/application-qa.yaml
+++ b/setup-service/src/main/resources/application-qa.yaml
@@ -202,8 +202,12 @@ shared:
       secret: ${JWT_SECRET}
     resource-server:
       enabled: true
+      verify-tenant-claim: true
       permit-all: ["/setup/systemParameters/**"]
       disable-csrf: false
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     stateless: true
     roles-claim: roles
     tenant-claim: tenant

--- a/setup-service/src/main/resources/application.yaml
+++ b/setup-service/src/main/resources/application.yaml
@@ -38,6 +38,10 @@ shared:
   security:
     enable-role-check: true
     resource-server:
-      enabled: false
+      enabled: true
+      verify-tenant-claim: true
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     jwt:
       token-period: 15m

--- a/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-dev.yaml
@@ -205,7 +205,11 @@ shared:
         - "/api/*/v3/api-docs/**"
         - "/api/*/swagger-ui/**"
       disable-csrf: false
+      verify-tenant-claim: true
     stateless: true
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     roles-claim: roles
     tenant-claim: tenant
     enable-role-check: true

--- a/shared-lib/shared-config/src/main/resources/application-shared-platform-dev.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-platform-dev.yaml
@@ -66,7 +66,11 @@ shared:
         - "/api/*/v3/api-docs/**"
         - "/api/*/swagger-ui/**"
       disable-csrf: false
+      verify-tenant-claim: true
     stateless: true
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     roles-claim: roles
     tenant-claim: tenant
 

--- a/shared-lib/shared-config/src/main/resources/application-shared-tenant-qa.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-tenant-qa.yaml
@@ -122,7 +122,11 @@ shared:
       permit-all:
         - "**"
       disable-csrf: false
+      verify-tenant-claim: true
     stateless: true
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     roles-claim: roles
     tenant-claim: tenant
     enable-role-check: true

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
@@ -11,11 +11,13 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -45,6 +47,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.util.UrlPathHelper;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -183,6 +187,24 @@ public class SecurityAutoConfiguration {
       SharedSecurityProps props,
       ObjectProvider<StringRedisTemplate> redisTemplateProvider) {
     return new TenantAwareJwtValidator(props, redisTemplateProvider.getIfAvailable());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public TenantContextValidatorInterceptor tenantContextValidatorInterceptor(SharedSecurityProps props) {
+    return new TenantContextValidatorInterceptor(props);
+  }
+
+  @Bean
+  @ConditionalOnBean(TenantContextValidatorInterceptor.class)
+  public WebMvcConfigurer tenantContextValidatorWebMvcConfigurer(
+      TenantContextValidatorInterceptor interceptor) {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(interceptor).order(Ordered.HIGHEST_PRECEDENCE + 100);
+      }
+    };
   }
 
   /* ---------------------------------------------------

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SharedSecurityProps.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SharedSecurityProps.java
@@ -24,6 +24,11 @@ import org.springframework.validation.annotation.Validated;
  *   shared.security.resource-server.permit-all[...]
  *   shared.security.resource-server.disable-csrf
  *   shared.security.resource-server.stateless
+ *   shared.security.resource-server.verify-tenant-claim
+ *
+ * Tenant verification block:
+ *   shared.security.tenant-verification.strict-mode
+ *   shared.security.tenant-verification.require-tenant-header
  */
 @Getter
 @Validated
@@ -67,6 +72,9 @@ public class SharedSecurityProps implements BaseStarterProperties {
   // --------- Resource Server defaults ---------
   private ResourceServer resourceServer = new ResourceServer();
 
+  /** Tenant context verification defaults. */
+  private TenantVerification tenantVerification = new TenantVerification();
+
   // ===========================================
   //            Nested types
   // ===========================================
@@ -90,6 +98,9 @@ public class SharedSecurityProps implements BaseStarterProperties {
   public static class ResourceServer {
     /** Master enable switch for the SecurityFilterChain */
     private boolean enabled = true;
+
+    /** Enforce tenant claim validation against inbound headers. */
+    private boolean verifyTenantClaim = false;
 
     /** Permit-all endpoints (ant matchers). */
     private String[] permitAll = new String[]{
@@ -130,6 +141,19 @@ public class SharedSecurityProps implements BaseStarterProperties {
     private String tokenPeriod;
   }
 
+  @Getter
+  @Setter
+  public static class TenantVerification {
+    /**
+     * Strict mode enforces tenant equality between JWT claims, headers and the
+     * current tenant context.
+     */
+    private boolean strictMode = false;
+
+    /** Require presence of X-Tenant-Id header on authenticated requests. */
+    private boolean requireTenantHeader = false;
+  }
+
   public void setHs256(Hs256 hs256) {
     this.hs256 = hs256 != null ? hs256 : new Hs256();
     applyLegacySecretFallback();
@@ -141,6 +165,11 @@ public class SharedSecurityProps implements BaseStarterProperties {
 
   public void setResourceServer(ResourceServer resourceServer) {
     this.resourceServer = resourceServer != null ? resourceServer : new ResourceServer();
+  }
+
+  public void setTenantVerification(TenantVerification tenantVerification) {
+    this.tenantVerification =
+        tenantVerification != null ? tenantVerification : new TenantVerification();
   }
 
   public void setJwt(LegacyJwt jwt) {

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/TenantContextValidatorInterceptor.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/TenantContextValidatorInterceptor.java
@@ -1,0 +1,96 @@
+package com.ejada.starter_security;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Validates tenant context against inbound headers to guard against tampering.
+ */
+class TenantContextValidatorInterceptor implements HandlerInterceptor {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(TenantContextValidatorInterceptor.class);
+
+  private final SharedSecurityProps props;
+
+  TenantContextValidatorInterceptor(SharedSecurityProps props) {
+    this.props = props;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request,
+                           HttpServletResponse response,
+                           Object handler) throws Exception {
+    SharedSecurityProps.ResourceServer resourceServer = props.getResourceServer();
+    SharedSecurityProps.TenantVerification verification = props.getTenantVerification();
+
+    if (resourceServer == null || verification == null) {
+      return true;
+    }
+
+    if (!resourceServer.isEnabled()) {
+      return true;
+    }
+
+    if (!resourceServer.isVerifyTenantClaim()
+        && !verification.isStrictMode()
+        && !verification.isRequireTenantHeader()) {
+      return true;
+    }
+
+    String headerTenant = normalize(request.getHeader(HeaderNames.X_TENANT_ID));
+    String contextTenant = normalize(ContextManager.Tenant.get());
+
+    if (verification.isRequireTenantHeader() && headerTenant == null) {
+      logMismatch("Missing required tenant header", headerTenant, contextTenant);
+      writeViolation(response, HttpServletResponse.SC_BAD_REQUEST,
+          "TENANT_HEADER_REQUIRED", "X-Tenant-Id header is required");
+      return false;
+    }
+
+    if (headerTenant != null && contextTenant != null && !Objects.equals(headerTenant, contextTenant)) {
+      logMismatch("Tenant context mismatch detected", headerTenant, contextTenant);
+      if (verification.isStrictMode()) {
+        writeViolation(response, HttpServletResponse.SC_BAD_REQUEST,
+            "TENANT_CONTEXT_MISMATCH", "Tenant header and context mismatch");
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private static void writeViolation(HttpServletResponse response,
+                                     int status,
+                                     String code,
+                                     String message) throws IOException {
+    response.setStatus(status);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response.getWriter()
+        .write(String.format("{\"code\":\"%s\",\"message\":\"%s\"}", code, message));
+  }
+
+  private static void logMismatch(String message,
+                                  @Nullable String headerTenant,
+                                  @Nullable String contextTenant) {
+    if (log.isWarnEnabled()) {
+      log.warn("{} (header='{}', context='{}')", message, headerTenant, contextTenant);
+    }
+  }
+
+  private static String normalize(@Nullable String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+}

--- a/shared-lib/shared-starters/starter-security/src/main/resources/application.yml
+++ b/shared-lib/shared-starters/starter-security/src/main/resources/application.yml
@@ -10,5 +10,9 @@ shared:
       secret: ${SHARED_SECURITY_HS256_SECRET:change-me}
     resource-server:
       enabled: ${SHARED_SECURITY_RESOURCE_SERVER_ENABLED:true}
+      verify-tenant-claim: ${SHARED_SECURITY_RESOURCE_SERVER_VERIFY_TENANT_CLAIM:false}
+    tenant-verification:
+      strict-mode: ${SHARED_SECURITY_TENANT_VERIFICATION_STRICT_MODE:false}
+      require-tenant-header: ${SHARED_SECURITY_TENANT_VERIFICATION_REQUIRE_TENANT_HEADER:false}
     roles-claim: ${SHARED_SECURITY_ROLES_CLAIM:roles}
     scope-claim: ${SHARED_SECURITY_SCOPE_CLAIM:scope}

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/JwtDecoderAutoConfigurationTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/JwtDecoderAutoConfigurationTest.java
@@ -12,6 +12,8 @@ import java.util.Date;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +23,8 @@ import static org.assertj.core.api.Assertions.fail;
 class JwtDecoderAutoConfigurationTest {
 
   private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-      .withConfiguration(AutoConfigurations.of(JwtDecoderAutoConfiguration.class));
+      .withConfiguration(AutoConfigurations.of(JwtDecoderAutoConfiguration.class))
+      .withUserConfiguration(TestTenantValidatorConfig.class);
 
   private static final String BASE64_SECRET = "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=";
 
@@ -29,8 +32,9 @@ class JwtDecoderAutoConfigurationTest {
   void missingSecretThrowsMeaningfulException() {
     SharedSecurityProps props = new SharedSecurityProps();
     JwtDecoderAutoConfiguration configuration = new JwtDecoderAutoConfiguration();
+    TenantAwareJwtValidator validator = new TenantAwareJwtValidator(props, null);
 
-    assertThatThrownBy(() -> configuration.jwtDecoder(props))
+    assertThatThrownBy(() -> configuration.jwtDecoder(props, validator))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("shared.security.hs256.secret");
   }
@@ -40,8 +44,9 @@ class JwtDecoderAutoConfigurationTest {
     SharedSecurityProps props = new SharedSecurityProps();
     props.setMode("jwks");
     JwtDecoderAutoConfiguration configuration = new JwtDecoderAutoConfiguration();
+    TenantAwareJwtValidator validator = new TenantAwareJwtValidator(props, null);
 
-    assertThatThrownBy(() -> configuration.jwtDecoder(props))
+    assertThatThrownBy(() -> configuration.jwtDecoder(props, validator))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("shared.security.jwks.uri");
   }
@@ -89,5 +94,13 @@ class JwtDecoderAutoConfigurationTest {
     SignedJWT signed = new SignedJWT(new com.nimbusds.jose.JWSHeader(JWSAlgorithm.HS256), claims);
     signed.sign(signer);
     return signed.serialize();
+  }
+
+  @Configuration
+  static class TestTenantValidatorConfig {
+    @Bean
+    TenantAwareJwtValidator tenantAwareJwtValidator(SharedSecurityProps props) {
+      return new TenantAwareJwtValidator(props, null);
+    }
   }
 }

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/TenantAwareJwtValidatorTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/TenantAwareJwtValidatorTest.java
@@ -1,0 +1,107 @@
+package com.ejada.starter_security;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.time.Instant;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TenantAwareJwtValidatorTest {
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
+    ContextManager.Tenant.clear();
+  }
+
+  @Test
+  void succeedsWhenHeaderMatchesClaim() {
+    TenantAwareJwtValidator validator = newValidator(true, true, true);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HeaderNames.X_TENANT_ID, "acme");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    OAuth2TokenValidatorResult result = validator.validate(jwtWithTenant("acme"));
+
+    assertFalse(result.hasErrors());
+  }
+
+  @Test
+  void failsWhenHeaderMissingAndRequired() {
+    TenantAwareJwtValidator validator = newValidator(true, true, true);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
+
+    OAuth2TokenValidatorResult result = validator.validate(jwtWithTenant("acme"));
+
+    assertTrue(result.hasErrors());
+  }
+
+  @Test
+  void failsWhenHeaderDiffersFromClaimInStrictMode() {
+    TenantAwareJwtValidator validator = newValidator(true, true, true);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HeaderNames.X_TENANT_ID, "acme");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    OAuth2TokenValidatorResult result = validator.validate(jwtWithTenant("other"));
+
+    assertTrue(result.hasErrors());
+  }
+
+  @Test
+  void failsWhenContextDiffersFromHeaderInStrictMode() {
+    TenantAwareJwtValidator validator = newValidator(true, true, true);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HeaderNames.X_TENANT_ID, "acme");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    ContextManager.Tenant.set("other");
+
+    OAuth2TokenValidatorResult result = validator.validate(jwtWithTenant("acme"));
+
+    assertTrue(result.hasErrors());
+  }
+
+  @Test
+  void logsButAllowsMismatchWhenVerificationDisabled() {
+    TenantAwareJwtValidator validator = newValidator(false, false, false);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HeaderNames.X_TENANT_ID, "acme");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    OAuth2TokenValidatorResult result = validator.validate(jwtWithTenant("other"));
+
+    assertFalse(result.hasErrors());
+  }
+
+  private TenantAwareJwtValidator newValidator(boolean verifyClaim,
+                                               boolean strictMode,
+                                               boolean requireHeader) {
+    SharedSecurityProps props = new SharedSecurityProps();
+    props.setTenantClaim("tenant");
+    props.getResourceServer().setVerifyTenantClaim(verifyClaim);
+    props.getTenantVerification().setStrictMode(strictMode);
+    props.getTenantVerification().setRequireTenantHeader(requireHeader);
+    return new TenantAwareJwtValidator(props, null);
+  }
+
+  private Jwt jwtWithTenant(String tenant) {
+    return Jwt.withTokenValue("token")
+        .issuedAt(Instant.now())
+        .expiresAt(Instant.now().plusSeconds(60))
+        .header("alg", "none")
+        .claims(claims -> {
+          if (tenant != null) {
+            claims.put("tenant", tenant);
+          }
+        })
+        .build();
+  }
+}

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/TenantContextValidatorInterceptorTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/TenantContextValidatorInterceptorTest.java
@@ -1,0 +1,78 @@
+package com.ejada.starter_security;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TenantContextValidatorInterceptorTest {
+
+  @AfterEach
+  void cleanup() {
+    ContextManager.Tenant.clear();
+  }
+
+  @Test
+  void allowsMatchingHeaderAndContext() throws Exception {
+    TenantContextValidatorInterceptor interceptor = newInterceptor(true, true, true);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HeaderNames.X_TENANT_ID, "acme");
+    ContextManager.Tenant.set("acme");
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assertTrue(interceptor.preHandle(request, response, new Object()));
+    assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+  }
+
+  @Test
+  void rejectsMissingHeaderWhenRequired() throws Exception {
+    TenantContextValidatorInterceptor interceptor = newInterceptor(false, true, true);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assertFalse(interceptor.preHandle(request, response, new Object()));
+    assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
+  void rejectsMismatchedContextInStrictMode() throws Exception {
+    TenantContextValidatorInterceptor interceptor = newInterceptor(true, true, false);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HeaderNames.X_TENANT_ID, "acme");
+    ContextManager.Tenant.set("other");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assertFalse(interceptor.preHandle(request, response, new Object()));
+    assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
+  void allowsMismatchWhenNotStrict() throws Exception {
+    TenantContextValidatorInterceptor interceptor = newInterceptor(true, false, false);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HeaderNames.X_TENANT_ID, "acme");
+    ContextManager.Tenant.set("other");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assertTrue(interceptor.preHandle(request, response, new Object()));
+    assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+  }
+
+  private TenantContextValidatorInterceptor newInterceptor(boolean verify,
+                                                            boolean strict,
+                                                            boolean requireHeader) {
+    SharedSecurityProps props = new SharedSecurityProps();
+    props.getResourceServer().setVerifyTenantClaim(verify);
+    props.getTenantVerification().setStrictMode(strict);
+    props.getTenantVerification().setRequireTenantHeader(requireHeader);
+    return new TenantContextValidatorInterceptor(props);
+  }
+}

--- a/tenant-platform/analytics-service/src/main/resources/application.yml
+++ b/tenant-platform/analytics-service/src/main/resources/application.yml
@@ -60,7 +60,11 @@ shared:
     hs256:
       secret: ${SHARED_SECURITY_HS256_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
     resource-server:
-      enabled: false
+      enabled: true
+      verify-tenant-claim: true
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     jwt:
       secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
       token-period: 15m

--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -39,6 +39,10 @@ shared:
   security:
     enable-role-check: true
     resource-server:
-      enabled: false
+      enabled: true
+      verify-tenant-claim: true
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     jwt:
       token-period: 15m

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -39,6 +39,10 @@ shared:
   security:
     enable-role-check: true
     resource-server:
-      enabled: false
+      enabled: true
+      verify-tenant-claim: true
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     jwt:
       token-period: 15m

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -39,6 +39,10 @@ shared:
   security:
     enable-role-check: true
     resource-server:
-      enabled: false
+      enabled: true
+      verify-tenant-claim: true
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     jwt:
       token-period: 15m

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -38,6 +38,10 @@ shared:
   security:
     enable-role-check: true
     resource-server:
-      enabled: false
+      enabled: true
+      verify-tenant-claim: true
+    tenant-verification:
+      strict-mode: true
+      require-tenant-header: true
     jwt:
       token-period: 15m


### PR DESCRIPTION
## Summary
- enable the shared resource-server tenant verification settings across service configurations
- extend the security starter with tenant claim verification, a context validator interceptor, and supporting properties
- add focused unit tests for the new validator behaviors and adjust decoder auto-configuration tests

## Testing
- mvn -pl shared-lib/shared-starters/starter-security -am test

------
https://chatgpt.com/codex/tasks/task_e_68e4f1d13c7c832f83004726e2f360ab