### PR TITLE
Fix tenant Kafka listener topic configuration

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/messaging/TenantOnboardingListener.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/messaging/TenantOnboardingListener.java
@@ -26,7 +26,7 @@ public class TenantOnboardingListener {
         this.topics = topics;
     }
 
-    @KafkaListener(topics = "#{@tenantKafkaTopicsProperties.tenantOnboarding()}")
+    @KafkaListener(topics = "${tenant.kafka.topics.tenant-onboarding}")
     public void handleTenantProvisioning(@Payload final Map<String, Object> payload) {
         try {
             TenantProvisioningEvent event = objectMapper.convertValue(payload, TenantProvisioningEvent.class);


### PR DESCRIPTION
## Summary
- update the tenant onboarding Kafka listener to resolve the topic name from configuration properties without referencing a bean

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145ed16df4832f965affcd2a5b51e3)