### PR TITLE
Fix YesNoBooleanDeserializer null handling

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/json/YesNoBooleanDeserializer.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/json/YesNoBooleanDeserializer.java
@@ -18,7 +18,7 @@ public class YesNoBooleanDeserializer extends JsonDeserializer<Boolean> {
     public Boolean deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
         JsonToken token = p.getCurrentToken();
         if (token == JsonToken.VALUE_NULL) {
-            return null;
+            return getNullValue(ctxt);
         }
         if (token == JsonToken.VALUE_TRUE) {
             return Boolean.TRUE;
@@ -29,11 +29,11 @@ public class YesNoBooleanDeserializer extends JsonDeserializer<Boolean> {
         if (token == JsonToken.VALUE_STRING) {
             String text = p.getText();
             if (text == null) {
-                return null;
+                return getNullValue(ctxt);
             }
             String normalized = text.trim();
             if (normalized.isEmpty()) {
-                return null;
+                return getNullValue(ctxt);
             }
             if ("Y".equalsIgnoreCase(normalized) || "YES".equalsIgnoreCase(normalized)) {
                 return Boolean.TRUE;


### PR DESCRIPTION
## Summary
- delegate null handling in YesNoBooleanDeserializer to Jackson's null handling hook to avoid explicit null returns
- ensure empty or missing string values reuse the same null handling logic

## Testing
- `mvn -pl subscription-service spotbugs:check` *(fails: missing internal dependencies on shared-lib 1.0.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a0b8bae0832fa319b709ee967cf3)