### PR TITLE
Handle JSON payloads in tenant onboarding listener

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/messaging/TenantOnboardingListener.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/messaging/TenantOnboardingListener.java
@@ -2,8 +2,8 @@ package com.ejada.tenant.messaging;
 
 import com.ejada.common.events.tenant.TenantProvisioningEvent;
 import com.ejada.tenant.properties.TenantKafkaTopicsProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -27,11 +27,11 @@ public class TenantOnboardingListener {
     }
 
     @KafkaListener(topics = "${tenant.kafka.topics.tenant-onboarding}")
-    public void handleTenantProvisioning(@Payload final Map<String, Object> payload) {
+    public void handleTenantProvisioning(@Payload final String payload) {
         try {
-            TenantProvisioningEvent event = objectMapper.convertValue(payload, TenantProvisioningEvent.class);
+            TenantProvisioningEvent event = objectMapper.readValue(payload, TenantProvisioningEvent.class);
             onboardingService.createOrUpdateTenant(event);
-        } catch (IllegalArgumentException ex) {
+        } catch (JsonProcessingException ex) {
             log.error("Failed to map tenant provisioning payload: {}", payload, ex);
         } catch (Exception ex) {
             log.error("Unexpected error while handling tenant provisioning payload from topic {}", topics.tenantOnboarding(), ex);


### PR DESCRIPTION
## Summary
- parse tenant onboarding Kafka messages from a raw JSON payload into `TenantProvisioningEvent`
- log JSON parsing issues explicitly while keeping existing error handling

## Testing
- mvn -f tenant-platform/pom.xml -pl tenant-service test *(fails: missing com.ejada:shared-lib:1.0.0 dependency from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69146754f5c8832fa9b5493c31e94f9d)