### PR TITLE
Add subscription token issuance endpoint

### DIFF
--- a/tenant-platform/subscription-service/docs/curl-get-token.sh
+++ b/tenant-platform/subscription-service/docs/curl-get-token.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+curl -X POST "http://localhost:8080/subscription/get-token" \
+  -H "Content-Type: application/json" \
+  -H "rqUID: c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd" \
+  -d '{
+    "loginName": "demo",
+    "password": "b03ddf3ca2e714a6548e7495e2a03f5e824eaac9837cd7f159c67b90fb4b7342"
+  }'

--- a/tenant-platform/subscription-service/docs/get-subscription-token.postman_collection.json
+++ b/tenant-platform/subscription-service/docs/get-subscription-token.postman_collection.json
@@ -1,0 +1,36 @@
+{
+  "info": {
+    "name": "Subscription - Get Token",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "Collection containing the /subscription/get-token request"
+  },
+  "item": [
+    {
+      "name": "Get Subscription Token",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "rqUID",
+            "value": "c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:8080/subscription/get-token",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8080",
+          "path": ["subscription", "get-token"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"loginName\": \"demo\",\n  \"password\": \"b03ddf3ca2e714a6548e7495e2a03f5e824eaac9837cd7f159c67b90fb4b7342\"\n}"
+        }
+      }
+    }
+  ]
+}

--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -97,6 +97,25 @@
       <artifactId>starter-mapstruct</artifactId>
     </dependency>
 
+    <!-- JWT signing -->
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.12.6</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.12.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.12.6</version>
+      <scope>runtime</scope>
+    </dependency>
+
    
       <!-- springdoc and servlet APIs are provided by starters -->
 
@@ -109,6 +128,11 @@
     <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>shared-test-support</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/SecurityConfig.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/SecurityConfig.java
@@ -1,0 +1,42 @@
+package com.ejada.subscription.config;
+
+import com.ejada.subscription.properties.SubscriptionSecurityProperties;
+import com.ejada.subscription.security.JwtSigner;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(SubscriptionSecurityProperties.class)
+public class SecurityConfig {
+
+  @Bean
+  public Clock utcClock() {
+    return Clock.systemUTC();
+  }
+
+  @Bean
+  public JwtSigner jwtSigner(final SubscriptionSecurityProperties properties, final Clock clock) {
+    SecretKey key = Keys.hmacShaKeyFor(properties.getJwt().getSecret().getBytes(StandardCharsets.UTF_8));
+    final Duration expiry = properties.getJwt().getExpiration();
+    return subject -> {
+      Instant now = clock.instant();
+      Instant expiration = now.plus(expiry);
+      return Jwts.builder()
+          .subject(subject)
+          .issuedAt(Date.from(now))
+          .expiration(Date.from(expiration))
+          .claim("scope", "subscription")
+          .signWith(key)
+          .compact();
+    };
+  }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionAuthController.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionAuthController.java
@@ -1,0 +1,86 @@
+package com.ejada.subscription.controller;
+
+import com.ejada.subscription.dto.auth.GetSubscriptionTokenRq;
+import com.ejada.subscription.dto.auth.GetSubscriptionTokenRs;
+import com.ejada.subscription.dto.auth.ServiceResult;
+import com.ejada.subscription.service.SubscriptionAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/subscription", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Validated
+public class SubscriptionAuthController {
+
+  private static final Logger log = LoggerFactory.getLogger(SubscriptionAuthController.class);
+  private static final Pattern RQUID_PATTERN =
+      Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+  private final SubscriptionAuthService authService;
+
+  @Operation(
+      summary = "Generate subscription JWT token",
+      description = "Authenticates a subscription user and returns a signed JWT token",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Successful Operation",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ServiceResult.class))),
+        @ApiResponse(responseCode = "400", description = "Validation failure"),
+        @ApiResponse(responseCode = "401", description = "Invalid credentials"),
+        @ApiResponse(responseCode = "500", description = "Unexpected error")
+      })
+  @PostMapping(value = "/get-token", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<ServiceResult<GetSubscriptionTokenRs>> getToken(
+      @Parameter(
+              in = ParameterIn.HEADER,
+              name = "rqUID",
+              required = true,
+              description = "Request unique identifier in UUID format",
+              example = "c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd")
+          @RequestHeader("rqUID")
+          final String rqUid,
+      @Valid @RequestBody final GetSubscriptionTokenRq request) {
+
+    log.info("Processing subscription token request rqUID={}", rqUid);
+    if (!isValidRqUid(rqUid)) {
+      log.warn("Invalid rqUID provided rqUID={}", rqUid);
+      ServiceResult<GetSubscriptionTokenRs> error =
+          ServiceResult.failure(rqUid, List.of("Invalid rqUID format"));
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    String token = authService.authenticate(request.loginName(), request.password());
+    ServiceResult<GetSubscriptionTokenRs> response =
+        ServiceResult.success(rqUid, new GetSubscriptionTokenRs(token));
+    log.info("Successfully issued subscription token rqUID={}", rqUid);
+    return ResponseEntity.ok(response);
+  }
+
+  private boolean isValidRqUid(final String rqUid) {
+    return rqUid != null && RQUID_PATTERN.matcher(rqUid).matches();
+  }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/auth/GetSubscriptionTokenRq.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/auth/GetSubscriptionTokenRq.java
@@ -1,0 +1,20 @@
+package com.ejada.subscription.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(name = "GetSubscriptionTokenRq", description = "Subscription token request payload")
+public record GetSubscriptionTokenRq(
+    @NotBlank
+    @Schema(description = "Unique user login name", example = "xyz")
+    String loginName,
+
+    @NotBlank
+    @Pattern(regexp = "^[A-Fa-f0-9]{64}$", message = "password must be a 64 character SHA-256 hex value")
+    @Schema(
+        description = "User password hashed with SHA-256 and encoded as hex",
+        example = "b03ddf3ca2e714a6548e7495e2a03f5e824eaac9837cd7f159c67b90fb4b7342"
+    )
+    String password
+) { }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/auth/GetSubscriptionTokenRs.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/auth/GetSubscriptionTokenRs.java
@@ -1,0 +1,9 @@
+package com.ejada.subscription.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "GetSubscriptionTokenRs", description = "Subscription token response payload")
+public record GetSubscriptionTokenRs(
+    @Schema(description = "Signed JWT token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    String token
+) { }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/auth/ServiceResult.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/auth/ServiceResult.java
@@ -1,0 +1,65 @@
+package com.ejada.subscription.dto.auth;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(name = "ServiceResult", description = "Standard subscription response envelope")
+public record ServiceResult<T>(
+    @Schema(description = "Echoed request identifier", example = "c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd")
+    String rqUID,
+    @Schema(allowableValues = {"I000000", "EINT000"}, example = "I000000")
+    String statusCode,
+    @Schema(description = "Status description", example = "Successful Operation")
+    String statusDesc,
+    @Schema(description = "Wrapped response payload")
+    T returnedObject,
+    @Schema(description = "Debug correlation identifier when errors occur", example = "a1b2c3d4")
+    String debugId,
+    @Schema(description = "Optional status details", example = "['Invalid credentials']")
+    List<String> statusDtls,
+    @Schema(description = "Flag indicating success")
+    boolean success
+) {
+
+  public static final String SUCCESS_CODE = "I000000";
+  public static final String ERROR_CODE = "EINT000";
+  private static final String SUCCESS_DESC = "Successful Operation";
+  private static final String ERROR_DESC = "Unexpected Error";
+
+  public ServiceResult {
+    statusDtls = statusDtls == null ? Collections.emptyList() : List.copyOf(statusDtls);
+  }
+
+  public static <T> ServiceResult<T> success(final String rqUid, final T returnedObject) {
+    return new ServiceResult<>(rqUid, SUCCESS_CODE, SUCCESS_DESC, returnedObject, null, List.of(), true);
+  }
+
+  public static <T> ServiceResult<T> failure(
+      final String rqUid, final List<String> details) {
+    return new ServiceResult<>(rqUid, ERROR_CODE, ERROR_DESC, null, null, safeDetails(details), false);
+  }
+
+  public static <T> ServiceResult<T> failure(
+      final String rqUid, final String debugId, final List<String> details) {
+    return new ServiceResult<>(rqUid, ERROR_CODE, ERROR_DESC, null, debugId, safeDetails(details), false);
+  }
+
+  public static <T> ServiceResult<T> failure(
+      final String rqUid,
+      final String statusCode,
+      final String statusDesc,
+      final List<String> details) {
+    return new ServiceResult<>(rqUid, statusCode, statusDesc, null, null, safeDetails(details), false);
+  }
+
+  private static List<String> safeDetails(final List<String> details) {
+    if (details == null || details.isEmpty()) {
+      return List.of();
+    }
+    return Collections.unmodifiableList(new ArrayList<>(details));
+  }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/exception/InvalidCredentialsException.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/exception/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package com.ejada.subscription.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+  public InvalidCredentialsException() {
+    super("Invalid credentials");
+  }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/handler/RestExceptionHandler.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/handler/RestExceptionHandler.java
@@ -1,0 +1,85 @@
+package com.ejada.subscription.handler;
+
+import com.ejada.subscription.dto.auth.ServiceResult;
+import com.ejada.subscription.exception.InvalidCredentialsException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+
+@RestControllerAdvice(assignableTypes = com.ejada.subscription.controller.SubscriptionAuthController.class)
+public class RestExceptionHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(RestExceptionHandler.class);
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ServiceResult<Void> handleValidation(
+      final MethodArgumentNotValidException ex, final HttpServletRequest request) {
+    String rqUid = request.getHeader("rqUID");
+    List<String> details =
+        ex.getBindingResult().getFieldErrors().stream()
+            .map(FieldError::getDefaultMessage)
+            .collect(Collectors.toList());
+    log.warn("Validation failure rqUID={} details={}", rqUid, details);
+    return ServiceResult.failure(rqUid, details);
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ServiceResult<Void> handleUnreadable(
+      final HttpMessageNotReadableException ex, final HttpServletRequest request) {
+    String rqUid = request.getHeader("rqUID");
+    log.warn("Malformed payload rqUID={}", rqUid, ex);
+    return ServiceResult.failure(rqUid, List.of("Malformed request payload"));
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ServiceResult<Void> handleTypeMismatch(
+      final MethodArgumentTypeMismatchException ex, final HttpServletRequest request) {
+    String rqUid = request.getHeader("rqUID");
+    log.warn("Type mismatch rqUID={}", rqUid, ex);
+    return ServiceResult.failure(rqUid, List.of("Invalid request parameter"));
+  }
+
+  @ExceptionHandler(MissingRequestHeaderException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ServiceResult<Void> handleMissingHeader(final MissingRequestHeaderException ex) {
+    log.warn("Missing required header: {}", ex.getHeaderName());
+    return ServiceResult.failure(null, List.of("Missing required header: " + ex.getHeaderName()));
+  }
+
+  @ExceptionHandler(InvalidCredentialsException.class)
+  public ResponseEntity<ServiceResult<Void>> handleInvalidCredentials(
+      final InvalidCredentialsException ex, final HttpServletRequest request) {
+    String rqUid = request.getHeader("rqUID");
+    log.info("Authentication failed for rqUID={}: {}", rqUid, ex.getMessage());
+    ServiceResult<Void> result =
+        ServiceResult.failure(rqUid, ServiceResult.ERROR_CODE, "Unexpected Error", List.of(ex.getMessage()));
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(result);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ServiceResult<Void>> handleAll(
+      final Exception ex, final HttpServletRequest request) {
+    String rqUid = request.getHeader("rqUID");
+    String debugId = UUID.randomUUID().toString();
+    log.error("Unhandled exception debugId={} rqUID={}", debugId, rqUid, ex);
+    ServiceResult<Void> result =
+        ServiceResult.failure(rqUid, debugId, List.of("An unexpected error occurred"));
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+  }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/auth/SubscriptionUser.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/auth/SubscriptionUser.java
@@ -1,0 +1,3 @@
+package com.ejada.subscription.model.auth;
+
+public record SubscriptionUser(String loginName, String password) { }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/properties/SubscriptionSecurityProperties.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/properties/SubscriptionSecurityProperties.java
@@ -1,0 +1,81 @@
+package com.ejada.subscription.properties;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "subscription.security")
+@Validated
+public class SubscriptionSecurityProperties {
+
+  private final Jwt jwt = new Jwt();
+  @Valid private List<User> users = new ArrayList<>();
+
+  public Jwt getJwt() {
+    return jwt;
+  }
+
+  public List<User> getUsers() {
+    return users;
+  }
+
+  public void setUsers(final List<User> users) {
+    this.users = users == null ? new ArrayList<>() : new ArrayList<>(users);
+  }
+
+  public static class Jwt {
+    @NotBlank
+    @Size(min = 32, message = "subscription.security.jwt.secret must be at least 32 characters")
+    private String secret;
+
+    private Duration expiration = Duration.ofMinutes(30);
+
+    public String getSecret() {
+      return secret;
+    }
+
+    public void setSecret(final String secret) {
+      this.secret = secret;
+    }
+
+    public Duration getExpiration() {
+      return expiration;
+    }
+
+    public void setExpiration(final Duration expiration) {
+      if (expiration != null) {
+        this.expiration = expiration;
+      }
+    }
+  }
+
+  public static class User {
+    @NotBlank private String loginName;
+
+    @NotBlank
+    @Pattern(regexp = "^[A-Fa-f0-9]{64}$", message = "password must be SHA-256 hex")
+    private String password;
+
+    public String getLoginName() {
+      return loginName;
+    }
+
+    public void setLoginName(final String loginName) {
+      this.loginName = loginName;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(final String password) {
+      this.password = password;
+    }
+  }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionUserRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/SubscriptionUserRepository.java
@@ -1,0 +1,8 @@
+package com.ejada.subscription.repository;
+
+import com.ejada.subscription.model.auth.SubscriptionUser;
+import java.util.Optional;
+
+public interface SubscriptionUserRepository {
+  Optional<SubscriptionUser> findByLoginName(String loginName);
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/impl/InMemorySubscriptionUserRepository.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/repository/impl/InMemorySubscriptionUserRepository.java
@@ -1,0 +1,46 @@
+package com.ejada.subscription.repository.impl;
+
+import com.ejada.subscription.model.auth.SubscriptionUser;
+import com.ejada.subscription.properties.SubscriptionSecurityProperties;
+import com.ejada.subscription.repository.SubscriptionUserRepository;
+import jakarta.annotation.PostConstruct;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemorySubscriptionUserRepository implements SubscriptionUserRepository {
+
+  private static final Logger log = LoggerFactory.getLogger(InMemorySubscriptionUserRepository.class);
+  private final SubscriptionSecurityProperties properties;
+  private final Map<String, SubscriptionUser> users = new ConcurrentHashMap<>();
+
+  public InMemorySubscriptionUserRepository(final SubscriptionSecurityProperties properties) {
+    this.properties = properties;
+  }
+
+  @PostConstruct
+  void loadUsers() {
+    properties.getUsers().forEach(user -> {
+      String key = normalize(user.getLoginName());
+      users.put(key, new SubscriptionUser(user.getLoginName(), user.getPassword()));
+    });
+    log.info("Loaded {} subscription authentication users", users.size());
+  }
+
+  @Override
+  public Optional<SubscriptionUser> findByLoginName(final String loginName) {
+    if (loginName == null) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(users.get(normalize(loginName)));
+  }
+
+  private String normalize(final String loginName) {
+    return loginName.toLowerCase(Locale.ROOT);
+  }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/security/JwtSigner.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/security/JwtSigner.java
@@ -1,0 +1,5 @@
+package com.ejada.subscription.security;
+
+public interface JwtSigner {
+  String generateToken(String subject);
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/SubscriptionAuthService.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/SubscriptionAuthService.java
@@ -1,0 +1,5 @@
+package com.ejada.subscription.service;
+
+public interface SubscriptionAuthService {
+  String authenticate(String loginName, String sha256Password);
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionAuthServiceImpl.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionAuthServiceImpl.java
@@ -1,0 +1,37 @@
+package com.ejada.subscription.service.impl;
+
+import com.ejada.subscription.exception.InvalidCredentialsException;
+import com.ejada.subscription.repository.SubscriptionUserRepository;
+import com.ejada.subscription.security.JwtSigner;
+import com.ejada.subscription.service.SubscriptionAuthService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionAuthServiceImpl implements SubscriptionAuthService {
+
+  private static final Logger log = LoggerFactory.getLogger(SubscriptionAuthServiceImpl.class);
+  private final SubscriptionUserRepository userRepository;
+  private final JwtSigner jwtSigner;
+
+  @Override
+  public String authenticate(final String loginName, final String sha256Password) {
+    return userRepository
+        .findByLoginName(loginName)
+        .filter(user -> passwordMatches(user.password(), sha256Password))
+        .map(user -> {
+          log.debug("Authentication succeeded for loginName={}", loginName);
+          return jwtSigner.generateToken(loginName);
+        })
+        .orElseThrow(InvalidCredentialsException::new);
+  }
+
+  private boolean passwordMatches(final String storedPassword, final String providedPassword) {
+    return storedPassword != null
+        && providedPassword != null
+        && storedPassword.equalsIgnoreCase(providedPassword);
+  }
+}

--- a/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-dev.yaml
@@ -198,6 +198,15 @@ shared:
       secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
     resource-server:
       enabled: true
+
+subscription:
+  security:
+    jwt:
+      secret: ${SUBSCRIPTION_JWT_SECRET:change-me-change-me-change-me-change}
+      expiration: 30m
+    users:
+      - loginName: demo
+        password: b03ddf3ca2e714a6548e7495e2a03f5e824eaac9837cd7f159c67b90fb4b7342
       permit-all:
         - "/**"
       disable-csrf: false

--- a/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application-qa.yaml
@@ -197,6 +197,15 @@ shared:
       secret: ${JWT_SECRET}
     resource-server:
       enabled: true
+
+subscription:
+  security:
+    jwt:
+      secret: ${SUBSCRIPTION_JWT_SECRET:change-me-change-me-change-me-change}
+      expiration: 30m
+    users:
+      - loginName: demo
+        password: b03ddf3ca2e714a6548e7495e2a03f5e824eaac9837cd7f159c67b90fb4b7342
       permit-all: ["**"]
       disable-csrf: false
     stateless: true

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -34,3 +34,12 @@ shared:
     enable-role-check: true
     jwt:
       token-period: 15m
+
+subscription:
+  security:
+    jwt:
+      secret: ${SUBSCRIPTION_JWT_SECRET:change-me-change-me-change-me-change}
+      expiration: 30m
+    users:
+      - loginName: demo
+        password: b03ddf3ca2e714a6548e7495e2a03f5e824eaac9837cd7f159c67b90fb4b7342

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/controller/SubscriptionAuthControllerTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/controller/SubscriptionAuthControllerTest.java
@@ -1,0 +1,97 @@
+package com.ejada.subscription.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ejada.subscription.exception.InvalidCredentialsException;
+import com.ejada.subscription.handler.RestExceptionHandler;
+import com.ejada.subscription.service.SubscriptionAuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionAuthControllerTest {
+
+  private static final String URL = "/subscription/get-token";
+  private static final String VALID_RQUID = "c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd";
+  private static final String PASSWORD =
+      "b03ddf3ca2e714a6548e7495e2a03f5e824eaac9837cd7f159c67b90fb4b7342";
+
+  @Mock private SubscriptionAuthService authService;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    SubscriptionAuthController controller = new SubscriptionAuthController(authService);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(new RestExceptionHandler())
+            .build();
+  }
+
+  @Test
+  void shouldReturnTokenWhenRequestValid() throws Exception {
+    when(authService.authenticate("xyz", PASSWORD)).thenReturn("jwt-token");
+
+    mockMvc
+        .perform(
+            post(URL)
+                .header("rqUID", VALID_RQUID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" + "\"loginName\":\"xyz\"," + "\"password\":\"" + PASSWORD + "\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.statusCode").value("I000000"))
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.returnedObject.token").value("jwt-token"));
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenRqUidInvalid() throws Exception {
+    mockMvc
+        .perform(
+            post(URL)
+                .header("rqUID", "invalid-rquid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" + "\"loginName\":\"xyz\"," + "\"password\":\"" + PASSWORD + "\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.statusDtls[0]").value("Invalid rqUID format"));
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenBodyInvalid() throws Exception {
+    mockMvc
+        .perform(
+            post(URL)
+                .header("rqUID", VALID_RQUID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" + "\"loginName\":\"\"," + "\"password\":\"" + PASSWORD + "\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.statusDtls[0]").exists());
+  }
+
+  @Test
+  void shouldReturnUnauthorizedWhenCredentialsInvalid() throws Exception {
+    when(authService.authenticate(anyString(), anyString())).thenThrow(new InvalidCredentialsException());
+
+    mockMvc
+        .perform(
+            post(URL)
+                .header("rqUID", VALID_RQUID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" + "\"loginName\":\"xyz\"," + "\"password\":\"" + PASSWORD + "\"}"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.statusDtls[0]").value("Invalid credentials"));
+  }
+}

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/integration/SubscriptionAuthIntegrationTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/integration/SubscriptionAuthIntegrationTest.java
@@ -1,0 +1,73 @@
+package com.ejada.subscription.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(
+    properties = {
+      "subscription.security.jwt.secret=abcdefghijklmnopqrstuvwxyz0123456789abcd",
+      "subscription.security.jwt.expiration=PT30M",
+      "subscription.security.users[0].login-name=tester",
+      "subscription.security.users[0].password=b03ddf3ca2e714a6548e7495e2a03f5e824eaac9837cd7f159c67b90fb4b7342"
+    })
+@AutoConfigureMockMvc
+class SubscriptionAuthIntegrationTest {
+
+  private static final String PASSWORD =
+      "b03ddf3ca2e714a6548e7495e2a03f5e824eaac9837cd7f159c67b90fb4b7342";
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  @Test
+  void shouldIssueTokenForValidCredentials() throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/subscription/get-token")
+                    .header("rqUID", "c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{" + "\"loginName\":\"tester\"," + "\"password\":\"" + PASSWORD + "\"}"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    JsonNode root = objectMapper.readTree(result.getResponse().getContentAsByteArray());
+    assertThat(root.path("success").asBoolean()).isTrue();
+    String token = root.path("returnedObject").path("token").asText();
+    assertThat(token).isNotBlank();
+
+    var claimsJws =
+        Jwts.parser()
+            .verifyWith(
+                Keys.hmacShaKeyFor("abcdefghijklmnopqrstuvwxyz0123456789abcd".getBytes(StandardCharsets.UTF_8)))
+            .build()
+            .parseSignedClaims(token);
+    assertThat(claimsJws.getPayload().getSubject()).isEqualTo("tester");
+    assertThat(claimsJws.getPayload().get("scope", String.class)).isEqualTo("subscription");
+  }
+
+  @Test
+  void shouldReturnUnauthorizedForInvalidPassword() throws Exception {
+    mockMvc
+        .perform(
+            post("/subscription/get-token")
+                .header("rqUID", "c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" + "\"loginName\":\"tester\"," + "\"password\":\"" + PASSWORD.replace('b', 'c') + "\"}"))
+        .andExpect(status().isUnauthorized());
+  }
+}

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionAuthServiceImplTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionAuthServiceImplTest.java
@@ -1,0 +1,60 @@
+package com.ejada.subscription.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.ejada.subscription.exception.InvalidCredentialsException;
+import com.ejada.subscription.model.auth.SubscriptionUser;
+import com.ejada.subscription.repository.SubscriptionUserRepository;
+import com.ejada.subscription.security.JwtSigner;
+import com.ejada.subscription.service.impl.SubscriptionAuthServiceImpl;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionAuthServiceImplTest {
+
+  private static final String LOGIN = "xyz";
+  private static final String PASSWORD =
+      "b03ddf3ca2e714a6548e7495e2a03f5e824eaac9837cd7f159c67b90fb4b7342";
+
+  @Mock private SubscriptionUserRepository repository;
+  @Mock private JwtSigner jwtSigner;
+
+  private SubscriptionAuthServiceImpl service;
+
+  @BeforeEach
+  void setUp() {
+    service = new SubscriptionAuthServiceImpl(repository, jwtSigner);
+  }
+
+  @Test
+  void authenticateReturnsTokenForValidCredentials() {
+    when(repository.findByLoginName(LOGIN)).thenReturn(Optional.of(new SubscriptionUser(LOGIN, PASSWORD)));
+    when(jwtSigner.generateToken(LOGIN)).thenReturn("token");
+
+    assertThat(service.authenticate(LOGIN, PASSWORD)).isEqualTo("token");
+  }
+
+  @Test
+  void authenticateThrowsWhenPasswordDoesNotMatch() {
+    when(repository.findByLoginName(LOGIN))
+        .thenReturn(Optional.of(new SubscriptionUser(LOGIN, PASSWORD)));
+
+    assertThatThrownBy(() -> service.authenticate(LOGIN, PASSWORD.replace('b', 'c')))
+        .isInstanceOf(InvalidCredentialsException.class);
+  }
+
+  @Test
+  void authenticateThrowsWhenUserMissing() {
+    when(repository.findByLoginName(LOGIN)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.authenticate(LOGIN, PASSWORD))
+        .isInstanceOf(InvalidCredentialsException.class);
+  }
+}


### PR DESCRIPTION
## Summary
- implement the `/subscription/get-token` controller, DTOs, and response envelope for issuing JWT tokens
- add security configuration, properties, and in-memory credential repository to sign tokens with HS256
- document the endpoint with curl and Postman samples and cover it with unit and integration tests

## Testing
- `mvn test` *(fails: repository depends on unavailable com.ejada shared artifacts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69105c606998832f8e8da01144e06a5c)