### PR TITLE
Ignore integration key mappings in TenantMapper

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
@@ -20,6 +20,7 @@ public interface TenantMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "active", source = "active")
     @Mapping(target = "isDeleted", constant = "false")
+    @Mapping(target = "integrationKeys", ignore = true)
     // DB-managed timestamps
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
@@ -42,6 +43,7 @@ public interface TenantMapper {
     @Mapping(target = "isDeleted", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "integrationKeys", ignore = true)
     void update(@MappingTarget @NonNull Tenant entity, @NonNull TenantUpdateReq req);
 
     // ---------- Response ----------


### PR DESCRIPTION
## Summary
- ignore Tenant.integrationKeys when mapping create and update DTOs to entities to satisfy MapStruct

## Testing
- `mvn -f tenant-platform/tenant-service/pom.xml compile` *(fails: missing internal dependency versions in tenant-platform pom)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69148cf8f9f8832f96bfa8c887956595)