### PR TITLE
Prevent Tenant integration keys exposure

### DIFF
--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/Tenant.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/Tenant.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -86,7 +87,7 @@ public class Tenant {
     }
 
     public final Set<TenantIntegrationKey> getIntegrationKeys() {
-        return integrationKeys;
+        return Collections.unmodifiableSet(new HashSet<>(integrationKeys));
     }
 
     public final void setIntegrationKeys(final Set<TenantIntegrationKey> integrationKeys) {


### PR DESCRIPTION
## Summary
- return an unmodifiable defensive copy from `Tenant#getIntegrationKeys`
- add the necessary `Collections` import to support the new defensive copy

## Testing
- mvn -pl tenant-service -am spotbugs:check *(fails: missing com.ejada:shared-lib:pom:1.0.0 import POM and unspecified org.springdoc dependency version in tenant-platform parent)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691590c34fbc832f8a283b519971a636)