### PR TITLE
Ensure Maven retries cached central downloads

### DIFF
--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,5 +1,39 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <!-- Use Maven Central without custom mirrors to allow dependency resolution -->
+  <!-- Ensure cached transfer failures for Maven Central artifacts are always retried -->
+  <profiles>
+    <profile>
+      <id>force-central-updates</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>force-central-updates</activeProfile>
+  </activeProfiles>
 </settings>


### PR DESCRIPTION
## Summary
- configure the shared Maven settings profile to force Maven Central releases to always update
- ensure plugin repositories inherit the same retry policy so cached transfer failures are retried automatically

## Testing
- mvn -f tenant-platform/pom.xml -DskipTests verify

------
https://chatgpt.com/codex/tasks/task_e_6909df007adc832fb224cccd5d0d5f7c