### PR TITLE
Handle Y/N boolean values in subscription payloads

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/SubscriptionAdditionalServiceDto.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/SubscriptionAdditionalServiceDto.java
@@ -1,5 +1,7 @@
 package com.ejada.subscription.dto;
 
+import com.ejada.subscription.json.YesNoBooleanDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
@@ -16,6 +18,7 @@ public record SubscriptionAdditionalServiceDto(
     BigDecimal totalAmount,
     String currency,
 
+    @JsonDeserialize(using = YesNoBooleanDeserializer.class)
     Boolean isCountable,    // entity will persist Y/N
     Long requestedCount,
 

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/SubscriptionInfoDto.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/dto/SubscriptionInfoDto.java
@@ -1,5 +1,7 @@
 package com.ejada.subscription.dto;
 
+import com.ejada.subscription.json.YesNoBooleanDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -31,10 +33,12 @@ public record SubscriptionInfoDto(
         String createChannel, // optional (PORTAL | GCP_MARKETPLACE)
 
         // Limits (we use Boolean here; entities handle Y/N conversion)
+        @JsonDeserialize(using = YesNoBooleanDeserializer.class)
         Boolean unlimitedUsersFlag,
         Long usersLimit,
         String usersLimitResetType, // FULL_SUBSCRIPTION_PERIOD | PAYMENT_FREQUENCY_PERIOD
 
+        @JsonDeserialize(using = YesNoBooleanDeserializer.class)
         Boolean unlimitedTransFlag,
         Long transactionsLimit,
         String transLimitResetType,
@@ -44,6 +48,7 @@ public record SubscriptionInfoDto(
 
         String environmentSizeCd, // L | XL
 
+        @JsonDeserialize(using = YesNoBooleanDeserializer.class)
         Boolean isAutoProvEnabled,
         Long prevSubscriptionId,
         String prevSubscriptionUpdateAction, // UPGRADE | DOWNGRADE | RENEWAL

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/json/YesNoBooleanDeserializer.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/json/YesNoBooleanDeserializer.java
@@ -1,0 +1,53 @@
+package com.ejada.subscription.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+
+/**
+ * Jackson deserializer that accepts either boolean literals or "Y"/"N" strings and
+ * normalizes them to {@link Boolean} values.
+ */
+public class YesNoBooleanDeserializer extends JsonDeserializer<Boolean> {
+
+    @Override
+    public Boolean deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
+        JsonToken token = p.getCurrentToken();
+        if (token == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        if (token == JsonToken.VALUE_TRUE) {
+            return Boolean.TRUE;
+        }
+        if (token == JsonToken.VALUE_FALSE) {
+            return Boolean.FALSE;
+        }
+        if (token == JsonToken.VALUE_STRING) {
+            String text = p.getText();
+            if (text == null) {
+                return null;
+            }
+            String normalized = text.trim();
+            if (normalized.isEmpty()) {
+                return null;
+            }
+            if ("Y".equalsIgnoreCase(normalized) || "YES".equalsIgnoreCase(normalized)) {
+                return Boolean.TRUE;
+            }
+            if ("N".equalsIgnoreCase(normalized) || "NO".equalsIgnoreCase(normalized)) {
+                return Boolean.FALSE;
+            }
+            if ("TRUE".equalsIgnoreCase(normalized)) {
+                return Boolean.TRUE;
+            }
+            if ("FALSE".equalsIgnoreCase(normalized)) {
+                return Boolean.FALSE;
+            }
+            return (Boolean)
+                    ctxt.handleWeirdStringValue(Boolean.class, normalized, "Expected 'Y' or 'N' (case-insensitive)");
+        }
+        return (Boolean) ctxt.handleUnexpectedToken(Boolean.class, p);
+    }
+}

--- a/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/json/YesNoBooleanDeserializerTest.java
+++ b/tenant-platform/subscription-service/src/test/java/com/ejada/subscription/json/YesNoBooleanDeserializerTest.java
@@ -1,0 +1,43 @@
+package com.ejada.subscription.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.jupiter.api.Test;
+
+class YesNoBooleanDeserializerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void deserializesYToTrue() throws Exception {
+        Wrapper wrapper = mapper.readValue("{\"value\":\"Y\"}", Wrapper.class);
+        assertThat(wrapper.value()).isTrue();
+    }
+
+    @Test
+    void deserializesNToFalse() throws Exception {
+        Wrapper wrapper = mapper.readValue("{\"value\":\"N\"}", Wrapper.class);
+        assertThat(wrapper.value()).isFalse();
+    }
+
+    @Test
+    void acceptsBooleanLiterals() throws Exception {
+        Wrapper wrapperTrue = mapper.readValue("{\"value\":true}", Wrapper.class);
+        Wrapper wrapperFalse = mapper.readValue("{\"value\":false}", Wrapper.class);
+        assertThat(wrapperTrue.value()).isTrue();
+        assertThat(wrapperFalse.value()).isFalse();
+    }
+
+    @Test
+    void rejectsInvalidString() {
+        assertThatThrownBy(() -> mapper.readValue("{\"value\":\"maybe\"}", Wrapper.class))
+                .isInstanceOf(JsonProcessingException.class)
+                .hasMessageContaining("Expected 'Y' or 'N'");
+    }
+
+    private record Wrapper(@JsonDeserialize(using = YesNoBooleanDeserializer.class) Boolean value) {}
+}


### PR DESCRIPTION
## Summary
- accept "Y"/"N" string values for boolean flags in incoming subscription payloads
- add a Jackson deserializer that normalizes yes/no strings to booleans and apply it to relevant DTO fields
- cover the custom deserializer with unit tests

## Testing
- mvn -f tenant-platform/subscription-service/pom.xml test *(fails: missing dependency versions for internal artifacts in tenant-platform/pom.xml)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69159cabced4832f81eae233c0b96718)