### PR TITLE
Create tenant admin user during onboarding

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/config/KafkaTopicsConfig.java
+++ b/sec-service/src/main/java/com/ejada/sec/config/KafkaTopicsConfig.java
@@ -1,0 +1,8 @@
+package com.ejada.sec.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(SecKafkaTopicsProperties.class)
+public class KafkaTopicsConfig { }

--- a/sec-service/src/main/java/com/ejada/sec/config/SecKafkaTopicsProperties.java
+++ b/sec-service/src/main/java/com/ejada/sec/config/SecKafkaTopicsProperties.java
@@ -1,0 +1,13 @@
+package com.ejada.sec.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "sec.kafka.topics")
+public record SecKafkaTopicsProperties(String tenantOnboarding) {
+
+    public SecKafkaTopicsProperties {
+        if (tenantOnboarding == null || tenantOnboarding.isBlank()) {
+            throw new IllegalArgumentException("sec.kafka.topics.tenant-onboarding must be configured");
+        }
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/messaging/TenantAdminProvisioningService.java
+++ b/sec-service/src/main/java/com/ejada/sec/messaging/TenantAdminProvisioningService.java
@@ -1,0 +1,134 @@
+package com.ejada.sec.messaging;
+
+import com.ejada.common.events.tenant.TenantProvisioningEvent;
+import com.ejada.common.events.tenant.TenantProvisioningEvent.TenantAdminInfo;
+import com.ejada.sec.domain.Role;
+import com.ejada.sec.domain.User;
+import com.ejada.sec.domain.UserRole;
+import com.ejada.sec.domain.UserRoleId;
+import com.ejada.sec.repository.RoleRepository;
+import com.ejada.sec.repository.UserRepository;
+import com.ejada.sec.repository.UserRoleRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TenantAdminProvisioningService {
+
+    private static final String TENANT_ADMIN_ROLE_CODE = "TENANT_ADMIN";
+
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final UserRoleRepository userRoleRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void provisionTenantAdmin(final TenantProvisioningEvent event) {
+        if (event == null) {
+            log.warn("Received null tenant provisioning event; skipping admin provisioning");
+            return;
+        }
+
+        String extCustomerId = normalize(event.extCustomerId());
+        if (!StringUtils.hasText(extCustomerId)) {
+            log.warn("Skipping admin provisioning: missing extCustomerId in event {}", event.subscriptionId());
+            return;
+        }
+
+        TenantAdminInfo adminInfo = event.adminInfo();
+        if (adminInfo == null) {
+            log.warn("Skipping admin provisioning for customer {}: admin info missing", extCustomerId);
+            return;
+        }
+
+        String username = normalize(adminInfo.adminUserName());
+        String email = normalize(adminInfo.email());
+        if (!StringUtils.hasText(username) || !StringUtils.hasText(email)) {
+            log.warn("Skipping admin provisioning for customer {}: incomplete admin info", extCustomerId);
+            return;
+        }
+
+        UUID tenantId = tenantIdFromExternal(extCustomerId);
+        Optional<User> existing = userRepository.findByTenantIdAndUsername(tenantId, username);
+        if (existing.isPresent()) {
+            updateExistingAdmin(existing.get(), email, tenantId);
+            ensureRoleAssignment(existing.get(), tenantId);
+            return;
+        }
+
+        if (userRepository.existsByTenantIdAndEmail(tenantId, email)) {
+            log.warn("Skipping admin creation for tenant {}: email {} already in use", tenantId, email);
+            return;
+        }
+
+        User user = new User();
+        user.setTenantId(tenantId);
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setPasswordHash(passwordEncoder.encode(generateRandomPassword()));
+        user.setEnabled(true);
+        user.setLocked(false);
+
+        user = userRepository.save(user);
+        ensureRoleAssignment(user, tenantId);
+        log.info("Provisioned tenant admin '{}' for tenant {}", username, tenantId);
+    }
+
+    private void updateExistingAdmin(final User user, final String email, final UUID tenantId) {
+        if (email.equalsIgnoreCase(user.getEmail())) {
+            return;
+        }
+        userRepository.findByTenantIdAndEmail(tenantId, email)
+                .filter(other -> !other.getId().equals(user.getId()))
+                .ifPresentOrElse(
+                        other -> log.warn(
+                                "Skipping email update for user {} in tenant {}: email already used by user {}",
+                                user.getId(), tenantId, other.getId()),
+                        () -> {
+                            user.setEmail(email);
+                            userRepository.save(user);
+                            log.info("Updated admin email for user {} in tenant {}", user.getId(), tenantId);
+                        });
+    }
+
+    private void ensureRoleAssignment(final User user, final UUID tenantId) {
+        Role role = roleRepository.findByTenantIdAndCode(tenantId, TENANT_ADMIN_ROLE_CODE)
+                .orElseGet(() -> roleRepository.save(Role.builder()
+                        .tenantId(tenantId)
+                        .code(TENANT_ADMIN_ROLE_CODE)
+                        .name("Tenant Administrator")
+                        .build()));
+
+        UserRoleId id = new UserRoleId(user.getId(), role.getId());
+        if (!userRoleRepository.existsById(id)) {
+            userRoleRepository.save(UserRole.builder()
+                    .id(id)
+                    .user(user)
+                    .role(role)
+                    .build());
+            log.info("Assigned TENANT_ADMIN role to user {} in tenant {}", user.getId(), tenantId);
+        }
+    }
+
+    private UUID tenantIdFromExternal(final String extCustomerId) {
+        String key = "tenant:" + extCustomerId;
+        return UUID.nameUUIDFromBytes(key.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String normalize(final String value) {
+        return value == null ? null : value.trim();
+    }
+
+    private String generateRandomPassword() {
+        return UUID.randomUUID().toString().replaceAll("-", "");
+    }
+}

--- a/sec-service/src/main/java/com/ejada/sec/messaging/TenantOnboardingListener.java
+++ b/sec-service/src/main/java/com/ejada/sec/messaging/TenantOnboardingListener.java
@@ -1,0 +1,41 @@
+package com.ejada.sec.messaging;
+
+import com.ejada.common.events.tenant.TenantProvisioningEvent;
+import com.ejada.sec.config.SecKafkaTopicsProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class TenantOnboardingListener {
+
+    private final ObjectMapper objectMapper;
+    private final TenantAdminProvisioningService provisioningService;
+    private final SecKafkaTopicsProperties topics;
+
+    public TenantOnboardingListener(
+            final ObjectMapper objectMapper,
+            final TenantAdminProvisioningService provisioningService,
+            final SecKafkaTopicsProperties topics) {
+        this.objectMapper = objectMapper.copy();
+        this.provisioningService = provisioningService;
+        this.topics = topics;
+    }
+
+    @KafkaListener(topics = "${sec.kafka.topics.tenant-onboarding}")
+    public void handleTenantProvisioning(@Payload final String payload) {
+        try {
+            TenantProvisioningEvent event = objectMapper.readValue(payload, TenantProvisioningEvent.class);
+            provisioningService.provisionTenantAdmin(event);
+        } catch (JsonProcessingException ex) {
+            log.error("Failed to map tenant provisioning payload: {}", payload, ex);
+        } catch (Exception ex) {
+            log.error("Unexpected error while handling tenant provisioning payload from topic {}", topics.tenantOnboarding(), ex);
+            throw ex;
+        }
+    }
+}

--- a/sec-service/src/main/resources/application.yaml
+++ b/sec-service/src/main/resources/application.yaml
@@ -33,3 +33,8 @@ shared:
     enable-role-check: true
     jwt:
       token-period: 15m
+
+sec:
+  kafka:
+    topics:
+      tenant-onboarding: ${SEC_KAFKA_TENANT_TOPIC:tenant-platform.onboarding.tenants}

--- a/sec-service/src/test/java/com/ejada/sec/messaging/TenantAdminProvisioningServiceTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/messaging/TenantAdminProvisioningServiceTest.java
@@ -1,0 +1,135 @@
+package com.ejada.sec.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.ejada.common.events.tenant.TenantProvisioningEvent;
+import com.ejada.common.events.tenant.TenantProvisioningEvent.TenantAdminInfo;
+import com.ejada.common.events.tenant.TenantProvisioningEvent.TenantCustomerInfo;
+import com.ejada.sec.domain.Role;
+import com.ejada.sec.domain.User;
+import com.ejada.sec.domain.UserRole;
+import com.ejada.sec.domain.UserRoleId;
+import com.ejada.sec.repository.RoleRepository;
+import com.ejada.sec.repository.UserRepository;
+import com.ejada.sec.repository.UserRoleRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class TenantAdminProvisioningServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private RoleRepository roleRepository;
+    @Mock private UserRoleRepository userRoleRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+
+    private TenantAdminProvisioningService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = new TenantAdminProvisioningService(userRepository, roleRepository, userRoleRepository, passwordEncoder);
+    }
+
+    @Test
+    void createsAdminUserWhenNotPresent() {
+        TenantProvisioningEvent event = provisioningEvent();
+        UUID tenantId = UUID.nameUUIDFromBytes("tenant:9054".getBytes(StandardCharsets.UTF_8));
+
+        when(userRepository.findByTenantIdAndUsername(tenantId, "m.alqahtani")).thenReturn(Optional.empty());
+        when(userRepository.existsByTenantIdAndEmail(tenantId, "m.alqahtani@alnoursolutions.com")).thenReturn(false);
+        when(passwordEncoder.encode(any())).thenReturn("hashed");
+
+        Role role = Role.builder().id(5L).tenantId(tenantId).code("TENANT_ADMIN").name("Tenant Administrator").build();
+        when(roleRepository.findByTenantIdAndCode(tenantId, "TENANT_ADMIN")).thenReturn(Optional.empty());
+        when(roleRepository.save(any(Role.class))).thenReturn(role);
+
+        User saved = new User();
+        saved.setId(42L);
+        saved.setTenantId(tenantId);
+        saved.setUsername("m.alqahtani");
+        saved.setEmail("m.alqahtani@alnoursolutions.com");
+        saved.setPasswordHash("hashed");
+        when(userRepository.save(any(User.class))).thenReturn(saved);
+
+        when(userRoleRepository.existsById(new UserRoleId(42L, 5L))).thenReturn(false);
+
+        service.provisionTenantAdmin(event);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getTenantId()).isEqualTo(tenantId);
+        assertThat(userCaptor.getValue().getUsername()).isEqualTo("m.alqahtani");
+        assertThat(userCaptor.getValue().getEmail()).isEqualTo("m.alqahtani@alnoursolutions.com");
+        assertThat(userCaptor.getValue().getPasswordHash()).isEqualTo("hashed");
+
+        ArgumentCaptor<UserRole> linkCaptor = ArgumentCaptor.forClass(UserRole.class);
+        verify(userRoleRepository).save(linkCaptor.capture());
+        assertThat(linkCaptor.getValue().getId()).isEqualTo(new UserRoleId(42L, 5L));
+    }
+
+    @Test
+    void skipsWhenAdminInfoMissing() {
+        TenantProvisioningEvent event = new TenantProvisioningEvent(5178L, "5178", "9054", customerInfo(), null);
+
+        service.provisionTenantAdmin(event);
+
+        verifyNoInteractions(userRepository, roleRepository, userRoleRepository, passwordEncoder);
+    }
+
+    @Test
+    void updatesEmailForExistingAdmin() {
+        TenantProvisioningEvent event = provisioningEvent();
+        UUID tenantId = UUID.nameUUIDFromBytes("tenant:9054".getBytes(StandardCharsets.UTF_8));
+
+        User existing = new User();
+        existing.setId(11L);
+        existing.setTenantId(tenantId);
+        existing.setUsername("m.alqahtani");
+        existing.setEmail("old@example.com");
+
+        when(userRepository.findByTenantIdAndUsername(tenantId, "m.alqahtani")).thenReturn(Optional.of(existing));
+        when(userRepository.findByTenantIdAndEmail(tenantId, "m.alqahtani@alnoursolutions.com"))
+                .thenReturn(Optional.of(existing));
+
+        Role role = Role.builder().id(5L).tenantId(tenantId).code("TENANT_ADMIN").name("Tenant Administrator").build();
+        when(roleRepository.findByTenantIdAndCode(tenantId, "TENANT_ADMIN")).thenReturn(Optional.of(role));
+        when(userRoleRepository.existsById(new UserRoleId(11L, 5L))).thenReturn(true);
+
+        service.provisionTenantAdmin(event);
+
+        verify(userRepository).save(existing);
+        assertThat(existing.getEmail()).isEqualTo("m.alqahtani@alnoursolutions.com");
+        verify(userRoleRepository, never()).save(any(UserRole.class));
+    }
+
+    private TenantProvisioningEvent provisioningEvent() {
+        return new TenantProvisioningEvent(5178L, "5178", "9054", customerInfo(),
+                new TenantAdminInfo("m.alqahtani", "m.alqahtani@alnoursolutions.com", "+966501234567", "AR"));
+    }
+
+    private TenantCustomerInfo customerInfo() {
+        return new TenantCustomerInfo(
+                "Al-Nour Solutions Co.",
+                "شركة النور للحلول",
+                "BUSINESS",
+                "1019876543",
+                "SA",
+                "JED",
+                "Prince Sultan Rd, Al Zahra, Jeddah",
+                "طريق الأمير سلطان، الزهراء، جدة",
+                "accounts@alnoursolutions.com",
+                "+966544556677");
+    }
+}

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/events/tenant/TenantProvisioningEvent.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/events/tenant/TenantProvisioningEvent.java
@@ -10,7 +10,8 @@ public record TenantProvisioningEvent(
         Long subscriptionId,
         String extSubscriptionId,
         String extCustomerId,
-        TenantCustomerInfo customerInfo
+        TenantCustomerInfo customerInfo,
+        TenantAdminInfo adminInfo
 ) implements Serializable {
 
     public TenantProvisioningEvent {
@@ -31,5 +32,13 @@ public record TenantProvisioningEvent(
             String addressAr,
             String email,
             String mobileNo
+    ) implements Serializable { }
+
+    /** Admin user details forwarded from the marketplace payload. */
+    public record TenantAdminInfo(
+            String adminUserName,
+            String email,
+            String mobileNo,
+            String preferredLang
     ) implements Serializable { }
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/messaging/TenantOnboardingProducer.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/messaging/TenantOnboardingProducer.java
@@ -1,8 +1,10 @@
 package com.ejada.subscription.messaging;
 
 import com.ejada.common.events.tenant.TenantProvisioningEvent;
+import com.ejada.common.events.tenant.TenantProvisioningEvent.TenantAdminInfo;
 import com.ejada.common.events.tenant.TenantProvisioningEvent.TenantCustomerInfo;
 import com.ejada.subscription.dto.CustomerInfoDto;
+import com.ejada.subscription.dto.AdminUserInfoDto;
 import com.ejada.subscription.model.Subscription;
 import com.ejada.subscription.properties.SubscriptionKafkaTopicsProperties;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -24,7 +26,8 @@ public class TenantOnboardingProducer {
     private final SubscriptionKafkaTopicsProperties topics;
 
     public void publishTenantCreateRequested(final Subscription subscription,
-            final CustomerInfoDto customerInfo) {
+            final CustomerInfoDto customerInfo,
+            final AdminUserInfoDto adminUserInfo) {
 
         if (subscription == null) {
             log.warn("Skipping tenant onboarding publish: subscription is null");
@@ -48,6 +51,14 @@ public class TenantOnboardingProducer {
                 customerInfo.email(),
                 customerInfo.mobileNo());
 
+        TenantAdminInfo payloadAdmin = adminUserInfo == null
+                ? null
+                : new TenantAdminInfo(
+                        adminUserInfo.adminUserName(),
+                        adminUserInfo.email(),
+                        adminUserInfo.mobileNo(),
+                        adminUserInfo.preferredLang());
+
         String extSubscriptionId = subscription.getExtSubscriptionId() == null
                 ? null
                 : subscription.getExtSubscriptionId().toString();
@@ -59,7 +70,8 @@ public class TenantOnboardingProducer {
                 subscription.getSubscriptionId(),
                 extSubscriptionId,
                 extCustomerId,
-                payloadCustomer);
+                payloadCustomer,
+                payloadAdmin);
 
         String topic = topics.tenantOnboarding();
         String key = extCustomerId;

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImpl.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/service/impl/SubscriptionInboundServiceImpl.java
@@ -344,7 +344,7 @@ public class SubscriptionInboundServiceImpl implements SubscriptionInboundServic
 
         Map<String, Object> tenantPayload = new LinkedHashMap<>(basePayload);
         tenantPayload.put("customerInfo", rq.customerInfo());
-        tenantOnboardingProducer.publishTenantCreateRequested(sub, rq.customerInfo());
+        tenantOnboardingProducer.publishTenantCreateRequested(sub, rq.customerInfo(), rq.adminUserInfo());
         emitOutbox("ONBOARDING", sub.getSubscriptionId().toString(), "TENANT_CREATE_REQUESTED", tenantPayload);
 
         Map<String, Object> catalogPayload = new LinkedHashMap<>(basePayload);

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/messaging/TenantOnboardingServiceTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/messaging/TenantOnboardingServiceTest.java
@@ -30,7 +30,8 @@ class TenantOnboardingServiceTest {
                 "SUB-42",
                 "CUST-1",
                 new TenantCustomerInfo("Ejada EN", "Ejada AR", "COMPANY", null, null, null, null, null,
-                        "ops@example.com", "+966500000000"));
+                        "ops@example.com", "+966500000000"),
+                null);
 
         service.createOrUpdateTenant(event);
 
@@ -63,7 +64,8 @@ class TenantOnboardingServiceTest {
                 "SUB-77",
                 "CUST-2",
                 new TenantCustomerInfo(null, "Ejada Arabic", null, null, null, null, null, null,
-                        "new@example.com", null));
+                        "new@example.com", null),
+                null);
 
         service.createOrUpdateTenant(event);
 
@@ -81,7 +83,8 @@ class TenantOnboardingServiceTest {
                 1L,
                 "SUB-1",
                 "  ",
-                new TenantCustomerInfo(null, null, null, null, null, null, null, null, null, null));
+                new TenantCustomerInfo(null, null, null, null, null, null, null, null, null, null),
+                null);
 
         service.createOrUpdateTenant(event);
 


### PR DESCRIPTION
## Summary
- extend the tenant provisioning event and onboarding publisher to include tenant admin details
- add a Kafka listener in the security service that provisions the tenant admin user and assigns the TENANT_ADMIN role
- expose security Kafka topic configuration and cover the provisioning logic with unit tests

## Testing
- mvn -f shared-lib/pom.xml install -DskipTests
- mvn -f sec-service/pom.xml test
- mvn -f tenant-platform/pom.xml -pl subscription-service -am test *(fails: SubscriptionAuthIntegrationTest requires a fully configured Spring context)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69146b026090832f93ef018c56782bf0)