### PR TITLE
Make tenant identifiers read-only in requests

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
@@ -1,5 +1,7 @@
 package com.ejada.common.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,9 +19,13 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 public class BaseRequest {
 
-    /** Tenant identifier for multi-tenant requests. */
+    /** Tenant identifier for multi-tenant requests (resolved from JWT). */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Resolved from the authenticated JWT token")
     private UUID tenantId;
 
-    /** Internal tenant identifier aligned with platform services. */
+    /** Internal tenant identifier aligned with platform services (resolved from JWT). */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Resolved from the authenticated JWT token")
     private UUID internalTenantId;
 }


### PR DESCRIPTION
## Summary
- ensure tenantId and internalTenantId in BaseRequest are marked as read-only so clients can no longer provide them
- document that these identifiers are resolved from the authenticated JWT and hide them from request payloads

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198eec2f8c832f84ae07c2210fc7da)