### PR TITLE
Fix SubscriptionMapper internalTenantId mapping

### DIFF
--- a/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionMapper.java
+++ b/tenant-platform/subscription-service/src/main/java/com/ejada/subscription/mapper/SubscriptionMapper.java
@@ -16,7 +16,7 @@ public interface SubscriptionMapper {
     @Mapping(target = "subscriptionId", ignore = true)
     @Mapping(target = "extSubscriptionId", source = "subscriptionId")
     @Mapping(target = "extCustomerId",    source = "customerId")
-    @Mapping(target = "internalTenantId", ignore = true)
+    @Mapping(target = "internalTenantId", expression = "java((java.util.UUID) null)")
     @Mapping(target = "extProductId",     source = "productId")
     @Mapping(target = "extTierId",        source = "tierId")
     @Mapping(target = "tierNmEn",         source = "tierNameEn")


### PR DESCRIPTION
## Summary
- update `SubscriptionMapper` to explicitly initialize `internalTenantId` so MapStruct no longer reports an unmapped target property during compilation

## Testing
- mvn -f tenant-platform/pom.xml -pl subscription-service compile *(fails: missing private `com.ejada:shared-lib:1.0.0` artifacts in Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915bf2b9ee4832fa1fecfef28caf3ad)