### PR TITLE
Return validation errors array in error response

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseResponse.java
@@ -71,6 +71,18 @@ public class BaseResponse<T> {
         return build(ApiStatus.ERROR, code, message, null);
     }
 
+    /**
+     * Create an error response with a payload.
+     *
+     * @param code    error code identifier
+     * @param message human-readable description
+     * @param data    optional payload containing additional error context
+     * @return a new BaseResponse with status ERROR
+     */
+    public static <T> BaseResponse<T> error(String code, String message, T data) {
+        return build(ApiStatus.ERROR, code, message, data);
+    }
+
     public static <T> BaseResponse<T> warning(String code, String message, T data) {
         return build(ApiStatus.WARNING, code, message, data);
     }


### PR DESCRIPTION
## Summary
- add an overloaded BaseResponse.error factory that accepts an error payload
- return structured validation error details from GlobalExceptionHandler as an array of field/message pairs

## Testing
- mvn -pl shared-starters/starter-core -am test

------
https://chatgpt.com/codex/tasks/task_e_690b3dd5be34832fb545331b6c8865d1