### PR TITLE
Fix JSONB persistence for inbound notification audit

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/InboundNotificationAudit.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/InboundNotificationAudit.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -43,6 +45,7 @@ public class InboundNotificationAudit {
     @Column(name = "endpoint", length = 64, nullable = false)
     private String endpoint; // RECEIVE_NOTIFICATION | RECEIVE_UPDATE
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
     private String payload;
 
@@ -61,6 +64,7 @@ public class InboundNotificationAudit {
     @Column(name = "status_desc", length = 64)
     private String statusDesc;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "status_dtls", columnDefinition = "jsonb")
     private String statusDtls;
 


### PR DESCRIPTION
## Summary
- ensure Hibernate binds JSONB columns in the inbound notification audit entity as native JSON
- annotate payload and status details fields with Json JDBC type metadata to prevent casting errors

## Testing
- `mvn -pl subscription-service -am test` *(fails: requires private com.ejada:shared-lib artifact and missing springdoc version)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ad76d3d4832f98430af6777526ea)