### PR TITLE
Fix tenant role authority names

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/Role.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/Role.java
@@ -5,8 +5,8 @@ package com.ejada.starter_security;
  */
 public enum Role {
     EJADA_OFFICER("ROLE_EJADA_OFFICER"),
-    TENANT_ADMIN("ROLE_TenantAdmin"),
-    TENANT_OFFICER("ROLE_TenantOfficer");
+    TENANT_ADMIN("ROLE_TENANT_ADMIN"),
+    TENANT_OFFICER("ROLE_TENANT_OFFICER");
 
     private final String authority;
 


### PR DESCRIPTION
## Summary
- align tenant role authorities with the ROLE_ prefix expected by the shared security starter so tenant roles are recognized during authorization

## Testing
- `mvn -f shared-lib/pom.xml -pl shared-starters/starter-security test` *(fails: missing dependency com.ejada:shared-common:1.0.0 in Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197be78d30832f8f69a1897ff1b3aa)