### PR TITLE
Fix SubscriptionInboundServiceImpl test constructor

### DIFF
--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionInboundServiceImplTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/service/SubscriptionInboundServiceImplTest.java
@@ -23,6 +23,7 @@ import com.ejada.subscription.mapper.SubscriptionMapper;
 import com.ejada.subscription.mapper.SubscriptionProductPropertyMapper;
 import com.ejada.subscription.mapper.SubscriptionUpdateEventMapper;
 import com.ejada.subscription.model.InboundNotificationAudit;
+import com.ejada.subscription.messaging.TenantOnboardingProducer;
 import com.ejada.subscription.repository.IdempotentRequestRepository;
 import com.ejada.subscription.repository.InboundNotificationAuditRepository;
 import com.ejada.subscription.repository.OutboxEventRepository;
@@ -67,6 +68,7 @@ class SubscriptionInboundServiceImplTest {
   @Mock private SubscriptionProductPropertyMapper subscriptionProductPropertyMapper;
   @Mock private SubscriptionEnvironmentIdentifierMapper subscriptionEnvironmentIdentifierMapper;
   @Mock private SubscriptionUpdateEventMapper subscriptionUpdateEventMapper;
+  @Mock private TenantOnboardingProducer tenantOnboardingProducer;
   @Mock private JwtValidator jwtValidator;
 
   private SubscriptionInboundServiceImpl service;
@@ -97,6 +99,7 @@ class SubscriptionInboundServiceImplTest {
             subscriptionProductPropertyMapper,
             subscriptionEnvironmentIdentifierMapper,
             subscriptionUpdateEventMapper,
+            tenantOnboardingProducer,
             new ObjectMapper(),
             jwtValidator);
   }


### PR DESCRIPTION
## Summary
- mock the new TenantOnboardingProducer dependency used by SubscriptionInboundServiceImpl
- pass the mock into the service constructor within the unit test setup

## Testing
- `mvn -f tenant-platform/pom.xml -pl subscription-service test -DskipITs` *(fails: missing internal dependencies in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914572e45a8832f9c098f73e534ee66)