### PR TITLE
Handle multiple token headers on subscription callbacks

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionInboundController.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/controller/SubscriptionInboundController.java
@@ -32,11 +32,11 @@ public class SubscriptionInboundController {
     )
     public ResponseEntity<ServiceResult<ReceiveSubscriptionNotificationRs>> receiveSubscriptionNotification(
             @RequestHeader("rqUID") final UUID rqUid,
-            @RequestHeader(value = "token", required = false) final String token,
+            @RequestHeader(value = "token", required = false) final java.util.List<String> tokenHeaders,
             @Valid @RequestBody final ReceiveSubscriptionNotificationRq body) {
 
         ServiceResult<ReceiveSubscriptionNotificationRs> result =
-                service.receiveSubscriptionNotification(rqUid, token, body);
+                service.receiveSubscriptionNotification(rqUid, collapseTokenHeaders(tokenHeaders), body);
         return ResponseEntity.ok(result);
     }
 
@@ -46,10 +46,23 @@ public class SubscriptionInboundController {
     )
     public ResponseEntity<ServiceResult<Void>> receiveSubscriptionUpdate(
             @RequestHeader("rqUID") final UUID rqUid,
-            @RequestHeader(value = "token", required = false) final String token,
+            @RequestHeader(value = "token", required = false) final java.util.List<String> tokenHeaders,
             @Valid @RequestBody final ReceiveSubscriptionUpdateRq body) {
 
-        ServiceResult<Void> result = service.receiveSubscriptionUpdate(rqUid, token, body);
+        ServiceResult<Void> result =
+                service.receiveSubscriptionUpdate(rqUid, collapseTokenHeaders(tokenHeaders), body);
         return ResponseEntity.ok(result);
+    }
+
+    private String collapseTokenHeaders(final java.util.List<String> tokenHeaders) {
+        if (tokenHeaders == null || tokenHeaders.isEmpty()) {
+            return null;
+        }
+        return tokenHeaders.stream()
+                .filter(java.util.Objects::nonNull)
+                .map(String::trim)
+                .filter(token -> !token.isEmpty())
+                .reduce((left, right) -> left + "," + right)
+                .orElse(null);
     }
 }

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/controller/SubscriptionInboundControllerTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/controller/SubscriptionInboundControllerTest.java
@@ -1,0 +1,115 @@
+package com.ejada.subscription.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ejada.subscription.dto.AdminUserInfoDto;
+import com.ejada.subscription.dto.CustomerInfoDto;
+import com.ejada.subscription.dto.ReceiveSubscriptionNotificationRq;
+import com.ejada.subscription.dto.ReceiveSubscriptionNotificationRs;
+import com.ejada.subscription.dto.ReceiveSubscriptionUpdateRq;
+import com.ejada.subscription.dto.ServiceResult;
+import com.ejada.subscription.dto.SubscriptionInfoDto;
+import com.ejada.subscription.dto.SubscriptionUpdateType;
+import com.ejada.subscription.service.SubscriptionInboundService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionInboundControllerTest {
+
+  private static final UUID RQ_UID = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
+  @Mock private SubscriptionInboundService service;
+
+  private SubscriptionInboundController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new SubscriptionInboundController(service);
+  }
+
+  @Test
+  void receiveSubscriptionNotificationCollapsesMultipleTokenHeaders() {
+    ReceiveSubscriptionNotificationRq request = notificationRequest();
+    ServiceResult<ReceiveSubscriptionNotificationRs> result =
+        new ServiceResult<>("I000000", "Successful Operation", null, new ReceiveSubscriptionNotificationRs(true, List.of()));
+    when(service.receiveSubscriptionNotification(eq(RQ_UID), eq("string,token"), eq(request))).thenReturn(result);
+
+    ResponseEntity<ServiceResult<ReceiveSubscriptionNotificationRs>> response =
+        controller.receiveSubscriptionNotification(RQ_UID, List.of("string", "token"), request);
+
+    assertThat(response.getBody()).isSameAs(result);
+    verify(service).receiveSubscriptionNotification(eq(RQ_UID), eq("string,token"), eq(request));
+  }
+
+  @Test
+  void receiveSubscriptionUpdateCollapsesMultipleTokenHeaders() {
+    ReceiveSubscriptionUpdateRq request = new ReceiveSubscriptionUpdateRq(1L, 2L, SubscriptionUpdateType.SUSPENDED);
+    ServiceResult<Void> result = new ServiceResult<>("I000000", "Successful Operation", null, null);
+    when(service.receiveSubscriptionUpdate(eq(RQ_UID), eq("string,token"), eq(request))).thenReturn(result);
+
+    ResponseEntity<ServiceResult<Void>> response =
+        controller.receiveSubscriptionUpdate(RQ_UID, List.of("string", "token"), request);
+
+    assertThat(response.getBody()).isSameAs(result);
+    verify(service).receiveSubscriptionUpdate(eq(RQ_UID), eq("string,token"), eq(request));
+  }
+
+  private ReceiveSubscriptionNotificationRq notificationRequest() {
+    CustomerInfoDto customer =
+        new CustomerInfoDto(
+            "Customer",
+            "العميل",
+            "COMPANY",
+            "123",
+            "SA",
+            "RYD",
+            "Address",
+            "العنوان",
+            "customer@example.com",
+            "0500000000");
+    AdminUserInfoDto admin = new AdminUserInfoDto("Admin", "EN", "0500000001", "admin@example.com");
+    SubscriptionInfoDto subscriptionInfo =
+        new SubscriptionInfoDto(
+            10L,
+            20L,
+            30L,
+            40L,
+            "Gold",
+            "ذهبي",
+            LocalDate.now(),
+            LocalDate.now().plusDays(30),
+            BigDecimal.ONE,
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            "ACTIVE",
+            "PORTAL",
+            Boolean.TRUE,
+            100L,
+            "FULL_SUBSCRIPTION_PERIOD",
+            Boolean.FALSE,
+            200L,
+            "MONTHLY",
+            BigDecimal.TEN,
+            "MONTHLY",
+            "L",
+            Boolean.TRUE,
+            null,
+            null,
+            List.of(),
+            List.of());
+
+    return new ReceiveSubscriptionNotificationRq(customer, admin, subscriptionInfo, List.of());
+  }
+}


### PR DESCRIPTION
## Summary
- normalize repeated `token` headers in the subscription inbound controller before delegating to the service
- add controller unit tests to verify both notification and update endpoints collapse multiple token values

## Testing
- mvn -f tenant-platform/pom.xml -pl subscription-service test *(fails: PostgreSQL not available in CI container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b7da3a40832f85932982a91b3928)