### PR TITLE
Align swagger annotations with springdoc

### DIFF
--- a/shared-lib/shared-common/pom.xml
+++ b/shared-lib/shared-common/pom.xml
@@ -23,7 +23,7 @@
     <commonLang.version>3.18.0</commonLang.version>
     <!--      Guava-->
     <guava.version>33.3.1-jre</guava.version>
-    <swagger.annotations.version>2.2.22</swagger.annotations.version>
+    <swagger.annotations.version>2.2.25</swagger.annotations.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary
- bump the shared swagger-annotations dependency to 2.2.25 so it matches the version expected by springdoc

## Testing
- `mvn -pl shared-common dependency:tree -Dincludes=io.swagger.core.v3:swagger-annotations`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69199318b30c832f87cb836e00a4365f)