### PR TITLE
Propagate tenant id for onboarding admin creation

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/messaging/TenantAdminProvisioningService.java
+++ b/sec-service/src/main/java/com/ejada/sec/messaging/TenantAdminProvisioningService.java
@@ -57,7 +57,11 @@ public class TenantAdminProvisioningService {
             return;
         }
 
-        UUID tenantId = tenantIdFromExternal(extCustomerId);
+        UUID tenantId = event.tenantId() != null ? event.tenantId() : tenantIdFromExternal(extCustomerId);
+        if (tenantId == null) {
+            log.warn("Skipping admin provisioning for customer {}: unable to determine tenant id", extCustomerId);
+            return;
+        }
         Optional<User> existing = userRepository.findByTenantIdAndUsername(tenantId, username);
         if (existing.isPresent()) {
             updateExistingAdmin(existing.get(), email, tenantId);

--- a/sec-service/src/test/java/com/ejada/sec/messaging/TenantAdminProvisioningServiceTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/messaging/TenantAdminProvisioningServiceTest.java
@@ -45,7 +45,7 @@ class TenantAdminProvisioningServiceTest {
     @Test
     void createsAdminUserWhenNotPresent() {
         TenantProvisioningEvent event = provisioningEvent();
-        UUID tenantId = UUID.nameUUIDFromBytes("tenant:9054".getBytes(StandardCharsets.UTF_8));
+        UUID tenantId = event.tenantId();
 
         when(userRepository.findByTenantIdAndUsername(tenantId, "m.alqahtani")).thenReturn(Optional.empty());
         when(userRepository.existsByTenantIdAndEmail(tenantId, "m.alqahtani@alnoursolutions.com")).thenReturn(false);
@@ -81,7 +81,7 @@ class TenantAdminProvisioningServiceTest {
 
     @Test
     void skipsWhenAdminInfoMissing() {
-        TenantProvisioningEvent event = new TenantProvisioningEvent(5178L, "5178", "9054", customerInfo(), null);
+        TenantProvisioningEvent event = new TenantProvisioningEvent(5178L, UUID.randomUUID(), "5178", "9054", customerInfo(), null);
 
         service.provisionTenantAdmin(event);
 
@@ -91,7 +91,7 @@ class TenantAdminProvisioningServiceTest {
     @Test
     void updatesEmailForExistingAdmin() {
         TenantProvisioningEvent event = provisioningEvent();
-        UUID tenantId = UUID.nameUUIDFromBytes("tenant:9054".getBytes(StandardCharsets.UTF_8));
+        UUID tenantId = event.tenantId();
 
         User existing = new User();
         existing.setId(11L);
@@ -115,7 +115,8 @@ class TenantAdminProvisioningServiceTest {
     }
 
     private TenantProvisioningEvent provisioningEvent() {
-        return new TenantProvisioningEvent(5178L, "5178", "9054", customerInfo(),
+        UUID tenantId = UUID.nameUUIDFromBytes("tenant:9054".getBytes(StandardCharsets.UTF_8));
+        return new TenantProvisioningEvent(5178L, tenantId, "5178", "9054", customerInfo(),
                 new TenantAdminInfo("m.alqahtani", "m.alqahtani@alnoursolutions.com", "+966501234567", "AR"));
     }
 

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/events/tenant/TenantProvisioningEvent.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/events/tenant/TenantProvisioningEvent.java
@@ -1,6 +1,7 @@
 package com.ejada.common.events.tenant;
 
 import java.io.Serializable;
+import java.util.UUID;
 
 /**
  * Event published by the subscription service to kick off tenant onboarding in
@@ -8,6 +9,7 @@ import java.io.Serializable;
  */
 public record TenantProvisioningEvent(
         Long subscriptionId,
+        UUID tenantId,
         String extSubscriptionId,
         String extCustomerId,
         TenantCustomerInfo customerInfo,

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/messaging/TenantOnboardingServiceTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/messaging/TenantOnboardingServiceTest.java
@@ -5,6 +5,7 @@ import com.ejada.common.events.tenant.TenantProvisioningEvent.TenantCustomerInfo
 import com.ejada.tenant.model.Tenant;
 import com.ejada.tenant.repository.TenantRepository;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -27,6 +28,7 @@ class TenantOnboardingServiceTest {
 
         TenantProvisioningEvent event = new TenantProvisioningEvent(
                 42L,
+                UUID.fromString("00000000-0000-0000-0000-000000000042"),
                 "SUB-42",
                 "CUST-1",
                 new TenantCustomerInfo("Ejada EN", "Ejada AR", "COMPANY", null, null, null, null, null,
@@ -61,6 +63,7 @@ class TenantOnboardingServiceTest {
 
         TenantProvisioningEvent event = new TenantProvisioningEvent(
                 77L,
+                UUID.fromString("00000000-0000-0000-0000-000000000077"),
                 "SUB-77",
                 "CUST-2",
                 new TenantCustomerInfo(null, "Ejada Arabic", null, null, null, null, null, null,
@@ -81,6 +84,7 @@ class TenantOnboardingServiceTest {
     void skipsEventWithoutCustomerId() {
         TenantProvisioningEvent event = new TenantProvisioningEvent(
                 1L,
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
                 "SUB-1",
                 "  ",
                 new TenantCustomerInfo(null, null, null, null, null, null, null, null, null, null),


### PR DESCRIPTION
## Summary
- include the internal tenant UUID in the TenantProvisioningEvent contract and onboarding payloads
- derive or reuse the tenant UUID when emitting onboarding events so the admin payload carries the same identifier
- teach the security service to rely on the provided tenant UUID and update related tests

## Testing
- mvn -pl subscription-service -am test *(fails: missing com.ejada:shared-lib:pom:1.0.0 import and springdoc version)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69148178764c832faba5d684dc45f9cd)