### PR TITLE
Prevent LazyInitializationException when listing users

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/repository/UserRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.ejada.sec.repository;
 
 import com.ejada.sec.domain.User;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -17,6 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
+    @EntityGraph(attributePaths = {"roles", "roles.role"})
     List<User> findAllByTenantId(UUID tenantId);
     
     boolean existsByTenantIdAndEmail(UUID tenantId, String email);


### PR DESCRIPTION
## Summary
- ensure `UserRepository#findAllByTenantId` eagerly fetches `roles` and the associated `role` entity so DTO mapping can occur outside of an active Hibernate session

## Testing
- `mvn -pl sec-service test` *(fails: missing dependency versions defined outside the repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197da0060c832f99b3e64f96ba8974)