### PR TITLE
Configure Kafka producer JSON serialization for tenant events

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/messaging/TenantOnboardingProducer.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/messaging/TenantOnboardingProducer.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "KafkaTemplate is a Spring-managed bean and safe to retain")
 public class TenantOnboardingProducer {
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final KafkaTemplate<String, TenantProvisioningEvent> kafkaTemplate;
     private final SubscriptionKafkaTopicsProperties topics;
 
     public void publishTenantCreateRequested(final Subscription subscription,
@@ -64,7 +64,7 @@ public class TenantOnboardingProducer {
         String topic = topics.tenantOnboarding();
         String key = extCustomerId;
 
-        CompletableFuture<SendResult<String, Object>> sendResultFuture =
+        CompletableFuture<SendResult<String, TenantProvisioningEvent>> sendResultFuture =
                 key == null ? kafkaTemplate.send(topic, event) : kafkaTemplate.send(topic, key, event);
 
         sendResultFuture.whenComplete((result, ex) -> {

--- a/tenant-platform/subscription-service/src/main/resources/application.yaml
+++ b/tenant-platform/subscription-service/src/main/resources/application.yaml
@@ -8,6 +8,12 @@ spring:
     baseline-version: 0
     default-schema: subscription
     schemas: subscription
+  kafka:
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
 
 server:
   port: 8080


### PR DESCRIPTION
## Summary
- type the tenant onboarding Kafka template to TenantProvisioningEvent to match the published payload
- configure Spring Kafka producer defaults to use the JsonSerializer and suppress type headers for outbound events

## Testing
- mvn -f tenant-platform/pom.xml -pl subscription-service test -DskipITs *(fails: missing private dependency com.ejada:shared-lib:1.0.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914600c9744832f8866a33e9b499b2c)