### PR TITLE
Configure superadmin password hash placeholder for Flyway

### DIFF
--- a/admin-service/src/main/resources/application-dev.yaml
+++ b/admin-service/src/main/resources/application-dev.yaml
@@ -31,6 +31,8 @@ spring:
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
     schemas: public,admin
     default-schema: admin
+    placeholders:
+      superadminPasswordHash: '${SUPERADMIN_PASSWORD_HASH:$2b$12$ySQKTgxd1J24X3Y9PE/Hw.oNYwR.aLalMKtoWh/5okcE5I3ciSzQO}'
 
   kafka:
     bootstrap-servers: kafka:9092

--- a/admin-service/src/main/resources/application.yaml
+++ b/admin-service/src/main/resources/application.yaml
@@ -8,6 +8,8 @@ spring:
     baseline-version: 0
     schemas: public,admin
     default-schema: admin
+    placeholders:
+      superadminPasswordHash: '${SUPERADMIN_PASSWORD_HASH:$2b$12$ySQKTgxd1J24X3Y9PE/Hw.oNYwR.aLalMKtoWh/5okcE5I3ciSzQO}'
 server:
   port: 8080
   shutdown: graceful


### PR DESCRIPTION
## Summary
- configure Flyway to supply the superadmin password hash placeholder used by the V4 migration
- allow overriding the default bcrypt hash through the SUPERADMIN_PASSWORD_HASH environment variable

## Testing
- mvn -f admin-service/pom.xml -DskipTests package *(fails: project depends on internal shared-lib artifacts that are not published to Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_690b0f4334a4832fa48c7fec4a6bdd6e