### PR TITLE
Enable Kafka topic provisioning auto-configuration

### DIFF
--- a/shared-lib/shared-starters/starter-kafka/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/shared-lib/shared-starters/starter-kafka/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 com.ejada.kafka_starter.config.KafkaAutoConfiguration
+com.ejada.kafka_starter.config.KafkaTopicConfig


### PR DESCRIPTION
## Summary
- register the Kafka topic auto-configuration so that it participates in Spring Boot's auto-config import
- ensure the topic creation helper validates definitions and only runs when Kafka support is available

## Testing
- mvn -pl shared-starters/starter-kafka test *(fails: missing internal dependency com.ejada:shared-common:jar:1.0.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691487633de8832fbd3a28bceb0ee322)