### PR TITLE
Assign tenant service Kafka consumer to unique group

### DIFF
--- a/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-dev.yaml
@@ -35,7 +35,7 @@ spring:
     bootstrap-servers: localhost:29092
     client-id: ejada-tenant-dev
     consumer:
-      group-id: ejada-backend-dev
+      group-id: ejada-tenant-dev
       auto-offset-reset: earliest
       enable-auto-commit: false
       properties:

--- a/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
+++ b/tenant-platform/tenant-service/src/main/resources/application-qa.yaml
@@ -30,7 +30,7 @@ spring:
     bootstrap-servers: kafka:9092
     client-id: ejada-tenant-qa
     consumer:
-      group-id: ejada-backend-qa
+      group-id: ejada-tenant-qa
       auto-offset-reset: earliest
       enable-auto-commit: false
       properties:


### PR DESCRIPTION
## Summary
- assign the tenant-service dev profile Kafka consumer group to `ejada-tenant-dev`
- assign the tenant-service QA profile Kafka consumer group to `ejada-tenant-qa`
- ensure tenant onboarding events are consumed alongside the security service instead of sharing a group

## Testing
- `mvn -f tenant-platform/pom.xml -pl tenant-service test` *(fails: missing internal dependencies in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b7655d54832f87e718f8013902ca)