### PR TITLE
Fix user-role mapping to include owning user

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/mapper/GrantMapper.java
+++ b/sec-service/src/main/java/com/ejada/sec/mapper/GrantMapper.java
@@ -26,7 +26,7 @@ public interface GrantMapper {
   default void applyAssignRoles(User user, AssignRolesToUserRequest req,
                                 @Context ReferenceResolver resolver) {
     var roles = resolver.rolesByCodes(req.getTenantId(), req.getRoleCodes());
-    user.setRoles(resolver.toUserRoles(user.getId(), roles));
+    user.setRoles(resolver.toUserRoles(user, roles));
   }
 
   default void applyRevokeRoles(User user, RevokeRolesFromUserRequest req) {

--- a/sec-service/src/main/java/com/ejada/sec/mapper/ReferenceResolver.java
+++ b/sec-service/src/main/java/com/ejada/sec/mapper/ReferenceResolver.java
@@ -53,13 +53,17 @@ public class ReferenceResolver {
       return rolePrivileges.stream().map(rp -> rp.getPrivilege().getCode()).toList();
   }
 
-  public Set<UserRole> toUserRoles(Long userId, List<Role> roles) {
-      if (roles == null) {
+  public Set<UserRole> toUserRoles(User user, List<Role> roles) {
+      if (roles == null || roles.isEmpty()) {
         return Set.of();
       }
       return roles.stream().map(r -> {
-      var id = new UserRoleId(userId, r.getId());
-      return UserRole.builder().id(id).role(r).build();
+      var id = new UserRoleId(user.getId(), r.getId());
+      return UserRole.builder()
+          .id(id)
+          .user(user)
+          .role(r)
+          .build();
     }).collect(Collectors.toSet());
   }
 

--- a/sec-service/src/main/java/com/ejada/sec/mapper/UserMapper.java
+++ b/sec-service/src/main/java/com/ejada/sec/mapper/UserMapper.java
@@ -41,6 +41,6 @@ public interface UserMapper {
   default void setRolesByCodes(User user, List<String> roleCodes, UUID tenantId,
                                @Context ReferenceResolver resolver) {
     var roles = resolver.rolesByCodes(tenantId, roleCodes);
-    user.setRoles(resolver.toUserRoles(user.getId(), roles));
+    user.setRoles(resolver.toUserRoles(user, roles));
   }
 }


### PR DESCRIPTION
## Summary
- ensure ReferenceResolver populates the owning user when materializing UserRole entities
- update UserMapper and GrantMapper to use the revised helper so role assignments can be persisted

## Testing
- `mvn test` *(fails: missing dependency versions for custom starters in sec-service/pom.xml)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198cbac590832f92515d0fd2dac31e)