### PR TITLE
Implement internal service API key authentication

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/config/WebClientConfig.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/config/WebClientConfig.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -78,6 +79,15 @@ public class WebClientConfig {
 
     customFilters.orderedStream().forEach(builder::filter);
     return builder;
+  }
+
+  @Bean
+  public WebClient internalServiceClient(
+      @Value("${gateway.internal.api-key}") String apiKey) {
+    return WebClient.builder()
+        .defaultHeader(HeaderNames.INTERNAL_AUTH, apiKey)
+        .defaultHeader(HeaderNames.GATEWAY_ORIGIN, "api-gateway")
+        .build();
   }
 
   private ExchangeFilterFunction contextPropagationFilter() {

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -2,6 +2,10 @@ server:
   port: ${SERVER_PORT:8000}
   shutdown: graceful
 
+gateway:
+  internal:
+    api-key: ${GATEWAY_INTERNAL_API_KEY:${SHARED_SECURITY_INTERNAL_CLIENT_API_KEY:local-dev-internal-key}}
+
 spring:
   # Import remote configuration first, allowing local overrides via active profiles.
   config:

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
@@ -63,4 +63,6 @@ public final class HeaderNames {
     // 🛡️ Custom Security Headers
     public static final String CSRF_TOKEN = "X-CSRF-Token";
     public static final String API_KEY = "X-API-Key";
+    public static final String INTERNAL_AUTH = "X-Internal-Auth";
+    public static final String GATEWAY_ORIGIN = "X-Gateway-Origin";
 }

--- a/shared-lib/shared-config/src/main/resources/application-shared-service.yaml
+++ b/shared-lib/shared-config/src/main/resources/application-shared-service.yaml
@@ -55,3 +55,9 @@ shared:
     key-prefix: ${app.cache-prefix}
     default-ttl: ${REDIS_DEFAULT_TTL:600s}
     reactive: false
+  security:
+    internal-client:
+      enabled: ${SHARED_SECURITY_INTERNAL_CLIENT_ENABLED:true}
+      api-key: ${SHARED_SECURITY_INTERNAL_CLIENT_API_KEY:local-dev-internal-key}
+      header-name: ${SHARED_SECURITY_INTERNAL_CLIENT_HEADER:X-Internal-Auth}
+      principal: ${SHARED_SECURITY_INTERNAL_CLIENT_PRINCIPAL:api-gateway}

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SharedSecurityProps.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SharedSecurityProps.java
@@ -1,6 +1,7 @@
 package com.ejada.starter_security;
 
 import com.ejada.common.BaseStarterProperties;
+import com.ejada.common.constants.HeaderNames;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -66,6 +67,7 @@ public class SharedSecurityProps implements BaseStarterProperties {
 
   // --------- Resource Server defaults ---------
   private ResourceServer resourceServer = new ResourceServer();
+  private InternalClient internalClient = new InternalClient();
 
   // ===========================================
   //            Nested types
@@ -122,6 +124,22 @@ public class SharedSecurityProps implements BaseStarterProperties {
 
   @Getter
   @Setter
+  public static class InternalClient {
+    /** Enable internal service authentication via shared secret. */
+    private boolean enabled = false;
+
+    /** Header carrying the internal authentication secret. */
+    private String headerName = HeaderNames.INTERNAL_AUTH;
+
+    /** Shared API key expected from internal callers. */
+    private String apiKey;
+
+    /** Logical principal applied to the authenticated request. */
+    private String principal = "internal-service";
+  }
+
+  @Getter
+  @Setter
   public static class LegacyJwt {
     /** Legacy secret property from shared.security.jwt.secret. */
     private String secret;
@@ -141,6 +159,10 @@ public class SharedSecurityProps implements BaseStarterProperties {
 
   public void setResourceServer(ResourceServer resourceServer) {
     this.resourceServer = resourceServer != null ? resourceServer : new ResourceServer();
+  }
+
+  public void setInternalClient(InternalClient internalClient) {
+    this.internalClient = internalClient != null ? internalClient : new InternalClient();
   }
 
   public void setJwt(LegacyJwt jwt) {

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/internal/InternalClientAuthenticationFilter.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/internal/InternalClientAuthenticationFilter.java
@@ -1,0 +1,103 @@
+package com.ejada.starter_security.internal;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.starter_security.SharedSecurityProps;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Validates shared secret authentication for intra-service calls bypassing the gateway.
+ */
+public class InternalClientAuthenticationFilter extends OncePerRequestFilter {
+
+  private static final Logger log = LoggerFactory.getLogger(InternalClientAuthenticationFilter.class);
+
+  private final SharedSecurityProps.InternalClient properties;
+  private final String headerName;
+  private final byte[] expected;
+
+  public InternalClientAuthenticationFilter(SharedSecurityProps.InternalClient properties) {
+    Assert.notNull(properties, "properties must not be null");
+    this.properties = properties;
+    Assert.isTrue(properties.isEnabled(), "Internal client authentication must be enabled");
+    Assert.hasText(properties.getApiKey(), "shared.security.internal-client.api-key must be configured");
+    this.headerName = StringUtils.hasText(properties.getHeaderName())
+        ? properties.getHeaderName()
+        : HeaderNames.INTERNAL_AUTH;
+    this.expected = properties.getApiKey().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    if (!properties.isEnabled()) {
+      return true;
+    }
+    String presented = extractPresentedKey(request);
+    return presented == null;
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    String presented = Objects.requireNonNull(extractPresentedKey(request), "presented secret");
+    if (!matches(presented)) {
+      log.warn("Rejected internal request with invalid credential from {}", request.getRemoteAddr());
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid internal service credential");
+      return;
+    }
+
+    Authentication previous = SecurityContextHolder.getContext().getAuthentication();
+    InternalServiceAuthenticationToken token = new InternalServiceAuthenticationToken(
+        resolvePrincipal(request), headerName);
+    SecurityContextHolder.getContext().setAuthentication(token);
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      Authentication current = SecurityContextHolder.getContext().getAuthentication();
+      if (current == token || current == null) {
+        SecurityContextHolder.getContext().setAuthentication(previous);
+      }
+    }
+  }
+
+  private String extractPresentedKey(HttpServletRequest request) {
+    String header = trimToNull(request.getHeader(headerName));
+    if (!StringUtils.hasText(header)) {
+      return null;
+    }
+    return header;
+  }
+
+  private boolean matches(String presented) {
+    byte[] candidate = presented.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    return MessageDigest.isEqual(expected, candidate);
+  }
+
+  private String resolvePrincipal(HttpServletRequest request) {
+    String origin = trimToNull(request.getHeader(HeaderNames.GATEWAY_ORIGIN));
+    if (StringUtils.hasText(origin)) {
+      return origin;
+    }
+    return properties.getPrincipal();
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/internal/InternalServiceAuthenticationToken.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/internal/InternalServiceAuthenticationToken.java
@@ -1,0 +1,49 @@
+package com.ejada.starter_security.internal;
+
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.util.StringUtils;
+
+/**
+ * Authentication token used for trusted internal service calls.
+ */
+public class InternalServiceAuthenticationToken extends AbstractAuthenticationToken {
+
+  private final String principal;
+  private final String headerName;
+
+  public InternalServiceAuthenticationToken(String principal, String headerName) {
+    this(principal, headerName, defaultAuthorities());
+  }
+
+  public InternalServiceAuthenticationToken(
+      String principal,
+      String headerName,
+      Collection<? extends GrantedAuthority> authorities) {
+    super(authorities == null ? defaultAuthorities() : List.copyOf(authorities));
+    this.principal = StringUtils.hasText(principal) ? principal : "internal-service";
+    this.headerName = headerName;
+    setAuthenticated(true);
+  }
+
+  @Override
+  public Object getCredentials() {
+    return "";
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return principal;
+  }
+
+  public String getHeaderName() {
+    return headerName;
+  }
+
+  private static List<GrantedAuthority> defaultAuthorities() {
+    return List.of(new SimpleGrantedAuthority("ROLE_SERVICE"));
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated gateway WebClient that propagates the configured internal API key header for service-to-service calls
- introduce shared security properties, authentication token, and filter to enforce internal API key validation across services
- expose default shared configuration and header constants so downstream services can enable the internal client guardrail

## Testing
- `mvn -pl shared-lib/shared-starters/starter-security -am -DskipITs test` *(fails: missing Maven dependency byte-buddy-agent)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f2bfdd2c832fb20af21a41a093bc