### PR TITLE
Fix static analysis warnings across gateway and subscription modules

### DIFF
--- a/api-gateway/src/main/java/com/ejada/gateway/filter/RequestBodyTransformationGatewayFilterFactory.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/filter/RequestBodyTransformationGatewayFilterFactory.java
@@ -15,7 +15,6 @@ import org.springframework.core.Ordered;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.core.io.buffer.DataBufferUtils;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpRequestDecorator;

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/CompositeLoadBalancer.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/CompositeLoadBalancer.java
@@ -61,6 +61,7 @@ public class CompositeLoadBalancer implements ReactorServiceInstanceLoadBalancer
   }
 
   @Override
+  @SuppressWarnings("rawtypes")
   public Mono<Response<ServiceInstance>> choose(Request request) {
     ServiceInstanceListSupplier supplier = supplierProvider.getIfAvailable();
     if (supplier == null) {

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/KubernetesServiceInstanceMetadataSupplier.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/KubernetesServiceInstanceMetadataSupplier.java
@@ -44,6 +44,7 @@ public class KubernetesServiceInstanceMetadataSupplier implements ServiceInstanc
   }
 
   @Override
+  @SuppressWarnings("rawtypes")
   public Flux<List<ServiceInstance>> get(Request request) {
     return delegate.get(request).map(this::enrichInstances);
   }

--- a/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/WeightedServiceInstanceListSupplier.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/loadbalancer/WeightedServiceInstanceListSupplier.java
@@ -37,6 +37,7 @@ public class WeightedServiceInstanceListSupplier implements ServiceInstanceListS
     return delegate.get().map(this::enrichInstances);
   }
 
+  @SuppressWarnings("rawtypes")
   public Flux<List<ServiceInstance>> get(Request request) {
     return delegate.get(request).map(this::enrichInstances);
   }

--- a/api-gateway/src/main/java/com/ejada/gateway/metrics/GatewayMetrics.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/metrics/GatewayMetrics.java
@@ -1,6 +1,5 @@
 package com.ejada.gateway.metrics;
 
-import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.micrometer.core.instrument.Counter;

--- a/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilter.java
@@ -149,7 +149,7 @@ totalRemaining = baseRemaining + burstRemaining
 return {tostring(allowed), tostring(totalRemaining), tostring(resetTimestamp), tostring(windowSeconds), tostring(burstUsed), tostring(baseRemaining), tostring(burstRemaining)}
 """;
 
-  private static final RedisScript<List> RATE_LIMIT_SCRIPT = new DefaultRedisScript<>(
+  private static final RedisScript<List<String>> RATE_LIMIT_SCRIPT = new DefaultRedisScript<>(
       LUA_RATE_LIMIT_SCRIPT, List.class);
 
   private final ReactiveStringRedisTemplate redisTemplate;

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteNotFoundException.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/repository/RouteNotFoundException.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 public class RouteNotFoundException extends RuntimeException {
 
+  private static final long serialVersionUID = 1L;
+
   public RouteNotFoundException(UUID id) {
     super("Route definition " + id + " not found");
   }

--- a/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionValidator.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/routes/service/RouteDefinitionValidator.java
@@ -58,6 +58,8 @@ public class RouteDefinitionValidator {
 
   public static class RouteValidationException extends RuntimeException {
 
+    private static final long serialVersionUID = 1L;
+
     public RouteValidationException(String message) {
       super(message);
     }

--- a/api-gateway/src/main/java/com/ejada/gateway/security/ApiKeyAuthenticationToken.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/security/ApiKeyAuthenticationToken.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.GrantedAuthority;
  */
 public class ApiKeyAuthenticationToken extends AbstractAuthenticationToken {
 
+  private static final long serialVersionUID = 1L;
+
   private final String apiKey;
   private final String tenantId;
 

--- a/api-gateway/src/main/java/com/ejada/gateway/subscription/SubscriptionCacheService.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/subscription/SubscriptionCacheService.java
@@ -213,8 +213,6 @@ public class SubscriptionCacheService {
     private Map<String, FeatureAllocationPayload> featureAllocations = new HashMap<>();
     private String upgradeUrl;
 
-    SubscriptionPayload() {
-    }
   }
 
   private static final class FeatureAllocationPayload {
@@ -222,7 +220,5 @@ public class SubscriptionCacheService {
     private Boolean enabled;
     private Long limit;
 
-    FeatureAllocationPayload() {
-    }
   }
 }

--- a/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionMappingResolver.java
+++ b/api-gateway/src/main/java/com/ejada/gateway/versioning/VersionMappingResolver.java
@@ -78,6 +78,7 @@ public class VersionMappingResolver {
     if (definitions == null) {
       return List.of();
     }
+    @SuppressWarnings("deprecation")
     PathPatternParser parser = new PathPatternParser();
     parser.setMatchOptionalTrailingSeparator(true);
     List<CompiledMapping> compiled = new ArrayList<>(definitions.size());

--- a/api-gateway/src/test/java/com/ejada/gateway/config/TestGatewayConfiguration.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/config/TestGatewayConfiguration.java
@@ -1,6 +1,5 @@
 package com.ejada.gateway.config;
 
-import com.ejada.gateway.config.TestGatewayConfiguration.NoOpReactiveCircuitBreakerFactory;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;

--- a/api-gateway/src/test/java/com/ejada/gateway/integration/GatewayIntegrationTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/integration/GatewayIntegrationTest.java
@@ -41,6 +41,7 @@ public abstract class GatewayIntegrationTest {
   protected WebTestClient webTestClient;
 
   @BeforeAll
+  @SuppressWarnings("resource")
   static void startWireMock() {
     wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
     wireMockServer.start();

--- a/api-gateway/src/test/java/com/ejada/gateway/loadbalancer/CompositeLoadBalancerTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/loadbalancer/CompositeLoadBalancerTest.java
@@ -174,6 +174,7 @@ class CompositeLoadBalancerTest {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public reactor.core.publisher.Flux<List<ServiceInstance>> get(Request request) {
       return get();
     }

--- a/api-gateway/src/test/java/com/ejada/gateway/loadbalancer/KubernetesServiceInstanceMetadataSupplierTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/loadbalancer/KubernetesServiceInstanceMetadataSupplierTest.java
@@ -99,6 +99,7 @@ class KubernetesServiceInstanceMetadataSupplierTest {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public Flux<List<ServiceInstance>> get(Request request) {
       return get();
     }

--- a/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/ratelimit/ReactiveRateLimiterFilterTest.java
@@ -30,6 +30,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class ReactiveRateLimiterFilterTest {
 
     @Container
+    @SuppressWarnings("resource")
     static final GenericContainer<?> REDIS = new GenericContainer<>("redis:7").withExposedPorts(6379);
 
     private ReactiveRateLimiterFilter filter;

--- a/api-gateway/src/test/java/com/ejada/gateway/security/ApiKeyAuthenticationFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/security/ApiKeyAuthenticationFilterTest.java
@@ -42,6 +42,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class ApiKeyAuthenticationFilterTest {
 
   @Container
+  @SuppressWarnings("resource")
   static final GenericContainer<?> REDIS = new GenericContainer<>("redis:7").withExposedPorts(6379);
 
   private ReactiveStringRedisTemplate redisTemplate;

--- a/api-gateway/src/test/java/com/ejada/gateway/security/GatewayTokenIntrospectionServiceTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/security/GatewayTokenIntrospectionServiceTest.java
@@ -33,6 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class GatewayTokenIntrospectionServiceTest {
 
   @Container
+  @SuppressWarnings("resource")
   static final GenericContainer<?> REDIS = new GenericContainer<>("redis:7").withExposedPorts(6379);
 
   private ReactiveStringRedisTemplate redisTemplate;

--- a/api-gateway/src/test/java/com/ejada/gateway/security/IpFilteringGatewayFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/security/IpFilteringGatewayFilterTest.java
@@ -27,6 +27,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class IpFilteringGatewayFilterTest {
 
   @Container
+  @SuppressWarnings("resource")
   static final GenericContainer<?> REDIS = new GenericContainer<>("redis:7").withExposedPorts(6379);
 
   private ReactiveStringRedisTemplate redisTemplate;

--- a/api-gateway/src/test/java/com/ejada/gateway/security/RequestSignatureValidationFilterTest.java
+++ b/api-gateway/src/test/java/com/ejada/gateway/security/RequestSignatureValidationFilterTest.java
@@ -30,6 +30,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class RequestSignatureValidationFilterTest {
 
   @Container
+  @SuppressWarnings("resource")
   static final GenericContainer<?> REDIS = new GenericContainer<>("redis:7").withExposedPorts(6379);
 
   private ReactiveStringRedisTemplate redisTemplate;

--- a/shared-lib/shared-starters/starter-core/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationToken.java
+++ b/shared-lib/shared-starters/starter-core/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationToken.java
@@ -13,6 +13,8 @@ import org.springframework.security.oauth2.jwt.Jwt;
  */
 public class JwtAuthenticationToken implements Authentication {
 
+    private static final long serialVersionUID = 1L;
+
     private final Jwt token;
     private final Collection<? extends GrantedAuthority> authorities;
     private boolean authenticated = true;

--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/internal/InternalServiceAuthenticationToken.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/internal/InternalServiceAuthenticationToken.java
@@ -12,6 +12,8 @@ import org.springframework.util.StringUtils;
  */
 public class InternalServiceAuthenticationToken extends AbstractAuthenticationToken {
 
+  private static final long serialVersionUID = 1L;
+
   private final String principal;
   private final String headerName;
 

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/config/FlywayRepairConfig.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/config/FlywayRepairConfig.java
@@ -1,6 +1,5 @@
 package com.ejada.analytics.config;
 
-import org.flywaydb.core.Flyway;
 import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/kafka/SubscriptionApprovalPublisher.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/kafka/SubscriptionApprovalPublisher.java
@@ -137,7 +137,7 @@ public class SubscriptionApprovalPublisher {
                 safeTrim(customerNameAr, TENANT_NAME_MAX),
                 resolvedAdminEmail,
                 resolvedAdminMobile,
-                tenantCode,
+                safeTrim(tenantCode, TENANT_CODE_MAX),
                 tenantName,
                 safeTrim(contactEmail, EMAIL_MAX),
                 safeTrim(contactPhone, PHONE_MAX),

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/acl/MarketplaceCallbackOrchestratorTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/acl/MarketplaceCallbackOrchestratorTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
+
 import com.ejada.common.dto.ServiceResult;
 import com.ejada.common.marketplace.subscription.dto.AdminUserInfoDto;
 import com.ejada.common.marketplace.subscription.dto.CustomerInfoDto;
@@ -50,6 +52,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -272,7 +275,7 @@ class MarketplaceCallbackOrchestratorTest {
 
         assertThat(result.statusCode()).isEqualTo("I000000");
         verify(subscriptionOutboxService)
-                .emit(eq("SUBSCRIPTION"), eq("300"), eq("CREATED_OR_UPDATED"), any(Map.class));
+                .emit(eq("SUBSCRIPTION"), eq("300"), eq("CREATED_OR_UPDATED"), ArgumentMatchers.<Map<String, ?>>any());
         verify(idempotentRequestService).record(rqUid, "RECEIVE_NOTIFICATION", request);
         verify(notificationAuditService)
                 .markSuccess(eq(42L), eq("I000000"), eq("Subscription auto-approved"), eq(null));
@@ -363,7 +366,7 @@ class MarketplaceCallbackOrchestratorTest {
 
         doThrow(new RuntimeException("outbox down"))
                 .when(subscriptionOutboxService)
-                .emit(eq("SUBSCRIPTION"), eq("200"), eq("STATUS_CHANGED"), any(Map.class));
+                .emit(eq("SUBSCRIPTION"), eq("200"), eq("STATUS_CHANGED"), ArgumentMatchers.<Map<String, ?>>any());
 
         ServiceResult<Void> result = orchestrator.processUpdate(rqUid, "token", request);
 
@@ -374,7 +377,7 @@ class MarketplaceCallbackOrchestratorTest {
         verify(notificationAuditService)
                 .markSuccess(eq(10L), eq("I000000"), eq("Successful Operation"), eq(null));
         verify(subscriptionOutboxService)
-                .emit(eq("SUBSCRIPTION"), eq("200"), eq("STATUS_CHANGED"), any(Map.class));
+                .emit(eq("SUBSCRIPTION"), eq("200"), eq("STATUS_CHANGED"), ArgumentMatchers.<Map<String, ?>>any());
     }
 
 }

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/kafka/SubscriptionApprovalConsumerIT.java
@@ -27,7 +27,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
@@ -41,10 +41,12 @@ class SubscriptionApprovalConsumerIT {
     private static final String CONSUMER_GROUP = "subscription-approvals-it-group";
 
     @Container
+    @SuppressWarnings("resource")
     static final PostgreSQLContainer<?> POSTGRES =
             new PostgreSQLContainer<>(DockerImageName.parse("postgres:15-alpine"));
 
     @Container
+    @SuppressWarnings("resource")
     static final KafkaContainer KAFKA =
             new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1"))
                     .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true");


### PR DESCRIPTION
## Summary
- parameterize the Redis rate limiting script and suppress unavoidable raw `Request` usage in load balancer components
- add missing `serialVersionUID` fields and trim tenant codes when building subscription approval messages
- silence resource leak warnings for Testcontainers-based tests and migrate to the non-deprecated Kafka container

## Testing
- not run (static analysis fixes only)


------
https://chatgpt.com/codex/tasks/task_e_68e4fefd82e8832fa25e65824c002235