### PR TITLE
Convert tenant onboarding Kafka identifiers to strings

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/messaging/TenantOnboardingProducer.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/messaging/TenantOnboardingProducer.java
@@ -43,13 +43,20 @@ public class TenantOnboardingProducer {
                 customerInfo.email(),
                 customerInfo.mobileNo());
 
+        String extSubscriptionId = subscription.getExtSubscriptionId() == null
+                ? null
+                : subscription.getExtSubscriptionId().toString();
+        String extCustomerId = subscription.getExtCustomerId() == null
+                ? null
+                : subscription.getExtCustomerId().toString();
+
         TenantProvisioningEvent event = new TenantProvisioningEvent(
                 subscription.getSubscriptionId(),
-                subscription.getExtSubscriptionId(),
-                subscription.getExtCustomerId(),
+                extSubscriptionId,
+                extCustomerId,
                 payloadCustomer);
 
-        String key = subscription.getExtCustomerId();
+        String key = extCustomerId;
         kafkaTemplate.send(topics.tenantOnboarding(), key, event)
                 .whenComplete((result, ex) -> {
                     if (ex != null) {


### PR DESCRIPTION
## Summary
- convert external subscription and customer identifiers to strings before constructing the tenant provisioning event
- reuse the string customer identifier when sending the Kafka message key to avoid type mismatches

## Testing
- mvn -q -DskipTests compile *(fails: missing internal dependencies in the tenant-platform parent POM)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69132aa0fa84832fadb89cc682075373)