### PR TITLE
Add auditing actor metadata sourced from JWT

### DIFF
--- a/sec-service/src/main/java/com/ejada/sec/SecServiceApplication.java
+++ b/sec-service/src/main/java/com/ejada/sec/SecServiceApplication.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
  * parent repository and exposes authentication and user management APIs.
  */
 @SpringBootApplication
-@EnableJpaAuditing
+@EnableJpaAuditing(auditorAwareRef = "requestAuditorAware")
 public class SecServiceApplication {
 
     private SecServiceApplication() {

--- a/sec-service/src/main/java/com/ejada/sec/context/RequestAuditorAware.java
+++ b/sec-service/src/main/java/com/ejada/sec/context/RequestAuditorAware.java
@@ -1,0 +1,26 @@
+package com.ejada.sec.context;
+
+import java.util.Optional;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring Data {@link AuditorAware} implementation that resolves the current actor
+ * from the {@link RequestAuditContextProvider}. The provider already knows how
+ * to extract usernames/emails from the authenticated JWT token, so we simply
+ * delegate to it for populating {@code created_by} / {@code updated_by} columns.
+ */
+@Component("requestAuditorAware")
+public class RequestAuditorAware implements AuditorAware<String> {
+
+  private final RequestAuditContextProvider requestAuditContextProvider;
+
+  public RequestAuditorAware(RequestAuditContextProvider requestAuditContextProvider) {
+    this.requestAuditContextProvider = requestAuditContextProvider;
+  }
+
+  @Override
+  public Optional<String> getCurrentAuditor() {
+    return requestAuditContextProvider.resolveUpdatedBy();
+  }
+}

--- a/sec-service/src/main/java/com/ejada/sec/domain/AuditableEntity.java
+++ b/sec-service/src/main/java/com/ejada/sec/domain/AuditableEntity.java
@@ -5,7 +5,9 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -24,4 +26,12 @@ public abstract class AuditableEntity {
     @LastModifiedDate
     @Column(name = "updated_at")
     private Instant updatedAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private String updatedBy;
 }

--- a/sec-service/src/main/resources/db/migration/postgresql/V9__audit_columns.sql
+++ b/sec-service/src/main/resources/db/migration/postgresql/V9__audit_columns.sql
@@ -1,0 +1,13 @@
+-- Add auditing actor columns to core security tables so we can persist who
+-- created/updated records based on JWT claims resolved via AuditorAware.
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS created_by VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS updated_by VARCHAR(255);
+
+ALTER TABLE roles
+    ADD COLUMN IF NOT EXISTS created_by VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS updated_by VARCHAR(255);
+
+ALTER TABLE privileges
+    ADD COLUMN IF NOT EXISTS created_by VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS updated_by VARCHAR(255);


### PR DESCRIPTION
## Summary
- expose a RequestAuditorAware implementation that reuses the existing JWT audit context provider so Spring Data can resolve created_by and updated_by values automatically
- extend the AuditableEntity base class and application configuration so all security entities store both timestamps and actor identifiers, and wire JPA auditing to the new provider
- add a Flyway migration that introduces the created_by / updated_by columns for the core security tables

## Testing
- `cd shared-lib && mvn -DskipTests install`
- `cd sec-service && mvn test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b3f950a4832fb9ce35c9a34c1b65)