### PR TITLE
Fix audit logging for email and template gateways

### DIFF
--- a/email-management/email-management-service/src/main/java/com/ejada/management/controller/EmailGatewayController.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/controller/EmailGatewayController.java
@@ -34,7 +34,7 @@ public class EmailGatewayController {
   public EmailSendResponse sendEmail(
       @PathVariable String tenantId, @Valid @RequestBody EmailSendRequest request) {
     rateLimiter.assertWithinQuota(tenantId, "email-send");
-    auditLogger.logTenantAction(tenantId, "EMAIL_SEND", request.subject());
+    auditLogger.logTenantAction(tenantId, "EMAIL_SEND", request.templateKey());
     return service.sendEmail(tenantId, request);
   }
 }

--- a/email-management/email-management-service/src/main/java/com/ejada/management/controller/TemplateGatewayController.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/controller/TemplateGatewayController.java
@@ -43,7 +43,7 @@ public class TemplateGatewayController {
   public void syncTemplates(
       @PathVariable String tenantId, @Valid @RequestBody TemplateSyncRequest request) {
     rateLimiter.assertWithinQuota(tenantId, "template-sync");
-    auditLogger.logTenantAction(tenantId, "TEMPLATE_SYNC", request.syncType());
+    auditLogger.logTenantAction(tenantId, "TEMPLATE_SYNC", request.versionTag());
     service.requestSync(tenantId, request);
   }
 }


### PR DESCRIPTION
## Summary
- update email send audit logging to use the available template key field
- log template sync operations using the request version tag field

## Testing
- mvn -pl email-management-service -am test *(fails: missing com.ejada:shared-lib:1.0.0 dependency from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a309d8d34832f91a7ada5ff8d03f9)