### PR TITLE
Fix duplicate gateway key in application YAML

### DIFF
--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -2,10 +2,6 @@ server:
   port: ${SERVER_PORT:8000}
   shutdown: graceful
 
-gateway:
-  internal:
-    api-key: ${GATEWAY_INTERNAL_API_KEY:${SHARED_SECURITY_INTERNAL_CLIENT_API_KEY:local-dev-internal-key}}
-
 spring:
   # Import remote configuration first, allowing local overrides via active profiles.
   config:
@@ -286,6 +282,8 @@ resilience4j:
 
 # Declarative downstream routes consumed by GatewayRoutesConfiguration
 gateway:
+  internal:
+    api-key: ${GATEWAY_INTERNAL_API_KEY:${SHARED_SECURITY_INTERNAL_CLIENT_API_KEY:local-dev-internal-key}}
   versioning:
     enabled: true
     compatibility:


### PR DESCRIPTION
## Summary
- merge the internal gateway configuration into the primary `gateway` section of `application.yaml` to avoid duplicate YAML keys during startup

## Testing
- `mvn -pl api-gateway -am test` *(interrupted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68e4fbee012c832f9fce8c5ec861d9f5