### PR TITLE
Populate request audit metadata from JWT

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/context/RequestAuditContextProvider.java
+++ b/sec-service/src/main/java/com/ejada/sec/context/RequestAuditContextProvider.java
@@ -1,0 +1,109 @@
+package com.ejada.sec.context;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+/**
+ * Helper component that extracts auditing metadata (created/updated timestamps and actors)
+ * from the authenticated JWT token.
+ */
+@Component
+@Slf4j
+public class RequestAuditContextProvider {
+
+  private static final String[] CREATED_BY_CLAIMS = {
+      "createdBy", "created_by", "email", "preferred_username", "username", "user_name", "sub"
+  };
+  private static final String[] UPDATED_BY_CLAIMS = {
+      "updatedBy", "updated_by"
+  };
+  private static final String[] CREATED_AT_CLAIMS = {
+      "createdAt", "created_at"
+  };
+  private static final String[] UPDATED_AT_CLAIMS = {
+      "updatedAt", "updated_at"
+  };
+
+  /** Resolve the creator identifier from JWT claims. */
+  public Optional<String> resolveCreatedBy() {
+    return resolveStringClaim(CREATED_BY_CLAIMS);
+  }
+
+  /** Resolve the modifier identifier from JWT claims (defaults to creator when missing). */
+  public Optional<String> resolveUpdatedBy() {
+    return resolveStringClaim(UPDATED_BY_CLAIMS).or(this::resolveCreatedBy);
+  }
+
+  /** Resolve the creation timestamp from JWT claims or fall back to iat claim. */
+  public Optional<Instant> resolveCreatedAt() {
+    return resolveInstantClaim(CREATED_AT_CLAIMS).or(this::resolveIssuedAt);
+  }
+
+  /** Resolve the last updated timestamp from JWT claims (defaults to creation time). */
+  public Optional<Instant> resolveUpdatedAt() {
+    return resolveInstantClaim(UPDATED_AT_CLAIMS).or(this::resolveCreatedAt);
+  }
+
+  private Optional<Instant> resolveInstantClaim(String[] claimNames) {
+    return currentJwt()
+        .flatMap(jwt -> {
+          for (String claim : claimNames) {
+            Object value = jwt.getClaims().get(claim);
+            if (value != null) {
+              return Optional.ofNullable(parseInstant(value, claim));
+            }
+          }
+          return Optional.empty();
+        });
+  }
+
+  private Optional<String> resolveStringClaim(String[] claimNames) {
+    return currentJwt()
+        .flatMap(jwt -> {
+          for (String claim : claimNames) {
+            Object value = jwt.getClaims().get(claim);
+            if (value instanceof String str && !str.isBlank()) {
+              return Optional.of(str);
+            }
+          }
+          return Optional.empty();
+        });
+  }
+
+  private Optional<Instant> resolveIssuedAt() {
+    return currentJwt().map(Jwt::getIssuedAt);
+  }
+
+  private Instant parseInstant(Object raw, String claimName) {
+    if (raw instanceof Instant instant) {
+      return instant;
+    }
+    if (raw instanceof Number number) {
+      long epochSeconds = number.longValue();
+      return Instant.ofEpochSecond(epochSeconds);
+    }
+    if (raw instanceof String text && !text.isBlank()) {
+      try {
+        return Instant.parse(text);
+      } catch (DateTimeParseException ex) {
+        log.debug("Unable to parse claim '{}' as Instant", claimName, ex);
+      }
+    }
+    return null;
+  }
+
+  private Optional<Jwt> currentJwt() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication instanceof JwtAuthenticationToken jwtAuth) {
+      return Optional.of(jwtAuth.getToken());
+    }
+    return Optional.empty();
+  }
+}

--- a/sec-service/src/main/java/com/ejada/sec/web/TenantRequestBodyAdvice.java
+++ b/sec-service/src/main/java/com/ejada/sec/web/TenantRequestBodyAdvice.java
@@ -1,6 +1,7 @@
 package com.ejada.sec.web;
 
 import com.ejada.common.dto.BaseRequest;
+import com.ejada.sec.context.RequestAuditContextProvider;
 import com.ejada.sec.context.TenantContextProvider;
 import java.lang.reflect.Type;
 import lombok.RequiredArgsConstructor;
@@ -12,14 +13,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdviceAdapter;
 
 /**
- * Automatically enriches every {@link BaseRequest} with tenant identifiers resolved from the
- * current request context or JWT token.
+ * Automatically enriches every {@link BaseRequest} with tenant identifiers and audit metadata
+ * resolved from the current request context or JWT token.
  */
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class TenantRequestBodyAdvice extends RequestBodyAdviceAdapter {
 
   private final TenantContextProvider tenantContextProvider;
+  private final RequestAuditContextProvider requestAuditContextProvider;
 
   @Override
   public boolean supports(MethodParameter methodParameter, Type targetType,
@@ -35,6 +37,10 @@ public class TenantRequestBodyAdvice extends RequestBodyAdviceAdapter {
       request.setTenantId(tenantContextProvider.requireTenantId());
       request.setInternalTenantId(
           tenantContextProvider.resolveInternalTenantId().orElse(null));
+      request.setCreatedAt(requestAuditContextProvider.resolveCreatedAt().orElse(null));
+      request.setCreatedBy(requestAuditContextProvider.resolveCreatedBy().orElse(null));
+      request.setUpdatedAt(requestAuditContextProvider.resolveUpdatedAt().orElse(null));
+      request.setUpdatedBy(requestAuditContextProvider.resolveUpdatedBy().orElse(null));
     }
     return body;
   }

--- a/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/dto/BaseRequest.java
@@ -31,22 +31,34 @@ public class BaseRequest {
     private UUID internalTenantId;
 
     /** Timestamp recording when the resource was originally created. */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     @Schema(
-            description = "UTC timestamp (ISO-8601) capturing when the resource was created. Required for create requests.",
+            accessMode = Schema.AccessMode.READ_ONLY,
+            description = "UTC timestamp (ISO-8601) capturing when the resource was created. Populated from the authenticated JWT.",
             example = "2024-05-10T08:15:30Z")
     private Instant createdAt;
 
     /** Identifier of the actor/system that created the resource. */
-    @Schema(description = "User or system identifier of the creator. Required for create requests.", example = "user@example.com")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @Schema(
+            accessMode = Schema.AccessMode.READ_ONLY,
+            description = "User or system identifier of the creator resolved from the authenticated JWT.",
+            example = "user@example.com")
     private String createdBy;
 
     /** Timestamp recording the last update applied to the resource. */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     @Schema(
-            description = "UTC timestamp (ISO-8601) capturing when the resource was last updated. Required for update/delete requests.",
+            accessMode = Schema.AccessMode.READ_ONLY,
+            description = "UTC timestamp (ISO-8601) capturing when the resource was last updated. Populated from the authenticated JWT.",
             example = "2024-05-18T11:42:00Z")
     private Instant updatedAt;
 
     /** Identifier of the actor/system that last modified the resource. */
-    @Schema(description = "User or system identifier responsible for the latest modification.", example = "admin@example.com")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @Schema(
+            accessMode = Schema.AccessMode.READ_ONLY,
+            description = "User or system identifier responsible for the latest modification, resolved from the authenticated JWT.",
+            example = "admin@example.com")
     private String updatedBy;
 }


### PR DESCRIPTION
## Summary
- mark BaseRequest audit fields as read-only in the API contract so callers cannot send them explicitly
- add a RequestAuditContextProvider that extracts created/updated metadata from the authenticated JWT
- update TenantRequestBodyAdvice to enrich every BaseRequest with tenant and audit data sourced from the token

## Testing
- `mvn -f sec-service/pom.xml test` *(fails: missing dependency versions for com.ejada/starters and springdoc in standalone module build)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691995aa9ec4832fa72cdada04709557)