### PR TITLE
Make subscription inbound audit index creation idempotent

### DIFF
--- a/tenant-platform/subscription-service/src/main/resources/db/migration/postgresql/V3__subscription_inbound_audit.sql
+++ b/tenant-platform/subscription-service/src/main/resources/db/migration/postgresql/V3__subscription_inbound_audit.sql
@@ -28,4 +28,4 @@ create table IF NOT EXISTS subscription_update_event (
   constraint ux_su_unique unique (rq_uid)
 );
 
-create index idx_sue_sub on subscription_update_event(ext_subscription_id);
+create index if not exists idx_sue_sub on subscription_update_event(ext_subscription_id);


### PR DESCRIPTION
## Summary
- make the subscription inbound audit Flyway script resilient when the subscription_update_event index already exists

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145771b694832f888df29c4aee3b77)