### PR TITLE
Add tenant gateway guardrails and portal APIs

### DIFF
--- a/email-management/email-management-service/README.md
+++ b/email-management/email-management-service/README.md
@@ -3,3 +3,18 @@
 Gateway facade that exposes a consolidated API surface for tenants while routing work to the
 specialized child services (template, sending, webhook, and usage). The service discovers the child
 base URLs via `child-services.*` properties and forwards requests using Spring's `RestClient`.
+
+The parent microservice also centralizes platform-wide capabilities:
+
+- **Tenant authz/authn** enforced through the `TenantAuthenticationFilter`, propagated via
+  `TenantContextHolder`, and validated with per-tenant tokens.
+- **Unified API gateway** controllers fan out into the appropriate downstream service and aggregate
+  the response for both REST and lightweight GraphQL clients.
+- **Global configuration and feature flags** are provided by `GlobalConfigService` so portal requests
+  can toggle optional capabilities per tenant.
+- **Centralized audit logging and monitoring** is captured through the `AuditLogger` helper that logs
+  every inbound request/action with the tenant id.
+- **Workflow orchestration** happens in `TenantExperienceService`, which blends template, usage, and
+  configuration data into UI-ready payloads.
+- **Rate limiting** is enforced at the API boundary via `TenantRateLimiter`, preventing noisy tenants
+  from exhausting resources.

--- a/email-management/email-management-service/src/main/java/com/ejada/management/EmailManagementServiceApplication.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/EmailManagementServiceApplication.java
@@ -1,6 +1,8 @@
 package com.ejada.management;
 
 import com.ejada.management.config.ChildServiceProperties;
+import com.ejada.management.config.GlobalConfigProperties;
+import com.ejada.management.config.TenantSecurityProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -8,7 +10,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
-@EnableConfigurationProperties(ChildServiceProperties.class)
+@EnableConfigurationProperties({
+  ChildServiceProperties.class,
+  TenantSecurityProperties.class,
+  GlobalConfigProperties.class
+})
 public class EmailManagementServiceApplication {
 
   public static void main(String[] args) {

--- a/email-management/email-management-service/src/main/java/com/ejada/management/config/GlobalConfigProperties.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/config/GlobalConfigProperties.java
@@ -1,0 +1,37 @@
+package com.ejada.management.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "global-config")
+public class GlobalConfigProperties {
+
+  private Map<String, String> sharedSettings = new HashMap<>();
+  private Map<String, Boolean> featureFlags = new HashMap<>();
+  private Map<String, Map<String, String>> tenantSettings = new HashMap<>();
+
+  public Map<String, String> getSharedSettings() {
+    return sharedSettings;
+  }
+
+  public void setSharedSettings(Map<String, String> sharedSettings) {
+    this.sharedSettings = sharedSettings;
+  }
+
+  public Map<String, Boolean> getFeatureFlags() {
+    return featureFlags;
+  }
+
+  public void setFeatureFlags(Map<String, Boolean> featureFlags) {
+    this.featureFlags = featureFlags;
+  }
+
+  public Map<String, Map<String, String>> getTenantSettings() {
+    return tenantSettings;
+  }
+
+  public void setTenantSettings(Map<String, Map<String, String>> tenantSettings) {
+    this.tenantSettings = tenantSettings;
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/config/RestClientConfig.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/config/RestClientConfig.java
@@ -1,5 +1,6 @@
 package com.ejada.management.config;
 
+import com.ejada.management.service.TenantContextHolder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
@@ -9,6 +10,15 @@ public class RestClientConfig {
 
   @Bean
   RestClient restClient() {
-    return RestClient.builder().build();
+    return RestClient
+        .builder()
+        .requestInterceptor(
+            (request, body, execution) -> {
+              TenantContextHolder
+                  .getTenantId()
+                  .ifPresent(tenantId -> request.getHeaders().add("X-Tenant-Id", tenantId));
+              return execution.execute(request, body);
+            })
+        .build();
   }
 }

--- a/email-management/email-management-service/src/main/java/com/ejada/management/config/TenantAuthenticationFilter.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/config/TenantAuthenticationFilter.java
@@ -1,0 +1,68 @@
+package com.ejada.management.config;
+
+import com.ejada.management.service.AuditLogger;
+import com.ejada.management.service.TenantAuthorizationService;
+import com.ejada.management.service.TenantContextHolder;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+public class TenantAuthenticationFilter extends OncePerRequestFilter {
+
+  private static final Pattern TENANT_PATTERN = Pattern.compile("/tenants/([^/]+)");
+
+  private final TenantAuthorizationService authorizationService;
+  private final AuditLogger auditLogger;
+
+  public TenantAuthenticationFilter(
+      TenantAuthorizationService authorizationService, AuditLogger auditLogger) {
+    this.authorizationService = authorizationService;
+    this.auditLogger = auditLogger;
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String path = request.getRequestURI();
+    return path.startsWith("/actuator") || path.startsWith("/api/v1/webhooks");
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    try {
+      String tenantId = resolveTenantId(request);
+      if (tenantId == null) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Missing tenant id");
+      }
+      authorizationService.verifyAccess(tenantId, request.getHeader("X-Tenant-Auth"));
+      TenantContextHolder.setTenantId(tenantId);
+      auditLogger.logTenantAction(tenantId, "REQUEST", request.getMethod() + " " + request.getRequestURI());
+      filterChain.doFilter(request, response);
+    } finally {
+      TenantContextHolder.clear();
+    }
+  }
+
+  private String resolveTenantId(HttpServletRequest request) {
+    String header = request.getHeader("X-Tenant-Id");
+    if (StringUtils.hasText(header)) {
+      return header;
+    }
+    Matcher matcher = TENANT_PATTERN.matcher(request.getRequestURI());
+    if (matcher.find()) {
+      return matcher.group(1);
+    }
+    return null;
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/config/TenantSecurityProperties.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/config/TenantSecurityProperties.java
@@ -1,0 +1,80 @@
+package com.ejada.management.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "tenant-security")
+public class TenantSecurityProperties {
+
+  private boolean authenticationRequired = true;
+  private Map<String, String> tokens = new HashMap<>();
+  private RateLimit rateLimit = new RateLimit();
+
+  public boolean isAuthenticationRequired() {
+    return authenticationRequired;
+  }
+
+  public void setAuthenticationRequired(boolean authenticationRequired) {
+    this.authenticationRequired = authenticationRequired;
+  }
+
+  public Map<String, String> getTokens() {
+    return tokens;
+  }
+
+  public void setTokens(Map<String, String> tokens) {
+    this.tokens = tokens;
+  }
+
+  public RateLimit getRateLimit() {
+    return rateLimit;
+  }
+
+  public void setRateLimit(RateLimit rateLimit) {
+    this.rateLimit = rateLimit;
+  }
+
+  public static class RateLimit {
+    private boolean enabled = true;
+    private int defaultQuota = 120;
+    private long windowSeconds = 60;
+    private Map<String, Integer> tenantQuotas = new HashMap<>();
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public int getDefaultQuota() {
+      return defaultQuota;
+    }
+
+    public void setDefaultQuota(int defaultQuota) {
+      this.defaultQuota = defaultQuota;
+    }
+
+    public long getWindowSeconds() {
+      return windowSeconds;
+    }
+
+    public void setWindowSeconds(long windowSeconds) {
+      this.windowSeconds = windowSeconds;
+    }
+
+    public Map<String, Integer> getTenantQuotas() {
+      return tenantQuotas;
+    }
+
+    public void setTenantQuotas(Map<String, Integer> tenantQuotas) {
+      this.tenantQuotas = tenantQuotas;
+    }
+
+    public int resolveLimitForTenant(String tenantId) {
+      return tenantQuotas.getOrDefault(tenantId, defaultQuota);
+    }
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/controller/EmailGatewayController.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/controller/EmailGatewayController.java
@@ -2,7 +2,9 @@ package com.ejada.management.controller;
 
 import com.ejada.management.dto.EmailSendRequest;
 import com.ejada.management.dto.EmailSendResponse;
+import com.ejada.management.service.AuditLogger;
 import com.ejada.management.service.EmailGatewayService;
+import com.ejada.management.service.TenantRateLimiter;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,15 +19,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class EmailGatewayController {
 
   private final EmailGatewayService service;
+  private final TenantRateLimiter rateLimiter;
+  private final AuditLogger auditLogger;
 
-  public EmailGatewayController(EmailGatewayService service) {
+  public EmailGatewayController(
+      EmailGatewayService service, TenantRateLimiter rateLimiter, AuditLogger auditLogger) {
     this.service = service;
+    this.rateLimiter = rateLimiter;
+    this.auditLogger = auditLogger;
   }
 
   @PostMapping("/send")
   @ResponseStatus(HttpStatus.ACCEPTED)
   public EmailSendResponse sendEmail(
       @PathVariable String tenantId, @Valid @RequestBody EmailSendRequest request) {
+    rateLimiter.assertWithinQuota(tenantId, "email-send");
+    auditLogger.logTenantAction(tenantId, "EMAIL_SEND", request.subject());
     return service.sendEmail(tenantId, request);
   }
 }

--- a/email-management/email-management-service/src/main/java/com/ejada/management/controller/GraphQlGatewayController.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/controller/GraphQlGatewayController.java
@@ -1,0 +1,64 @@
+package com.ejada.management.controller;
+
+import com.ejada.management.dto.GraphQlRequest;
+import com.ejada.management.dto.GraphQlResponse;
+import com.ejada.management.dto.TenantPortalView;
+import com.ejada.management.service.AuditLogger;
+import com.ejada.management.service.TenantContextHolder;
+import com.ejada.management.service.TenantExperienceService;
+import com.ejada.management.service.TenantRateLimiter;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/v1/graphql")
+public class GraphQlGatewayController {
+
+  private static final Pattern TENANT_PORTAL_QUERY =
+      Pattern.compile("tenantPortal\\s*\\(\\s*tenantId\\s*:\\s*\\\"(?<tenant>[^\\\"]+)\\\"(,\\s*from:\\s*\\\"(?<from>[^\\\"]+)\\\")?(,\\s*to:\\s*\\\"(?<to>[^\\\"]+)\\\")?\\s*\\)");
+
+  private final TenantExperienceService tenantExperienceService;
+  private final TenantRateLimiter rateLimiter;
+  private final AuditLogger auditLogger;
+
+  public GraphQlGatewayController(
+      TenantExperienceService tenantExperienceService,
+      TenantRateLimiter rateLimiter,
+      AuditLogger auditLogger) {
+    this.tenantExperienceService = tenantExperienceService;
+    this.rateLimiter = rateLimiter;
+    this.auditLogger = auditLogger;
+  }
+
+  @PostMapping
+  public GraphQlResponse execute(@RequestBody GraphQlRequest request) {
+    Matcher matcher = TENANT_PORTAL_QUERY.matcher(request.query());
+    if (matcher.find()) {
+      String tenantId = matcher.group("tenant");
+      ensureTenantContextMatches(tenantId);
+      LocalDate from = matcher.group("from") != null ? LocalDate.parse(matcher.group("from")) : LocalDate.now().minusDays(30);
+      LocalDate to = matcher.group("to") != null ? LocalDate.parse(matcher.group("to")) : LocalDate.now();
+      rateLimiter.assertWithinQuota(tenantId, "graphql-portal");
+      TenantPortalView view = tenantExperienceService.buildTenantPortal(tenantId, from, to);
+      auditLogger.logTenantAction(tenantId, "GRAPHQL_PORTAL", from + "-" + to);
+      return new GraphQlResponse(Map.of("tenantPortal", view));
+    }
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported GraphQL query");
+  }
+
+  private void ensureTenantContextMatches(String tenantId) {
+    String contextTenant = TenantContextHolder.getTenantId().orElse(null);
+    if (contextTenant == null || !contextTenant.equals(tenantId)) {
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN, "Tenant id mismatch for GraphQL request");
+    }
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/controller/TemplateGatewayController.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/controller/TemplateGatewayController.java
@@ -2,7 +2,9 @@ package com.ejada.management.controller;
 
 import com.ejada.management.dto.TemplateSummary;
 import com.ejada.management.dto.TemplateSyncRequest;
+import com.ejada.management.service.AuditLogger;
 import com.ejada.management.service.TemplateGatewayService;
+import com.ejada.management.service.TenantRateLimiter;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -19,13 +21,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class TemplateGatewayController {
 
   private final TemplateGatewayService service;
+  private final TenantRateLimiter rateLimiter;
+  private final AuditLogger auditLogger;
 
-  public TemplateGatewayController(TemplateGatewayService service) {
+  public TemplateGatewayController(
+      TemplateGatewayService service, TenantRateLimiter rateLimiter, AuditLogger auditLogger) {
     this.service = service;
+    this.rateLimiter = rateLimiter;
+    this.auditLogger = auditLogger;
   }
 
   @GetMapping
   public List<TemplateSummary> listTemplates(@PathVariable String tenantId) {
+    rateLimiter.assertWithinQuota(tenantId, "template-list");
+    auditLogger.logTenantAction(tenantId, "TEMPLATE_LIST", "fetch");
     return service.fetchTemplates(tenantId);
   }
 
@@ -33,6 +42,8 @@ public class TemplateGatewayController {
   @ResponseStatus(HttpStatus.ACCEPTED)
   public void syncTemplates(
       @PathVariable String tenantId, @Valid @RequestBody TemplateSyncRequest request) {
+    rateLimiter.assertWithinQuota(tenantId, "template-sync");
+    auditLogger.logTenantAction(tenantId, "TEMPLATE_SYNC", request.syncType());
     service.requestSync(tenantId, request);
   }
 }

--- a/email-management/email-management-service/src/main/java/com/ejada/management/controller/TenantPortalController.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/controller/TenantPortalController.java
@@ -1,0 +1,44 @@
+package com.ejada.management.controller;
+
+import com.ejada.management.dto.TenantPortalView;
+import com.ejada.management.service.AuditLogger;
+import com.ejada.management.service.TenantExperienceService;
+import com.ejada.management.service.TenantRateLimiter;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tenants/{tenantId}/portal")
+public class TenantPortalController {
+
+  private final TenantExperienceService tenantExperienceService;
+  private final TenantRateLimiter rateLimiter;
+  private final AuditLogger auditLogger;
+
+  public TenantPortalController(
+      TenantExperienceService tenantExperienceService,
+      TenantRateLimiter rateLimiter,
+      AuditLogger auditLogger) {
+    this.tenantExperienceService = tenantExperienceService;
+    this.rateLimiter = rateLimiter;
+    this.auditLogger = auditLogger;
+  }
+
+  @GetMapping
+  public TenantPortalView portal(
+      @PathVariable String tenantId,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+    LocalDate effectiveTo = to != null ? to : LocalDate.now();
+    LocalDate effectiveFrom = from != null ? from : effectiveTo.minusDays(30);
+    rateLimiter.assertWithinQuota(tenantId, "portal-view");
+    TenantPortalView view = tenantExperienceService.buildTenantPortal(tenantId, effectiveFrom, effectiveTo);
+    auditLogger.logTenantAction(tenantId, "PORTAL_VIEW", effectiveFrom + "-" + effectiveTo);
+    return view;
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/dto/GraphQlRequest.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/dto/GraphQlRequest.java
@@ -1,0 +1,3 @@
+package com.ejada.management.dto;
+
+public record GraphQlRequest(String query) {}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/dto/GraphQlResponse.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/dto/GraphQlResponse.java
@@ -1,0 +1,5 @@
+package com.ejada.management.dto;
+
+import java.util.Map;
+
+public record GraphQlResponse(Map<String, Object> data) {}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/dto/TenantPortalView.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/dto/TenantPortalView.java
@@ -1,0 +1,7 @@
+package com.ejada.management.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record TenantPortalView(
+    String tenantId, List<TemplateSummary> templates, UsageReport usage, Map<String, String> settings) {}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/service/AuditLogger.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/service/AuditLogger.java
@@ -1,0 +1,15 @@
+package com.ejada.management.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditLogger {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AuditLogger.class);
+
+  public void logTenantAction(String tenantId, String action, String details) {
+    LOGGER.info("[tenant={}] action={} details={}", tenantId, action, details);
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/service/GlobalConfigService.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/service/GlobalConfigService.java
@@ -1,0 +1,29 @@
+package com.ejada.management.service;
+
+import com.ejada.management.config.GlobalConfigProperties;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GlobalConfigService {
+
+  private final GlobalConfigProperties properties;
+
+  public GlobalConfigService(GlobalConfigProperties properties) {
+    this.properties = properties;
+  }
+
+  public boolean isFeatureEnabled(String feature) {
+    return properties.getFeatureFlags().getOrDefault(feature, Boolean.TRUE);
+  }
+
+  public Map<String, String> tenantSettings(String tenantId) {
+    Map<String, String> merged = new HashMap<>(properties.getSharedSettings());
+    Map<String, String> overrides = properties.getTenantSettings().get(tenantId);
+    if (overrides != null) {
+      merged.putAll(overrides);
+    }
+    return merged;
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/service/TenantAuthorizationService.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/service/TenantAuthorizationService.java
@@ -1,0 +1,27 @@
+package com.ejada.management.service;
+
+import com.ejada.management.config.TenantSecurityProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class TenantAuthorizationService {
+
+  private final TenantSecurityProperties properties;
+
+  public TenantAuthorizationService(TenantSecurityProperties properties) {
+    this.properties = properties;
+  }
+
+  public void verifyAccess(String tenantId, String presentedToken) {
+    if (!properties.isAuthenticationRequired()) {
+      return;
+    }
+    String expectedToken = properties.getTokens().get(tenantId);
+    if (!StringUtils.hasText(expectedToken) || !expectedToken.equals(presentedToken)) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid tenant token");
+    }
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/service/TenantContextHolder.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/service/TenantContextHolder.java
@@ -1,0 +1,22 @@
+package com.ejada.management.service;
+
+import java.util.Optional;
+
+public final class TenantContextHolder {
+
+  private static final ThreadLocal<String> TENANT = new ThreadLocal<>();
+
+  private TenantContextHolder() {}
+
+  public static void setTenantId(String tenantId) {
+    TENANT.set(tenantId);
+  }
+
+  public static Optional<String> getTenantId() {
+    return Optional.ofNullable(TENANT.get());
+  }
+
+  public static void clear() {
+    TENANT.remove();
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/service/TenantExperienceService.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/service/TenantExperienceService.java
@@ -1,0 +1,41 @@
+package com.ejada.management.service;
+
+import com.ejada.management.dto.TenantPortalView;
+import com.ejada.management.dto.TemplateSummary;
+import com.ejada.management.dto.UsageReport;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TenantExperienceService {
+
+  private final TemplateGatewayService templateGatewayService;
+  private final UsageGatewayService usageGatewayService;
+  private final GlobalConfigService globalConfigService;
+
+  public TenantExperienceService(
+      TemplateGatewayService templateGatewayService,
+      UsageGatewayService usageGatewayService,
+      GlobalConfigService globalConfigService) {
+    this.templateGatewayService = templateGatewayService;
+    this.usageGatewayService = usageGatewayService;
+    this.globalConfigService = globalConfigService;
+  }
+
+  public TenantPortalView buildTenantPortal(String tenantId, LocalDate from, LocalDate to) {
+    List<TemplateSummary> templates = List.of();
+    if (globalConfigService.isFeatureEnabled("templates")) {
+      templates = templateGatewayService.fetchTemplates(tenantId);
+    }
+
+    UsageReport usage = null;
+    if (globalConfigService.isFeatureEnabled("usage")) {
+      usage = usageGatewayService.fetchUsage(tenantId, from, to);
+    }
+
+    Map<String, String> settings = globalConfigService.tenantSettings(tenantId);
+    return new TenantPortalView(tenantId, templates, usage, settings);
+  }
+}

--- a/email-management/email-management-service/src/main/java/com/ejada/management/service/TenantRateLimiter.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/service/TenantRateLimiter.java
@@ -1,0 +1,60 @@
+package com.ejada.management.service;
+
+import com.ejada.management.config.TenantSecurityProperties;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class TenantRateLimiter {
+
+  private final TenantSecurityProperties properties;
+  private final Map<String, RequestWindow> windows = new ConcurrentHashMap<>();
+
+  public TenantRateLimiter(TenantSecurityProperties properties) {
+    this.properties = properties;
+  }
+
+  public void assertWithinQuota(String tenantId, String bucket) {
+    TenantSecurityProperties.RateLimit rateLimit = properties.getRateLimit();
+    if (!rateLimit.isEnabled()) {
+      return;
+    }
+    String key = tenantId + ":" + bucket;
+    RequestWindow window = windows.compute(key, (k, existing) -> resetIfNeeded(existing, rateLimit));
+    int current = window.counter.incrementAndGet();
+    int limit = rateLimit.resolveLimitForTenant(tenantId);
+    if (limit > 0 && current > limit) {
+      throw new ResponseStatusException(
+          HttpStatus.TOO_MANY_REQUESTS,
+          "Rate limit exceeded for tenant " + tenantId + " bucket " + bucket);
+    }
+  }
+
+  private RequestWindow resetIfNeeded(
+      RequestWindow existing, TenantSecurityProperties.RateLimit rateLimit) {
+    Instant now = Instant.now();
+    if (existing == null) {
+      return new RequestWindow(now, new AtomicInteger(0));
+    }
+    long windowSeconds = Math.max(rateLimit.getWindowSeconds(), 1);
+    if (now.isAfter(existing.windowStart.plusSeconds(windowSeconds))) {
+      return new RequestWindow(now, new AtomicInteger(0));
+    }
+    return existing;
+  }
+
+  private static final class RequestWindow {
+    private final Instant windowStart;
+    private final AtomicInteger counter;
+
+    private RequestWindow(Instant windowStart, AtomicInteger counter) {
+      this.windowStart = windowStart;
+      this.counter = counter;
+    }
+  }
+}

--- a/email-management/email-management-service/src/main/resources/application.yaml
+++ b/email-management/email-management-service/src/main/resources/application.yaml
@@ -10,3 +10,26 @@ child-services:
     base-url: http://email-webhook-service:8083
   usage:
     base-url: http://email-usage-service:8084
+
+tenant-security:
+  authentication-required: true
+  tokens:
+    demo: secret-token
+    premium: premium-token
+  rate-limit:
+    enabled: true
+    default-quota: 120
+    window-seconds: 60
+    tenant-quotas:
+      premium: 500
+
+global-config:
+  shared-settings:
+    locale: en-US
+    timezone: UTC
+  feature-flags:
+    templates: true
+    usage: true
+  tenant-settings:
+    premium:
+      locale: en-GB


### PR DESCRIPTION
## Summary
- add tenant authentication, rate limiting, audit logging, and tenant-context propagation to the parent email-management gateway
- introduce configuration-backed feature flags plus tenant portal/GraphQL controllers that orchestrate downstream email child services
- expose new DTOs and services for tenant portal aggregation along with configuration updates documenting the capabilities

## Testing
- `mvn -q test` *(fails: missing com.ejada:shared-lib parent pom in public maven repo)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2e04ba54832fa4d083163423825c)