### PR TITLE
Enforce template validation and cache active versions

### DIFF
--- a/email-management/email-template-service/src/main/java/com/ejada/template/exception/TemplateValidationException.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/exception/TemplateValidationException.java
@@ -1,0 +1,14 @@
+package com.ejada.template.exception;
+
+import com.ejada.template.dto.TemplateValidationResponse;
+import lombok.Getter;
+
+@Getter
+public class TemplateValidationException extends RuntimeException {
+  private final TemplateValidationResponse validation;
+
+  public TemplateValidationException(TemplateValidationResponse validation) {
+    super("Dynamic data failed validation against allowed variables");
+    this.validation = validation;
+  }
+}

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/TemplateServiceImpl.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/TemplateServiceImpl.java
@@ -61,7 +61,7 @@ public class TemplateServiceImpl implements TemplateService {
   }
 
   @Override
-  @CacheEvict(value = "templates", key = "#templateId")
+  @CacheEvict(value = {"templates", "activeTemplateVersions"}, key = "#templateId")
   public TemplateDto updateTemplate(Long templateId, UpdateTemplateRequest request) {
     TemplateEntity entity = templateRepository.findById(templateId).orElseThrow(() -> new TemplateNotFoundException(templateId));
     if (request.getDescription() != null) {
@@ -77,7 +77,7 @@ public class TemplateServiceImpl implements TemplateService {
   }
 
   @Override
-  @CacheEvict(value = "templates", key = "#templateId")
+  @CacheEvict(value = {"templates", "activeTemplateVersions"}, key = "#templateId")
   public TemplateDto archiveTemplate(Long templateId) {
     TemplateEntity entity = templateRepository.findById(templateId).orElseThrow(() -> new TemplateNotFoundException(templateId));
     entity.setArchived(true);
@@ -128,7 +128,9 @@ public class TemplateServiceImpl implements TemplateService {
   }
 
   @Override
-  @CacheEvict(value = {"templates", "templateVersions"}, allEntries = true)
+  @CacheEvict(
+      value = {"templates", "templateVersions", "activeTemplateVersions"},
+      allEntries = true)
   public TemplateVersionDto publishVersion(Long templateId, Long versionId) {
     TemplateEntity template = templateRepository.findById(templateId).orElseThrow(() -> new TemplateNotFoundException(templateId));
     TemplateVersionEntity version = versionRepository.findById(versionId).orElseThrow(() -> new TemplateVersionNotFoundException(templateId, versionId));

--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/support/TemplateLookupService.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/support/TemplateLookupService.java
@@ -1,0 +1,27 @@
+package com.ejada.template.service.support;
+
+import com.ejada.template.domain.entity.TemplateVersionEntity;
+import com.ejada.template.domain.enums.TemplateVersionStatus;
+import com.ejada.template.exception.TemplateVersionNotFoundException;
+import com.ejada.template.repository.TemplateVersionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TemplateLookupService {
+
+  private final TemplateVersionRepository templateVersionRepository;
+
+  @Cacheable(
+      value = "activeTemplateVersions",
+      key =
+          "T(com.ejada.common.context.ContextManager$Tenant).get() + ':' + #templateId + ':active'")
+  public TemplateVersionEntity getActivePublishedVersion(Long templateId) {
+    return templateVersionRepository
+        .findFirstByTemplateIdAndStatusOrderByVersionNumberDesc(
+            templateId, TemplateVersionStatus.PUBLISHED)
+        .orElseThrow(() -> new TemplateVersionNotFoundException(templateId, null));
+  }
+}


### PR DESCRIPTION
## Summary
- enforce allowed dynamic variable validation when sending emails and raise a dedicated exception on violations
- cache active published template versions to speed up lookups for send requests
- evict active template caches when templates are updated, archived, or versions are published

## Testing
- mvn -pl email-template-service test *(fails: missing parent dependency com.ejada:shared-lib:1.0.0 in Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2fda9548832fb62d0d22bdd0ede0)