### PR TITLE
Restrict SecurityAutoConfiguration to servlet web apps

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/SecurityAutoConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
@@ -74,6 +75,7 @@ import java.util.stream.Collectors;
 @AutoConfiguration
 @EnableConfigurationProperties(SharedSecurityProps.class)
 @ConditionalOnClass(SecurityFilterChain.class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @EnableMethodSecurity
 public class SecurityAutoConfiguration {
 


### PR DESCRIPTION
## Summary
- gate the shared security auto-configuration behind a servlet web application condition so reactive gateways no longer load servlet security beans

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4ffe46658832f95ae4bfc24fcab90