### PR TITLE
Ensure Maven reattempts dependency downloads

### DIFF
--- a/tenant-platform/pom.xml
+++ b/tenant-platform/pom.xml
@@ -74,8 +74,22 @@
     <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-observability</artifactId>
-    </dependency> 
+    </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Maven Central</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <releases>
+        <updatePolicy>always</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
## Summary
- configure the tenant-platform aggregator POM to declare Maven Central with an always update policy
- ensure dependency downloads such as Testcontainers are retried instead of relying on cached failures

## Testing
- mvn -f tenant-platform/pom.xml dependency:resolve -DskipTests *(fails: project depends on unpublished com.ejada artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6909e0d78768832fad460f2350c25e23