### PR TITLE
Accept snake case phone number in user requests

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/dto/CreateUserRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/CreateUserRequest.java
@@ -1,6 +1,7 @@
 package com.ejada.sec.dto;
 
 import com.ejada.common.dto.BaseRequest;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -15,6 +16,7 @@ import java.util.List;
 public class CreateUserRequest extends BaseRequest {
   @NotBlank @Size(max = 120) private String username;
   @Email @NotBlank @Size(max = 255) private String email;
+  @JsonAlias({"phone_number", "phoneNumber"})
   @Size(max = 32) private String phoneNumber;
   @NotBlank @Size(min = 8, max = 120) private String password;
   private List<@NotBlank String> roles;

--- a/sec-service/src/main/java/com/ejada/sec/dto/UpdateUserRequest.java
+++ b/sec-service/src/main/java/com/ejada/sec/dto/UpdateUserRequest.java
@@ -1,5 +1,6 @@
 package com.ejada.sec.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import java.util.List;
@@ -7,6 +8,7 @@ import java.util.List;
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class UpdateUserRequest {
   @Email @Size(max = 255) private String email;
+  @JsonAlias({"phone_number", "phoneNumber"})
   @Size(max = 32) private String phoneNumber;
   private Boolean enabled;
   private Boolean locked;


### PR DESCRIPTION
## Summary
- allow the user creation request DTO to bind either `phoneNumber` or `phone_number`
- do the same for the user update request DTO so both endpoints accept the snake_case field

## Testing
- `cd sec-service && mvn test` *(fails: dependency versions for shared starters are not defined in this standalone module)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198e9885f8832f88184947822ddf26)