### PR TITLE
Fix lazy initialization when loading user roles

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/repository/UserRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/UserRepository.java
@@ -29,4 +29,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByTenantIdAndUsername(UUID tenantId, String username);
 
+    @EntityGraph(attributePaths = {"roles", "roles.role"})
+    Optional<User> findByIdWithRoles(Long id);
+
 }

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/UserServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/UserServiceImpl.java
@@ -62,7 +62,7 @@ public class UserServiceImpl implements UserService {
 
   @Override
   public BaseResponse<UserDto> get(Long userId) {
-    return userRepository.findById(userId)
+    return userRepository.findByIdWithRoles(userId)
         .map(u -> userMapper.toDto(u, resolver))
         .map(dto -> BaseResponse.success("User fetched", dto))
         .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));


### PR DESCRIPTION
## Summary
- add an entity-graph-backed repository method that eagerly loads a user's roles
- make the user retrieval flow use the eager-loading repository method to avoid LazyInitializationException when mapping to DTOs

## Testing
- `mvn -pl sec-service test` *(fails: module is not part of the current Maven reactor)*
- `cd sec-service && mvn test` *(fails: missing dependency versions defined outside of this module)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197efbcbbc832f9d9e7ecc46d8a307)