### PR TITLE
Ensure correlation metadata in error responses

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/ErrorResponse.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/ErrorResponse.java
@@ -1,13 +1,15 @@
 package com.ejada.common.dto;
 
+import com.ejada.common.context.ContextManager;
+import com.ejada.common.context.CorrelationContextUtil;
 import com.ejada.common.enums.StatusEnums.ApiStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.time.Instant;
-import java.util.List;
 
 /**
  * Standardized error response for Shared APIs.
@@ -35,7 +37,8 @@ public class ErrorResponse {
     private String tenantId;
 
     /** Correlation identifier for tracing */
-    private String correlationId;
+    @Builder.Default
+    private String correlationId = CorrelationContextUtil.getCorrelationId();
 
     /** Timestamp of error */
     @Builder.Default
@@ -67,5 +70,21 @@ public class ErrorResponse {
                 .tenantId(tenantId)
                 .timestamp(Instant.now())
                 .build();
+    }
+
+    @JsonProperty("tenantId")
+    public String getTenantId() {
+        if (tenantId == null || tenantId.isBlank()) {
+            tenantId = ContextManager.Tenant.get();
+        }
+        return tenantId;
+    }
+
+    @JsonProperty("correlationId")
+    public String getCorrelationId() {
+        if (correlationId == null || correlationId.isBlank()) {
+            correlationId = CorrelationContextUtil.getCorrelationId();
+        }
+        return correlationId;
     }
 }

--- a/shared-lib/shared-common/src/test/java/com/ejada/common/dto/ErrorResponseTest.java
+++ b/shared-lib/shared-common/src/test/java/com/ejada/common/dto/ErrorResponseTest.java
@@ -1,0 +1,25 @@
+package com.ejada.common.dto;
+
+import com.ejada.common.context.ContextManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ErrorResponseTest {
+
+    @Test
+    void correlationIdIsAlwaysReturned() {
+        ErrorResponse response = ErrorResponse.of("ERR", "boom");
+
+        assertNotNull(response.getCorrelationId());
+        assertFalse(response.getCorrelationId().isBlank());
+    }
+
+    @Test
+    void tenantIdDefaultsFromContext() {
+        try (ContextManager.Tenant.Scope ignored = ContextManager.Tenant.openScope("tenant-x")) {
+            ErrorResponse response = ErrorResponse.of("ERR", "boom");
+            assertEquals("tenant-x", response.getTenantId());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `ErrorResponse` always exposes tenant and correlation identifiers by defaulting to the current context
- cover the new behavior with dedicated unit tests for correlation and tenant propagation

## Testing
- `mvn test` *(fails: missing internal BOM dependency `com.ejada:shared-bom:1.0.0` when building shared-common module)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691987d3b460832f9928ae37030505ec)