### PR TITLE
Include correlation id in error responses

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/ErrorResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/ErrorResponse.java
@@ -34,6 +34,9 @@ public class ErrorResponse {
     /** Tenant ID (multi-tenant awareness) */
     private String tenantId;
 
+    /** Correlation identifier for tracing */
+    private String correlationId;
+
     /** Timestamp of error */
     @Builder.Default
     private Instant timestamp = Instant.now();

--- a/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/ApiResponseEntityExceptionHandler.java
+++ b/shared-lib/shared-starters/starter-core/src/main/java/com/ejada/starter_core/web/ApiResponseEntityExceptionHandler.java
@@ -179,6 +179,7 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
                 header(req, HeaderNames.CORRELATION_ID),
                 header(req, HeaderNames.REQUEST_ID)
         );
+        err.setCorrelationId(cid);
         if (req instanceof ServletWebRequest swr && cid != null) {
             swr.getResponse().setHeader(HeaderNames.CORRELATION_ID, cid);
         }


### PR DESCRIPTION
## Summary
- add correlationId property to the shared ErrorResponse DTO
- ensure the API response exception handler populates the correlation id when building error payloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690b417bab6c832fbf476ffc44fc6e0d