### PR TITLE
Honor APP_ENV when selecting Spring profile

### DIFF
--- a/Dockerfile.spring-service
+++ b/Dockerfile.spring-service
@@ -30,8 +30,13 @@ RUN set -eux; \
 set -e
 
 if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
-  export SPRING_PROFILES_ACTIVE=dev
-  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  if [ -n "${APP_ENV:-}" ]; then
+    export SPRING_PROFILES_ACTIVE="${APP_ENV}"
+    echo "SPRING_PROFILES_ACTIVE not set. Using APP_ENV='${APP_ENV}'."
+  else
+    export SPRING_PROFILES_ACTIVE=dev
+    echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  fi
 else
   echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
 fi

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -22,8 +22,13 @@ RUN set -eux; \
 set -e
 
 if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
-  export SPRING_PROFILES_ACTIVE=dev
-  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  if [ -n "${APP_ENV:-}" ]; then
+    export SPRING_PROFILES_ACTIVE="${APP_ENV}"
+    echo "SPRING_PROFILES_ACTIVE not set. Using APP_ENV='${APP_ENV}'."
+  else
+    export SPRING_PROFILES_ACTIVE=dev
+    echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  fi
 else
   echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
 fi

--- a/sec-service/Dockerfile
+++ b/sec-service/Dockerfile
@@ -21,8 +21,13 @@ RUN set -eux; \
 set -e
 
 if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
-  export SPRING_PROFILES_ACTIVE=dev
-  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  if [ -n "${APP_ENV:-}" ]; then
+    export SPRING_PROFILES_ACTIVE="${APP_ENV}"
+    echo "SPRING_PROFILES_ACTIVE not set. Using APP_ENV='${APP_ENV}'."
+  else
+    export SPRING_PROFILES_ACTIVE=dev
+    echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  fi
 else
   echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
 fi

--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
   main:
     lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:${APP_ENV:dev}}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0

--- a/setup-service/Dockerfile
+++ b/setup-service/Dockerfile
@@ -21,8 +21,13 @@ RUN set -eux; \
 set -e
 
 if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
-  export SPRING_PROFILES_ACTIVE=dev
-  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  if [ -n "${APP_ENV:-}" ]; then
+    export SPRING_PROFILES_ACTIVE="${APP_ENV}"
+    echo "SPRING_PROFILES_ACTIVE not set. Using APP_ENV='${APP_ENV}'."
+  else
+    export SPRING_PROFILES_ACTIVE=dev
+    echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  fi
 else
   echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
 fi

--- a/setup-service/src/main/resources/application.yaml
+++ b/setup-service/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
   main:
     lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:${APP_ENV:dev}}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0

--- a/tenant-platform/analytics-service/Dockerfile
+++ b/tenant-platform/analytics-service/Dockerfile
@@ -21,8 +21,13 @@ RUN set -eux; \
 set -e
 
 if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
-  export SPRING_PROFILES_ACTIVE=dev
-  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  if [ -n "${APP_ENV:-}" ]; then
+    export SPRING_PROFILES_ACTIVE="${APP_ENV}"
+    echo "SPRING_PROFILES_ACTIVE not set. Using APP_ENV='${APP_ENV}'."
+  else
+    export SPRING_PROFILES_ACTIVE=dev
+    echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  fi
 else
   echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
 fi

--- a/tenant-platform/analytics-service/src/main/resources/application.yml
+++ b/tenant-platform/analytics-service/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   main:
     lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:${APP_ENV:dev}}
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:lms}?currentSchema=${app.schema}}
     username: ${SPRING_DATASOURCE_USERNAME:postgres}

--- a/tenant-platform/billing-service/Dockerfile
+++ b/tenant-platform/billing-service/Dockerfile
@@ -21,8 +21,13 @@ RUN set -eux; \
 set -e
 
 if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
-  export SPRING_PROFILES_ACTIVE=dev
-  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  if [ -n "${APP_ENV:-}" ]; then
+    export SPRING_PROFILES_ACTIVE="${APP_ENV}"
+    echo "SPRING_PROFILES_ACTIVE not set. Using APP_ENV='${APP_ENV}'."
+  else
+    export SPRING_PROFILES_ACTIVE=dev
+    echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  fi
 else
   echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
 fi

--- a/tenant-platform/billing-service/src/main/resources/application.yaml
+++ b/tenant-platform/billing-service/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
   main:
     lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:${APP_ENV:dev}}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0

--- a/tenant-platform/catalog-service/Dockerfile
+++ b/tenant-platform/catalog-service/Dockerfile
@@ -21,8 +21,13 @@ RUN set -eux; \
 set -e
 
 if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
-  export SPRING_PROFILES_ACTIVE=dev
-  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  if [ -n "${APP_ENV:-}" ]; then
+    export SPRING_PROFILES_ACTIVE="${APP_ENV}"
+    echo "SPRING_PROFILES_ACTIVE not set. Using APP_ENV='${APP_ENV}'."
+  else
+    export SPRING_PROFILES_ACTIVE=dev
+    echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  fi
 else
   echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
 fi

--- a/tenant-platform/catalog-service/src/main/resources/application.yaml
+++ b/tenant-platform/catalog-service/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
   main:
     lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:${APP_ENV:dev}}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0

--- a/tenant-platform/subscription-service/Dockerfile
+++ b/tenant-platform/subscription-service/Dockerfile
@@ -21,8 +21,13 @@ RUN set -eux; \
 set -e
 
 if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
-  export SPRING_PROFILES_ACTIVE=dev
-  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  if [ -n "${APP_ENV:-}" ]; then
+    export SPRING_PROFILES_ACTIVE="${APP_ENV}"
+    echo "SPRING_PROFILES_ACTIVE not set. Using APP_ENV='${APP_ENV}'."
+  else
+    export SPRING_PROFILES_ACTIVE=dev
+    echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  fi
 else
   echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
 fi

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
   main:
     lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:${APP_ENV:dev}}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0

--- a/tenant-platform/tenant-service/Dockerfile
+++ b/tenant-platform/tenant-service/Dockerfile
@@ -21,8 +21,13 @@ RUN set -eux; \
 set -e
 
 if [ -z "${SPRING_PROFILES_ACTIVE:-}" ]; then
-  export SPRING_PROFILES_ACTIVE=dev
-  echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  if [ -n "${APP_ENV:-}" ]; then
+    export SPRING_PROFILES_ACTIVE="${APP_ENV}"
+    echo "SPRING_PROFILES_ACTIVE not set. Using APP_ENV='${APP_ENV}'."
+  else
+    export SPRING_PROFILES_ACTIVE=dev
+    echo "SPRING_PROFILES_ACTIVE not set. Defaulting to 'dev'."
+  fi
 else
   echo "SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}"
 fi

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
   main:
     lazy-initialization: ${SPRING_MAIN_LAZY_INITIALIZATION:true}
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:${APP_ENV:dev}}
   flyway:
     baseline-on-migrate: true
     baseline-version: 0


### PR DESCRIPTION
## Summary
- allow service entrypoints to derive SPRING_PROFILES_ACTIVE from APP_ENV when unset so non-dev environments activate the right profile by default
- update Spring configuration files to fall back to APP_ENV before using the dev profile

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e51c3a7800832fba73b24422a62468