### PR TITLE
Fix jsonb column mappings in subscription service

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/EntitlementCache.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/EntitlementCache.java
@@ -17,6 +17,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -84,6 +86,7 @@ public class EntitlementCache {
     @Column(name = "effective_to")
     private OffsetDateTime effectiveTo;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "source_meta", columnDefinition = "jsonb")
     private String sourceMeta;
 

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/OutboxEvent.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/OutboxEvent.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 
@@ -42,9 +44,11 @@ public class OutboxEvent {
     @Column(name = "event_type", length = 64, nullable = false)
     private String eventType;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
     private String payload;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "headers", columnDefinition = "jsonb")
     private String headers;
 

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/Subscription.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/Subscription.java
@@ -14,6 +14,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -127,6 +129,7 @@ public class Subscription {
     private String prevSubscriptionUpdateAction; // UPGRADE | DOWNGRADE | RENEWAL
 
     // housekeeping
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "meta", columnDefinition = "jsonb")
     private String meta;
 


### PR DESCRIPTION
## Summary
- ensure the subscription entity's meta column uses the PostgreSQL jsonb type mapping
- align other jsonb columns on entitlement cache and outbox event entities with the same JDBC JSON type mapping

## Testing
- mvn -pl subscription-service test *(fails: missing com.ejada:shared-lib and unresolved springdoc version)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911bd7628a8832f80079a24fc3e822c)