### PR TITLE
Handle superadmin not found with error responses

### DIFF
--- a/admin-service/src/main/java/com/ejada/admin/controller/SuperadminController.java
+++ b/admin-service/src/main/java/com/ejada/admin/controller/SuperadminController.java
@@ -1,5 +1,6 @@
 package com.ejada.admin.controller;
 
+import com.ejada.common.constants.ErrorCodes;
 import com.ejada.common.dto.BaseResponse;
 import com.ejada.admin.dto.ChangePasswordRequest;
 import com.ejada.admin.dto.CreateSuperadminRequest;
@@ -27,40 +28,54 @@ public class SuperadminController {
   @PostMapping
   public ResponseEntity<BaseResponse<SuperadminDto>> createSuperadmin(
       @Valid @RequestBody CreateSuperadminRequest request) {
-    return ResponseEntity.status(HttpStatus.CREATED).body(superadminService.createSuperadmin(request));
+    return buildResponse(superadminService.createSuperadmin(request), HttpStatus.CREATED);
   }
 
   @PutMapping("/{id}")
   public ResponseEntity<BaseResponse<SuperadminDto>> updateSuperadmin(
       @PathVariable Long id,
       @Valid @RequestBody UpdateSuperadminRequest request) {
-    return ResponseEntity.ok(superadminService.updateSuperadmin(id, request));
+    return buildResponse(superadminService.updateSuperadmin(id, request), HttpStatus.OK);
   }
 
   @DeleteMapping("/{id}")
   public ResponseEntity<BaseResponse<Void>> deleteSuperadmin(@PathVariable Long id) {
-    return ResponseEntity.ok(superadminService.deleteSuperadmin(id));
+    return buildResponse(superadminService.deleteSuperadmin(id), HttpStatus.OK);
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<BaseResponse<SuperadminDto>> getSuperadmin(@PathVariable Long id) {
-    return ResponseEntity.ok(superadminService.getSuperadmin(id));
+    return buildResponse(superadminService.getSuperadmin(id), HttpStatus.OK);
   }
 
   @GetMapping
   public ResponseEntity<BaseResponse<Page<SuperadminDto>>> listSuperadmins(Pageable pageable) {
-    return ResponseEntity.ok(superadminService.listSuperadmins(pageable));
+    return buildResponse(superadminService.listSuperadmins(pageable), HttpStatus.OK);
   }
 
   @PostMapping("/first-login")
   public ResponseEntity<BaseResponse<Void>> completeFirstLogin(
       @Valid @RequestBody FirstLoginRequest request) {
-    return ResponseEntity.ok(superadminService.completeFirstLogin(request));
+    return buildResponse(superadminService.completeFirstLogin(request), HttpStatus.OK);
   }
 
   @PostMapping("/change-password")
   public ResponseEntity<BaseResponse<Void>> changeSuperadminPassword(
       @Valid @RequestBody ChangePasswordRequest request) {
-    return ResponseEntity.ok(superadminService.changePassword(request));
+    return buildResponse(superadminService.changePassword(request), HttpStatus.OK);
+  }
+
+  private <T> ResponseEntity<BaseResponse<T>> buildResponse(
+      BaseResponse<T> response,
+      HttpStatus successStatus) {
+    if (response == null || response.isSuccess()) {
+      return ResponseEntity.status(successStatus).body(response);
+    }
+
+    HttpStatus errorStatus = ErrorCodes.NOT_FOUND.equals(response.getCode())
+        ? HttpStatus.NOT_FOUND
+        : HttpStatus.BAD_REQUEST;
+
+    return ResponseEntity.status(errorStatus).body(response);
   }
 }


### PR DESCRIPTION
## Summary
- return BaseResponse.error for missing superadmin records across fetch, update, delete, and self-service flows
- centralize HTTP status mapping in SuperadminController so BaseResponse error codes translate to REST-friendly statuses

## Testing
- mvn -f admin-service/pom.xml -DskipTests package *(fails: missing shared BOM/artifacts in the local environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f3b0d4b10832f9de159f6220d192d)