### PR TITLE
Fix SpotBugs exposure findings in subscription service

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/SecurityConfig.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/SecurityConfig.java
@@ -25,8 +25,8 @@ public class SecurityConfig {
 
   @Bean
   public JwtSigner jwtSigner(final SubscriptionSecurityProperties properties, final Clock clock) {
-    SecretKey key = Keys.hmacShaKeyFor(properties.getJwt().getSecret().getBytes(StandardCharsets.UTF_8));
-    final Duration expiry = properties.getJwt().getExpiration();
+    SecretKey key = Keys.hmacShaKeyFor(properties.jwt().secret().getBytes(StandardCharsets.UTF_8));
+    final Duration expiry = properties.jwt().expiration();
     return subject -> {
       Instant now = clock.instant();
       Instant expiration = now.plus(expiry);

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/auth/ServiceResult.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/auth/ServiceResult.java
@@ -34,6 +34,11 @@ public record ServiceResult<T>(
     statusDtls = statusDtls == null ? Collections.emptyList() : List.copyOf(statusDtls);
   }
 
+  @Override
+  public List<String> statusDtls() {
+    return statusDtls == null ? List.of() : List.copyOf(statusDtls);
+  }
+
   public static <T> ServiceResult<T> success(final String rqUid, final T returnedObject) {
     return new ServiceResult<>(rqUid, SUCCESS_CODE, SUCCESS_DESC, returnedObject, null, List.of(), true);
   }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/properties/SubscriptionSecurityProperties.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/properties/SubscriptionSecurityProperties.java
@@ -5,77 +5,36 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties(prefix = "subscription.security")
 @Validated
-public class SubscriptionSecurityProperties {
+public record SubscriptionSecurityProperties(
+    @Valid Jwt jwt,
+    @Valid List<User> users) {
 
-  private final Jwt jwt = new Jwt();
-  @Valid private List<User> users = new ArrayList<>();
-
-  public Jwt getJwt() {
-    return jwt;
+  public SubscriptionSecurityProperties {
+    Objects.requireNonNull(jwt, "subscription.security.jwt must be configured");
+    users = users == null ? List.of() : List.copyOf(users);
   }
 
-  public List<User> getUsers() {
-    return users;
-  }
+  public record Jwt(
+      @NotBlank
+      @Size(min = 32, message = "subscription.security.jwt.secret must be at least 32 characters")
+      String secret,
+      Duration expiration) {
 
-  public void setUsers(final List<User> users) {
-    this.users = users == null ? new ArrayList<>() : new ArrayList<>(users);
-  }
-
-  public static class Jwt {
-    @NotBlank
-    @Size(min = 32, message = "subscription.security.jwt.secret must be at least 32 characters")
-    private String secret;
-
-    private Duration expiration = Duration.ofMinutes(30);
-
-    public String getSecret() {
-      return secret;
-    }
-
-    public void setSecret(final String secret) {
-      this.secret = secret;
-    }
-
-    public Duration getExpiration() {
-      return expiration;
-    }
-
-    public void setExpiration(final Duration expiration) {
-      if (expiration != null) {
-        this.expiration = expiration;
-      }
+    public Jwt {
+      expiration = expiration == null ? Duration.ofMinutes(30) : expiration;
     }
   }
 
-  public static class User {
-    @NotBlank private String loginName;
-
-    @NotBlank
-    @Pattern(regexp = "^[A-Fa-f0-9]{64}$", message = "password must be SHA-256 hex")
-    private String password;
-
-    public String getLoginName() {
-      return loginName;
-    }
-
-    public void setLoginName(final String loginName) {
-      this.loginName = loginName;
-    }
-
-    public String getPassword() {
-      return password;
-    }
-
-    public void setPassword(final String password) {
-      this.password = password;
-    }
-  }
+  public record User(
+      @NotBlank String loginName,
+      @NotBlank
+      @Pattern(regexp = "^[A-Fa-f0-9]{64}$", message = "password must be SHA-256 hex")
+      String password) { }
 }


### PR DESCRIPTION
## Summary
- convert subscription security configuration to immutable value objects to avoid exposing mutable state
- defensively copy service result status details and in-memory user definitions to prevent external mutation
- update JWT signer configuration to use the new immutable configuration API

## Testing
- mvn clean verify *(fails: missing com.ejada artifacts from external repositories)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69119a6dae80832f9b8d4c3851cd2130)