### PR TITLE
Add Redis-free dev profile for analytics service

### DIFF
--- a/tenant-platform/analytics-service/src/main/resources/application-dev.yml
+++ b/tenant-platform/analytics-service/src/main/resources/application-dev.yml
@@ -1,0 +1,16 @@
+spring:
+  cache:
+    type: simple
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+
+shared:
+  redis:
+    enabled: false
+
+management:
+  health:
+    redis:
+      enabled: false


### PR DESCRIPTION
## Summary
- add an `application-dev.yml` profile for the analytics service that disables Redis auto-configuration and health checks
- fall back to the simple in-memory cache when running with the default dev profile so the service no longer logs Redis health check failures without Redis available

## Testing
- `mvn -pl tenant-platform/analytics-service test` *(fails: missing internal com.ejada starter artifacts in Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e51a479fac832f909609dfd20b11c4