### PR TITLE
Add shared-common dependency to subscription service

### DIFF
--- a/tenant-platform/subscription-service/pom.xml
+++ b/tenant-platform/subscription-service/pom.xml
@@ -90,6 +90,10 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
+      <artifactId>shared-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
       <artifactId>starter-audit</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Summary
- add the shared-common module as a direct dependency of the subscription-service module so TenantProvisioningEvent nested types are available during compilation

## Testing
- mvn -pl subscription-service -am clean compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69146f837534832f89196eacdb69335f)