### PR TITLE
Make Flyway index creation idempotent

### DIFF
--- a/tenant-platform/subscription-service/src/main/resources/db/migration/postgresql/V4__subscription_infra.sql
+++ b/tenant-platform/subscription-service/src/main/resources/db/migration/postgresql/V4__subscription_infra.sql
@@ -9,7 +9,7 @@ create table IF NOT EXISTS outbox_event (
   created_at     timestamptz not null default now(),
   processed_at   timestamptz
 );
-create index idx_outbox_unprocessed on outbox_event(aggregate_type, aggregate_id) where processed_at is null;
+create index if not exists idx_outbox_unprocessed on outbox_event(aggregate_type, aggregate_id) where processed_at is null;
 
 -- ========= Idempotent request keys for write paths (rqUID) =========
 create table IF NOT EXISTS idempotent_request (


### PR DESCRIPTION
## Summary
- update the subscription Flyway migration to guard the outbox index creation with `IF NOT EXISTS`

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691458a07b4c832faeb2221b17e39e66)