### PR TITLE
Add one-to-many relationship between Tenant and integration keys

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/Tenant.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/Tenant.java
@@ -2,16 +2,21 @@ package com.ejada.tenant.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(
@@ -69,12 +74,23 @@ public class Tenant {
     @Column(name = "updated_at", insertable = false)
     private java.time.OffsetDateTime updatedAt;
 
+    @OneToMany(mappedBy = "tenant", fetch = FetchType.LAZY)
+    private Set<TenantIntegrationKey> integrationKeys = new HashSet<>();
+
     public final boolean isActive() {
         return Boolean.TRUE.equals(active);
     }
 
     public final boolean isDeleted() {
         return Boolean.TRUE.equals(isDeleted);
+    }
+
+    public final Set<TenantIntegrationKey> getIntegrationKeys() {
+        return integrationKeys;
+    }
+
+    public final void setIntegrationKeys(final Set<TenantIntegrationKey> integrationKeys) {
+        this.integrationKeys = integrationKeys == null ? new HashSet<>() : new HashSet<>(integrationKeys);
     }
 
     /** id-only reference helper */


### PR DESCRIPTION
## Summary
- map the Tenant entity to its tenant_integration_key rows via a lazy one-to-many association backed by tenant_id

## Testing
- mvn -pl tenant-service -am -DskipTests compile *(fails: missing com.ejada:shared-lib:pom:1.0.0 and unspecified org.springdoc dependency version)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691483d7f520832f92dd9d38a5bb8d99)