### PR TITLE
Add explicit BouncyCastle version for email template service

### DIFF
--- a/email-management/email-template-service/pom.xml
+++ b/email-management/email-template-service/pom.xml
@@ -16,6 +16,7 @@
 
   <properties>
     <java.version>21</java.version>
+    <bouncycastle.version>1.78</bouncycastle.version>
   </properties>
 
   <dependencies>
@@ -113,6 +114,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
     </dependency>
 
 


### PR DESCRIPTION
## Summary
- add a dedicated property for the BouncyCastle library version in the email-template-service module
- apply the version to the bcprov-jdk18on dependency to satisfy Maven requirements

## Testing
- mvn -pl email-template-service -am -DskipTests package *(fails: missing com.ejada:shared-lib:pom:1.0.0 artifact in repositories)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2f1fbb28832fa7c761fc4a170939)