### PR TITLE
Ensure correlation id is included in API responses

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseResponse.java
@@ -44,7 +44,8 @@ public class BaseResponse<T> {
     private String tenantId;
 
     /** Correlation identifier echoed back to clients */
-    private String correlationId;
+    @Builder.Default
+    private String correlationId = CorrelationContextUtil.getCorrelationId();
 
     @JsonProperty("tenantId")
     public String getTenantId() {

--- a/shared-lib/shared-common/src/test/java/com/ejada/common/dto/BaseResponseTest.java
+++ b/shared-lib/shared-common/src/test/java/com/ejada/common/dto/BaseResponseTest.java
@@ -78,4 +78,11 @@ class BaseResponseTest {
             assertEquals("tenantA", r.getTenantId());
         }
     }
+
+    @Test
+    void correlationIdIsAlwaysPopulated() {
+        BaseResponse<String> response = BaseResponse.success("ok", "payload");
+        assertNotNull(response.getCorrelationId());
+        assertFalse(response.getCorrelationId().isBlank());
+    }
 }


### PR DESCRIPTION
## Summary
- default the `BaseResponse` correlation id to the current MDC value so REST payloads always echo the tracing identifier
- add a regression test that asserts a freshly created response contains a non-empty correlation id

## Testing
- `(cd shared-lib/shared-common && mvn test)` *(fails: missing internal artifacts such as `com.ejada:shared-bom:1.0.0` when building the shared modules)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198456d004832f872993ad8a291d18)