### PR TITLE
Align checker-qual dependency version for admin-service

### DIFF
--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -26,7 +26,7 @@
     </properties>
 
   <!-- Import shared  to pin internal starter & shared-lib versions -->
-   <dependencyManagement>
+  <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>com.ejada</groupId>
@@ -34,6 +34,11 @@
         <version>${ejada.shared.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <version>3.43.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Summary
- pin org.checkerframework:checker-qual to version 3.43.0 via dependency management to resolve convergence failure

## Testing
- mvn -q clean verify *(fails: missing internal shared-lib/shared-bom artifacts and unresolved dependency versions in pom)*

------
https://chatgpt.com/codex/tasks/task_e_690b05bcf140832fbfa26e88cfb6bfe6