### PR TITLE
Add configuration properties scanning for tenant service

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/TenantApplication.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/TenantApplication.java
@@ -2,11 +2,13 @@ package com.ejada.tenant;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cache.annotation.EnableCaching;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan(basePackages = "com.ejada.tenant")
 @EnableCaching
 @OpenAPIDefinition(info = @Info(title = "Ejada Tenant Service", version = "1.0"))
 public class TenantApplication {


### PR DESCRIPTION
## Summary
- enable configuration properties scanning in the tenant service application so TenantKafkaTopicsProperties is registered

## Testing
- mvn -f tenant-platform/pom.xml -pl tenant-service -am test *(fails: requires internal com.ejada:shared-lib:1.0.0 BOM and springdoc version metadata)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145bb5b490832f9f3d11695b61746b)