### PR TITLE
Align subscription-service YAML configuration

### DIFF
--- a/tenant-platform/subscription-service/k8s/deployment.yaml
+++ b/tenant-platform/subscription-service/k8s/deployment.yaml
@@ -1,28 +1,31 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ejada-catalog
+  name: subscription-service
   labels:
-    app: ejada-catalog
+    app: subscription-service
     version: 1.0.0
 spec:
   replicas: 2
-  selector: 
-    matchLabels: 
-      app: ejada-catalog
+  selector:
+    matchLabels:
+      app: subscription-service
   template:
-    metadata: 
-      labels: 
-        app: ejada-catalog
+    metadata:
+      labels:
+        app: subscription-service
         version: 1.0.0
     spec:
       containers:
-        - name: app
-          image: your.registry/ejada-catalog:1.0.0
-          ports: [{ containerPort: 8080 }]
+        - name: subscription-service
+          image: your.registry/ejada-subscription:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
           env:
             - name: SPRING_DATASOURCE_URL
-              value: jdbc:postgresql://postgres:5432/ejada?currentSchema=catalog
+              value: jdbc:postgresql://postgres:5432/ejada?currentSchema=subscription
             - name: SPRING_DATASOURCE_USERNAME
               value: ejada
             - name: SPRING_DATASOURCE_PASSWORD
@@ -42,13 +45,13 @@ spec:
               cpu: "500m"
           livenessProbe:
             httpGet:
-              path: /core/actuator/health
+              path: /subscription/actuator/health
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /core/actuator/health
+              path: /subscription/actuator/health
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/tenant-platform/subscription-service/k8s/service.yaml
+++ b/tenant-platform/subscription-service/k8s/service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ejada-catalog
+  name: subscription-service
   labels:
-    app: ejada-catalog
+    app: subscription-service
     version: 1.0.0
 spec:
   selector:
-    app: ejada-catalog
+    app: subscription-service
   ports:
     - protocol: TCP
       port: 80

--- a/tenant-platform/subscription-service/src/test/resources/application-test.yml
+++ b/tenant-platform/subscription-service/src/test/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
     allow-bean-definition-overriding: true
 
   datasource:
-    url: 'jdbc:h2:mem:${random.uuid};MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;INIT=CREATE SCHEMA IF NOT EXISTS catalog\\;SET SCHEMA catalog'
+    url: 'jdbc:h2:mem:${random.uuid};MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;INIT=CREATE SCHEMA IF NOT EXISTS subscription\\;SET SCHEMA subscription'
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -16,7 +16,7 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
-        default_schema: catalog
+        default_schema: subscription
         hbm2ddl.create_namespaces: true
         format_sql: true
 


### PR DESCRIPTION
## Summary
- rename the Kubernetes deployment and service metadata to reference the subscription service and adjust probe endpoints
- update the deployment image configuration and datasource schema to match the subscription domain
- fix the test application profile to create and use the subscription schema when running against H2

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911aaba8e74832f9cadf1b6838f65df)