### PR TITLE
Add internal tenant identifiers across platform services

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/domain/User.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/User.java
@@ -29,6 +29,9 @@ public class User extends AuditableEntity {
     @Column(name = "tenant_id", nullable = false)
     private UUID tenantId;
 
+    @Column(name = "internal_tenant_id", nullable = false)
+    private UUID internalTenantId;
+
     @Column(nullable = false, length = 120)
     private String username;
 

--- a/sec-service/src/main/java/com/ejada/sec/dto/UserDto.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/UserDto.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public class UserDto {
   private Long id;
   @NotNull private UUID tenantId;
+  @NotNull private UUID internalTenantId;
   @NotBlank @Size(max = 120) private String username;
   @Email @NotBlank @Size(max = 255) private String email;
   private boolean enabled;

--- a/sec-service/src/main/java/com/ejada/sec/dto/UserSummary.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/UserSummary.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 public class UserSummary {
   private Long id;
   private UUID tenantId;
+  private UUID internalTenantId;
   private String username;
   private String email;
   private boolean enabled;

--- a/sec-service/src/main/resources/db/migration/postgresql/V5__users_internal_tenant.sql
+++ b/sec-service/src/main/resources/db/migration/postgresql/V5__users_internal_tenant.sql
@@ -1,0 +1,14 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS internal_tenant_id UUID;
+
+UPDATE users
+   SET internal_tenant_id = tenant_id
+ WHERE internal_tenant_id IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN internal_tenant_id SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS ix_users_internal_tenant
+    ON users(internal_tenant_id);

--- a/sec-service/src/test/java/com/ejada/sec/messaging/TenantAdminProvisioningServiceTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/messaging/TenantAdminProvisioningServiceTest.java
@@ -45,7 +45,7 @@ class TenantAdminProvisioningServiceTest {
     @Test
     void createsAdminUserWhenNotPresent() {
         TenantProvisioningEvent event = provisioningEvent();
-        UUID tenantId = event.tenantId();
+        UUID tenantId = event.internalTenantId();
 
         when(userRepository.findByTenantIdAndUsername(tenantId, "m.alqahtani")).thenReturn(Optional.empty());
         when(userRepository.existsByTenantIdAndEmail(tenantId, "m.alqahtani@alnoursolutions.com")).thenReturn(false);
@@ -58,6 +58,7 @@ class TenantAdminProvisioningServiceTest {
         User saved = new User();
         saved.setId(42L);
         saved.setTenantId(tenantId);
+        saved.setInternalTenantId(tenantId);
         saved.setUsername("m.alqahtani");
         saved.setEmail("m.alqahtani@alnoursolutions.com");
         saved.setPasswordHash("hashed");
@@ -91,11 +92,12 @@ class TenantAdminProvisioningServiceTest {
     @Test
     void updatesEmailForExistingAdmin() {
         TenantProvisioningEvent event = provisioningEvent();
-        UUID tenantId = event.tenantId();
+        UUID tenantId = event.internalTenantId();
 
         User existing = new User();
         existing.setId(11L);
         existing.setTenantId(tenantId);
+        existing.setInternalTenantId(tenantId);
         existing.setUsername("m.alqahtani");
         existing.setEmail("old@example.com");
 

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
@@ -21,4 +21,8 @@ public class BaseRequest {
     /** Tenant identifier for multi-tenant requests. */
     @NotNull
     private UUID tenantId;
+
+    /** Internal tenant identifier aligned with platform services. */
+    @NotNull
+    private UUID internalTenantId;
 }

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/events/tenant/TenantProvisioningEvent.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/events/tenant/TenantProvisioningEvent.java
@@ -22,6 +22,10 @@ public record TenantProvisioningEvent(
         }
     }
 
+    public UUID internalTenantId() {
+        return tenantId;
+    }
+
     /** Customer details forwarded from the marketplace payload. */
     public record TenantCustomerInfo(
             String customerNameEn,

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/messaging/TenantOnboardingProducer.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/messaging/TenantOnboardingProducer.java
@@ -171,10 +171,19 @@ public class TenantOnboardingProducer {
     }
 
     private UUID deriveTenantId(final Subscription subscription) {
-        if (subscription == null || subscription.getExtCustomerId() == null) {
+        if (subscription == null) {
+            return null;
+        }
+        UUID internalTenantId = subscription.getInternalTenantId();
+        if (internalTenantId != null) {
+            return internalTenantId;
+        }
+        if (subscription.getExtCustomerId() == null) {
             return null;
         }
         String key = "tenant:" + subscription.getExtCustomerId();
-        return UUID.nameUUIDFromBytes(key.getBytes(StandardCharsets.UTF_8));
+        internalTenantId = UUID.nameUUIDFromBytes(key.getBytes(StandardCharsets.UTF_8));
+        subscription.setInternalTenantId(internalTenantId);
+        return internalTenantId;
     }
 }

--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/Subscription.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/model/Subscription.java
@@ -20,6 +20,7 @@ import org.hibernate.type.SqlTypes;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Entity
 @Table(
@@ -50,6 +51,9 @@ public class Subscription {
 
     @Column(name = "ext_customer_id", nullable = false)
     private Long extCustomerId;
+
+    @Column(name = "internal_tenant_id", nullable = false)
+    private UUID internalTenantId;
 
     @Column(name = "ext_product_id", nullable = false)
     private Long extProductId;

--- a/tenant-platform/subscription-service/src/main/resources/db/migration/postgresql/V6__subscription_internal_tenant.sql
+++ b/tenant-platform/subscription-service/src/main/resources/db/migration/postgresql/V6__subscription_internal_tenant.sql
@@ -1,0 +1,15 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+ALTER TABLE subscription
+    ADD COLUMN IF NOT EXISTS internal_tenant_id UUID;
+
+UPDATE subscription
+   SET internal_tenant_id = uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'tenant:' || ext_customer_id::text)
+ WHERE internal_tenant_id IS NULL;
+
+ALTER TABLE subscription
+    ALTER COLUMN internal_tenant_id SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sub_internal_tenant
+    ON subscription(internal_tenant_id)
+    WHERE is_deleted = false;

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantCreateReq.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantCreateReq.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import java.util.UUID;
 
 @Schema(name = "TenantCreateReq")
 public record TenantCreateReq(
@@ -34,5 +35,8 @@ public record TenantCreateReq(
         String logoUrl,
 
         @Schema(description = "Active flag; defaults to true if null")
-        Boolean active
+        Boolean active,
+
+        @Schema(description = "Internal tenant identifier used across services")
+        UUID internalTenantId
 ) { }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantRes.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantRes.java
@@ -2,6 +2,7 @@ package com.ejada.tenant.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Schema(name = "TenantRes")
 public record TenantRes(
@@ -12,6 +13,7 @@ public record TenantRes(
         String contactPhone,
         String logoUrl,
         Boolean active,
+        UUID internalTenantId,
         Boolean isDeleted,
         OffsetDateTime createdAt,
         OffsetDateTime updatedAt

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantUpdateReq.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/dto/TenantUpdateReq.java
@@ -9,6 +9,7 @@ import static com.ejada.tenant.model.Tenant.PHONE_LENGTH;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
+import java.util.UUID;
 
 @Schema(name = "TenantUpdateReq")
 public record TenantUpdateReq(
@@ -33,5 +34,8 @@ public record TenantUpdateReq(
         String logoUrl,
 
         @Schema(description = "Active flag")
-        Boolean active
+        Boolean active,
+
+        @Schema(description = "Internal tenant identifier used across services")
+        UUID internalTenantId
 ) { }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/messaging/TenantOnboardingService.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/messaging/TenantOnboardingService.java
@@ -10,6 +10,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -35,6 +38,14 @@ public class TenantOnboardingService {
             created.setCode(code);
             return created;
         });
+
+        UUID internalTenantId = event.internalTenantId();
+        if (internalTenantId != null) {
+            tenant.setInternalTenantId(internalTenantId);
+        } else if (tenant.getInternalTenantId() == null) {
+            String derivedKey = "tenant:" + code;
+            tenant.setInternalTenantId(UUID.nameUUIDFromBytes(derivedKey.getBytes(StandardCharsets.UTF_8)));
+        }
 
         TenantCustomerInfo customer = event.customerInfo();
         tenant.setName(determineName(customer, code));

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/Tenant.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/model/Tenant.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.DynamicUpdate;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 @Entity
 @Table(
@@ -49,6 +50,9 @@ public class Tenant {
 
     @Column(name = "code", length = CODE_LENGTH, nullable = false)
     private String code;
+
+    @Column(name = "internal_tenant_id", nullable = false)
+    private UUID internalTenantId;
 
     @Column(name = "name", length = NAME_LENGTH, nullable = false)
     private String name;

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/repository/TenantRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 public interface TenantRepository extends JpaRepository<Tenant, Integer> {
@@ -31,8 +32,10 @@ public interface TenantRepository extends JpaRepository<Tenant, Integer> {
     boolean existsByNameIgnoreCase(String name);
 
     boolean existsByNameIgnoreCaseAndIdNot(String name, Integer id);
-    
+
     boolean existsByCodeAndIsDeletedFalse(String code);
 
     boolean existsByNameIgnoreCaseAndIsDeletedFalse(String name);
+
+    Optional<Tenant> findByInternalTenantId(UUID internalTenantId);
 }

--- a/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantServiceImpl.java
+++ b/tenant-platform/tenant-service/src/main/java/com/ejada/tenant/service/impl/TenantServiceImpl.java
@@ -36,6 +36,10 @@ public class TenantServiceImpl implements TenantService {
         if (repo.existsByNameIgnoreCaseAndIsDeletedFalse(req.name())) {
             throw new IllegalStateException("tenant name exists: " + req.name());
         }
+        if (req.internalTenantId() != null
+                && repo.findByInternalTenantId(req.internalTenantId()).isPresent()) {
+            throw new IllegalStateException("internal tenant id exists: " + req.internalTenantId());
+        }
         Tenant e = mapper.toEntity(req);
         e = repo.save(e);
         return BaseResponse.success("Tenant created", mapper.toRes(e));
@@ -53,6 +57,12 @@ public class TenantServiceImpl implements TenantService {
         if (req.name() != null && !req.name().equalsIgnoreCase(e.getName())
                 && repo.existsByNameIgnoreCaseAndIdNot(req.name(), id)) {
             throw new IllegalStateException("tenant name exists: " + req.name());
+        }
+        if (req.internalTenantId() != null
+                && repo.findByInternalTenantId(req.internalTenantId())
+                        .filter(other -> !other.getId().equals(id))
+                        .isPresent()) {
+            throw new IllegalStateException("internal tenant id exists: " + req.internalTenantId());
         }
 
         mapper.update(e, req);

--- a/tenant-platform/tenant-service/src/main/resources/db/migration/common/V8__tenant_internal_id.sql
+++ b/tenant-platform/tenant-service/src/main/resources/db/migration/common/V8__tenant_internal_id.sql
@@ -1,0 +1,15 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+ALTER TABLE tenants
+    ADD COLUMN IF NOT EXISTS internal_tenant_id UUID;
+
+UPDATE tenants
+   SET internal_tenant_id = uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'tenant:' || code)
+ WHERE internal_tenant_id IS NULL;
+
+ALTER TABLE tenants
+    ALTER COLUMN internal_tenant_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_tenants_internal_tenant
+    ON tenants(internal_tenant_id)
+    WHERE is_deleted = false;

--- a/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/messaging/TenantOnboardingServiceTest.java
+++ b/tenant-platform/tenant-service/src/test/java/com/ejada/tenant/messaging/TenantOnboardingServiceTest.java
@@ -46,6 +46,7 @@ class TenantOnboardingServiceTest {
         assertThat(saved.getContactPhone()).isEqualTo("+966500000000");
         assertThat(saved.isActive()).isTrue();
         assertThat(saved.isDeleted()).isFalse();
+        assertThat(saved.getInternalTenantId()).isEqualTo(event.internalTenantId());
     }
 
     @Test
@@ -57,6 +58,7 @@ class TenantOnboardingServiceTest {
         existing.setContactPhone("1111");
         existing.setActive(false);
         existing.setIsDeleted(true);
+        existing.setInternalTenantId(UUID.fromString("00000000-0000-0000-0000-000000000999"));
 
         when(tenantRepository.findByCode("CUST-2")).thenReturn(Optional.of(existing));
         when(tenantRepository.save(existing)).thenReturn(existing);
@@ -77,6 +79,7 @@ class TenantOnboardingServiceTest {
         assertThat(existing.getContactPhone()).isNull();
         assertThat(existing.isActive()).isTrue();
         assertThat(existing.isDeleted()).isFalse();
+        assertThat(existing.getInternalTenantId()).isEqualTo(event.internalTenantId());
         verify(tenantRepository).save(existing);
     }
 


### PR DESCRIPTION
## Summary
- add internal_tenant_id columns and migrations for subscription, tenant, and user schemas
- propagate the internal tenant identifier through entities, DTOs, services, and onboarding flows
- enforce uniqueness checks and expose the new identifier in API contracts and provisioning events

## Testing
- mvn -pl subscription-service -am test *(fails: missing com.ejada:shared-lib parent artifacts)*
- mvn test *(fails in sec-service module: unresolved com.ejada starter dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ba537c20832f9a7cf20aaceabf83)