### PR TITLE
Use JWT tenant context for tenant identifiers

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/context/TenantContextProvider.java
+++ b/sec-service/src/main/java/com/ejada/sec/context/TenantContextProvider.java
@@ -1,0 +1,78 @@
+package com.ejada.sec.context;
+
+import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
+import com.ejada.common.exception.ValidationException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Provides access to tenant identifiers for the current request. The provider first looks at the
+ * propagated header/context and falls back to JWT claims when necessary.
+ */
+@Component
+public class TenantContextProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(TenantContextProvider.class);
+
+  private static final String[] TENANT_CLAIMS = {"tenant", "tenant_id", "tid"};
+  private static final String[] INTERNAL_TENANT_CLAIMS = {
+      "internal_tenant_id", "internalTenantId", "internal_tid", "itid"
+  };
+
+  /** Retrieve the current tenant identifier or throw if unavailable. */
+  public UUID requireTenantId() {
+    return resolveTenantId()
+        .orElseThrow(() -> new ValidationException(
+            "Missing tenant context",
+            "Tenant id was not provided in headers or token"));
+  }
+
+  /** Resolve the tenant identifier if available. */
+  public Optional<UUID> resolveTenantId() {
+    String tenantFromContext = ContextManager.Tenant.get();
+    if (StringUtils.hasText(tenantFromContext)) {
+      return Optional.of(parseUuid(tenantFromContext,
+          "header '%s'".formatted(HeaderNames.X_TENANT_ID)));
+    }
+    return resolveFromJwt(TENANT_CLAIMS);
+  }
+
+  /** Resolve the internal tenant identifier if available. */
+  public Optional<UUID> resolveInternalTenantId() {
+    return resolveFromJwt(INTERNAL_TENANT_CLAIMS);
+  }
+
+  private Optional<UUID> resolveFromJwt(String[] claimNames) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication instanceof JwtAuthenticationToken jwtAuth) {
+      Jwt jwt = jwtAuth.getToken();
+      for (String claim : claimNames) {
+        Object value = jwt.getClaims().get(claim);
+        if (value != null) {
+          return Optional.of(parseUuid(String.valueOf(value), "JWT claim '%s'".formatted(claim)));
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  private UUID parseUuid(String raw, String source) {
+    try {
+      return UUID.fromString(raw.trim());
+    } catch (IllegalArgumentException ex) {
+      log.debug("Failed to parse {} as UUID", source, ex);
+      throw new ValidationException(
+          "Invalid tenant identifier",
+          "%s is not a valid UUID".formatted(source));
+    }
+  }
+}

--- a/sec-service/src/main/java/com/ejada/sec/controller/EffectivePrivilegesController.java
+++ b/sec-service/src/main/java/com/ejada/sec/controller/EffectivePrivilegesController.java
@@ -1,14 +1,12 @@
 package com.ejada.sec.controller;
 
-import com.ejada.common.context.ContextManager;
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.exception.ValidationException;
 import com.ejada.sec.domain.EffectivePrivilegeProjection;
 import com.ejada.sec.repository.EffectivePrivilegeViewRepository;
+import com.ejada.sec.context.TenantContextProvider;
 import com.ejada.starter_core.tenant.RequireTenant;
 import com.ejada.sec.security.SecAuthorized;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,17 +19,12 @@ import org.springframework.web.bind.annotation.*;
 public class EffectivePrivilegesController {
 
   private final EffectivePrivilegeViewRepository viewRepo;
+  private final TenantContextProvider tenantContextProvider;
 
   @GetMapping("/{userId}")
   public ResponseEntity<BaseResponse<List<EffectivePrivilegeProjection>>> list(@PathVariable Long userId) {
-	  String tenantIdStr = ContextManager.Tenant.get();
-	    UUID tenantId;
-	    try {
-	      tenantId = UUID.fromString(tenantIdStr);
-	    } catch (RuntimeException ex) {
-	      throw new ValidationException("Invalid tenant ID format", ex.getMessage());
-	    }
-	        return ResponseEntity.ok(
+    var tenantId = tenantContextProvider.requireTenantId();
+    return ResponseEntity.ok(
         BaseResponse.success("Effective privileges listed",
             viewRepo.findEffectiveByUserAndTenant(userId, tenantId)));
   }

--- a/sec-service/src/main/java/com/ejada/sec/service/impl/UserServiceImpl.java
+++ b/sec-service/src/main/java/com/ejada/sec/service/impl/UserServiceImpl.java
@@ -1,11 +1,11 @@
 package com.ejada.sec.service.impl;
 
 import com.ejada.common.dto.BaseResponse;
-import com.ejada.common.exception.ValidationException;
 import com.ejada.sec.domain.User;
 import com.ejada.sec.dto.*;
 import com.ejada.sec.mapper.ReferenceResolver;
 import com.ejada.sec.mapper.UserMapper;
+import com.ejada.sec.context.TenantContextProvider;
 import com.ejada.sec.repository.UserRepository;
 import com.ejada.sec.service.UserService;
 import jakarta.transaction.Transactional;
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
-import com.ejada.common.context.ContextManager;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +25,7 @@ public class UserServiceImpl implements UserService {
   private final UserMapper userMapper;
   private final ReferenceResolver resolver;
   private final PasswordEncoder passwordEncoder;
+  private final TenantContextProvider tenantContextProvider;
 
   @Transactional
   @Override
@@ -70,14 +70,8 @@ public class UserServiceImpl implements UserService {
 
   @Override
   public BaseResponse<List<UserDto>> listByTenant() {
-	  String tenantIdStr = ContextManager.Tenant.get();
-	    UUID tenantId;
-	    try {
-	      tenantId = UUID.fromString(tenantIdStr);
-	    } catch (RuntimeException ex) {
-	      throw new ValidationException("Invalid tenant ID format", ex.getMessage());
-	    }
-	        return BaseResponse.success("Users listed",
+    UUID tenantId = tenantContextProvider.requireTenantId();
+    return BaseResponse.success("Users listed",
         userMapper.toDto(userRepository.findAllByTenantId(tenantId), resolver));
   }
 

--- a/sec-service/src/main/java/com/ejada/sec/web/TenantRequestBodyAdvice.java
+++ b/sec-service/src/main/java/com/ejada/sec/web/TenantRequestBodyAdvice.java
@@ -1,0 +1,41 @@
+package com.ejada.sec.web;
+
+import com.ejada.common.dto.BaseRequest;
+import com.ejada.sec.context.TenantContextProvider;
+import java.lang.reflect.Type;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdviceAdapter;
+
+/**
+ * Automatically enriches every {@link BaseRequest} with tenant identifiers resolved from the
+ * current request context or JWT token.
+ */
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class TenantRequestBodyAdvice extends RequestBodyAdviceAdapter {
+
+  private final TenantContextProvider tenantContextProvider;
+
+  @Override
+  public boolean supports(MethodParameter methodParameter, Type targetType,
+      Class<? extends HttpMessageConverter<?>> converterType) {
+    Class<?> targetClass = ResolvableType.forType(targetType).resolve();
+    return targetClass != null && BaseRequest.class.isAssignableFrom(targetClass);
+  }
+
+  @Override
+  public Object afterBodyRead(Object body, HttpInputMessage inputMessage, MethodParameter parameter,
+      Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+    if (body instanceof BaseRequest request) {
+      request.setTenantId(tenantContextProvider.requireTenantId());
+      request.setInternalTenantId(
+          tenantContextProvider.resolveInternalTenantId().orElse(null));
+    }
+    return body;
+  }
+}

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
@@ -1,6 +1,5 @@
 package com.ejada.common.dto;
 
-import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,10 +18,8 @@ import lombok.experimental.SuperBuilder;
 public class BaseRequest {
 
     /** Tenant identifier for multi-tenant requests. */
-    @NotNull
     private UUID tenantId;
 
     /** Internal tenant identifier aligned with platform services. */
-    @NotNull
     private UUID internalTenantId;
 }


### PR DESCRIPTION
## Summary
- stop requiring clients to send `tenantId` and `internalTenantId` by dropping the validation constraint in `BaseRequest`
- add a `TenantContextProvider` plus `TenantRequestBodyAdvice` that resolve tenant identifiers from the current header/JWT context and populate every `BaseRequest`
- reuse the shared provider in the controller and list services so tenant scoped queries always pull the identifier from the authenticated context

## Testing
- `mvn test` *(fails because the standalone module build expects managed versions from the multi-module reactor, so Maven cannot resolve the shared dependency versions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919889efd44832fadde912a9a1a96d9)