### PR TITLE
Ensure HS256 resource servers decode Base64 secrets

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/JwtDecoderAutoConfigurationTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/JwtDecoderAutoConfigurationTest.java
@@ -29,4 +29,26 @@ class JwtDecoderAutoConfigurationTest {
           .hasMessageContaining("shared.security.jwks.uri");
     });
   }
+
+  @Test
+  void invalidBase64SecretIsRejected() {
+    contextRunner.withPropertyValues("shared.security.hs256.secret=not-base64!!!").run(context -> {
+      assertThat(context).hasFailed();
+      assertThat(context.getStartupFailure())
+          .hasRootCauseInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Base64-encoded");
+    });
+  }
+
+  @Test
+  void shortDecodedSecretIsRejected() {
+    contextRunner
+        .withPropertyValues("shared.security.hs256.secret=dG9vLXNob3J0")
+        .run(context -> {
+          assertThat(context).hasFailed();
+          assertThat(context.getStartupFailure())
+              .hasRootCauseInstanceOf(IllegalArgumentException.class)
+              .hasMessageContaining("at least 32 bytes");
+        });
+  }
 }

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/RoleCheckerAutoConfigurationTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/RoleCheckerAutoConfigurationTest.java
@@ -12,7 +12,7 @@ class RoleCheckerAutoConfigurationTest {
   private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
       .withConfiguration(AutoConfigurations.of(SecurityAutoConfiguration.class))
       .withPropertyValues(
-          "shared.security.hs256.secret=secret",
+          "shared.security.hs256.secret=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=",
           "shared.security.resource-server.enabled=false");
 
   @Test

--- a/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/SharedSecurityPropsTest.java
+++ b/shared-lib/shared-starters/starter-security/src/test/java/com/ejada/starter_security/SharedSecurityPropsTest.java
@@ -14,10 +14,10 @@ class SharedSecurityPropsTest {
   @Test
   void bindsHs256Secret() {
     MapConfigurationPropertySource source = new MapConfigurationPropertySource(
-        Map.of("shared.security.hs256.secret", "s3cr3t"));
+        Map.of("shared.security.hs256.secret", "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE="));
     SharedSecurityProps props = new Binder(source)
         .bind("shared.security", SharedSecurityProps.class).get();
-    assertEquals("s3cr3t", props.getHs256().getSecret());
+    assertEquals("MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=", props.getHs256().getSecret());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- decode HS256 shared security secrets from Base64 before building Nimbus decoders
- validate HS256 keys are at least 32 bytes to match the signing service
- refresh starter-security tests with Base64 sample secrets and new validation coverage

## Testing
- mvn -pl shared-starters/starter-security -am test


------
https://chatgpt.com/codex/tasks/task_e_690b348d5a6c832fad21440fe5d03e87