### PR TITLE
Fix custom user query to load roles

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/repository/UserRepository.java
+++ b/sec-service/src/main/java/com/ejada/sec/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.ejada.sec.repository;
 import com.ejada.sec.domain.User;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,6 +32,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByTenantIdAndUsername(UUID tenantId, String username);
 
     @EntityGraph(attributePaths = {"roles", "roles.role"})
-    Optional<User> findByIdWithRoles(Long id);
+    @Query("SELECT u FROM User u WHERE u.id = :id")
+    Optional<User> findByIdWithRoles(@Param("id") Long id);
 
 }


### PR DESCRIPTION
## Summary
- add a custom JPQL query for `UserRepository#findByIdWithRoles`
- ensure the method continues to eagerly load user roles via an `@EntityGraph`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691985dbc63c832fa57697dc627a8f83)