### PR TITLE
Fix swagger UI path for setup service behind gateway

### DIFF
--- a/setup-service/src/main/resources/application.yaml
+++ b/setup-service/src/main/resources/application.yaml
@@ -45,3 +45,10 @@ shared:
       require-tenant-header: true
     jwt:
       token-period: 15m
+
+springdoc:
+  swagger-ui:
+    disable-swagger-default-url: true
+    urls:
+      - name: Setup Service API
+        url: ../v3/api-docs


### PR DESCRIPTION
## Summary
- make the setup-service Swagger UI reference the OpenAPI document using a relative path so it continues to work when accessed through the gateway

## Testing
- `mvn -pl setup-service -am test -DskipITs` *(fails: starter-security test compilation error complaining about missing corsConfigurationSource method)*

------
https://chatgpt.com/codex/tasks/task_e_68e518e0f6e8832f940cb3e99f516c9f