### PR TITLE
Fix TenantMapper integration keys mapping

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/mapper/TenantMapper.java
@@ -19,6 +19,7 @@ public interface TenantMapper {
     // ---------- Create ----------
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "active", source = "active")
+    @Mapping(target = "integrationKeys", ignore = true)
     @Mapping(target = "isDeleted", constant = "false")
     // DB-managed timestamps
     @Mapping(target = "createdAt", ignore = true)
@@ -42,6 +43,7 @@ public interface TenantMapper {
     @Mapping(target = "isDeleted", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "integrationKeys", ignore = true)
     void update(@MappingTarget @NonNull Tenant entity, @NonNull TenantUpdateReq req);
 
     // ---------- Response ----------


### PR DESCRIPTION
## Summary
- ignore the Tenant integrationKeys association when mapping from create and update DTOs
- prevent MapStruct from requiring integration key mappings on entity updates

## Testing
- mvn -pl tenant-service -am compile *(fails: missing com.ejada:shared-lib:1.0.0 import POM and unspecified springdoc-openapi version in parent POM)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69158e96f378832fa7470ef8278d2ccb)