### PR TITLE
Add audit metadata fields to base requests

### DIFF
--- a/shared-lib/shared-common/pom.xml
+++ b/shared-lib/shared-common/pom.xml
@@ -23,6 +23,7 @@
     <commonLang.version>3.18.0</commonLang.version>
     <!--      Guava-->
     <guava.version>33.3.1-jre</guava.version>
+    <swagger.annotations.version>2.2.22</swagger.annotations.version>
   </properties>
 
   <dependencies>
@@ -93,6 +94,13 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <optional>true</optional>
+    </dependency>
+
+    <!-- OpenAPI annotations used by shared DTOs -->
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>${swagger.annotations.version}</version>
     </dependency>
 
     <!-- Validation API for jakarta.validation annotations like @NotNull -->

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
@@ -2,6 +2,7 @@ package com.ejada.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -28,4 +29,24 @@ public class BaseRequest {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Resolved from the authenticated JWT token")
     private UUID internalTenantId;
+
+    /** Timestamp recording when the resource was originally created. */
+    @Schema(
+            description = "UTC timestamp (ISO-8601) capturing when the resource was created. Required for create requests.",
+            example = "2024-05-10T08:15:30Z")
+    private Instant createdAt;
+
+    /** Identifier of the actor/system that created the resource. */
+    @Schema(description = "User or system identifier of the creator. Required for create requests.", example = "user@example.com")
+    private String createdBy;
+
+    /** Timestamp recording the last update applied to the resource. */
+    @Schema(
+            description = "UTC timestamp (ISO-8601) capturing when the resource was last updated. Required for update/delete requests.",
+            example = "2024-05-18T11:42:00Z")
+    private Instant updatedAt;
+
+    /** Identifier of the actor/system that last modified the resource. */
+    @Schema(description = "User or system identifier responsible for the latest modification.", example = "admin@example.com")
+    private String updatedBy;
 }


### PR DESCRIPTION
## Summary
- extend `BaseRequest` with `createdAt`, `createdBy`, `updatedAt`, and `updatedBy` fields so all create/update/delete payloads include audit metadata
- declare the `swagger-annotations` dependency in `shared-common` to compile the OpenAPI annotations used by these DTOs

## Testing
- `mvn -pl shared-lib/shared-common test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919905efee4832f9c3ad25b841070d2)