### PR TITLE
Make Redis caching optional with fallback

### DIFF
--- a/shared-lib/shared-starters/starter-redis/src/main/java/com/ejada/redis/starter/config/RedisAutoConfiguration.java
+++ b/shared-lib/shared-starters/starter-redis/src/main/java/com/ejada/redis/starter/config/RedisAutoConfiguration.java
@@ -30,6 +30,7 @@ import java.util.Map;
 @AutoConfiguration
 @EnableConfigurationProperties(RedisProperties.class)
 @ConditionalOnClass({RedisTemplate.class, LettuceConnectionFactory.class})
+@ConditionalOnProperty(prefix = "shared.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class RedisAutoConfiguration {
 
   @Bean

--- a/shared-lib/shared-starters/starter-redis/src/main/java/com/ejada/redis/starter/props/RedisProperties.java
+++ b/shared-lib/shared-starters/starter-redis/src/main/java/com/ejada/redis/starter/props/RedisProperties.java
@@ -34,6 +34,8 @@ public class RedisProperties {
   private Duration defaultTtl = Duration.ofMinutes(10);
   @Builder.Default
   private Boolean reactive = false;
+  @Builder.Default
+  private boolean enabled = true;
 
   private Map<String, CacheSpec> caches;
 

--- a/shared-lib/shared-starters/starter-redis/src/main/resources/application.yml
+++ b/shared-lib/shared-starters/starter-redis/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
 
 shared:
   redis:
+    enabled: ${SHARED_REDIS_ENABLED:true}
     url: ${SHARED_REDIS_URL:${REDIS_URL:}}
     host: ${SHARED_REDIS_HOST:${REDIS_HOST:redis}}
     port: ${SHARED_REDIS_PORT:${REDIS_PORT:6379}}

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/config/CacheConfig.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/config/CacheConfig.java
@@ -2,13 +2,14 @@ package com.ejada.analytics.config;
 
 import java.time.Duration;
 import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
-import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 @Configuration
-@EnableCaching
+@ConditionalOnBean(RedisConnectionFactory.class)
 public class CacheConfig {
 
   private static final Duration CACHE_TTL = Duration.ofHours(1);

--- a/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/config/SimpleCacheConfig.java
+++ b/tenant-platform/analytics-service/src/main/java/com/ejada/analytics/config/SimpleCacheConfig.java
@@ -1,0 +1,17 @@
+package com.ejada.analytics.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnMissingBean(CacheManager.class)
+public class SimpleCacheConfig {
+
+  @Bean
+  public CacheManager fallbackCacheManager() {
+    return new ConcurrentMapCacheManager();
+  }
+}

--- a/tenant-platform/analytics-service/src/main/resources/application.yml
+++ b/tenant-platform/analytics-service/src/main/resources/application.yml
@@ -54,7 +54,13 @@ management:
       probes:
         enabled: true
 
+  health:
+    redis:
+      enabled: ${shared.redis.enabled:true}
+
 shared:
+  redis:
+    enabled: ${SHARED_REDIS_ENABLED:true}
   security:
     mode: ${SHARED_SECURITY_MODE:hs256}
     hs256:


### PR DESCRIPTION
## Summary
- gate the shared Redis auto-configuration behind a `shared.redis.enabled` switch and expose the flag in the default properties
- make the analytics service Redis cache configuration conditional and add an in-memory fallback cache manager
- wire `shared.redis.enabled` through the analytics service properties so Redis health probes can be disabled when Redis is not required

## Testing
- mvn -pl tenant-platform/analytics-service -am test *(fails: starter-security test sources reference missing `corsConfigurationSource`)*

------
https://chatgpt.com/codex/tasks/task_e_68e511a202f8832f874c94dc3fe2d88b