### PR TITLE
Annotate nullable return in YesNoBooleanDeserializer

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/json/YesNoBooleanDeserializer.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/json/YesNoBooleanDeserializer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
 
 /**
@@ -13,6 +14,7 @@ import java.io.IOException;
 public class YesNoBooleanDeserializer extends JsonDeserializer<Boolean> {
 
     @Override
+    @Nullable
     public Boolean deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
         JsonToken token = p.getCurrentToken();
         if (token == JsonToken.VALUE_NULL) {


### PR DESCRIPTION
## Summary
- import `jakarta.annotation.Nullable` in `YesNoBooleanDeserializer`
- annotate the deserializer method as `@Nullable` to signal SpotBugs the method may return null

## Testing
- `mvn -pl subscription-service -am spotbugs:check` *(fails: missing local com.ejada shared-lib artifacts in Maven repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69159e9fc26c832f9abad2e8542a5537)