### PR TITLE
Align subscription-service JWT dependency versions

### DIFF
--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -101,18 +101,15 @@
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-api</artifactId>
-      <version>0.12.6</version>
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-impl</artifactId>
-      <version>0.12.6</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-jackson</artifactId>
-      <version>0.12.6</version>
       <scope>runtime</scope>
     </dependency>
 


### PR DESCRIPTION
## Summary
- remove hard-coded 0.12.6 JWT dependency versions from the subscription-service module so it inherits the 0.13.0 versions supplied by the shared BOM
- ensure dependency convergence by relying on the managed versions provided by shared-lib

## Testing
- not run (local Maven verification requires significant additional dependency downloads)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911979c74d0832f98844ec88c6ac13a)