### PR TITLE
Remove redundant internal tenant id from user table

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/domain/User.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/User.java
@@ -29,9 +29,6 @@ public class User extends AuditableEntity {
     @Column(name = "tenant_id", nullable = false)
     private UUID tenantId;
 
-    @Column(name = "internal_tenant_id", nullable = false)
-    private UUID internalTenantId;
-
     @Column(nullable = false, length = 120)
     private String username;
 

--- a/sec-service/src/main/java/com/ejada/sec/dto/UserDto.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/UserDto.java
@@ -10,7 +10,6 @@ import lombok.*;
 public class UserDto {
   private Long id;
   @NotNull private UUID tenantId;
-  @NotNull private UUID internalTenantId;
   @NotBlank @Size(max = 120) private String username;
   @Email @NotBlank @Size(max = 255) private String email;
   private boolean enabled;

--- a/sec-service/src/main/java/com/ejada/sec/dto/UserSummary.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/UserSummary.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 public class UserSummary {
   private Long id;
   private UUID tenantId;
-  private UUID internalTenantId;
   private String username;
   private String email;
   private boolean enabled;

--- a/sec-service/src/main/resources/db/migration/postgresql/V7__drop_users_internal_tenant.sql
+++ b/sec-service/src/main/resources/db/migration/postgresql/V7__drop_users_internal_tenant.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS ix_users_internal_tenant;
+ALTER TABLE users DROP COLUMN IF EXISTS internal_tenant_id;

--- a/sec-service/src/test/java/com/ejada/sec/messaging/TenantAdminProvisioningServiceTest.java
+++ b/sec-service/src/test/java/com/ejada/sec/messaging/TenantAdminProvisioningServiceTest.java
@@ -58,7 +58,6 @@ class TenantAdminProvisioningServiceTest {
         User saved = new User();
         saved.setId(42L);
         saved.setTenantId(tenantId);
-        saved.setInternalTenantId(tenantId);
         saved.setUsername("m.alqahtani");
         saved.setEmail("m.alqahtani@alnoursolutions.com");
         saved.setPasswordHash("hashed");
@@ -97,7 +96,6 @@ class TenantAdminProvisioningServiceTest {
         User existing = new User();
         existing.setId(11L);
         existing.setTenantId(tenantId);
-        existing.setInternalTenantId(tenantId);
         existing.setUsername("m.alqahtani");
         existing.setEmail("old@example.com");
 


### PR DESCRIPTION
## Summary
- add a Flyway migration that drops the obsolete `internal_tenant_id` column and its index from the `users` table
- update the user entity, DTOs, and provisioning logic to rely only on `tenant_id`
- adjust the tenant admin provisioning test to reflect the new schema

## Testing
- `mvn test` *(fails: missing internal dependencies and BOM versions in the provided POM)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197d11bae8832f8595244739903a09)