### PR TITLE
feat: modularize email management services

### DIFF
--- a/email-management/README.md
+++ b/email-management/README.md
@@ -1,0 +1,18 @@
+# Email Management Platform
+
+This module now acts as a Maven aggregator for the tenant-focused notification platform. Each child
+service has a narrow responsibility and can be deployed independently on GKE.
+
+| Module | Purpose |
+| --- | --- |
+| `email-management-service` | API gateway/orchestrator that fronts the other services and keeps tenant routing logic centralized. |
+| `email-template-service` | Template CRUD/versioning and SendGrid synchronization. |
+| `email-sending-service` | Idempotent email dispatch, Kafka fan-out, Redis rate limits. |
+| `email-webhook-service` | Secure SendGrid webhook ingestion and event emission. |
+| `email-usage-service` | Queryable usage analytics backed by Cloud SQL. |
+
+Build everything:
+
+```bash
+mvn -pl email-management -am clean package
+```

--- a/email-management/email-management-service/README.md
+++ b/email-management/email-management-service/README.md
@@ -1,0 +1,5 @@
+# email-management-service
+
+Gateway facade that exposes a consolidated API surface for tenants while routing work to the
+specialized child services (template, sending, webhook, and usage). The service discovers the child
+base URLs via `child-services.*` properties and forwards requests using Spring's `RestClient`.

--- a/email-management/email-management-service/pom.xml
+++ b/email-management/email-management-service/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>email-management</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>email-management-service</artifactId>
+  <name>email-management-service</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/email-management/email-management-service/src/main/java/com/ejada/management/EmailManagementServiceApplication.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/EmailManagementServiceApplication.java
@@ -1,0 +1,17 @@
+package com.ejada.management;
+
+import com.ejada.management.config.ChildServiceProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+@EnableConfigurationProperties(ChildServiceProperties.class)
+public class EmailManagementServiceApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(EmailManagementServiceApplication.class, args);
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/config/ChildServiceProperties.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/config/ChildServiceProperties.java
@@ -1,0 +1,41 @@
+package com.ejada.management.config;
+
+import java.net.URI;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "child-services")
+public class ChildServiceProperties {
+
+  private final ServiceEndpoint template = new ServiceEndpoint();
+  private final ServiceEndpoint sending = new ServiceEndpoint();
+  private final ServiceEndpoint webhook = new ServiceEndpoint();
+  private final ServiceEndpoint usage = new ServiceEndpoint();
+
+  public ServiceEndpoint getTemplate() {
+    return template;
+  }
+
+  public ServiceEndpoint getSending() {
+    return sending;
+  }
+
+  public ServiceEndpoint getWebhook() {
+    return webhook;
+  }
+
+  public ServiceEndpoint getUsage() {
+    return usage;
+  }
+
+  public static class ServiceEndpoint {
+    private URI baseUrl;
+
+    public URI getBaseUrl() {
+      return baseUrl;
+    }
+
+    public void setBaseUrl(URI baseUrl) {
+      this.baseUrl = baseUrl;
+    }
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/config/RestClientConfig.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.ejada.management.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+  @Bean
+  RestClient restClient() {
+    return RestClient.builder().build();
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/controller/EmailGatewayController.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/controller/EmailGatewayController.java
@@ -1,0 +1,31 @@
+package com.ejada.management.controller;
+
+import com.ejada.management.dto.EmailSendRequest;
+import com.ejada.management.dto.EmailSendResponse;
+import com.ejada.management.service.EmailGatewayService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tenants/{tenantId}/emails")
+public class EmailGatewayController {
+
+  private final EmailGatewayService service;
+
+  public EmailGatewayController(EmailGatewayService service) {
+    this.service = service;
+  }
+
+  @PostMapping("/send")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public EmailSendResponse sendEmail(
+      @PathVariable String tenantId, @Valid @RequestBody EmailSendRequest request) {
+    return service.sendEmail(tenantId, request);
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/controller/TemplateGatewayController.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/controller/TemplateGatewayController.java
@@ -1,0 +1,38 @@
+package com.ejada.management.controller;
+
+import com.ejada.management.dto.TemplateSummary;
+import com.ejada.management.dto.TemplateSyncRequest;
+import com.ejada.management.service.TemplateGatewayService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tenants/{tenantId}/templates")
+public class TemplateGatewayController {
+
+  private final TemplateGatewayService service;
+
+  public TemplateGatewayController(TemplateGatewayService service) {
+    this.service = service;
+  }
+
+  @GetMapping
+  public List<TemplateSummary> listTemplates(@PathVariable String tenantId) {
+    return service.fetchTemplates(tenantId);
+  }
+
+  @PostMapping("/sync")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public void syncTemplates(
+      @PathVariable String tenantId, @Valid @RequestBody TemplateSyncRequest request) {
+    service.requestSync(tenantId, request);
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/controller/UsageGatewayController.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/controller/UsageGatewayController.java
@@ -1,0 +1,30 @@
+package com.ejada.management.controller;
+
+import com.ejada.management.dto.UsageReport;
+import com.ejada.management.service.UsageGatewayService;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tenants/{tenantId}/usage")
+public class UsageGatewayController {
+
+  private final UsageGatewayService service;
+
+  public UsageGatewayController(UsageGatewayService service) {
+    this.service = service;
+  }
+
+  @GetMapping
+  public UsageReport usage(
+      @PathVariable String tenantId,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+    return service.fetchUsage(tenantId, from, to);
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/controller/WebhookGatewayController.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/controller/WebhookGatewayController.java
@@ -1,0 +1,28 @@
+package com.ejada.management.controller;
+
+import com.ejada.management.dto.SendGridWebhookRequest;
+import com.ejada.management.service.WebhookGatewayService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/webhooks/sendgrid")
+public class WebhookGatewayController {
+
+  private final WebhookGatewayService service;
+
+  public WebhookGatewayController(WebhookGatewayService service) {
+    this.service = service;
+  }
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public void ingestWebhook(@Valid @RequestBody SendGridWebhookRequest request) {
+    service.forwardWebhook(request);
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/dto/EmailSendRequest.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/dto/EmailSendRequest.java
@@ -1,0 +1,26 @@
+package com.ejada.management.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+public record EmailSendRequest(
+    @NotBlank String templateKey,
+    @NotEmpty List<@Email String> recipients,
+    Map<String, Object> dynamicData,
+    List<AttachmentRequest> attachments,
+    @NotNull SendMode mode,
+    String idempotencyKey) {
+
+  public enum SendMode {
+    PRODUCTION,
+    TEST,
+    DRAFT
+  }
+
+  public record AttachmentRequest(
+      @NotBlank String fileName, @NotBlank String contentType, @NotBlank String url) {}
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/dto/EmailSendResponse.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/dto/EmailSendResponse.java
@@ -1,0 +1,3 @@
+package com.ejada.management.dto;
+
+public record EmailSendResponse(String sendId, String status) {}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/dto/SendGridWebhookRequest.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/dto/SendGridWebhookRequest.java
@@ -1,0 +1,7 @@
+package com.ejada.management.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import java.util.Map;
+
+public record SendGridWebhookRequest(@NotEmpty List<Map<String, Object>> events) {}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/dto/TemplateSummary.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/dto/TemplateSummary.java
@@ -1,0 +1,4 @@
+package com.ejada.management.dto;
+
+import java.time.Instant;
+public record TemplateSummary(Long id, String name, String locale, boolean archived, Instant updatedAt) {}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/dto/TemplateSyncRequest.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/dto/TemplateSyncRequest.java
@@ -1,0 +1,5 @@
+package com.ejada.management.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TemplateSyncRequest(@NotBlank String versionTag) {}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/dto/UsageMetric.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/dto/UsageMetric.java
@@ -1,0 +1,5 @@
+package com.ejada.management.dto;
+
+import java.time.LocalDate;
+
+public record UsageMetric(LocalDate date, long delivered, long bounced, long complaints) {}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/dto/UsageReport.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/dto/UsageReport.java
@@ -1,0 +1,5 @@
+package com.ejada.management.dto;
+
+import java.util.List;
+
+public record UsageReport(String tenantId, List<UsageMetric> metrics) {}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/exception/ChildServiceException.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/exception/ChildServiceException.java
@@ -1,0 +1,7 @@
+package com.ejada.management.exception;
+
+public class ChildServiceException extends RuntimeException {
+  public ChildServiceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/service/ChildServiceInvoker.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/service/ChildServiceInvoker.java
@@ -1,0 +1,46 @@
+package com.ejada.management.service;
+
+import com.ejada.management.exception.ChildServiceException;
+import java.net.URI;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+public class ChildServiceInvoker {
+
+  private final RestClient restClient;
+
+  public ChildServiceInvoker(RestClient restClient) {
+    this.restClient = restClient;
+  }
+
+  public <T> T get(URI baseUrl, String path, Class<T> responseType) {
+    try {
+      return restClient
+          .get()
+          .uri(baseUrl.resolve(path))
+          .accept(MediaType.APPLICATION_JSON)
+          .retrieve()
+          .body(responseType);
+    } catch (RestClientException ex) {
+      throw new ChildServiceException("Failed to call child service: " + baseUrl, ex);
+    }
+  }
+
+  public <B, T> T post(URI baseUrl, String path, B body, Class<T> responseType) {
+    try {
+      return restClient
+          .post()
+          .uri(baseUrl.resolve(path))
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
+          .body(body)
+          .retrieve()
+          .body(responseType);
+    } catch (RestClientException ex) {
+      throw new ChildServiceException("Failed to call child service: " + baseUrl, ex);
+    }
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/service/EmailGatewayService.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/service/EmailGatewayService.java
@@ -1,0 +1,31 @@
+package com.ejada.management.service;
+
+import com.ejada.management.config.ChildServiceProperties;
+import com.ejada.management.dto.EmailSendRequest;
+import com.ejada.management.dto.EmailSendResponse;
+import java.net.URI;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Service
+public class EmailGatewayService {
+
+  private final ChildServiceProperties properties;
+  private final ChildServiceInvoker invoker;
+
+  public EmailGatewayService(ChildServiceProperties properties, ChildServiceInvoker invoker) {
+    this.properties = properties;
+    this.invoker = invoker;
+  }
+
+  public EmailSendResponse sendEmail(String tenantId, EmailSendRequest request) {
+    URI baseUrl = requireEndpoint(properties.getSending().getBaseUrl(), "sending");
+    return invoker.post(
+        baseUrl, "/api/v1/tenants/" + tenantId + "/emails/send", request, EmailSendResponse.class);
+  }
+
+  private URI requireEndpoint(URI uri, String name) {
+    Assert.notNull(uri, () -> "Missing baseUrl for " + name + " service");
+    return uri;
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/service/TemplateGatewayService.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/service/TemplateGatewayService.java
@@ -1,0 +1,46 @@
+package com.ejada.management.service;
+
+import com.ejada.management.config.ChildServiceProperties;
+import com.ejada.management.dto.TemplateSummary;
+import com.ejada.management.dto.TemplateSyncRequest;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Service
+public class TemplateGatewayService {
+
+  private final ChildServiceProperties properties;
+  private final ChildServiceInvoker invoker;
+
+  public TemplateGatewayService(ChildServiceProperties properties, ChildServiceInvoker invoker) {
+    this.properties = properties;
+    this.invoker = invoker;
+  }
+
+  public List<TemplateSummary> fetchTemplates(String tenantId) {
+    URI baseUrl = requireEndpoint(properties.getTemplate().getBaseUrl(), "template");
+    TemplateSummary[] response =
+        invoker.get(
+            baseUrl,
+            "/internal/api/v1/tenants/" + tenantId + "/templates",
+            TemplateSummary[].class);
+    return response == null ? List.of() : Arrays.asList(response);
+  }
+
+  public void requestSync(String tenantId, TemplateSyncRequest request) {
+    URI baseUrl = requireEndpoint(properties.getTemplate().getBaseUrl(), "template");
+    invoker.post(
+        baseUrl,
+        "/internal/api/v1/tenants/" + tenantId + "/templates/sync",
+        request,
+        Void.class);
+  }
+
+  private URI requireEndpoint(URI uri, String name) {
+    Assert.notNull(uri, () -> "Missing baseUrl for " + name + " service");
+    return uri;
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/service/UsageGatewayService.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/service/UsageGatewayService.java
@@ -1,0 +1,41 @@
+package com.ejada.management.service;
+
+import com.ejada.management.config.ChildServiceProperties;
+import com.ejada.management.dto.UsageReport;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Service
+public class UsageGatewayService {
+
+  private static final DateTimeFormatter ISO = DateTimeFormatter.ISO_DATE;
+
+  private final ChildServiceProperties properties;
+  private final ChildServiceInvoker invoker;
+
+  public UsageGatewayService(ChildServiceProperties properties, ChildServiceInvoker invoker) {
+    this.properties = properties;
+    this.invoker = invoker;
+  }
+
+  public UsageReport fetchUsage(String tenantId, LocalDate from, LocalDate to) {
+    URI baseUrl = requireEndpoint(properties.getUsage().getBaseUrl(), "usage");
+    String path =
+        String.format(
+            "/api/v1/tenants/%s/usage?from=%s&to=%s",
+            tenantId, format(from), format(to));
+    return invoker.get(baseUrl, path, UsageReport.class);
+  }
+
+  private String format(LocalDate date) {
+    return date.format(ISO);
+  }
+
+  private URI requireEndpoint(URI uri, String name) {
+    Assert.notNull(uri, () -> "Missing baseUrl for " + name + " service");
+    return uri;
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/service/WebhookGatewayService.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/service/WebhookGatewayService.java
@@ -1,0 +1,29 @@
+package com.ejada.management.service;
+
+import com.ejada.management.config.ChildServiceProperties;
+import com.ejada.management.dto.SendGridWebhookRequest;
+import java.net.URI;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Service
+public class WebhookGatewayService {
+
+  private final ChildServiceProperties properties;
+  private final ChildServiceInvoker invoker;
+
+  public WebhookGatewayService(ChildServiceProperties properties, ChildServiceInvoker invoker) {
+    this.properties = properties;
+    this.invoker = invoker;
+  }
+
+  public void forwardWebhook(SendGridWebhookRequest request) {
+    URI baseUrl = requireEndpoint(properties.getWebhook().getBaseUrl(), "webhook");
+    invoker.post(baseUrl, "/api/v1/webhooks/sendgrid", request, Void.class);
+  }
+
+  private URI requireEndpoint(URI uri, String name) {
+    Assert.notNull(uri, () -> "Missing baseUrl for " + name + " service");
+    return uri;
+  }
+}

--- a/email-management/email-management-service/src/main/resources/application.yaml
+++ b/email-management/email-management-service/src/main/resources/application.yaml
@@ -1,0 +1,12 @@
+server:
+  port: 8080
+
+child-services:
+  template:
+    base-url: http://email-template-service:8081
+  sending:
+    base-url: http://email-sending-service:8082
+  webhook:
+    base-url: http://email-webhook-service:8083
+  usage:
+    base-url: http://email-usage-service:8084

--- a/email-management/email-sending-service/README.md
+++ b/email-management/email-sending-service/README.md
@@ -1,0 +1,4 @@
+# email-sending-service
+
+Exposes the sending APIs, performs Redis-backed idempotency and rate-limiting, and publishes
+normalized envelopes onto Kafka topics for async delivery workers.

--- a/email-management/email-sending-service/pom.xml
+++ b/email-management/email-sending-service/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>email-management</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>email-sending-service</artifactId>
+  <name>email-sending-service</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/EmailSendingServiceApplication.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/EmailSendingServiceApplication.java
@@ -1,0 +1,18 @@
+package com.ejada.sending;
+
+import com.ejada.sending.config.KafkaTopicsProperties;
+import com.ejada.sending.config.RateLimitProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+@EnableConfigurationProperties({KafkaTopicsProperties.class, RateLimitProperties.class})
+public class EmailSendingServiceApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(EmailSendingServiceApplication.class, args);
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/config/KafkaTopicsProperties.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/config/KafkaTopicsProperties.java
@@ -1,0 +1,34 @@
+package com.ejada.sending.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kafka.topics")
+public class KafkaTopicsProperties {
+  private String emailSend;
+  private String emailBulk;
+  private String deadLetter;
+
+  public String getEmailSend() {
+    return emailSend;
+  }
+
+  public void setEmailSend(String emailSend) {
+    this.emailSend = emailSend;
+  }
+
+  public String getEmailBulk() {
+    return emailBulk;
+  }
+
+  public void setEmailBulk(String emailBulk) {
+    this.emailBulk = emailBulk;
+  }
+
+  public String getDeadLetter() {
+    return deadLetter;
+  }
+
+  public void setDeadLetter(String deadLetter) {
+    this.deadLetter = deadLetter;
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/config/RateLimitProperties.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/config/RateLimitProperties.java
@@ -1,0 +1,25 @@
+package com.ejada.sending.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "rate-limit")
+public class RateLimitProperties {
+  private int capacity = 100;
+  private int refillPerMinute = 100;
+
+  public int getCapacity() {
+    return capacity;
+  }
+
+  public void setCapacity(int capacity) {
+    this.capacity = capacity;
+  }
+
+  public int getRefillPerMinute() {
+    return refillPerMinute;
+  }
+
+  public void setRefillPerMinute(int refillPerMinute) {
+    this.refillPerMinute = refillPerMinute;
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/controller/EmailSendController.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/controller/EmailSendController.java
@@ -1,0 +1,39 @@
+package com.ejada.sending.controller;
+
+import com.ejada.sending.dto.BulkEmailSendRequest;
+import com.ejada.sending.dto.EmailSendRequest;
+import com.ejada.sending.dto.EmailSendResponse;
+import com.ejada.sending.service.EmailDispatchService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tenants/{tenantId}/emails")
+public class EmailSendController {
+
+  private final EmailDispatchService service;
+
+  public EmailSendController(EmailDispatchService service) {
+    this.service = service;
+  }
+
+  @PostMapping("/send")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public EmailSendResponse send(
+      @PathVariable String tenantId, @Valid @RequestBody EmailSendRequest request) {
+    return service.sendEmail(tenantId, request);
+  }
+
+  @PostMapping("/send/bulk")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public void bulkSend(
+      @PathVariable String tenantId, @Valid @RequestBody BulkEmailSendRequest request) {
+    service.sendBulk(tenantId, request);
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/AttachmentMetadataDto.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/AttachmentMetadataDto.java
@@ -1,0 +1,6 @@
+package com.ejada.sending.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AttachmentMetadataDto(
+    @NotBlank String fileName, @NotBlank String contentType, @NotBlank String url) {}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/BulkEmailSendRequest.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/BulkEmailSendRequest.java
@@ -1,0 +1,7 @@
+package com.ejada.sending.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record BulkEmailSendRequest(@NotEmpty List<@Valid EmailSendRequest> entries) {}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/EmailSendRequest.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/EmailSendRequest.java
@@ -1,0 +1,26 @@
+package com.ejada.sending.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+public record EmailSendRequest(
+    @NotBlank String templateKey,
+    @NotEmpty List<@Email String> to,
+    List<@Email String> cc,
+    List<@Email String> bcc,
+    Map<String, Object> dynamicData,
+    @Valid List<AttachmentMetadataDto> attachments,
+    @NotNull SendMode mode,
+    String idempotencyKey) {
+
+  public enum SendMode {
+    PRODUCTION,
+    TEST,
+    DRAFT
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/EmailSendResponse.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/EmailSendResponse.java
@@ -1,0 +1,3 @@
+package com.ejada.sending.dto;
+
+public record EmailSendResponse(String sendId, String status) {}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/messaging/EmailEnvelope.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/messaging/EmailEnvelope.java
@@ -1,0 +1,35 @@
+package com.ejada.sending.messaging;
+
+import com.ejada.sending.dto.AttachmentMetadataDto;
+import com.ejada.sending.dto.EmailSendRequest;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record EmailEnvelope(
+    String id,
+    String tenantId,
+    String templateKey,
+    List<String> to,
+    List<String> cc,
+    List<String> bcc,
+    Map<String, Object> dynamicData,
+    List<AttachmentMetadataDto> attachments,
+    EmailSendRequest.SendMode mode,
+    Instant createdAt) {
+
+  public static EmailEnvelope from(String tenantId, EmailSendRequest request) {
+    return new EmailEnvelope(
+        UUID.randomUUID().toString(),
+        tenantId,
+        request.templateKey(),
+        request.to(),
+        request.cc(),
+        request.bcc(),
+        request.dynamicData(),
+        request.attachments(),
+        request.mode(),
+        Instant.now());
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/EmailDispatchService.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/EmailDispatchService.java
@@ -1,0 +1,11 @@
+package com.ejada.sending.service;
+
+import com.ejada.sending.dto.BulkEmailSendRequest;
+import com.ejada.sending.dto.EmailSendRequest;
+import com.ejada.sending.dto.EmailSendResponse;
+
+public interface EmailDispatchService {
+  EmailSendResponse sendEmail(String tenantId, EmailSendRequest request);
+
+  void sendBulk(String tenantId, BulkEmailSendRequest request);
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/IdempotencyService.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/IdempotencyService.java
@@ -1,0 +1,5 @@
+package com.ejada.sending.service;
+
+public interface IdempotencyService {
+  boolean register(String tenantId, String key, String value);
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/RateLimiterService.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/RateLimiterService.java
@@ -1,0 +1,5 @@
+package com.ejada.sending.service;
+
+public interface RateLimiterService {
+  boolean tryConsume(String tenantId);
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/EmailDispatchServiceImpl.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/EmailDispatchServiceImpl.java
@@ -1,0 +1,59 @@
+package com.ejada.sending.service.impl;
+
+import com.ejada.sending.config.KafkaTopicsProperties;
+import com.ejada.sending.dto.BulkEmailSendRequest;
+import com.ejada.sending.dto.EmailSendRequest;
+import com.ejada.sending.dto.EmailSendResponse;
+import com.ejada.sending.messaging.EmailEnvelope;
+import com.ejada.sending.service.EmailDispatchService;
+import com.ejada.sending.service.IdempotencyService;
+import com.ejada.sending.service.RateLimiterService;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Service
+public class EmailDispatchServiceImpl implements EmailDispatchService {
+
+  private final KafkaTemplate<String, EmailEnvelope> kafkaTemplate;
+  private final KafkaTopicsProperties topics;
+  private final IdempotencyService idempotencyService;
+  private final RateLimiterService rateLimiterService;
+
+  public EmailDispatchServiceImpl(
+      KafkaTemplate<String, EmailEnvelope> kafkaTemplate,
+      KafkaTopicsProperties topics,
+      IdempotencyService idempotencyService,
+      RateLimiterService rateLimiterService) {
+    this.kafkaTemplate = kafkaTemplate;
+    this.topics = topics;
+    this.idempotencyService = idempotencyService;
+    this.rateLimiterService = rateLimiterService;
+  }
+
+  @Override
+  public EmailSendResponse sendEmail(String tenantId, EmailSendRequest request) {
+    Assert.hasText(tenantId, "tenantId is required");
+    if (!rateLimiterService.tryConsume(tenantId)) {
+      return new EmailSendResponse(null, "RATE_LIMITED");
+    }
+
+    if (request.idempotencyKey() != null
+        && !idempotencyService.register(tenantId, request.idempotencyKey(), "queued")) {
+      return new EmailSendResponse(null, "DUPLICATE");
+    }
+
+    EmailEnvelope envelope = EmailEnvelope.from(tenantId, request);
+    kafkaTemplate.send(topics.getEmailSend(), tenantId, envelope);
+    return new EmailSendResponse(envelope.id(), "QUEUED");
+  }
+
+  @Override
+  public void sendBulk(String tenantId, BulkEmailSendRequest request) {
+    request.entries().forEach(entry -> {
+      EmailEnvelope envelope = EmailEnvelope.from(tenantId, entry);
+      CompletableFuture.runAsync(() -> kafkaTemplate.send(topics.getEmailBulk(), tenantId, envelope));
+    });
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/RedisIdempotencyService.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/RedisIdempotencyService.java
@@ -1,0 +1,23 @@
+package com.ejada.sending.service.impl;
+
+import com.ejada.sending.service.IdempotencyService;
+import java.time.Duration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisIdempotencyService implements IdempotencyService {
+
+  private final StringRedisTemplate redisTemplate;
+
+  public RedisIdempotencyService(StringRedisTemplate redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  @Override
+  public boolean register(String tenantId, String key, String value) {
+    String redisKey = "email:idempotency:" + tenantId + ':' + key;
+    Boolean stored = redisTemplate.opsForValue().setIfAbsent(redisKey, value, Duration.ofHours(2));
+    return Boolean.TRUE.equals(stored);
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/RedisRateLimiterService.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/RedisRateLimiterService.java
@@ -1,0 +1,37 @@
+package com.ejada.sending.service.impl;
+
+import com.ejada.sending.config.RateLimitProperties;
+import com.ejada.sending.service.RateLimiterService;
+import java.time.Duration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisRateLimiterService implements RateLimiterService {
+
+  private final StringRedisTemplate redisTemplate;
+  private final RateLimitProperties properties;
+
+  public RedisRateLimiterService(
+      StringRedisTemplate redisTemplate, RateLimitProperties properties) {
+    this.redisTemplate = redisTemplate;
+    this.properties = properties;
+  }
+
+  @Override
+  public boolean tryConsume(String tenantId) {
+    String redisKey = "email:rate:" + tenantId;
+    Long tokens = redisTemplate.opsForValue().increment(redisKey, -1);
+    if (tokens == null) {
+      redisTemplate
+          .opsForValue()
+          .set(redisKey, String.valueOf(properties.getCapacity() - 1), Duration.ofMinutes(1));
+      return true;
+    }
+    if (tokens >= 0) {
+      return true;
+    }
+    redisTemplate.opsForValue().set(redisKey, String.valueOf(properties.getCapacity()), Duration.ofMinutes(1));
+    return false;
+  }
+}

--- a/email-management/email-sending-service/src/main/resources/application.yaml
+++ b/email-management/email-sending-service/src/main/resources/application.yaml
@@ -1,0 +1,20 @@
+server:
+  port: 8082
+
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+kafka:
+  topics:
+    email-send: email.send
+    email-bulk: email.bulk
+    dead-letter: email.dlq
+
+rate-limit:
+  capacity: 200
+  refill-per-minute: 200

--- a/email-management/email-template-service/pom.xml
+++ b/email-management/email-template-service/pom.xml
@@ -32,6 +32,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
 
     <!-- DB & Migrations -->
     <dependency>
@@ -97,7 +101,21 @@
       <artifactId>starter-mapstruct</artifactId>
     </dependency>
 
-   
+    <dependency>
+      <groupId>com.sendgrid</groupId>
+      <artifactId>sendgrid-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.jknack</groupId>
+      <artifactId>handlebars</artifactId>
+      <version>4.4.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+    </dependency>
+
+
       <!-- springdoc and servlet APIs are provided by starters -->
 
     <!-- Test utils -->

--- a/email-management/email-template-service/src/main/java/com/ejada/template/config/KafkaTopicsProperties.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/config/KafkaTopicsProperties.java
@@ -1,0 +1,11 @@
+package com.ejada.template.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "email.kafka-topics")
+public record KafkaTopicsProperties(
+    String emailSend,
+    String emailSendRetry,
+    String emailSendDlq,
+    String webhookEvents,
+    String emailEvents) {}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/config/RateLimitProperties.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/config/RateLimitProperties.java
@@ -1,0 +1,16 @@
+package com.ejada.template.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "email.rate-limit")
+public record RateLimitProperties(
+    long defaultLimitPerMinute,
+    long burstMultiplier,
+    Duration window,
+    Duration idempotencyTtl) {
+
+  public long allowedTokens() {
+    return defaultLimitPerMinute * burstMultiplier;
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/config/SendGridConfiguration.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/config/SendGridConfiguration.java
@@ -1,0 +1,25 @@
+package com.ejada.template.config;
+
+import com.sendgrid.SendGrid;
+import jakarta.annotation.PostConstruct;
+import java.security.Security;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SendGridConfiguration {
+
+  @PostConstruct
+  public void registerSecurityProvider() {
+    if (Security.getProvider("BC") == null) {
+      Security.addProvider(new BouncyCastleProvider());
+    }
+  }
+
+  @Bean
+  public SendGrid sendGrid(@Value("${email.sendgrid.api-key:changeme}") String apiKey) {
+    return new SendGrid(apiKey);
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/config/SendGridProperties.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/config/SendGridProperties.java
@@ -1,0 +1,12 @@
+package com.ejada.template.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "email.sendgrid")
+public record SendGridProperties(
+    boolean sandboxMode,
+    Duration timeout,
+    String webhookPublicKey,
+    String defaultFromEmail,
+    String defaultFromName) {}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/controller/AnalyticsController.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/controller/AnalyticsController.java
@@ -1,0 +1,29 @@
+package com.ejada.template.controller;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.template.dto.EmailStatsResponse;
+import com.ejada.template.service.EmailAnalyticsService;
+import java.time.Instant;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/analytics")
+public class AnalyticsController {
+
+  private final EmailAnalyticsService analyticsService;
+
+  public AnalyticsController(EmailAnalyticsService analyticsService) {
+    this.analyticsService = analyticsService;
+  }
+
+  @GetMapping("/email-stats")
+  public BaseResponse<EmailStatsResponse> getEmailStats(
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
+    return BaseResponse.success(analyticsService.getEmailStats(from, to));
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/controller/EmailController.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/controller/EmailController.java
@@ -1,0 +1,34 @@
+package com.ejada.template.controller;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.template.dto.BulkEmailSendRequest;
+import com.ejada.template.dto.EmailSendRequest;
+import com.ejada.template.dto.EmailSendResponse;
+import com.ejada.template.service.EmailSendService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/emails")
+public class EmailController {
+
+  private final EmailSendService emailSendService;
+
+  public EmailController(EmailSendService emailSendService) {
+    this.emailSendService = emailSendService;
+  }
+
+  @PostMapping("/send")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public BaseResponse<EmailSendResponse> sendEmail(@Valid @RequestBody EmailSendRequest request) {
+    return BaseResponse.success(emailSendService.sendEmail(request));
+  }
+
+  @PostMapping("/send/bulk")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public BaseResponse<java.util.List<EmailSendResponse>> sendBulk(
+      @Valid @RequestBody BulkEmailSendRequest request) {
+    return BaseResponse.success(emailSendService.sendBulkEmails(request));
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/controller/TemplateController.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/controller/TemplateController.java
@@ -1,0 +1,93 @@
+package com.ejada.template.controller;
+
+import com.ejada.common.dto.BaseResponse;
+import com.ejada.template.dto.CreateTemplateRequest;
+import com.ejada.template.dto.TemplateCloneRequest;
+import com.ejada.template.dto.TemplateDto;
+import com.ejada.template.dto.TemplatePreviewRequest;
+import com.ejada.template.dto.TemplatePreviewResponse;
+import com.ejada.template.dto.TemplateValidationRequest;
+import com.ejada.template.dto.TemplateValidationResponse;
+import com.ejada.template.dto.TemplateVersionCreateRequest;
+import com.ejada.template.dto.TemplateVersionDto;
+import com.ejada.template.dto.UpdateTemplateRequest;
+import com.ejada.template.service.TemplateService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/templates")
+public class TemplateController {
+
+  private final TemplateService templateService;
+
+  public TemplateController(TemplateService templateService) {
+    this.templateService = templateService;
+  }
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  public BaseResponse<TemplateDto> createTemplate(@Valid @RequestBody CreateTemplateRequest request) {
+    return BaseResponse.success(templateService.createTemplate(request));
+  }
+
+  @PutMapping("/{templateId}")
+  public BaseResponse<TemplateDto> updateTemplate(
+      @PathVariable Long templateId, @Valid @RequestBody UpdateTemplateRequest request) {
+    return BaseResponse.success(templateService.updateTemplate(templateId, request));
+  }
+
+  @PostMapping("/{templateId}/archive")
+  public BaseResponse<TemplateDto> archiveTemplate(@PathVariable Long templateId) {
+    return BaseResponse.success(templateService.archiveTemplate(templateId));
+  }
+
+  @PostMapping("/{templateId}/clone")
+  public BaseResponse<TemplateDto> cloneTemplate(
+      @PathVariable Long templateId, @Valid @RequestBody TemplateCloneRequest request) {
+    return BaseResponse.success(templateService.cloneTemplate(templateId, request));
+  }
+
+  @GetMapping
+  public BaseResponse<Page<TemplateDto>> listTemplates(Pageable pageable) {
+    return BaseResponse.success(templateService.listTemplates(pageable));
+  }
+
+  @PostMapping("/{templateId}/versions")
+  @ResponseStatus(HttpStatus.CREATED)
+  public BaseResponse<TemplateVersionDto> createVersion(
+      @PathVariable Long templateId, @Valid @RequestBody TemplateVersionCreateRequest request) {
+    return BaseResponse.success(templateService.createVersion(templateId, request));
+  }
+
+  @PostMapping("/{templateId}/versions/{versionId}/publish")
+  public BaseResponse<TemplateVersionDto> publishVersion(
+      @PathVariable Long templateId, @PathVariable Long versionId) {
+    return BaseResponse.success(templateService.publishVersion(templateId, versionId));
+  }
+
+  @GetMapping("/{templateId}/versions/{versionId}")
+  public BaseResponse<TemplateVersionDto> getVersion(
+      @PathVariable Long templateId, @PathVariable Long versionId) {
+    return BaseResponse.success(templateService.getVersion(templateId, versionId));
+  }
+
+  @PostMapping("/{templateId}/versions/{versionId}/preview")
+  public BaseResponse<TemplatePreviewResponse> previewVersion(
+      @PathVariable Long templateId,
+      @PathVariable Long versionId,
+      @Valid @RequestBody TemplatePreviewRequest request) {
+    return BaseResponse.success(templateService.preview(templateId, versionId, request));
+  }
+
+  @PostMapping("/{templateId}/versions/{versionId}/validate")
+  public BaseResponse<TemplateValidationResponse> validate(
+      @PathVariable Long templateId,
+      @PathVariable Long versionId,
+      @Valid @RequestBody TemplateValidationRequest request) {
+    return BaseResponse.success(templateService.validate(templateId, versionId, request));
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/controller/WebhookController.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/controller/WebhookController.java
@@ -1,0 +1,30 @@
+package com.ejada.template.controller;
+
+import com.ejada.template.service.WebhookService;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@RestController
+@RequestMapping("/api/v1/webhooks/sendgrid")
+public class WebhookController {
+
+  private final WebhookService webhookService;
+
+  public WebhookController(WebhookService webhookService) {
+    this.webhookService = webhookService;
+  }
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public void handleWebhook(
+      @RequestHeader("X-Tenant-Id") @NotBlank String tenantId,
+      @RequestHeader("X-Twilio-Email-Event-Webhook-Signature") String signature,
+      @RequestHeader("X-Twilio-Email-Event-Webhook-Timestamp") String timestamp,
+      @RequestBody String payload) {
+    webhookService.handleWebhook(tenantId, payload, signature, timestamp);
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/domain/entity/EmailEventEntity.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/domain/entity/EmailEventEntity.java
@@ -1,0 +1,35 @@
+package com.ejada.template.domain.entity;
+
+import com.ejada.starter_data.tenant.TenantBaseEntity;
+import com.ejada.template.domain.enums.EmailEventType;
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "email_event")
+public class EmailEventEntity extends TenantBaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "email_send_id")
+  private EmailSendEntity emailSend;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 32)
+  private EmailEventType eventType;
+
+  private Instant eventTimestamp;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb")
+  private Map<String, Object> payload;
+
+  @Column(length = 128)
+  private String sendGridMessageId;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/domain/entity/EmailSendEntity.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/domain/entity/EmailSendEntity.java
@@ -1,0 +1,74 @@
+package com.ejada.template.domain.entity;
+
+import com.ejada.starter_data.tenant.TenantBaseEntity;
+import com.ejada.template.domain.enums.EmailSendMode;
+import com.ejada.template.domain.enums.EmailSendStatus;
+import com.ejada.template.domain.value.AttachmentMetadata;
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "email_send")
+public class EmailSendEntity extends TenantBaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "template_version_id")
+  private TemplateVersionEntity templateVersion;
+
+  @ElementCollection
+  @CollectionTable(name = "email_send_recipient", joinColumns = @JoinColumn(name = "send_id"))
+  @Column(name = "recipient")
+  private List<String> recipients;
+
+  @ElementCollection
+  @CollectionTable(name = "email_send_cc", joinColumns = @JoinColumn(name = "send_id"))
+  @Column(name = "cc")
+  private List<String> cc;
+
+  @ElementCollection
+  @CollectionTable(name = "email_send_bcc", joinColumns = @JoinColumn(name = "send_id"))
+  @Column(name = "bcc")
+  private List<String> bcc;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb")
+  private Map<String, Object> dynamicData;
+
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(name = "email_send_attachment", joinColumns = @JoinColumn(name = "send_id"))
+  private Set<AttachmentMetadata> attachments = new LinkedHashSet<>();
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 32)
+  private EmailSendStatus status = EmailSendStatus.QUEUED;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 32)
+  private EmailSendMode mode = EmailSendMode.PRODUCTION;
+
+  @Column(length = 128, unique = true)
+  private String idempotencyKey;
+
+  @Column(length = 128)
+  private String sendGridMessageId;
+
+  private Instant requestedAt;
+
+  private Instant processedAt;
+
+  @Column(length = 128)
+  private String errorCode;
+
+  @Column(length = 512)
+  private String errorMessage;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/domain/entity/SendGridSettingEntity.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/domain/entity/SendGridSettingEntity.java
@@ -1,0 +1,30 @@
+package com.ejada.template.domain.entity;
+
+import com.ejada.starter_data.tenant.TenantBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "sendgrid_setting")
+public class SendGridSettingEntity extends TenantBaseEntity {
+
+  @Column(nullable = false, length = 128)
+  private String secretId;
+
+  @Column(length = 128)
+  private String fromEmail;
+
+  @Column(length = 128)
+  private String fromName;
+
+  @Column(length = 128)
+  private String replyToEmail;
+
+  @Column(nullable = false)
+  private boolean sandboxMode;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/domain/entity/TemplateEntity.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/domain/entity/TemplateEntity.java
@@ -1,0 +1,48 @@
+package com.ejada.template.domain.entity;
+
+import com.ejada.starter_data.tenant.TenantBaseEntity;
+import com.ejada.template.domain.value.AttachmentMetadata;
+import jakarta.persistence.*;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "email_template")
+public class TemplateEntity extends TenantBaseEntity {
+
+  @Column(nullable = false, length = 128)
+  private String name;
+
+  @Column(nullable = false, length = 32)
+  private String locale;
+
+  @Column(length = 512)
+  private String description;
+
+  @Column(nullable = false)
+  private boolean archived = false;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb")
+  private Map<String, Object> metadata;
+
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+      name = "email_template_attachment",
+      joinColumns = @JoinColumn(name = "template_id"))
+  private Set<AttachmentMetadata> defaultAttachments = new LinkedHashSet<>();
+
+  @OneToMany(
+      mappedBy = "template",
+      cascade = CascadeType.ALL,
+      orphanRemoval = true,
+      fetch = FetchType.LAZY)
+  private Set<TemplateVersionEntity> versions = new LinkedHashSet<>();
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/domain/entity/TemplateVersionEntity.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/domain/entity/TemplateVersionEntity.java
@@ -1,0 +1,67 @@
+package com.ejada.template.domain.entity;
+
+import com.ejada.starter_data.tenant.TenantBaseEntity;
+import com.ejada.template.domain.enums.TemplateVersionStatus;
+import com.ejada.template.domain.value.AttachmentMetadata;
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "email_template_version")
+public class TemplateVersionEntity extends TenantBaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "template_id", nullable = false)
+  private TemplateEntity template;
+
+  @Column(nullable = false)
+  private int versionNumber;
+
+  @Column(nullable = false, length = 256)
+  private String subject;
+
+  @Lob
+  @Column(nullable = false)
+  private String htmlBody;
+
+  @Lob
+  private String textBody;
+
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+      name = "email_template_version_attachment",
+      joinColumns = @JoinColumn(name = "template_version_id"))
+  private Set<AttachmentMetadata> attachments = new LinkedHashSet<>();
+
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+      name = "email_template_allowed_variable",
+      joinColumns = @JoinColumn(name = "template_version_id"))
+  @Column(name = "variable_name", length = 128)
+  private Set<String> allowedVariables = new LinkedHashSet<>();
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb")
+  private Map<String, Object> metadata;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 32)
+  private TemplateVersionStatus status = TemplateVersionStatus.DRAFT;
+
+  private Instant publishedAt;
+
+  @Column(length = 128)
+  private String sendGridTemplateId;
+
+  @Column(length = 64)
+  private String sendGridVersionId;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/domain/enums/EmailEventType.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/domain/enums/EmailEventType.java
@@ -1,0 +1,13 @@
+package com.ejada.template.domain.enums;
+
+public enum EmailEventType {
+  PROCESSED,
+  DELIVERED,
+  DROPPED,
+  DEFERRED,
+  BOUNCED,
+  OPENED,
+  CLICKED,
+  SPAM,
+  UNSUBSCRIBED
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/domain/enums/EmailSendMode.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/domain/enums/EmailSendMode.java
@@ -1,0 +1,7 @@
+package com.ejada.template.domain.enums;
+
+public enum EmailSendMode {
+  PRODUCTION,
+  DRAFT,
+  TEST
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/domain/enums/EmailSendStatus.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/domain/enums/EmailSendStatus.java
@@ -1,0 +1,11 @@
+package com.ejada.template.domain.enums;
+
+public enum EmailSendStatus {
+  QUEUED,
+  DISPATCHED,
+  SENT,
+  FAILED,
+  RETRYING,
+  DEAD_LETTERED,
+  TESTED
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/domain/enums/TemplateVersionStatus.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/domain/enums/TemplateVersionStatus.java
@@ -1,0 +1,7 @@
+package com.ejada.template.domain.enums;
+
+public enum TemplateVersionStatus {
+  DRAFT,
+  PUBLISHED,
+  ARCHIVED
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/domain/value/AttachmentMetadata.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/domain/value/AttachmentMetadata.java
@@ -1,0 +1,31 @@
+package com.ejada.template.domain.value;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class AttachmentMetadata {
+
+  @Column(name = "attachment_name")
+  private String fileName;
+
+  @Column(name = "attachment_type")
+  private String contentType;
+
+  @Column(name = "attachment_url", length = 1024)
+  private String storageUrl;
+
+  @Column(name = "attachment_size")
+  private long sizeInBytes;
+
+  @Column(name = "inline_attachment")
+  private boolean inline;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/AttachmentMetadataDto.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/AttachmentMetadataDto.java
@@ -1,0 +1,16 @@
+package com.ejada.template.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class AttachmentMetadataDto {
+  @NotBlank String fileName;
+  @NotBlank String contentType;
+  @NotBlank String storageUrl;
+  long sizeInBytes;
+  @NotNull Boolean inline;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/BulkEmailSendRequest.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/BulkEmailSendRequest.java
@@ -1,0 +1,11 @@
+package com.ejada.template.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class BulkEmailSendRequest {
+  @NotEmpty private List<@Valid EmailSendRequest> sends;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/CreateTemplateRequest.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/CreateTemplateRequest.java
@@ -1,0 +1,24 @@
+package com.ejada.template.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class CreateTemplateRequest {
+  @NotBlank
+  private String name;
+
+  @NotBlank
+  @Size(max = 32)
+  private String locale;
+
+  @Size(max = 512)
+  private String description;
+
+  private Map<String, Object> metadata;
+
+  private List<AttachmentMetadataDto> defaultAttachments;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/EmailSendRequest.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/EmailSendRequest.java
@@ -1,0 +1,32 @@
+package com.ejada.template.dto;
+
+import com.ejada.template.domain.enums.EmailSendMode;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class EmailSendRequest {
+  @NotNull private Long templateId;
+  private Long templateVersionId;
+
+  @NotEmpty private List<@Email String> recipients;
+
+  private List<@Email String> cc;
+  private List<@Email String> bcc;
+
+  private Map<String, Object> dynamicData;
+  private List<AttachmentMetadataDto> attachments;
+
+  @Size(max = 128)
+  private String idempotencyKey;
+
+  private EmailSendMode mode = EmailSendMode.PRODUCTION;
+  private Map<String, Object> customArgs;
+
+  private String subjectOverride;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/EmailSendResponse.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/EmailSendResponse.java
@@ -1,0 +1,13 @@
+package com.ejada.template.dto;
+
+import com.ejada.template.domain.enums.EmailSendStatus;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class EmailSendResponse {
+  Long sendId;
+  EmailSendStatus status;
+  String idempotencyKey;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/EmailStatsPoint.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/EmailStatsPoint.java
@@ -1,0 +1,12 @@
+package com.ejada.template.dto;
+
+import com.ejada.template.domain.enums.EmailEventType;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class EmailStatsPoint {
+  EmailEventType type;
+  long total;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/EmailStatsResponse.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/EmailStatsResponse.java
@@ -1,0 +1,14 @@
+package com.ejada.template.dto;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class EmailStatsResponse {
+  Instant from;
+  Instant to;
+  List<EmailStatsPoint> points;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateCloneRequest.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateCloneRequest.java
@@ -1,0 +1,11 @@
+package com.ejada.template.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class TemplateCloneRequest {
+  @NotBlank private String name;
+  @NotBlank private String locale;
+  private boolean includeVersions = true;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateDto.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateDto.java
@@ -1,0 +1,22 @@
+package com.ejada.template.dto;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class TemplateDto {
+  Long id;
+  String name;
+  String locale;
+  String description;
+  boolean archived;
+  Map<String, Object> metadata;
+  List<AttachmentMetadataDto> defaultAttachments;
+  List<TemplateVersionDto> versions;
+  Instant createdAt;
+  Instant updatedAt;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplatePreviewRequest.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplatePreviewRequest.java
@@ -1,0 +1,10 @@
+package com.ejada.template.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class TemplatePreviewRequest {
+  @NotNull private Map<String, Object> dynamicData;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplatePreviewResponse.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplatePreviewResponse.java
@@ -1,0 +1,11 @@
+package com.ejada.template.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class TemplatePreviewResponse {
+  String htmlBody;
+  String textBody;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateValidationRequest.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateValidationRequest.java
@@ -1,0 +1,10 @@
+package com.ejada.template.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class TemplateValidationRequest {
+  @NotNull private Map<String, Object> dynamicData;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateValidationResponse.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateValidationResponse.java
@@ -1,0 +1,13 @@
+package com.ejada.template.dto;
+
+import java.util.Set;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class TemplateValidationResponse {
+  boolean valid;
+  Set<String> missingVariables;
+  Set<String> unexpectedVariables;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateVersionCreateRequest.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateVersionCreateRequest.java
@@ -1,0 +1,19 @@
+package com.ejada.template.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.Data;
+
+@Data
+public class TemplateVersionCreateRequest {
+  @NotBlank private String subject;
+  @NotBlank private String htmlBody;
+  private String textBody;
+  @NotNull private Set<String> allowedVariables;
+  private Map<String, Object> metadata;
+  private List<AttachmentMetadataDto> attachments;
+  private Long sourceVersionId;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateVersionDto.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/TemplateVersionDto.java
@@ -1,0 +1,24 @@
+package com.ejada.template.dto;
+
+import com.ejada.template.domain.enums.TemplateVersionStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class TemplateVersionDto {
+  Long id;
+  int versionNumber;
+  String subject;
+  String htmlBody;
+  String textBody;
+  Set<String> allowedVariables;
+  Map<String, Object> metadata;
+  TemplateVersionStatus status;
+  Instant publishedAt;
+  List<AttachmentMetadataDto> attachments;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/dto/UpdateTemplateRequest.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/dto/UpdateTemplateRequest.java
@@ -1,0 +1,17 @@
+package com.ejada.template.dto;
+
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class UpdateTemplateRequest {
+
+  @Size(max = 512)
+  private String description;
+
+  private Map<String, Object> metadata;
+
+  private List<AttachmentMetadataDto> defaultAttachments;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/exception/RateLimitExceededException.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/exception/RateLimitExceededException.java
@@ -1,0 +1,7 @@
+package com.ejada.template.exception;
+
+public class RateLimitExceededException extends RuntimeException {
+  public RateLimitExceededException(String tenantId, String action) {
+    super("Rate limit exceeded for tenant=" + tenantId + " action=" + action);
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/exception/SendGridSyncException.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/exception/SendGridSyncException.java
@@ -1,0 +1,11 @@
+package com.ejada.template.exception;
+
+public class SendGridSyncException extends RuntimeException {
+  public SendGridSyncException(String message) {
+    super(message);
+  }
+
+  public SendGridSyncException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/exception/TemplateNotFoundException.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/exception/TemplateNotFoundException.java
@@ -1,0 +1,7 @@
+package com.ejada.template.exception;
+
+public class TemplateNotFoundException extends RuntimeException {
+  public TemplateNotFoundException(Long id) {
+    super("Template not found: " + id);
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/exception/TemplateVersionNotFoundException.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/exception/TemplateVersionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.ejada.template.exception;
+
+public class TemplateVersionNotFoundException extends RuntimeException {
+  public TemplateVersionNotFoundException(Long templateId, Long versionId) {
+    super("Template version not found: template=" + templateId + " version=" + versionId);
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/gateway/controller/TenantTemplateGatewayController.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/gateway/controller/TenantTemplateGatewayController.java
@@ -1,0 +1,38 @@
+package com.ejada.template.gateway.controller;
+
+import com.ejada.template.gateway.dto.TemplateSummaryView;
+import com.ejada.template.gateway.dto.TemplateSyncRequest;
+import com.ejada.template.gateway.service.TemplateGatewayFacade;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/api/v1/tenants/{tenantId}/templates")
+public class TenantTemplateGatewayController {
+
+  private final TemplateGatewayFacade facade;
+
+  public TenantTemplateGatewayController(TemplateGatewayFacade facade) {
+    this.facade = facade;
+  }
+
+  @GetMapping
+  public List<TemplateSummaryView> summaries(@PathVariable String tenantId) {
+    return facade.summaries();
+  }
+
+  @PostMapping("/sync")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public void sync(@PathVariable String tenantId, @Valid @RequestBody TemplateSyncRequest request) {
+    // In a full implementation this would kick off a SendGrid synchronization job scoped to the
+    // tenant. For now the endpoint simply acknowledges the request so the orchestrator can proceed.
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/gateway/dto/TemplateSummaryView.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/gateway/dto/TemplateSummaryView.java
@@ -1,0 +1,5 @@
+package com.ejada.template.gateway.dto;
+
+import java.time.Instant;
+
+public record TemplateSummaryView(Long id, String name, String locale, boolean archived, Instant updatedAt) {}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/gateway/dto/TemplateSyncRequest.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/gateway/dto/TemplateSyncRequest.java
@@ -1,0 +1,5 @@
+package com.ejada.template.gateway.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TemplateSyncRequest(@NotBlank String versionTag) {}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/gateway/service/TemplateGatewayFacade.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/gateway/service/TemplateGatewayFacade.java
@@ -1,0 +1,29 @@
+package com.ejada.template.gateway.service;
+
+import com.ejada.template.dto.TemplateDto;
+import com.ejada.template.gateway.dto.TemplateSummaryView;
+import com.ejada.template.service.TemplateService;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TemplateGatewayFacade {
+
+  private final TemplateService templateService;
+
+  public TemplateGatewayFacade(TemplateService templateService) {
+    this.templateService = templateService;
+  }
+
+  public List<TemplateSummaryView> summaries() {
+    return templateService.listTemplates(PageRequest.of(0, 100)).stream()
+        .map(this::toSummary)
+        .collect(Collectors.toList());
+  }
+
+  private TemplateSummaryView toSummary(TemplateDto dto) {
+    return new TemplateSummaryView(dto.getId(), dto.getName(), dto.getLocale(), dto.isArchived(), dto.getUpdatedAt());
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/mapper/TemplateMapper.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/mapper/TemplateMapper.java
@@ -1,0 +1,26 @@
+package com.ejada.template.mapper;
+
+import com.ejada.template.domain.entity.TemplateEntity;
+import com.ejada.template.domain.entity.TemplateVersionEntity;
+import com.ejada.template.domain.value.AttachmentMetadata;
+import com.ejada.template.dto.AttachmentMetadataDto;
+import com.ejada.template.dto.TemplateDto;
+import com.ejada.template.dto.TemplateVersionDto;
+import java.util.List;
+import java.util.Set;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface TemplateMapper {
+
+  TemplateDto toDto(TemplateEntity entity);
+
+  List<TemplateVersionDto> toVersionDtos(Set<TemplateVersionEntity> versions);
+
+  TemplateVersionDto toDto(TemplateVersionEntity entity);
+
+  List<AttachmentMetadataDto> toAttachmentDtos(Set<AttachmentMetadata> attachments);
+
+  Set<AttachmentMetadata> toAttachments(List<AttachmentMetadataDto> attachments);
+
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/messaging/model/EmailSendMessage.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/messaging/model/EmailSendMessage.java
@@ -1,0 +1,23 @@
+package com.ejada.template.messaging.model;
+
+import com.ejada.template.domain.enums.EmailSendMode;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class EmailSendMessage {
+  Long sendId;
+  Long templateId;
+  Long templateVersionId;
+  List<String> recipients;
+  List<String> cc;
+  List<String> bcc;
+  Map<String, Object> dynamicData;
+  EmailSendMode mode;
+  Instant requestedAt;
+  Map<String, Object> customArgs;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/messaging/model/WebhookEventMessage.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/messaging/model/WebhookEventMessage.java
@@ -1,0 +1,15 @@
+package com.ejada.template.messaging.model;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class WebhookEventMessage {
+  String tenantId;
+  List<Map<String, Object>> events;
+  Instant receivedAt;
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/messaging/producer/EmailSendProducer.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/messaging/producer/EmailSendProducer.java
@@ -1,0 +1,22 @@
+package com.ejada.template.messaging.producer;
+
+import com.ejada.template.config.KafkaTopicsProperties;
+import com.ejada.template.messaging.model.EmailSendMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailSendProducer {
+
+  private final KafkaTemplate<String, Object> kafkaTemplate;
+  private final KafkaTopicsProperties topicsProperties;
+
+  public void publish(EmailSendMessage message) {
+    kafkaTemplate.send(topicsProperties.emailSend(), message.getSendId().toString(), message);
+    log.info("Published email send {} to Kafka", message.getSendId());
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/messaging/producer/WebhookEventProducer.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/messaging/producer/WebhookEventProducer.java
@@ -1,0 +1,22 @@
+package com.ejada.template.messaging.producer;
+
+import com.ejada.template.config.KafkaTopicsProperties;
+import com.ejada.template.messaging.model.WebhookEventMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebhookEventProducer {
+
+  private final KafkaTemplate<String, Object> kafkaTemplate;
+  private final KafkaTopicsProperties topicsProperties;
+
+  public void publish(WebhookEventMessage message) {
+    kafkaTemplate.send(topicsProperties.webhookEvents(), message.getTenantId(), message);
+    log.info("Published {} webhook events for tenant {}", message.getEvents().size(), message.getTenantId());
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/repository/EmailEventRepository.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/repository/EmailEventRepository.java
@@ -1,0 +1,26 @@
+package com.ejada.template.repository;
+
+import com.ejada.template.domain.entity.EmailEventEntity;
+import com.ejada.template.domain.enums.EmailEventType;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EmailEventRepository extends JpaRepository<EmailEventEntity, Long> {
+
+  @Query(
+      "select e.eventType as type, count(e) as total "
+          + "from EmailEventEntity e "
+          + "where e.eventTimestamp between :from and :to "
+          + "group by e.eventType")
+  List<EventAggregation> aggregateBetween(
+      @Param("from") Instant from, @Param("to") Instant to);
+
+  interface EventAggregation {
+    EmailEventType getType();
+
+    long getTotal();
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/repository/EmailSendRepository.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/repository/EmailSendRepository.java
@@ -1,0 +1,9 @@
+package com.ejada.template.repository;
+
+import com.ejada.template.domain.entity.EmailSendEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailSendRepository extends JpaRepository<EmailSendEntity, Long> {
+  Optional<EmailSendEntity> findByIdempotencyKey(String idempotencyKey);
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/repository/SendGridSettingRepository.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/repository/SendGridSettingRepository.java
@@ -1,0 +1,9 @@
+package com.ejada.template.repository;
+
+import com.ejada.template.domain.entity.SendGridSettingEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SendGridSettingRepository extends JpaRepository<SendGridSettingEntity, Long> {
+  Optional<SendGridSettingEntity> findTopByOrderByIdDesc();
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/repository/TemplateRepository.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/repository/TemplateRepository.java
@@ -1,0 +1,9 @@
+package com.ejada.template.repository;
+
+import com.ejada.template.domain.entity.TemplateEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemplateRepository extends JpaRepository<TemplateEntity, Long> {
+  Optional<TemplateEntity> findByNameIgnoreCaseAndLocale(String name, String locale);
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/repository/TemplateVersionRepository.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/repository/TemplateVersionRepository.java
@@ -1,0 +1,13 @@
+package com.ejada.template.repository;
+
+import com.ejada.template.domain.entity.TemplateVersionEntity;
+import com.ejada.template.domain.enums.TemplateVersionStatus;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemplateVersionRepository extends JpaRepository<TemplateVersionEntity, Long> {
+  Optional<TemplateVersionEntity> findFirstByTemplateIdOrderByVersionNumberDesc(Long templateId);
+
+  Optional<TemplateVersionEntity> findFirstByTemplateIdAndStatusOrderByVersionNumberDesc(
+      Long templateId, TemplateVersionStatus status);
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/EmailAnalyticsService.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/EmailAnalyticsService.java
@@ -1,0 +1,8 @@
+package com.ejada.template.service;
+
+import com.ejada.template.dto.EmailStatsResponse;
+import java.time.Instant;
+
+public interface EmailAnalyticsService {
+  EmailStatsResponse getEmailStats(Instant from, Instant to);
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/EmailSendService.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/EmailSendService.java
@@ -1,0 +1,12 @@
+package com.ejada.template.service;
+
+import com.ejada.template.dto.BulkEmailSendRequest;
+import com.ejada.template.dto.EmailSendRequest;
+import com.ejada.template.dto.EmailSendResponse;
+import java.util.List;
+
+public interface EmailSendService {
+  EmailSendResponse sendEmail(EmailSendRequest request);
+
+  List<EmailSendResponse> sendBulkEmails(BulkEmailSendRequest request);
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/TemplateService.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/TemplateService.java
@@ -1,0 +1,37 @@
+package com.ejada.template.service;
+
+import com.ejada.template.dto.TemplateCloneRequest;
+import com.ejada.template.dto.TemplateDto;
+import com.ejada.template.dto.TemplatePreviewRequest;
+import com.ejada.template.dto.TemplatePreviewResponse;
+import com.ejada.template.dto.TemplateValidationRequest;
+import com.ejada.template.dto.TemplateValidationResponse;
+import com.ejada.template.dto.TemplateVersionCreateRequest;
+import com.ejada.template.dto.TemplateVersionDto;
+import com.ejada.template.dto.UpdateTemplateRequest;
+import com.ejada.template.dto.CreateTemplateRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface TemplateService {
+
+  TemplateDto createTemplate(CreateTemplateRequest request);
+
+  TemplateDto updateTemplate(Long templateId, UpdateTemplateRequest request);
+
+  TemplateDto archiveTemplate(Long templateId);
+
+  TemplateDto cloneTemplate(Long templateId, TemplateCloneRequest request);
+
+  TemplateVersionDto createVersion(Long templateId, TemplateVersionCreateRequest request);
+
+  TemplateVersionDto publishVersion(Long templateId, Long versionId);
+
+  TemplateVersionDto getVersion(Long templateId, Long versionId);
+
+  TemplatePreviewResponse preview(Long templateId, Long versionId, TemplatePreviewRequest request);
+
+  TemplateValidationResponse validate(Long templateId, Long versionId, TemplateValidationRequest request);
+
+  Page<TemplateDto> listTemplates(Pageable pageable);
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/WebhookService.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/WebhookService.java
@@ -1,0 +1,5 @@
+package com.ejada.template.service;
+
+public interface WebhookService {
+  void handleWebhook(String tenantId, String payload, String signature, String timestamp);
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/EmailAnalyticsServiceImpl.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/EmailAnalyticsServiceImpl.java
@@ -1,0 +1,29 @@
+package com.ejada.template.service.impl;
+
+import com.ejada.template.dto.EmailStatsPoint;
+import com.ejada.template.dto.EmailStatsResponse;
+import com.ejada.template.repository.EmailEventRepository;
+import com.ejada.template.service.EmailAnalyticsService;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailAnalyticsServiceImpl implements EmailAnalyticsService {
+
+  private final EmailEventRepository emailEventRepository;
+
+  @Override
+  public EmailStatsResponse getEmailStats(Instant from, Instant to) {
+    List<EmailStatsPoint> points = emailEventRepository.aggregateBetween(from, to).stream()
+        .map(aggregation -> EmailStatsPoint.builder()
+            .type(aggregation.getType())
+            .total(aggregation.getTotal())
+            .build())
+        .collect(Collectors.toList());
+    return EmailStatsResponse.builder().from(from).to(to).points(points).build();
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/EmailSendServiceImpl.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/EmailSendServiceImpl.java
@@ -1,0 +1,167 @@
+package com.ejada.template.service.impl;
+
+import com.ejada.common.context.ContextManager;
+import com.ejada.template.domain.entity.EmailSendEntity;
+import com.ejada.template.domain.entity.TemplateEntity;
+import com.ejada.template.domain.entity.TemplateVersionEntity;
+import com.ejada.template.domain.enums.EmailSendMode;
+import com.ejada.template.domain.enums.EmailSendStatus;
+import com.ejada.template.domain.enums.TemplateVersionStatus;
+import com.ejada.template.domain.value.AttachmentMetadata;
+import com.ejada.template.dto.AttachmentMetadataDto;
+import com.ejada.template.dto.BulkEmailSendRequest;
+import com.ejada.template.dto.EmailSendRequest;
+import com.ejada.template.dto.EmailSendResponse;
+import com.ejada.template.exception.TemplateNotFoundException;
+import com.ejada.template.exception.TemplateVersionNotFoundException;
+import com.ejada.template.messaging.model.EmailSendMessage;
+import com.ejada.template.messaging.producer.EmailSendProducer;
+import com.ejada.template.repository.EmailSendRepository;
+import com.ejada.template.repository.TemplateRepository;
+import com.ejada.template.repository.TemplateVersionRepository;
+import com.ejada.template.service.EmailSendService;
+import com.ejada.template.service.support.RateLimiterService;
+import com.ejada.template.service.support.RedisIdempotencyService;
+import jakarta.transaction.Transactional;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EmailSendServiceImpl implements EmailSendService {
+
+  private final EmailSendRepository emailSendRepository;
+  private final TemplateRepository templateRepository;
+  private final TemplateVersionRepository templateVersionRepository;
+  private final EmailSendProducer emailSendProducer;
+  private final RedisIdempotencyService idempotencyService;
+  private final RateLimiterService rateLimiterService;
+
+  @Override
+  public EmailSendResponse sendEmail(EmailSendRequest request) {
+    String tenantId = ContextManager.Tenant.get();
+    rateLimiterService.validateQuota(tenantId, "email-send");
+
+    if (request.getIdempotencyKey() != null) {
+      var existing = idempotencyService.findSendId(tenantId, request.getIdempotencyKey());
+      if (existing.isPresent()) {
+        EmailSendEntity entity =
+            emailSendRepository
+                .findById(existing.get())
+                .orElseThrow(() -> new IllegalStateException("Idempotent send missing"));
+        return buildResponse(entity);
+      }
+    }
+
+    TemplateVersionEntity version = resolveVersion(request);
+    EmailSendEntity entity = new EmailSendEntity();
+    entity.setTemplateVersion(version);
+    entity.setRecipients(request.getRecipients());
+    entity.setCc(request.getCc());
+    entity.setBcc(request.getBcc());
+    entity.setDynamicData(request.getDynamicData());
+    entity.setAttachments(mergeAttachments(version, request.getAttachments()));
+    EmailSendMode mode = request.getMode() == null ? EmailSendMode.PRODUCTION : request.getMode();
+    entity.setMode(mode);
+    entity.setRequestedAt(Instant.now());
+    entity.setIdempotencyKey(request.getIdempotencyKey());
+    entity.setStatus(resolveStatus(mode));
+
+    EmailSendEntity saved = emailSendRepository.save(entity);
+    if (request.getIdempotencyKey() != null) {
+      idempotencyService.storeSendId(tenantId, request.getIdempotencyKey(), saved.getId());
+    }
+
+    EmailSendMessage message = EmailSendMessage.builder()
+        .sendId(saved.getId())
+        .templateId(request.getTemplateId())
+        .templateVersionId(saved.getTemplateVersion().getId())
+        .recipients(saved.getRecipients())
+        .cc(saved.getCc())
+        .bcc(saved.getBcc())
+        .dynamicData(saved.getDynamicData())
+        .mode(saved.getMode())
+        .requestedAt(saved.getRequestedAt())
+        .customArgs(request.getCustomArgs())
+        .build();
+    emailSendProducer.publish(message);
+    return buildResponse(saved);
+  }
+
+  @Override
+  public List<EmailSendResponse> sendBulkEmails(BulkEmailSendRequest request) {
+    return request.getSends().stream().map(this::sendEmail).collect(Collectors.toList());
+  }
+
+  private TemplateVersionEntity resolveVersion(EmailSendRequest request) {
+    if (request.getTemplateVersionId() != null) {
+      return templateVersionRepository
+          .findById(request.getTemplateVersionId())
+          .filter(version -> version.getTemplate() != null && version.getTemplate().getId().equals(request.getTemplateId()))
+          .orElseThrow(() -> new TemplateVersionNotFoundException(request.getTemplateId(), request.getTemplateVersionId()));
+    }
+    TemplateEntity template = templateRepository.findById(request.getTemplateId()).orElseThrow(() -> new TemplateNotFoundException(request.getTemplateId()));
+    return templateVersionRepository
+        .findFirstByTemplateIdAndStatusOrderByVersionNumberDesc(template.getId(), TemplateVersionStatus.PUBLISHED)
+        .orElseThrow(() -> new TemplateVersionNotFoundException(request.getTemplateId(), null));
+  }
+
+  private Set<AttachmentMetadata> mergeAttachments(
+      TemplateVersionEntity version, List<AttachmentMetadataDto> overrides) {
+    Set<AttachmentMetadata> merged = new LinkedHashSet<>();
+    if (version.getTemplate() != null) {
+      merged.addAll(copyAttachments(version.getTemplate().getDefaultAttachments()));
+    }
+    merged.addAll(copyAttachments(version.getAttachments()));
+    if (overrides != null) {
+      overrides.stream().filter(Objects::nonNull).forEach(dto -> merged.add(copyAttachment(dto)));
+    }
+    return merged;
+  }
+
+  private Set<AttachmentMetadata> copyAttachments(Set<AttachmentMetadata> attachments) {
+    if (attachments == null) {
+      return Set.of();
+    }
+    return attachments.stream().map(this::copyAttachment).collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private AttachmentMetadata copyAttachment(AttachmentMetadata attachment) {
+    return AttachmentMetadata.builder()
+        .fileName(attachment.getFileName())
+        .contentType(attachment.getContentType())
+        .storageUrl(attachment.getStorageUrl())
+        .sizeInBytes(attachment.getSizeInBytes())
+        .inline(attachment.isInline())
+        .build();
+  }
+
+  private AttachmentMetadata copyAttachment(AttachmentMetadataDto dto) {
+    return AttachmentMetadata.builder()
+        .fileName(dto.getFileName())
+        .contentType(dto.getContentType())
+        .storageUrl(dto.getStorageUrl())
+        .sizeInBytes(dto.getSizeInBytes())
+        .inline(Boolean.TRUE.equals(dto.getInline()))
+        .build();
+  }
+
+  private EmailSendStatus resolveStatus(EmailSendMode mode) {
+    return mode == EmailSendMode.PRODUCTION ? EmailSendStatus.QUEUED : EmailSendStatus.TESTED;
+  }
+
+  private EmailSendResponse buildResponse(EmailSendEntity entity) {
+    return EmailSendResponse.builder()
+        .sendId(entity.getId())
+        .status(entity.getStatus())
+        .idempotencyKey(entity.getIdempotencyKey())
+        .build();
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/TemplateServiceImpl.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/TemplateServiceImpl.java
@@ -1,0 +1,225 @@
+package com.ejada.template.service.impl;
+
+import com.ejada.template.domain.entity.TemplateEntity;
+import com.ejada.template.domain.entity.TemplateVersionEntity;
+import com.ejada.template.domain.enums.TemplateVersionStatus;
+import com.ejada.template.domain.value.AttachmentMetadata;
+import com.ejada.template.dto.AttachmentMetadataDto;
+import com.ejada.template.dto.CreateTemplateRequest;
+import com.ejada.template.dto.TemplateCloneRequest;
+import com.ejada.template.dto.TemplateDto;
+import com.ejada.template.dto.TemplatePreviewRequest;
+import com.ejada.template.dto.TemplatePreviewResponse;
+import com.ejada.template.dto.TemplateValidationRequest;
+import com.ejada.template.dto.TemplateValidationResponse;
+import com.ejada.template.dto.TemplateVersionCreateRequest;
+import com.ejada.template.dto.TemplateVersionDto;
+import com.ejada.template.dto.UpdateTemplateRequest;
+import com.ejada.template.exception.TemplateNotFoundException;
+import com.ejada.template.exception.TemplateVersionNotFoundException;
+import com.ejada.template.mapper.TemplateMapper;
+import com.ejada.template.repository.TemplateRepository;
+import com.ejada.template.repository.TemplateVersionRepository;
+import com.ejada.template.service.TemplateService;
+import com.ejada.template.service.support.SendGridTemplateClient;
+import com.ejada.template.service.support.TemplateRenderer;
+import com.ejada.template.service.support.TemplateValidator;
+import jakarta.transaction.Transactional;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TemplateServiceImpl implements TemplateService {
+
+  private final TemplateRepository templateRepository;
+  private final TemplateVersionRepository versionRepository;
+  private final TemplateMapper templateMapper;
+  private final TemplateRenderer templateRenderer;
+  private final TemplateValidator templateValidator;
+  private final SendGridTemplateClient sendGridTemplateClient;
+
+  @Override
+  public TemplateDto createTemplate(CreateTemplateRequest request) {
+    TemplateEntity entity = new TemplateEntity();
+    entity.setName(request.getName());
+    entity.setLocale(request.getLocale());
+    entity.setDescription(request.getDescription());
+    entity.setMetadata(request.getMetadata());
+    entity.setDefaultAttachments(convertAttachments(request.getDefaultAttachments()));
+    TemplateEntity saved = templateRepository.save(entity);
+    return templateMapper.toDto(saved);
+  }
+
+  @Override
+  @CacheEvict(value = "templates", key = "#templateId")
+  public TemplateDto updateTemplate(Long templateId, UpdateTemplateRequest request) {
+    TemplateEntity entity = templateRepository.findById(templateId).orElseThrow(() -> new TemplateNotFoundException(templateId));
+    if (request.getDescription() != null) {
+      entity.setDescription(request.getDescription());
+    }
+    if (request.getMetadata() != null) {
+      entity.setMetadata(request.getMetadata());
+    }
+    if (request.getDefaultAttachments() != null) {
+      entity.setDefaultAttachments(convertAttachments(request.getDefaultAttachments()));
+    }
+    return templateMapper.toDto(entity);
+  }
+
+  @Override
+  @CacheEvict(value = "templates", key = "#templateId")
+  public TemplateDto archiveTemplate(Long templateId) {
+    TemplateEntity entity = templateRepository.findById(templateId).orElseThrow(() -> new TemplateNotFoundException(templateId));
+    entity.setArchived(true);
+    return templateMapper.toDto(entity);
+  }
+
+  @Override
+  public TemplateDto cloneTemplate(Long templateId, TemplateCloneRequest request) {
+    TemplateEntity source = templateRepository.findById(templateId).orElseThrow(() -> new TemplateNotFoundException(templateId));
+    TemplateEntity clone = new TemplateEntity();
+    clone.setName(request.getName());
+    clone.setLocale(request.getLocale());
+    clone.setDescription(source.getDescription());
+    clone.setMetadata(source.getMetadata());
+    clone.setDefaultAttachments(copyAttachments(source.getDefaultAttachments()));
+    clone.setArchived(false);
+    TemplateEntity saved = templateRepository.save(clone);
+    if (request.isIncludeVersions()) {
+      source.getVersions().forEach(version -> {
+        TemplateVersionEntity copy = copyVersion(version);
+        copy.setTemplate(saved);
+        versionRepository.save(copy);
+      });
+    }
+    return templateMapper.toDto(saved);
+  }
+
+  @Override
+  @CacheEvict(value = "templates", key = "#templateId")
+  public TemplateVersionDto createVersion(Long templateId, TemplateVersionCreateRequest request) {
+    TemplateEntity template = templateRepository.findById(templateId).orElseThrow(() -> new TemplateNotFoundException(templateId));
+    TemplateVersionEntity entity = new TemplateVersionEntity();
+    entity.setTemplate(template);
+    entity.setSubject(request.getSubject());
+    entity.setHtmlBody(request.getHtmlBody());
+    entity.setTextBody(request.getTextBody());
+    entity.setMetadata(request.getMetadata());
+    entity.setAllowedVariables(new LinkedHashSet<>(request.getAllowedVariables()));
+    entity.setAttachments(convertAttachments(request.getAttachments()));
+    int versionNumber =
+        versionRepository
+            .findFirstByTemplateIdOrderByVersionNumberDesc(templateId)
+            .map(v -> v.getVersionNumber() + 1)
+            .orElse(1);
+    entity.setVersionNumber(versionNumber);
+    TemplateVersionEntity saved = versionRepository.save(entity);
+    return templateMapper.toDto(saved);
+  }
+
+  @Override
+  @CacheEvict(value = {"templates", "templateVersions"}, allEntries = true)
+  public TemplateVersionDto publishVersion(Long templateId, Long versionId) {
+    TemplateEntity template = templateRepository.findById(templateId).orElseThrow(() -> new TemplateNotFoundException(templateId));
+    TemplateVersionEntity version = versionRepository.findById(versionId).orElseThrow(() -> new TemplateVersionNotFoundException(templateId, versionId));
+    version.setStatus(TemplateVersionStatus.PUBLISHED);
+    version.setPublishedAt(Instant.now());
+    if (version.getSendGridTemplateId() == null) {
+      version.setSendGridTemplateId(template.getName());
+    }
+    sendGridTemplateClient.syncTemplate(template, version);
+    sendGridTemplateClient.publishVersion(template, version);
+    return templateMapper.toDto(version);
+  }
+
+  @Override
+  @Cacheable(
+      value = "templateVersions",
+      key = "T(com.ejada.common.context.ContextManager$Tenant).get() + ':' + #templateId + ':' + #versionId")
+  public TemplateVersionDto getVersion(Long templateId, Long versionId) {
+    TemplateVersionEntity version = versionRepository.findById(versionId).orElseThrow(() -> new TemplateVersionNotFoundException(templateId, versionId));
+    return templateMapper.toDto(version);
+  }
+
+  @Override
+  public TemplatePreviewResponse preview(Long templateId, Long versionId, TemplatePreviewRequest request) {
+    TemplateVersionEntity version = versionRepository.findById(versionId).orElseThrow(() -> new TemplateVersionNotFoundException(templateId, versionId));
+    return templateRenderer.render(version, request.getDynamicData());
+  }
+
+  @Override
+  public TemplateValidationResponse validate(Long templateId, Long versionId, TemplateValidationRequest request) {
+    TemplateVersionEntity version = versionRepository.findById(versionId).orElseThrow(() -> new TemplateVersionNotFoundException(templateId, versionId));
+    return templateValidator.validate(version, request.getDynamicData());
+  }
+
+  @Override
+  public Page<TemplateDto> listTemplates(Pageable pageable) {
+    return templateRepository.findAll(pageable).map(templateMapper::toDto);
+  }
+
+  private TemplateVersionEntity copyVersion(TemplateVersionEntity version) {
+    TemplateVersionEntity copy = new TemplateVersionEntity();
+    copy.setSubject(version.getSubject());
+    copy.setHtmlBody(version.getHtmlBody());
+    copy.setTextBody(version.getTextBody());
+    copy.setMetadata(version.getMetadata());
+    copy.setAllowedVariables(
+        version.getAllowedVariables() == null
+            ? new LinkedHashSet<>()
+            : new LinkedHashSet<>(version.getAllowedVariables()));
+    copy.setAttachments(copyAttachments(version.getAttachments()));
+    copy.setVersionNumber(version.getVersionNumber());
+    copy.setStatus(TemplateVersionStatus.DRAFT);
+    copy.setPublishedAt(null);
+    return copy;
+  }
+
+  private Set<AttachmentMetadata> convertAttachments(List<AttachmentMetadataDto> attachments) {
+    if (attachments == null || attachments.isEmpty()) {
+      return new LinkedHashSet<>();
+    }
+    Set<AttachmentMetadata> mapped = new LinkedHashSet<>();
+    attachments.stream().filter(dto -> dto != null).forEach(dto -> mapped.add(copyAttachment(dto)));
+    return mapped;
+  }
+
+  private Set<AttachmentMetadata> copyAttachments(Set<AttachmentMetadata> attachments) {
+    if (attachments == null || attachments.isEmpty()) {
+      return new LinkedHashSet<>();
+    }
+    Set<AttachmentMetadata> copies = new LinkedHashSet<>();
+    attachments.stream().filter(item -> item != null).forEach(item -> copies.add(copyAttachment(item)));
+    return copies;
+  }
+
+  private AttachmentMetadata copyAttachment(AttachmentMetadataDto dto) {
+    return AttachmentMetadata.builder()
+        .fileName(dto.getFileName())
+        .contentType(dto.getContentType())
+        .storageUrl(dto.getStorageUrl())
+        .sizeInBytes(dto.getSizeInBytes())
+        .inline(dto.getInline())
+        .build();
+  }
+
+  private AttachmentMetadata copyAttachment(AttachmentMetadata attachment) {
+    return AttachmentMetadata.builder()
+        .fileName(attachment.getFileName())
+        .contentType(attachment.getContentType())
+        .storageUrl(attachment.getStorageUrl())
+        .sizeInBytes(attachment.getSizeInBytes())
+        .inline(attachment.isInline())
+        .build();
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/WebhookServiceImpl.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/WebhookServiceImpl.java
@@ -1,0 +1,86 @@
+package com.ejada.template.service.impl;
+
+import com.ejada.template.config.SendGridProperties;
+import com.ejada.template.messaging.model.WebhookEventMessage;
+import com.ejada.template.messaging.producer.WebhookEventProducer;
+import com.ejada.template.service.WebhookService;
+import com.ejada.template.service.support.WebhookDeduplicationService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sendgrid.helpers.eventwebhook.EventWebhook;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WebhookServiceImpl implements WebhookService {
+
+  private static final Duration DEDUP_TTL = Duration.ofHours(1);
+
+  private final ObjectMapper objectMapper;
+  private final SendGridProperties sendGridProperties;
+  private final WebhookEventProducer webhookEventProducer;
+  private final WebhookDeduplicationService deduplicationService;
+  private final EventWebhook eventWebhook = new EventWebhook();
+
+  @Override
+  public void handleWebhook(String tenantId, String payload, String signature, String timestamp) {
+    verifySignature(payload, signature, timestamp);
+    List<Map<String, Object>> events = parsePayload(payload);
+    List<Map<String, Object>> filtered =
+        events.stream()
+            .filter(event -> !deduplicationService.isDuplicate(tenantId, dedupKey(event), DEDUP_TTL))
+            .collect(Collectors.toList());
+    if (filtered.isEmpty()) {
+      log.info("All webhook events were duplicates for tenant {}", tenantId);
+      return;
+    }
+    WebhookEventMessage message = WebhookEventMessage.builder()
+        .tenantId(tenantId)
+        .events(filtered)
+        .receivedAt(Instant.now())
+        .build();
+    webhookEventProducer.publish(message);
+  }
+
+  private void verifySignature(String payload, String signature, String timestamp) {
+    String publicKeyValue = sendGridProperties.webhookPublicKey();
+    if (publicKeyValue == null || publicKeyValue.isBlank()) {
+      throw new IllegalStateException("SendGrid webhook public key is not configured");
+    }
+    byte[] publicKey = publicKeyValue.getBytes();
+    try {
+      boolean valid =
+          eventWebhook.VerifySignature(
+              eventWebhook.ConvertPublicKeyToECDSA(publicKeyValue), payload, signature, timestamp);
+      if (!valid) {
+        throw new IllegalArgumentException("Invalid webhook signature");
+      }
+    } catch (Exception ex) {
+      throw new IllegalArgumentException("Unable to verify webhook signature", ex);
+    }
+  }
+
+  private List<Map<String, Object>> parsePayload(String payload) {
+    try {
+      return objectMapper.readValue(payload, new TypeReference<>() {});
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Unable to parse webhook payload", e);
+    }
+  }
+
+  private String dedupKey(Map<String, Object> event) {
+    Object id = event.getOrDefault("event_id", event.get("sg_message_id"));
+    Object type = event.get("event");
+    Object timestamp = event.get("timestamp");
+    return id + ":" + type + ":" + timestamp;
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/support/RateLimiterService.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/support/RateLimiterService.java
@@ -1,0 +1,36 @@
+package com.ejada.template.service.support;
+
+import com.ejada.template.config.RateLimitProperties;
+import com.ejada.template.exception.RateLimitExceededException;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimiterService {
+
+  private final StringRedisTemplate redisTemplate;
+  private final RateLimitProperties properties;
+
+  public void validateQuota(String tenantId, String action) {
+    String key = rateKey(normalizeTenant(tenantId), action);
+    Long current = redisTemplate.opsForValue().increment(key);
+    Duration window = properties.window();
+    if (current != null && current == 1L) {
+      redisTemplate.expire(key, window);
+    }
+    if (current != null && current > properties.allowedTokens()) {
+      throw new RateLimitExceededException(tenantId, action);
+    }
+  }
+
+  private String rateKey(String tenantId, String action) {
+    return "rate:" + tenantId + ":" + action;
+  }
+
+  private String normalizeTenant(String tenantId) {
+    return (tenantId == null || tenantId.isBlank()) ? "global" : tenantId;
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/support/RedisIdempotencyService.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/support/RedisIdempotencyService.java
@@ -1,0 +1,39 @@
+package com.ejada.template.service.support;
+
+import com.ejada.template.config.RateLimitProperties;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisIdempotencyService {
+
+  private final StringRedisTemplate redisTemplate;
+  private final RateLimitProperties properties;
+
+  public Optional<Long> findSendId(String tenantId, String key) {
+    String value = redisTemplate.opsForValue().get(idempotencyKey(normalizeTenant(tenantId), key));
+    if (value == null) {
+      return Optional.empty();
+    }
+    return Optional.of(Long.parseLong(value));
+  }
+
+  public void storeSendId(String tenantId, String key, Long sendId) {
+    Duration ttl = properties.idempotencyTtl();
+    redisTemplate
+        .opsForValue()
+        .set(idempotencyKey(normalizeTenant(tenantId), key), String.valueOf(sendId), ttl);
+  }
+
+  private String idempotencyKey(String tenantId, String key) {
+    return "idem:" + tenantId + ":" + key;
+  }
+
+  private String normalizeTenant(String tenantId) {
+    return (tenantId == null || tenantId.isBlank()) ? "global" : tenantId;
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/support/SendGridTemplateClient.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/support/SendGridTemplateClient.java
@@ -1,0 +1,69 @@
+package com.ejada.template.service.support;
+
+import com.ejada.template.config.SendGridProperties;
+import com.ejada.template.domain.entity.TemplateEntity;
+import com.ejada.template.domain.entity.TemplateVersionEntity;
+import com.ejada.template.exception.SendGridSyncException;
+import com.sendgrid.Method;
+import com.sendgrid.Request;
+import com.sendgrid.Response;
+import com.sendgrid.SendGrid;
+import java.io.IOException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SendGridTemplateClient {
+
+  private final SendGrid sendGrid;
+  private final SendGridProperties properties;
+
+  public void syncTemplate(TemplateEntity template, TemplateVersionEntity version) {
+    try {
+      Request request = new Request();
+      request.setMethod(Method.POST);
+      request.setEndpoint("/v3/templates");
+      request.setBody(
+          "{" +
+              "\"name\":\"" + template.getName() + " v" + version.getVersionNumber() + "\"," +
+              "\"generation\":\"dynamic\"}");
+      Response response = sendGrid.api(request);
+      if (response.getStatusCode() >= 400) {
+        throw new SendGridSyncException("Failed to sync template: " + response.getBody());
+      }
+      version.setSendGridTemplateId(template.getName());
+      version.setSendGridVersionId("v" + version.getVersionNumber());
+      log.info("SendGrid template sync succeeded for template {}", template.getName());
+    } catch (IOException ex) {
+      throw new SendGridSyncException("SendGrid API failure", ex);
+    }
+  }
+
+  public void publishVersion(TemplateEntity template, TemplateVersionEntity version) {
+    try {
+      String templateId =
+          version.getSendGridTemplateId() != null
+              ? version.getSendGridTemplateId()
+              : template.getName();
+      Request request = new Request();
+      request.setMethod(Method.POST);
+      request.setEndpoint(String.format("/v3/templates/%s/versions", templateId));
+      request.setBody("{}");
+      Response response = sendGrid.api(request);
+      if (response.getStatusCode() >= 400) {
+        throw new SendGridSyncException("Failed to publish template version: " + response.getBody());
+      }
+      log.info("Published SendGrid version for template {}", template.getName());
+    } catch (IOException ex) {
+      throw new SendGridSyncException("SendGrid version publish failed", ex);
+    }
+  }
+
+  public Map<String, Object> defaultHeaders() {
+    return Map.of("from", properties.defaultFromEmail(), "fromName", properties.defaultFromName());
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/support/TemplateRenderer.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/support/TemplateRenderer.java
@@ -1,0 +1,33 @@
+package com.ejada.template.service.support;
+
+import com.ejada.template.domain.entity.TemplateVersionEntity;
+import com.ejada.template.dto.TemplatePreviewResponse;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import java.io.IOException;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TemplateRenderer {
+  private final Handlebars handlebars = new Handlebars();
+
+  public TemplatePreviewResponse render(TemplateVersionEntity version, Map<String, Object> model) {
+    return TemplatePreviewResponse.builder()
+        .htmlBody(renderBody(version.getHtmlBody(), model))
+        .textBody(renderBody(version.getTextBody(), model))
+        .build();
+  }
+
+  private String renderBody(String body, Map<String, Object> model) {
+    if (body == null) {
+      return null;
+    }
+    try {
+      Template compiled = handlebars.compileInline(body);
+      return compiled.apply(model);
+    } catch (IOException ex) {
+      throw new IllegalStateException("Failed to render template", ex);
+    }
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/support/TemplateValidator.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/support/TemplateValidator.java
@@ -1,0 +1,30 @@
+package com.ejada.template.service.support;
+
+import com.ejada.template.domain.entity.TemplateVersionEntity;
+import com.ejada.template.dto.TemplateValidationResponse;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TemplateValidator {
+
+  public TemplateValidationResponse validate(
+      TemplateVersionEntity version, Map<String, Object> dynamicData) {
+    Set<String> allowed = version.getAllowedVariables();
+    Set<String> provided = dynamicData != null ? dynamicData.keySet() : Set.of();
+
+    Set<String> missing = new TreeSet<>(allowed);
+    missing.removeAll(provided);
+
+    Set<String> unexpected = new TreeSet<>(provided);
+    unexpected.removeAll(allowed);
+
+    return TemplateValidationResponse.builder()
+        .valid(missing.isEmpty() && unexpected.isEmpty())
+        .missingVariables(missing)
+        .unexpectedVariables(unexpected)
+        .build();
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/support/WebhookDeduplicationService.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/support/WebhookDeduplicationService.java
@@ -1,0 +1,19 @@
+package com.ejada.template.service.support;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WebhookDeduplicationService {
+
+  private final StringRedisTemplate redisTemplate;
+
+  public boolean isDuplicate(String tenantId, String eventId, Duration ttl) {
+    String key = "webhook:" + tenantId + ":" + eventId;
+    Boolean created = redisTemplate.opsForValue().setIfAbsent(key, "1", ttl);
+    return Boolean.FALSE.equals(created);
+  }
+}

--- a/email-management/email-template-service/src/main/resources/application.yaml
+++ b/email-management/email-template-service/src/main/resources/application.yaml
@@ -1,40 +1,46 @@
 spring:
   application:
     name: email-template-service
-  profiles:
-    active: dev
+  datasource:
+    url: jdbc:postgresql://localhost:5432/email
+    username: email
+    password: email
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          time_zone: UTC
   flyway:
-    baseline-on-migrate: true
-    baseline-version: 0
-    schemas: public,tenant
-    default-schema: tenant
-server:
-  port: 8081
-  shutdown: graceful
-  servlet:
-    context-path: /tenant
-  compression:
     enabled: true
-    mime-types:
-      - text/html
-      - text/plain
-      - text/css
-      - application/json
-      - application/javascript
-    min-response-size: 2KB
-  error:
-    include-message: always
-    include-binding-errors: always
+    locations: classpath:db/migration
+  cache:
+    type: redis
 
-shared:
-  observability:
-    application-name: email-template-service
-  security:
-    enable-role-check: true
-    jwt:
-      token-period: 15m
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
 
-tenant:
-  kafka:
-    topics:
-      tenant-onboarding: "${TENANT_KAFKA_TENANT_TOPIC:email-management.onboarding.tenants}"
+email:
+  kafka-topics:
+    email-send: email-send
+    email-send-retry: email-send-retry
+    email-send-dlq: email-send-dlq
+    webhook-events: sendgrid-webhooks
+    email-events: email-events
+  sendgrid:
+    sandbox-mode: false
+    timeout: PT30S
+    webhook-public-key: ""
+    default-from-email: noreply@example.com
+    default-from-name: Notification Service
+    api-key: changeme
+  rate-limit:
+    default-limit-per-minute: 300
+    burst-multiplier: 2
+    window: PT1M
+    idempotency-ttl: PT24H

--- a/email-management/email-usage-service/README.md
+++ b/email-management/email-usage-service/README.md
@@ -1,0 +1,4 @@
+# email-usage-service
+
+Aggregates delivery analytics per tenant directly from the relational email event log and exposes a
+simple reporting API.

--- a/email-management/email-usage-service/pom.xml
+++ b/email-management/email-usage-service/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>email-management</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>email-usage-service</artifactId>
+  <name>email-usage-service</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/email-management/email-usage-service/src/main/java/com/ejada/usage/EmailUsageServiceApplication.java
+++ b/email-management/email-usage-service/src/main/java/com/ejada/usage/EmailUsageServiceApplication.java
@@ -1,0 +1,12 @@
+package com.ejada.usage;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EmailUsageServiceApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(EmailUsageServiceApplication.class, args);
+  }
+}

--- a/email-management/email-usage-service/src/main/java/com/ejada/usage/controller/UsageController.java
+++ b/email-management/email-usage-service/src/main/java/com/ejada/usage/controller/UsageController.java
@@ -1,0 +1,30 @@
+package com.ejada.usage.controller;
+
+import com.ejada.usage.dto.UsageReportDto;
+import com.ejada.usage.service.UsageService;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tenants/{tenantId}/usage")
+public class UsageController {
+
+  private final UsageService service;
+
+  public UsageController(UsageService service) {
+    this.service = service;
+  }
+
+  @GetMapping
+  public UsageReportDto report(
+      @PathVariable String tenantId,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+    return service.report(tenantId, from, to);
+  }
+}

--- a/email-management/email-usage-service/src/main/java/com/ejada/usage/domain/UsageAggregate.java
+++ b/email-management/email-usage-service/src/main/java/com/ejada/usage/domain/UsageAggregate.java
@@ -1,0 +1,5 @@
+package com.ejada.usage.domain;
+
+import java.time.LocalDate;
+
+public record UsageAggregate(LocalDate date, long delivered, long bounced, long complaints) {}

--- a/email-management/email-usage-service/src/main/java/com/ejada/usage/dto/UsageMetricDto.java
+++ b/email-management/email-usage-service/src/main/java/com/ejada/usage/dto/UsageMetricDto.java
@@ -1,0 +1,5 @@
+package com.ejada.usage.dto;
+
+import java.time.LocalDate;
+
+public record UsageMetricDto(LocalDate date, long delivered, long bounced, long complaints) {}

--- a/email-management/email-usage-service/src/main/java/com/ejada/usage/dto/UsageReportDto.java
+++ b/email-management/email-usage-service/src/main/java/com/ejada/usage/dto/UsageReportDto.java
@@ -1,0 +1,5 @@
+package com.ejada.usage.dto;
+
+import java.util.List;
+
+public record UsageReportDto(String tenantId, List<UsageMetricDto> metrics) {}

--- a/email-management/email-usage-service/src/main/java/com/ejada/usage/repository/UsageRepository.java
+++ b/email-management/email-usage-service/src/main/java/com/ejada/usage/repository/UsageRepository.java
@@ -1,0 +1,44 @@
+package com.ejada.usage.repository;
+
+import com.ejada.usage.domain.UsageAggregate;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UsageRepository {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public UsageRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public List<UsageAggregate> loadUsage(String tenantId, LocalDate from, LocalDate to) {
+    String sql =
+        """
+        select date_trunc('day', occurred_at)::date as day,
+               sum(case when event_type = 'DELIVERED' then 1 else 0 end) as delivered,
+               sum(case when event_type = 'BOUNCED' then 1 else 0 end) as bounced,
+               sum(case when event_type = 'SPAM' then 1 else 0 end) as complaints
+          from email_event_log
+         where tenant_id = :tenantId
+           and occurred_at between :from and :to
+         group by 1
+         order by 1 asc
+        """;
+    return jdbcTemplate.query(
+        sql,
+        new MapSqlParameterSource().addValue("tenantId", tenantId).addValue("from", from).addValue("to", to),
+        this::mapRow);
+  }
+
+  private UsageAggregate mapRow(ResultSet rs, int rowNum) throws SQLException {
+    return new UsageAggregate(
+        rs.getDate("day").toLocalDate(), rs.getLong("delivered"), rs.getLong("bounced"), rs.getLong("complaints"));
+  }
+}

--- a/email-management/email-usage-service/src/main/java/com/ejada/usage/service/UsageService.java
+++ b/email-management/email-usage-service/src/main/java/com/ejada/usage/service/UsageService.java
@@ -1,0 +1,8 @@
+package com.ejada.usage.service;
+
+import com.ejada.usage.dto.UsageReportDto;
+import java.time.LocalDate;
+
+public interface UsageService {
+  UsageReportDto report(String tenantId, LocalDate from, LocalDate to);
+}

--- a/email-management/email-usage-service/src/main/java/com/ejada/usage/service/impl/UsageServiceImpl.java
+++ b/email-management/email-usage-service/src/main/java/com/ejada/usage/service/impl/UsageServiceImpl.java
@@ -1,0 +1,31 @@
+package com.ejada.usage.service.impl;
+
+import com.ejada.usage.domain.UsageAggregate;
+import com.ejada.usage.dto.UsageMetricDto;
+import com.ejada.usage.dto.UsageReportDto;
+import com.ejada.usage.repository.UsageRepository;
+import com.ejada.usage.service.UsageService;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UsageServiceImpl implements UsageService {
+
+  private final UsageRepository repository;
+
+  public UsageServiceImpl(UsageRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  public UsageReportDto report(String tenantId, LocalDate from, LocalDate to) {
+    List<UsageAggregate> aggregates = repository.loadUsage(tenantId, from, to);
+    List<UsageMetricDto> metrics =
+        aggregates.stream()
+            .map(a -> new UsageMetricDto(a.date(), a.delivered(), a.bounced(), a.complaints()))
+            .collect(Collectors.toList());
+    return new UsageReportDto(tenantId, metrics);
+  }
+}

--- a/email-management/email-usage-service/src/main/resources/application.yaml
+++ b/email-management/email-usage-service/src/main/resources/application.yaml
@@ -1,0 +1,14 @@
+server:
+  port: 8084
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/email
+    username: email
+    password: email
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: true

--- a/email-management/email-webhook-service/README.md
+++ b/email-management/email-webhook-service/README.md
@@ -1,0 +1,4 @@
+# email-webhook-service
+
+Dedicated SendGrid webhook ingestion surface that verifies signatures, deduplicates payloads with
+Redis, and emits normalized events to Kafka for downstream consumers.

--- a/email-management/email-webhook-service/pom.xml
+++ b/email-management/email-webhook-service/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>email-management</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>email-webhook-service</artifactId>
+  <name>email-webhook-service</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/EmailWebhookServiceApplication.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/EmailWebhookServiceApplication.java
@@ -1,0 +1,17 @@
+package com.ejada.webhook;
+
+import com.ejada.webhook.config.SendGridWebhookProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+@EnableConfigurationProperties(SendGridWebhookProperties.class)
+public class EmailWebhookServiceApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(EmailWebhookServiceApplication.class, args);
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/config/SendGridWebhookProperties.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/config/SendGridWebhookProperties.java
@@ -1,0 +1,25 @@
+package com.ejada.webhook.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "sendgrid.webhook")
+public class SendGridWebhookProperties {
+  private String signingSecret;
+  private long toleranceSeconds = 300;
+
+  public String getSigningSecret() {
+    return signingSecret;
+  }
+
+  public void setSigningSecret(String signingSecret) {
+    this.signingSecret = signingSecret;
+  }
+
+  public long getToleranceSeconds() {
+    return toleranceSeconds;
+  }
+
+  public void setToleranceSeconds(long toleranceSeconds) {
+    this.toleranceSeconds = toleranceSeconds;
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/controller/WebhookController.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/controller/WebhookController.java
@@ -1,0 +1,43 @@
+package com.ejada.webhook.controller;
+
+import com.ejada.webhook.dto.SendGridWebhookRequest;
+import com.ejada.webhook.service.SignatureVerifier;
+import com.ejada.webhook.service.WebhookService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/webhooks/sendgrid")
+public class WebhookController {
+
+  private final WebhookService webhookService;
+  private final SignatureVerifier signatureVerifier;
+  private final ObjectMapper objectMapper;
+
+  public WebhookController(
+      WebhookService webhookService, SignatureVerifier signatureVerifier, ObjectMapper objectMapper) {
+    this.webhookService = webhookService;
+    this.signatureVerifier = signatureVerifier;
+    this.objectMapper = objectMapper;
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> ingest(
+      @RequestHeader("X-Timestamp") long timestamp,
+      @RequestHeader("X-Signature") String signature,
+      @RequestBody String payload) throws JsonProcessingException {
+    if (!signatureVerifier.isValid(payload, signature, timestamp)) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    SendGridWebhookRequest request = objectMapper.readValue(payload, SendGridWebhookRequest.class);
+    webhookService.handle(request);
+    return ResponseEntity.accepted().build();
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/dto/SendGridEvent.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/dto/SendGridEvent.java
@@ -1,0 +1,55 @@
+package com.ejada.webhook.dto;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SendGridEvent {
+  private String event;
+  private String email;
+  private String sgMessageId;
+  private Instant timestamp;
+  private final Map<String, Object> customArgs = new HashMap<>();
+
+  public String getEvent() {
+    return event;
+  }
+
+  public void setEvent(String event) {
+    this.event = event;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public String getSgMessageId() {
+    return sgMessageId;
+  }
+
+  public void setSgMessageId(String sgMessageId) {
+    this.sgMessageId = sgMessageId;
+  }
+
+  public Instant getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Instant timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public Map<String, Object> getCustomArgs() {
+    return customArgs;
+  }
+
+  @JsonAnySetter
+  public void addCustomArg(String key, Object value) {
+    customArgs.put(key, value);
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/dto/SendGridWebhookRequest.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/dto/SendGridWebhookRequest.java
@@ -1,0 +1,6 @@
+package com.ejada.webhook.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record SendGridWebhookRequest(@NotEmpty List<SendGridEvent> events) {}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/messaging/WebhookEventMessage.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/messaging/WebhookEventMessage.java
@@ -1,0 +1,7 @@
+package com.ejada.webhook.messaging;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record WebhookEventMessage(
+    String tenantId, String eventType, String sgMessageId, Map<String, Object> payload, Instant occurredAt) {}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/DeduplicationService.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/DeduplicationService.java
@@ -1,0 +1,5 @@
+package com.ejada.webhook.service;
+
+public interface DeduplicationService {
+  boolean seen(String messageId);
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/SignatureVerifier.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/SignatureVerifier.java
@@ -1,0 +1,5 @@
+package com.ejada.webhook.service;
+
+public interface SignatureVerifier {
+  boolean isValid(String payload, String signature, long timestamp);
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/WebhookService.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/WebhookService.java
@@ -1,0 +1,7 @@
+package com.ejada.webhook.service;
+
+import com.ejada.webhook.dto.SendGridWebhookRequest;
+
+public interface WebhookService {
+  void handle(SendGridWebhookRequest request);
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/impl/HmacSignatureVerifier.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/impl/HmacSignatureVerifier.java
@@ -1,0 +1,47 @@
+package com.ejada.webhook.service.impl;
+
+import com.ejada.webhook.config.SendGridWebhookProperties;
+import com.ejada.webhook.service.SignatureVerifier;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+public class HmacSignatureVerifier implements SignatureVerifier {
+
+  private final SendGridWebhookProperties properties;
+
+  public HmacSignatureVerifier(SendGridWebhookProperties properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public boolean isValid(String payload, String signature, long timestamp) {
+    Assert.hasText(signature, "signature required");
+    long toleranceSeconds = properties.getToleranceSeconds();
+    long now = System.currentTimeMillis() / 1000;
+    if (Math.abs(now - timestamp) > toleranceSeconds) {
+      return false;
+    }
+    try {
+      Mac mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(properties.getSigningSecret().getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+      byte[] digest = mac.doFinal((timestamp + payload).getBytes(StandardCharsets.UTF_8));
+      String expected = bytesToHex(digest);
+      return expected.equalsIgnoreCase(signature);
+    } catch (GeneralSecurityException ex) {
+      return false;
+    }
+  }
+
+  private static String bytesToHex(byte[] bytes) {
+    StringBuilder builder = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      builder.append(String.format("%02x", b));
+    }
+    return builder.toString();
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/impl/RedisDeduplicationService.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/impl/RedisDeduplicationService.java
@@ -1,0 +1,23 @@
+package com.ejada.webhook.service.impl;
+
+import com.ejada.webhook.service.DeduplicationService;
+import java.time.Duration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisDeduplicationService implements DeduplicationService {
+
+  private final StringRedisTemplate redisTemplate;
+
+  public RedisDeduplicationService(StringRedisTemplate redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  @Override
+  public boolean seen(String messageId) {
+    Boolean stored =
+        redisTemplate.opsForValue().setIfAbsent("webhook:event:" + messageId, "1", Duration.ofHours(1));
+    return !Boolean.TRUE.equals(stored);
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/impl/WebhookServiceImpl.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/webhook/service/impl/WebhookServiceImpl.java
@@ -1,0 +1,44 @@
+package com.ejada.webhook.service.impl;
+
+import com.ejada.webhook.dto.SendGridEvent;
+import com.ejada.webhook.dto.SendGridWebhookRequest;
+import com.ejada.webhook.messaging.WebhookEventMessage;
+import com.ejada.webhook.service.DeduplicationService;
+import com.ejada.webhook.service.WebhookService;
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WebhookServiceImpl implements WebhookService {
+
+  private final KafkaTemplate<String, WebhookEventMessage> kafkaTemplate;
+  private final DeduplicationService deduplicationService;
+
+  public WebhookServiceImpl(
+      KafkaTemplate<String, WebhookEventMessage> kafkaTemplate,
+      DeduplicationService deduplicationService) {
+    this.kafkaTemplate = kafkaTemplate;
+    this.deduplicationService = deduplicationService;
+  }
+
+  @Override
+  public void handle(SendGridWebhookRequest request) {
+    for (SendGridEvent event : request.events()) {
+      if (deduplicationService.seen(event.getSgMessageId())) {
+        continue;
+      }
+      WebhookEventMessage message =
+          new WebhookEventMessage(
+              (String) event.getCustomArgs().getOrDefault("tenantId", "unknown"),
+              event.getEvent(),
+              event.getSgMessageId(),
+              Map.of(
+                  "email", event.getEmail(),
+                  "timestamp", event.getTimestamp() == null ? Instant.now() : event.getTimestamp()),
+              event.getTimestamp() == null ? Instant.now() : event.getTimestamp());
+      kafkaTemplate.send("email.events", message.tenantId(), message);
+    }
+  }
+}

--- a/email-management/email-webhook-service/src/main/resources/application.yaml
+++ b/email-management/email-webhook-service/src/main/resources/application.yaml
@@ -1,0 +1,15 @@
+server:
+  port: 8083
+
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+sendgrid:
+  webhook:
+    signing-secret: change-me
+    tolerance-seconds: 300

--- a/email-management/pom.xml
+++ b/email-management/pom.xml
@@ -17,8 +17,11 @@
   <name>email-management</name>
 
   <modules>
-  <!--   <module>shared-lib</module>-->
+    <module>email-management-service</module>
     <module>email-template-service</module>
+    <module>email-sending-service</module>
+    <module>email-webhook-service</module>
+    <module>email-usage-service</module>
   </modules>
 
   <properties>
@@ -26,6 +29,7 @@
     <maven.min.version>3.9.6</maven.min.version>
 
     <ejada.shared.version>1.0.0</ejada.shared.version>
+    <springdoc.version>2.6.0</springdoc.version>
 
     <plugin.enforcer.version>3.5.0</plugin.enforcer.version>
     <plugin.jacoco.version>0.8.12</plugin.jacoco.version>
@@ -59,9 +63,10 @@
       <artifactId>lombok</artifactId>
       <optional>true</optional>
     </dependency>
-     <dependency>
+    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>${springdoc.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
## Summary
- add the email-management-service gateway along with shared DTOs, service clients, and configuration to route tenant API requests to the specialized child services
- scaffold standalone email-sending, email-webhook, and email-usage Spring Boot services with their own REST endpoints, Redis/Kafka/PostgreSQL integrations, and deployment defaults
- expose a lightweight internal template gateway inside the template service and update the parent module/README to document the new multi-service layout

## Testing
- `mvn -DskipTests package` *(fails: the build imports the internal `com.ejada:shared-lib:1.0.0` BOM which is not available on Maven Central inside this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a249b3044832f893f95341f7adb79)