### PR TITLE
Fix TestObjectProviders visibility

### DIFF
--- a/api-gateway/src/test/java/com/ejada/gateway/security/TestObjectProviders.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/security/TestObjectProviders.java
@@ -4,12 +4,12 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.springframework.beans.factory.ObjectProvider;
 
-final class TestObjectProviders {
+public final class TestObjectProviders {
   private TestObjectProviders() {
   }
 
   static <T> ObjectProvider<T> of(T instance) {
-    return new ObjectProvider<>() {
+    return new ObjectProvider<T>() {
       @Override
       public T getObject(Object... args) {
         return instance;


### PR DESCRIPTION
## Summary
- make the test-only TestObjectProviders helper public so it is visible in all security tests
- replace the diamond operator in the helper with an explicit generic type for broader compiler compatibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4fa35d17c832fb10303e9245780ab