### PR TITLE
Add Kafka integration between subscription and tenant services

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/events/tenant/TenantProvisioningEvent.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/events/tenant/TenantProvisioningEvent.java
@@ -1,0 +1,35 @@
+package com.ejada.common.events.tenant;
+
+import java.io.Serializable;
+
+/**
+ * Event published by the subscription service to kick off tenant onboarding in
+ * downstream services.
+ */
+public record TenantProvisioningEvent(
+        Long subscriptionId,
+        String extSubscriptionId,
+        String extCustomerId,
+        TenantCustomerInfo customerInfo
+) implements Serializable {
+
+    public TenantProvisioningEvent {
+        if (extCustomerId != null) {
+            extCustomerId = extCustomerId.trim();
+        }
+    }
+
+    /** Customer details forwarded from the marketplace payload. */
+    public record TenantCustomerInfo(
+            String customerNameEn,
+            String customerNameAr,
+            String customerType,
+            String crNumber,
+            String countryCd,
+            String cityCd,
+            String addressEn,
+            String addressAr,
+            String email,
+            String mobileNo
+    ) implements Serializable { }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/KafkaTopicsConfig.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/config/KafkaTopicsConfig.java
@@ -1,0 +1,9 @@
+package com.ejada.subscription.config;
+
+import com.ejada.subscription.properties.SubscriptionKafkaTopicsProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(SubscriptionKafkaTopicsProperties.class)
+public class KafkaTopicsConfig { }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/messaging/TenantOnboardingProducer.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/messaging/TenantOnboardingProducer.java
@@ -1,0 +1,62 @@
+package com.ejada.subscription.messaging;
+
+import com.ejada.common.events.tenant.TenantProvisioningEvent;
+import com.ejada.common.events.tenant.TenantProvisioningEvent.TenantCustomerInfo;
+import com.ejada.subscription.dto.CustomerInfoDto;
+import com.ejada.subscription.model.Subscription;
+import com.ejada.subscription.properties.SubscriptionKafkaTopicsProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TenantOnboardingProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final SubscriptionKafkaTopicsProperties topics;
+
+    public void publishTenantCreateRequested(final Subscription subscription,
+            final CustomerInfoDto customerInfo) {
+
+        if (subscription == null) {
+            log.warn("Skipping tenant onboarding publish: subscription is null");
+            return;
+        }
+        if (customerInfo == null) {
+            log.warn("Skipping tenant onboarding publish for subscription {}: missing customer info",
+                    subscription.getSubscriptionId());
+            return;
+        }
+
+        TenantCustomerInfo payloadCustomer = new TenantCustomerInfo(
+                customerInfo.customerNameEn(),
+                customerInfo.customerNameAr(),
+                customerInfo.customerType(),
+                customerInfo.crNumber(),
+                customerInfo.countryCd(),
+                customerInfo.cityCd(),
+                customerInfo.addressEn(),
+                customerInfo.addressAr(),
+                customerInfo.email(),
+                customerInfo.mobileNo());
+
+        TenantProvisioningEvent event = new TenantProvisioningEvent(
+                subscription.getSubscriptionId(),
+                subscription.getExtSubscriptionId(),
+                subscription.getExtCustomerId(),
+                payloadCustomer);
+
+        String key = subscription.getExtCustomerId();
+        kafkaTemplate.send(topics.tenantOnboarding(), key, event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Failed to publish tenant onboarding event for subscription {}", subscription.getSubscriptionId(), ex);
+                    } else if (result != null) {
+                        log.info("Published tenant onboarding event to {} partition {} offset {}", result.getRecordMetadata().topic(), result.getRecordMetadata().partition(), result.getRecordMetadata().offset());
+                    }
+                });
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/properties/SubscriptionKafkaTopicsProperties.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/properties/SubscriptionKafkaTopicsProperties.java
@@ -1,0 +1,13 @@
+package com.ejada.subscription.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "subscription.kafka.topics")
+public record SubscriptionKafkaTopicsProperties(String tenantOnboarding) {
+
+    public SubscriptionKafkaTopicsProperties {
+        if (tenantOnboarding == null || tenantOnboarding.isBlank()) {
+            throw new IllegalArgumentException("subscription.kafka.topics.tenant-onboarding must be configured");
+        }
+    }
+}

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImpl.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImpl.java
@@ -22,6 +22,7 @@ import com.ejada.subscription.model.SubscriptionAdditionalService;
 import com.ejada.subscription.model.SubscriptionEnvironmentIdentifier;
 import com.ejada.subscription.model.SubscriptionFeature;
 import com.ejada.subscription.model.SubscriptionProductProperty;
+import com.ejada.subscription.messaging.TenantOnboardingProducer;
 import com.ejada.subscription.repository.InboundNotificationAuditRepository;
 import com.ejada.subscription.repository.IdempotentRequestRepository;
 import com.ejada.subscription.repository.OutboxEventRepository;
@@ -83,6 +84,8 @@ public class SubscriptionInboundServiceImpl implements SubscriptionInboundServic
     private final SubscriptionProductPropertyMapper propertyMapper;
     private final SubscriptionEnvironmentIdentifierMapper envIdMapper;
     private final SubscriptionUpdateEventMapper updateEventMapper;
+
+    private final TenantOnboardingProducer tenantOnboardingProducer;
 
     // JSON
     @SuppressFBWarnings("EI_EXPOSE_REP2")
@@ -341,6 +344,7 @@ public class SubscriptionInboundServiceImpl implements SubscriptionInboundServic
 
         Map<String, Object> tenantPayload = new LinkedHashMap<>(basePayload);
         tenantPayload.put("customerInfo", rq.customerInfo());
+        tenantOnboardingProducer.publishTenantCreateRequested(sub, rq.customerInfo());
         emitOutbox("ONBOARDING", sub.getSubscriptionId().toString(), "TENANT_CREATE_REQUESTED", tenantPayload);
 
         Map<String, Object> catalogPayload = new LinkedHashMap<>(basePayload);

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -43,3 +43,6 @@ subscription:
     users:
       - loginName: demo
         password: b03ddf3ca2e714a6548e7495e2a03f5e824eaac9837cd7f159c67b90fb4b7342
+  kafka:
+    topics:
+      tenant-onboarding: ${SUBSCRIPTION_KAFKA_TENANT_TOPIC:tenant-platform.onboarding.tenants}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/config/KafkaTopicsConfig.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/config/KafkaTopicsConfig.java
@@ -1,0 +1,9 @@
+package com.ejada.tenant.config;
+
+import com.ejada.tenant.properties.TenantKafkaTopicsProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(TenantKafkaTopicsProperties.class)
+public class KafkaTopicsConfig { }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/messaging/TenantOnboardingListener.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/messaging/TenantOnboardingListener.java
@@ -1,0 +1,34 @@
+package com.ejada.tenant.messaging;
+
+import com.ejada.common.events.tenant.TenantProvisioningEvent;
+import com.ejada.tenant.properties.TenantKafkaTopicsProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TenantOnboardingListener {
+
+    private final ObjectMapper objectMapper;
+    private final TenantOnboardingService onboardingService;
+    private final TenantKafkaTopicsProperties topics;
+
+    @KafkaListener(topics = "#{@tenantKafkaTopicsProperties.tenantOnboarding()}")
+    public void handleTenantProvisioning(@Payload final Map<String, Object> payload) {
+        try {
+            TenantProvisioningEvent event = objectMapper.convertValue(payload, TenantProvisioningEvent.class);
+            onboardingService.createOrUpdateTenant(event);
+        } catch (IllegalArgumentException ex) {
+            log.error("Failed to map tenant provisioning payload: {}", payload, ex);
+        } catch (Exception ex) {
+            log.error("Unexpected error while handling tenant provisioning payload from topic {}", topics.tenantOnboarding(), ex);
+            throw ex;
+        }
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/messaging/TenantOnboardingService.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/messaging/TenantOnboardingService.java
@@ -1,0 +1,87 @@
+package com.ejada.tenant.messaging;
+
+import com.ejada.common.events.tenant.TenantProvisioningEvent;
+import com.ejada.common.events.tenant.TenantProvisioningEvent.TenantCustomerInfo;
+import com.ejada.tenant.model.Tenant;
+import com.ejada.tenant.repository.TenantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TenantOnboardingService {
+
+    private final TenantRepository tenantRepository;
+
+    @Transactional
+    public void createOrUpdateTenant(final TenantProvisioningEvent event) {
+        if (event == null) {
+            log.warn("Received null tenant provisioning event");
+            return;
+        }
+
+        String code = normalize(event.extCustomerId());
+        if (!StringUtils.hasText(code)) {
+            log.warn("Skipping tenant provisioning event without extCustomerId: {}", event);
+            return;
+        }
+
+        Tenant tenant = tenantRepository.findByCode(code).orElseGet(() -> {
+            Tenant created = new Tenant();
+            created.setCode(code);
+            return created;
+        });
+
+        TenantCustomerInfo customer = event.customerInfo();
+        tenant.setName(determineName(customer, code));
+        tenant.setContactEmail(truncateNullable(customer == null ? null : customer.email(), Tenant.EMAIL_LENGTH));
+        tenant.setContactPhone(truncateNullable(customer == null ? null : customer.mobileNo(), Tenant.PHONE_LENGTH));
+        tenant.setActive(Boolean.TRUE);
+        tenant.setIsDeleted(Boolean.FALSE);
+
+        tenantRepository.save(tenant);
+        log.info("Tenant [{}] upserted from subscription event", tenant.getCode());
+    }
+
+    private String determineName(final TenantCustomerInfo customer, final String fallback) {
+        if (customer == null) {
+            return fallback;
+        }
+        if (StringUtils.hasText(customer.customerNameEn())) {
+            return truncate(customer.customerNameEn(), Tenant.NAME_LENGTH);
+        }
+        if (StringUtils.hasText(customer.customerNameAr())) {
+            return truncate(customer.customerNameAr(), Tenant.NAME_LENGTH);
+        }
+        return fallback;
+    }
+
+    private String normalize(final String value) {
+        if (value == null) {
+            return null;
+        }
+        return truncate(value.trim(), Tenant.CODE_LENGTH);
+    }
+
+    private String truncate(final String value, final int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+
+    private String truncateNullable(final String value, final int maxLength) {
+        String trimmed = value == null ? null : value.trim();
+        if (!StringUtils.hasText(trimmed)) {
+            return null;
+        }
+        return truncate(trimmed, maxLength);
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/properties/TenantKafkaTopicsProperties.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/properties/TenantKafkaTopicsProperties.java
@@ -1,0 +1,13 @@
+package com.ejada.tenant.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "tenant.kafka.topics")
+public record TenantKafkaTopicsProperties(String tenantOnboarding) {
+
+    public TenantKafkaTopicsProperties {
+        if (tenantOnboarding == null || tenantOnboarding.isBlank()) {
+            throw new IllegalArgumentException("tenant.kafka.topics.tenant-onboarding must be configured");
+        }
+    }
+}

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
@@ -22,6 +22,8 @@ public interface TenantRepository extends JpaRepository<Tenant, Integer> {
 
     Page<Tenant> findByNameContainingIgnoreCaseAndActiveAndIsDeletedFalse(String name, boolean active, Pageable pageable);
 
+    Optional<Tenant> findByCode(String code);
+
     boolean existsByCode(String code);
 
     boolean existsByCodeAndIdNot(String code, Integer id);

--- a/tenant-platform/tenant-service/src/main/resources/application.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application.yaml
@@ -33,3 +33,8 @@ shared:
     enable-role-check: true
     jwt:
       token-period: 15m
+
+tenant:
+  kafka:
+    topics:
+      tenant-onboarding: ${TENANT_KAFKA_TENANT_TOPIC:tenant-platform.onboarding.tenants}

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/messaging/TenantOnboardingServiceTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/messaging/TenantOnboardingServiceTest.java
@@ -1,0 +1,90 @@
+package com.ejada.tenant.messaging;
+
+import com.ejada.common.events.tenant.TenantProvisioningEvent;
+import com.ejada.common.events.tenant.TenantProvisioningEvent.TenantCustomerInfo;
+import com.ejada.tenant.model.Tenant;
+import com.ejada.tenant.repository.TenantRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TenantOnboardingServiceTest {
+
+    private final TenantRepository tenantRepository = mock(TenantRepository.class);
+    private final TenantOnboardingService service = new TenantOnboardingService(tenantRepository);
+
+    @Test
+    void createsTenantWhenNotExists() {
+        when(tenantRepository.findByCode("CUST-1")).thenReturn(Optional.empty());
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        TenantProvisioningEvent event = new TenantProvisioningEvent(
+                42L,
+                "SUB-42",
+                "CUST-1",
+                new TenantCustomerInfo("Ejada EN", "Ejada AR", "COMPANY", null, null, null, null, null,
+                        "ops@example.com", "+966500000000"));
+
+        service.createOrUpdateTenant(event);
+
+        ArgumentCaptor<Tenant> captor = ArgumentCaptor.forClass(Tenant.class);
+        verify(tenantRepository).save(captor.capture());
+        Tenant saved = captor.getValue();
+        assertThat(saved.getCode()).isEqualTo("CUST-1");
+        assertThat(saved.getName()).isEqualTo("Ejada EN");
+        assertThat(saved.getContactEmail()).isEqualTo("ops@example.com");
+        assertThat(saved.getContactPhone()).isEqualTo("+966500000000");
+        assertThat(saved.isActive()).isTrue();
+        assertThat(saved.isDeleted()).isFalse();
+    }
+
+    @Test
+    void updatesExistingTenantAndReactivates() {
+        Tenant existing = new Tenant();
+        existing.setCode("CUST-2");
+        existing.setName("Old Name");
+        existing.setContactEmail("old@example.com");
+        existing.setContactPhone("1111");
+        existing.setActive(false);
+        existing.setIsDeleted(true);
+
+        when(tenantRepository.findByCode("CUST-2")).thenReturn(Optional.of(existing));
+        when(tenantRepository.save(existing)).thenReturn(existing);
+
+        TenantProvisioningEvent event = new TenantProvisioningEvent(
+                77L,
+                "SUB-77",
+                "CUST-2",
+                new TenantCustomerInfo(null, "Ejada Arabic", null, null, null, null, null, null,
+                        "new@example.com", null));
+
+        service.createOrUpdateTenant(event);
+
+        assertThat(existing.getName()).isEqualTo("Ejada Arabic");
+        assertThat(existing.getContactEmail()).isEqualTo("new@example.com");
+        assertThat(existing.getContactPhone()).isNull();
+        assertThat(existing.isActive()).isTrue();
+        assertThat(existing.isDeleted()).isFalse();
+        verify(tenantRepository).save(existing);
+    }
+
+    @Test
+    void skipsEventWithoutCustomerId() {
+        TenantProvisioningEvent event = new TenantProvisioningEvent(
+                1L,
+                "SUB-1",
+                "  ",
+                new TenantCustomerInfo(null, null, null, null, null, null, null, null, null, null));
+
+        service.createOrUpdateTenant(event);
+
+        verify(tenantRepository, never()).save(any(Tenant.class));
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared `TenantProvisioningEvent` contract used to send onboarding details between services
- publish tenant onboarding events from the subscription service via Kafka when a new subscription is processed
- consume the onboarding topic in the tenant service to upsert tenant records and cover the flow with unit tests and topic configuration updates

## Testing
- `mvn -f tenant-platform/pom.xml -pl subscription-service,tenant-service -am test` *(fails: repository lacks the private com.ejada:shared-lib BOM required for dependency resolution)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c74fcb00832fbeb967caf8fabbc0)