### PR TITLE
Enhance email sending pipeline

### DIFF
--- a/email-management/email-sending-service/pom.xml
+++ b/email-management/email-sending-service/pom.xml
@@ -28,6 +28,19 @@
       <artifactId>spring-boot-starter-data-redis</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sendgrid</groupId>
+      <artifactId>sendgrid-java</artifactId>
+      <version>4.10.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
     </dependency>

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/EmailSendingServiceApplication.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/EmailSendingServiceApplication.java
@@ -1,7 +1,9 @@
 package com.ejada.sending;
 
+import com.ejada.sending.config.EmailSendingProperties;
 import com.ejada.sending.config.KafkaTopicsProperties;
 import com.ejada.sending.config.RateLimitProperties;
+import com.ejada.sending.config.SendGridProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -9,7 +11,12 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
-@EnableConfigurationProperties({KafkaTopicsProperties.class, RateLimitProperties.class})
+@EnableConfigurationProperties({
+    KafkaTopicsProperties.class,
+    RateLimitProperties.class,
+    SendGridProperties.class,
+    EmailSendingProperties.class
+})
 public class EmailSendingServiceApplication {
 
   public static void main(String[] args) {

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/client/TemplateClient.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/client/TemplateClient.java
@@ -1,0 +1,7 @@
+package com.ejada.sending.client;
+
+import com.ejada.sending.client.dto.TemplateDescriptor;
+
+public interface TemplateClient {
+  TemplateDescriptor fetchTemplate(String tenantId, String templateKey);
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/client/dto/TemplateDescriptor.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/client/dto/TemplateDescriptor.java
@@ -1,0 +1,12 @@
+package com.ejada.sending.client.dto;
+
+import com.ejada.sending.dto.AttachmentMetadataDto;
+import java.util.List;
+
+public record TemplateDescriptor(
+    String templateKey, List<AttachmentMetadataDto> defaultAttachments, boolean sandboxEnabled) {
+
+  public TemplateDescriptor {
+    this.defaultAttachments = defaultAttachments == null ? List.of() : defaultAttachments;
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/client/impl/HttpTemplateClient.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/client/impl/HttpTemplateClient.java
@@ -1,0 +1,50 @@
+package com.ejada.sending.client.impl;
+
+import com.ejada.sending.client.TemplateClient;
+import com.ejada.sending.client.dto.TemplateDescriptor;
+import com.ejada.sending.config.EmailSendingProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class HttpTemplateClient implements TemplateClient {
+
+  private static final Logger log = LoggerFactory.getLogger(HttpTemplateClient.class);
+
+  private final RestTemplate restTemplate;
+  private final EmailSendingProperties properties;
+
+  public HttpTemplateClient(RestTemplate restTemplate, EmailSendingProperties properties) {
+    this.restTemplate = restTemplate;
+    this.properties = properties;
+  }
+
+  @Override
+  public TemplateDescriptor fetchTemplate(String tenantId, String templateKey) {
+    if (properties.getTemplateServiceBaseUrl() == null || properties.getTemplateServiceBaseUrl().isBlank()) {
+      return new TemplateDescriptor(templateKey, null, false);
+    }
+
+    String url = properties.getTemplateServiceBaseUrl() + "/api/v1/tenants/" + tenantId + "/templates/" + templateKey;
+    try {
+      HttpHeaders headers = new HttpHeaders();
+      headers.add("X-Tenant-ID", tenantId);
+      ResponseEntity<TemplateDescriptor> response =
+          restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(null, headers), TemplateDescriptor.class);
+      if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+        return response.getBody();
+      }
+      log.warn("Template service returned non-success status {} for template {}", response.getStatusCode(), templateKey);
+    } catch (RestClientException ex) {
+      log.warn("Failed to fetch template {} for tenant {}", templateKey, tenantId, ex);
+    }
+    return new TemplateDescriptor(templateKey, null, false);
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/config/EmailSendingConfiguration.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/config/EmailSendingConfiguration.java
@@ -1,0 +1,24 @@
+package com.ejada.sending.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class EmailSendingConfiguration {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+
+  @Bean
+  public TaskScheduler taskScheduler() {
+    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setPoolSize(4);
+    scheduler.setThreadNamePrefix("email-send-retry-");
+    return scheduler;
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/config/EmailSendingProperties.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/config/EmailSendingProperties.java
@@ -1,0 +1,44 @@
+package com.ejada.sending.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "email-sending")
+public class EmailSendingProperties {
+
+  private int maxAttempts = 3;
+  private long backoffInitialMillis = 1000;
+  private String templateServiceBaseUrl;
+  private String testOverrideEmail;
+
+  public int getMaxAttempts() {
+    return maxAttempts;
+  }
+
+  public void setMaxAttempts(int maxAttempts) {
+    this.maxAttempts = maxAttempts;
+  }
+
+  public long getBackoffInitialMillis() {
+    return backoffInitialMillis;
+  }
+
+  public void setBackoffInitialMillis(long backoffInitialMillis) {
+    this.backoffInitialMillis = backoffInitialMillis;
+  }
+
+  public String getTemplateServiceBaseUrl() {
+    return templateServiceBaseUrl;
+  }
+
+  public void setTemplateServiceBaseUrl(String templateServiceBaseUrl) {
+    this.templateServiceBaseUrl = templateServiceBaseUrl;
+  }
+
+  public String getTestOverrideEmail() {
+    return testOverrideEmail;
+  }
+
+  public void setTestOverrideEmail(String testOverrideEmail) {
+    this.testOverrideEmail = testOverrideEmail;
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/config/SendGridProperties.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/config/SendGridProperties.java
@@ -1,0 +1,35 @@
+package com.ejada.sending.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "sendgrid")
+public class SendGridProperties {
+
+  private String apiKey;
+  private String fromEmail;
+  private String fromName;
+
+  public String getApiKey() {
+    return apiKey;
+  }
+
+  public void setApiKey(String apiKey) {
+    this.apiKey = apiKey;
+  }
+
+  public String getFromEmail() {
+    return fromEmail;
+  }
+
+  public void setFromEmail(String fromEmail) {
+    this.fromEmail = fromEmail;
+  }
+
+  public String getFromName() {
+    return fromName;
+  }
+
+  public void setFromName(String fromName) {
+    this.fromName = fromName;
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/messaging/EmailEnvelope.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/messaging/EmailEnvelope.java
@@ -17,7 +17,8 @@ public record EmailEnvelope(
     Map<String, Object> dynamicData,
     List<AttachmentMetadataDto> attachments,
     EmailSendRequest.SendMode mode,
-    Instant createdAt) {
+    Instant createdAt,
+    String idempotencyKey) {
 
   public static EmailEnvelope from(String tenantId, EmailSendRequest request) {
     return new EmailEnvelope(
@@ -27,9 +28,10 @@ public record EmailEnvelope(
         request.to(),
         request.cc(),
         request.bcc(),
-        request.dynamicData(),
-        request.attachments(),
+        request.dynamicData() == null ? Map.of() : request.dynamicData(),
+        request.attachments() == null ? List.of() : request.attachments(),
         request.mode(),
-        Instant.now());
+        Instant.now(),
+        request.idempotencyKey());
   }
 }

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/messaging/EmailSendConsumer.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/messaging/EmailSendConsumer.java
@@ -1,0 +1,90 @@
+package com.ejada.sending.messaging;
+
+import com.ejada.sending.config.EmailSendingProperties;
+import com.ejada.sending.config.KafkaTopicsProperties;
+import com.ejada.sending.service.EmailLogService;
+import com.ejada.sending.service.EmailSender;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmailSendConsumer {
+
+  private static final Logger log = LoggerFactory.getLogger(EmailSendConsumer.class);
+
+  private final EmailSender emailSender;
+  private final EmailLogService emailLogService;
+  private final KafkaTemplate<String, EmailEnvelope> kafkaTemplate;
+  private final KafkaTopicsProperties topics;
+  private final EmailSendingProperties properties;
+  private final TaskScheduler taskScheduler;
+
+  public EmailSendConsumer(
+      EmailSender emailSender,
+      EmailLogService emailLogService,
+      KafkaTemplate<String, EmailEnvelope> kafkaTemplate,
+      KafkaTopicsProperties topics,
+      EmailSendingProperties properties,
+      TaskScheduler taskScheduler) {
+    this.emailSender = emailSender;
+    this.emailLogService = emailLogService;
+    this.kafkaTemplate = kafkaTemplate;
+    this.topics = topics;
+    this.properties = properties;
+    this.taskScheduler = taskScheduler;
+  }
+
+  @KafkaListener(topics = {"#{kafkaTopicsProperties.emailSend}", "#{kafkaTopicsProperties.emailBulk}"})
+  public void consume(
+      @Payload EmailEnvelope envelope,
+      @Header(name = "x-attempt", required = false) Integer attemptHeader,
+      @Header(name = KafkaHeaders.RECEIVED_TOPIC) String topic) {
+    int attempt = attemptHeader == null ? 1 : attemptHeader;
+    emailLogService.incrementAttempts(envelope.id());
+    try {
+      if (envelope.mode() == com.ejada.sending.dto.EmailSendRequest.SendMode.DRAFT) {
+        emailLogService.markDraftSkipped(envelope.id());
+        return;
+      }
+      emailSender.send(envelope);
+      if (envelope.mode() == com.ejada.sending.dto.EmailSendRequest.SendMode.TEST) {
+        emailLogService.markTestSent(envelope.id());
+      } else {
+        emailLogService.markSent(envelope.id());
+      }
+    } catch (Exception ex) {
+      log.warn("Failed to process email {} on attempt {}", envelope.id(), attempt, ex);
+      handleRetry(envelope, topic, attempt, ex);
+    }
+  }
+
+  private void handleRetry(EmailEnvelope envelope, String topic, int attempt, Exception ex) {
+    if (attempt >= properties.getMaxAttempts()) {
+      sendWithAttempt(topics.getDeadLetter(), envelope, attempt + 1);
+      emailLogService.markDeadLetter(envelope.id(), ex.getMessage());
+      return;
+    }
+
+    long delayMillis = properties.getBackoffInitialMillis() * (long) Math.pow(2, attempt - 1);
+    taskScheduler.schedule(() -> sendWithAttempt(topic, envelope, attempt + 1), Instant.now().plusMillis(delayMillis));
+    emailLogService.markFailed(envelope.id(), ex.getMessage());
+  }
+
+  private void sendWithAttempt(String topic, EmailEnvelope envelope, int attempt) {
+    kafkaTemplate.send(
+        MessageBuilder.withPayload(envelope)
+            .setHeader(KafkaHeaders.TOPIC, topic)
+            .setHeader(KafkaHeaders.MESSAGE_KEY, envelope.tenantId())
+            .setHeader("x-attempt", attempt)
+            .build());
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/persistence/EmailLog.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/persistence/EmailLog.java
@@ -1,0 +1,171 @@
+package com.ejada.sending.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "email_logs")
+public class EmailLog {
+
+  @Id
+  private String id;
+
+  @Column(name = "tenant_id", nullable = false)
+  private String tenantId;
+
+  @Column(name = "template_key", nullable = false)
+  private String templateKey;
+
+  @Column(name = "mode", nullable = false)
+  private String mode;
+
+  @Column(name = "to_recipients", length = 2000)
+  private String toRecipients;
+
+  @Column(name = "cc_recipients", length = 2000)
+  private String ccRecipients;
+
+  @Column(name = "bcc_recipients", length = 2000)
+  private String bccRecipients;
+
+  @Enumerated(EnumType.STRING)
+  private EmailStatus status;
+
+  @Column(name = "attempt_count")
+  private int attemptCount;
+
+  @Column(name = "idempotency_key")
+  private String idempotencyKey;
+
+  @Column(name = "last_error", length = 4000)
+  private String lastError;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public String getTemplateKey() {
+    return templateKey;
+  }
+
+  public void setTemplateKey(String templateKey) {
+    this.templateKey = templateKey;
+  }
+
+  public String getMode() {
+    return mode;
+  }
+
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
+
+  public String getToRecipients() {
+    return toRecipients;
+  }
+
+  public void setToRecipients(String toRecipients) {
+    this.toRecipients = toRecipients;
+  }
+
+  public String getCcRecipients() {
+    return ccRecipients;
+  }
+
+  public void setCcRecipients(String ccRecipients) {
+    this.ccRecipients = ccRecipients;
+  }
+
+  public String getBccRecipients() {
+    return bccRecipients;
+  }
+
+  public void setBccRecipients(String bccRecipients) {
+    this.bccRecipients = bccRecipients;
+  }
+
+  public EmailStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(EmailStatus status) {
+    this.status = status;
+  }
+
+  public int getAttemptCount() {
+    return attemptCount;
+  }
+
+  public void setAttemptCount(int attemptCount) {
+    this.attemptCount = attemptCount;
+  }
+
+  public String getIdempotencyKey() {
+    return idempotencyKey;
+  }
+
+  public void setIdempotencyKey(String idempotencyKey) {
+    this.idempotencyKey = idempotencyKey;
+  }
+
+  public String getLastError() {
+    return lastError;
+  }
+
+  public void setLastError(String lastError) {
+    this.lastError = lastError;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(Instant createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(Instant updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+
+  @PrePersist
+  public void onCreate() {
+    Instant now = Instant.now();
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+
+  @PreUpdate
+  public void onUpdate() {
+    this.updatedAt = Instant.now();
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/persistence/EmailLogRepository.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/persistence/EmailLogRepository.java
@@ -1,0 +1,5 @@
+package com.ejada.sending.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailLogRepository extends JpaRepository<EmailLog, String> {}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/persistence/EmailStatus.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/persistence/EmailStatus.java
@@ -1,0 +1,12 @@
+package com.ejada.sending.persistence;
+
+public enum EmailStatus {
+  QUEUED,
+  SENT,
+  FAILED,
+  DEAD_LETTER,
+  SKIPPED_TEST,
+  SKIPPED_DRAFT,
+  RATE_LIMITED,
+  DUPLICATE
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/AttachmentMergeService.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/AttachmentMergeService.java
@@ -1,0 +1,8 @@
+package com.ejada.sending.service;
+
+import com.ejada.sending.dto.AttachmentMetadataDto;
+import java.util.List;
+
+public interface AttachmentMergeService {
+  List<AttachmentMetadataDto> merge(List<AttachmentMetadataDto> templateDefaults, List<AttachmentMetadataDto> adHoc);
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/EmailLogService.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/EmailLogService.java
@@ -1,0 +1,23 @@
+package com.ejada.sending.service;
+
+import com.ejada.sending.messaging.EmailEnvelope;
+
+public interface EmailLogService {
+  void recordQueued(EmailEnvelope envelope);
+
+  void markSent(String id);
+
+  void markTestSent(String id);
+
+  void markDraftSkipped(String id);
+
+  void markFailed(String id, String errorMessage);
+
+  void markDeadLetter(String id, String errorMessage);
+
+  void markRateLimited(String tenantId);
+
+  void markDuplicate(String tenantId, String idempotencyKey);
+
+  void incrementAttempts(String id);
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/EmailSender.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/EmailSender.java
@@ -1,0 +1,7 @@
+package com.ejada.sending.service;
+
+import com.ejada.sending.messaging.EmailEnvelope;
+
+public interface EmailSender {
+  void send(EmailEnvelope envelope);
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/AttachmentMergeServiceImpl.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/AttachmentMergeServiceImpl.java
@@ -1,0 +1,24 @@
+package com.ejada.sending.service.impl;
+
+import com.ejada.sending.dto.AttachmentMetadataDto;
+import com.ejada.sending.service.AttachmentMergeService;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AttachmentMergeServiceImpl implements AttachmentMergeService {
+
+  @Override
+  public List<AttachmentMetadataDto> merge(
+      List<AttachmentMetadataDto> templateDefaults, List<AttachmentMetadataDto> adHoc) {
+    Map<String, AttachmentMetadataDto> merged = new LinkedHashMap<>();
+    Stream.concat(
+            templateDefaults == null ? Stream.empty() : templateDefaults.stream(),
+            adHoc == null ? Stream.empty() : adHoc.stream())
+        .forEach(attachment -> merged.putIfAbsent(attachment.fileName(), attachment));
+    return List.copyOf(merged.values());
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/EmailDispatchServiceImpl.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/EmailDispatchServiceImpl.java
@@ -7,9 +7,13 @@ import com.ejada.sending.dto.EmailSendResponse;
 import com.ejada.sending.messaging.EmailEnvelope;
 import com.ejada.sending.service.EmailDispatchService;
 import com.ejada.sending.service.IdempotencyService;
+import com.ejada.sending.service.EmailLogService;
 import com.ejada.sending.service.RateLimiterService;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -20,40 +24,66 @@ public class EmailDispatchServiceImpl implements EmailDispatchService {
   private final KafkaTopicsProperties topics;
   private final IdempotencyService idempotencyService;
   private final RateLimiterService rateLimiterService;
+  private final EmailLogService emailLogService;
 
   public EmailDispatchServiceImpl(
       KafkaTemplate<String, EmailEnvelope> kafkaTemplate,
       KafkaTopicsProperties topics,
       IdempotencyService idempotencyService,
-      RateLimiterService rateLimiterService) {
+      RateLimiterService rateLimiterService,
+      EmailLogService emailLogService) {
     this.kafkaTemplate = kafkaTemplate;
     this.topics = topics;
     this.idempotencyService = idempotencyService;
     this.rateLimiterService = rateLimiterService;
+    this.emailLogService = emailLogService;
   }
 
   @Override
   public EmailSendResponse sendEmail(String tenantId, EmailSendRequest request) {
     Assert.hasText(tenantId, "tenantId is required");
     if (!rateLimiterService.tryConsume(tenantId)) {
+      emailLogService.markRateLimited(tenantId);
       return new EmailSendResponse(null, "RATE_LIMITED");
     }
 
     if (request.idempotencyKey() != null
         && !idempotencyService.register(tenantId, request.idempotencyKey(), "queued")) {
+      emailLogService.markDuplicate(tenantId, request.idempotencyKey());
       return new EmailSendResponse(null, "DUPLICATE");
     }
 
     EmailEnvelope envelope = EmailEnvelope.from(tenantId, request);
-    kafkaTemplate.send(topics.getEmailSend(), tenantId, envelope);
+    emailLogService.recordQueued(envelope);
+    kafkaTemplate.send(buildMessage(topics.getEmailSend(), tenantId, envelope, 1));
     return new EmailSendResponse(envelope.id(), "QUEUED");
   }
 
   @Override
   public void sendBulk(String tenantId, BulkEmailSendRequest request) {
     request.entries().forEach(entry -> {
+      if (!rateLimiterService.tryConsume(tenantId)) {
+        emailLogService.markRateLimited(tenantId);
+        return;
+      }
+      if (entry.idempotencyKey() != null
+          && !idempotencyService.register(tenantId, entry.idempotencyKey(), "queued")) {
+        emailLogService.markDuplicate(tenantId, entry.idempotencyKey());
+        return;
+      }
       EmailEnvelope envelope = EmailEnvelope.from(tenantId, entry);
-      CompletableFuture.runAsync(() -> kafkaTemplate.send(topics.getEmailBulk(), tenantId, envelope));
+      emailLogService.recordQueued(envelope);
+      CompletableFuture.runAsync(
+          () -> kafkaTemplate.send(buildMessage(topics.getEmailBulk(), tenantId, envelope, 1)));
     });
+  }
+
+  private Message<EmailEnvelope> buildMessage(
+      String topic, String tenantId, EmailEnvelope envelope, int attempt) {
+    return MessageBuilder.withPayload(envelope)
+        .setHeader(KafkaHeaders.TOPIC, topic)
+        .setHeader(KafkaHeaders.MESSAGE_KEY, tenantId)
+        .setHeader("x-attempt", attempt)
+        .build();
   }
 }

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/EmailLogServiceImpl.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/EmailLogServiceImpl.java
@@ -1,0 +1,106 @@
+package com.ejada.sending.service.impl;
+
+import com.ejada.sending.messaging.EmailEnvelope;
+import com.ejada.sending.persistence.EmailLog;
+import com.ejada.sending.persistence.EmailLogRepository;
+import com.ejada.sending.persistence.EmailStatus;
+import com.ejada.sending.service.EmailLogService;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class EmailLogServiceImpl implements EmailLogService {
+
+  private static final Logger log = LoggerFactory.getLogger(EmailLogServiceImpl.class);
+
+  private final EmailLogRepository repository;
+
+  public EmailLogServiceImpl(EmailLogRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  @Transactional
+  public void recordQueued(EmailEnvelope envelope) {
+    EmailLog logEntry = new EmailLog();
+    logEntry.setId(envelope.id());
+    logEntry.setTenantId(envelope.tenantId());
+    logEntry.setTemplateKey(envelope.templateKey());
+    logEntry.setMode(envelope.mode().name());
+    logEntry.setToRecipients(String.join(",", envelope.to()));
+    logEntry.setCcRecipients(envelope.cc() == null ? null : String.join(",", envelope.cc()));
+    logEntry.setBccRecipients(envelope.bcc() == null ? null : String.join(",", envelope.bcc()));
+    logEntry.setStatus(EmailStatus.QUEUED);
+    logEntry.setAttemptCount(0);
+    logEntry.setIdempotencyKey(envelope.idempotencyKey());
+    repository.save(logEntry);
+  }
+
+  @Override
+  @Transactional
+  public void markSent(String id) {
+    updateStatus(id, EmailStatus.SENT, null);
+  }
+
+  @Override
+  @Transactional
+  public void markTestSent(String id) {
+    updateStatus(id, EmailStatus.SKIPPED_TEST, null);
+  }
+
+  @Override
+  @Transactional
+  public void markDraftSkipped(String id) {
+    updateStatus(id, EmailStatus.SKIPPED_DRAFT, null);
+  }
+
+  @Override
+  @Transactional
+  public void markFailed(String id, String errorMessage) {
+    updateStatus(id, EmailStatus.FAILED, errorMessage);
+  }
+
+  @Override
+  @Transactional
+  public void markDeadLetter(String id, String errorMessage) {
+    updateStatus(id, EmailStatus.DEAD_LETTER, errorMessage);
+  }
+
+  @Override
+  @Transactional
+  public void markRateLimited(String tenantId) {
+    log.info("Rate limit exceeded for tenant {}", tenantId);
+  }
+
+  @Override
+  @Transactional
+  public void markDuplicate(String tenantId, String idempotencyKey) {
+    log.info("Duplicate send detected for tenant {} with key {}", tenantId, idempotencyKey);
+  }
+
+  @Override
+  @Transactional
+  public void incrementAttempts(String id) {
+    Optional<EmailLog> maybeLog = repository.findById(id);
+    maybeLog.ifPresent(
+        entry -> {
+          entry.setAttemptCount(entry.getAttemptCount() + 1);
+          repository.save(entry);
+        });
+  }
+
+  private void updateStatus(String id, EmailStatus status, String errorMessage) {
+    Optional<EmailLog> maybeLog = repository.findById(id);
+    if (maybeLog.isEmpty()) {
+      log.warn("Email log {} not found for status update to {}", id, status);
+      return;
+    }
+    EmailLog emailLog = maybeLog.get();
+    emailLog.setStatus(status);
+    emailLog.setLastError(errorMessage);
+    repository.save(emailLog);
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/RedisRateLimiterService.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/RedisRateLimiterService.java
@@ -2,8 +2,10 @@ package com.ejada.sending.service.impl;
 
 import com.ejada.sending.config.RateLimitProperties;
 import com.ejada.sending.service.RateLimiterService;
-import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,27 +13,46 @@ public class RedisRateLimiterService implements RateLimiterService {
 
   private final StringRedisTemplate redisTemplate;
   private final RateLimitProperties properties;
+  private final DefaultRedisScript<Long> tokenScript;
 
   public RedisRateLimiterService(
       StringRedisTemplate redisTemplate, RateLimitProperties properties) {
     this.redisTemplate = redisTemplate;
     this.properties = properties;
+    this.tokenScript =
+        new DefaultRedisScript<>(
+            "local tokens_key = KEYS[1]\n"
+                + "local timestamp_key = KEYS[2]\n"
+                + "local capacity = tonumber(ARGV[1])\n"
+                + "local refill_per_minute = tonumber(ARGV[2])\n"
+                + "local now = tonumber(ARGV[3])\n"
+                + "local last_refill = tonumber(redis.call('get', timestamp_key) or now)\n"
+                + "local tokens = tonumber(redis.call('get', tokens_key) or capacity)\n"
+                + "local elapsed = now - last_refill\n"
+                + "local refill = (elapsed * refill_per_minute) / 60\n"
+                + "tokens = math.min(capacity, tokens + refill)\n"
+                + "if tokens < 1 then\n"
+                + "  redis.call('set', tokens_key, tokens)\n"
+                + "  redis.call('set', timestamp_key, now)\n"
+                + "  return 0\n"
+                + "end\n"
+                + "tokens = tokens - 1\n"
+                + "redis.call('set', tokens_key, tokens)\n"
+                + "redis.call('set', timestamp_key, now)\n"
+                + "return 1",
+            Long.class);
   }
 
   @Override
   public boolean tryConsume(String tenantId) {
-    String redisKey = "email:rate:" + tenantId;
-    Long tokens = redisTemplate.opsForValue().increment(redisKey, -1);
-    if (tokens == null) {
-      redisTemplate
-          .opsForValue()
-          .set(redisKey, String.valueOf(properties.getCapacity() - 1), Duration.ofMinutes(1));
-      return true;
-    }
-    if (tokens >= 0) {
-      return true;
-    }
-    redisTemplate.opsForValue().set(redisKey, String.valueOf(properties.getCapacity()), Duration.ofMinutes(1));
-    return false;
+    List<String> keys = List.of("email:rate:tokens:" + tenantId, "email:rate:ts:" + tenantId);
+    Long allowed =
+        redisTemplate.execute(
+            tokenScript,
+            keys,
+            String.valueOf(properties.getCapacity()),
+            String.valueOf(properties.getRefillPerMinute()),
+            String.valueOf(Instant.now().getEpochSecond()));
+    return Long.valueOf(1L).equals(allowed);
   }
 }

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/SendGridEmailSender.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/SendGridEmailSender.java
@@ -1,0 +1,144 @@
+package com.ejada.sending.service.impl;
+
+import com.ejada.sending.client.TemplateClient;
+import com.ejada.sending.client.dto.TemplateDescriptor;
+import com.ejada.sending.config.EmailSendingProperties;
+import com.ejada.sending.config.SendGridProperties;
+import com.ejada.sending.dto.AttachmentMetadataDto;
+import com.ejada.sending.messaging.EmailEnvelope;
+import com.ejada.sending.service.AttachmentMergeService;
+import com.ejada.sending.service.EmailSender;
+import com.sendgrid.Attachments;
+import com.sendgrid.Mail;
+import com.sendgrid.MailSettings;
+import com.sendgrid.Method;
+import com.sendgrid.Personalization;
+import com.sendgrid.Request;
+import com.sendgrid.Response;
+import com.sendgrid.SendGrid;
+import com.sendgrid.helpers.mail.objects.Email;
+import com.sendgrid.helpers.mail.objects.MailSettings.SandboxMode;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class SendGridEmailSender implements EmailSender {
+
+  private static final Logger log = LoggerFactory.getLogger(SendGridEmailSender.class);
+
+  private final SendGrid client;
+  private final SendGridProperties properties;
+  private final TemplateClient templateClient;
+  private final AttachmentMergeService attachmentMergeService;
+  private final RestTemplate restTemplate;
+  private final EmailSendingProperties emailSendingProperties;
+
+  public SendGridEmailSender(
+      SendGridProperties properties,
+      TemplateClient templateClient,
+      AttachmentMergeService attachmentMergeService,
+      RestTemplate restTemplate,
+      EmailSendingProperties emailSendingProperties) {
+    this.properties = properties;
+    this.client = new SendGrid(properties.getApiKey());
+    this.templateClient = templateClient;
+    this.attachmentMergeService = attachmentMergeService;
+    this.restTemplate = restTemplate;
+    this.emailSendingProperties = emailSendingProperties;
+  }
+
+  @Override
+  public void send(EmailEnvelope envelope) {
+    if (properties.getApiKey() == null || properties.getApiKey().isBlank()) {
+      throw new IllegalStateException("SendGrid API key is not configured");
+    }
+    if (envelope.mode() == com.ejada.sending.dto.EmailSendRequest.SendMode.DRAFT) {
+      log.info("Skipping send for draft email {}", envelope.id());
+      return;
+    }
+
+    TemplateDescriptor template = templateClient.fetchTemplate(envelope.tenantId(), envelope.templateKey());
+    List<AttachmentMetadataDto> attachments =
+        attachmentMergeService.merge(template.defaultAttachments(), envelope.attachments());
+
+    Mail mail = new Mail();
+    mail.setFrom(new Email(properties.getFromEmail(), properties.getFromName()));
+    mail.setTemplateId(envelope.templateKey());
+
+    Personalization personalization = new Personalization();
+    addRecipients(personalization, envelope);
+    applyDynamicTemplateData(personalization, envelope.dynamicData());
+    mail.addPersonalization(personalization);
+
+    if (!CollectionUtils.isEmpty(attachments)) {
+      attachments.forEach(attachment -> mail.addAttachments(resolveAttachment(attachment)));
+    }
+
+    if (envelope.mode() == com.ejada.sending.dto.EmailSendRequest.SendMode.TEST || template.sandboxEnabled()) {
+      MailSettings mailSettings = new MailSettings();
+      SandboxMode sandboxMode = new SandboxMode();
+      sandboxMode.setEnable(true);
+      mailSettings.setSandboxMode(sandboxMode);
+      mail.setMailSettings(mailSettings);
+    }
+
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("mail/send");
+    request.setBody(mail.build());
+    try {
+      Response response = client.api(request);
+      if (response.getStatusCode() >= 400) {
+        throw new IllegalStateException("SendGrid returned status " + response.getStatusCode());
+      }
+    } catch (IOException ex) {
+      throw new IllegalStateException("SendGrid API call failed", ex);
+    }
+  }
+
+  private void addRecipients(Personalization personalization, EmailEnvelope envelope) {
+    if (emailSendingProperties.getTestOverrideEmail() != null
+        && !emailSendingProperties.getTestOverrideEmail().isBlank()
+        && envelope.mode() == com.ejada.sending.dto.EmailSendRequest.SendMode.TEST) {
+      personalization.addTo(new Email(emailSendingProperties.getTestOverrideEmail()));
+      return;
+    }
+
+    envelope.to().forEach(address -> personalization.addTo(new Email(address)));
+    if (envelope.cc() != null) {
+      envelope.cc().forEach(address -> personalization.addCc(new Email(address)));
+    }
+    if (envelope.bcc() != null) {
+      envelope.bcc().forEach(address -> personalization.addBcc(new Email(address)));
+    }
+  }
+
+  private void applyDynamicTemplateData(Personalization personalization, Map<String, Object> data) {
+    if (data == null || data.isEmpty()) {
+      return;
+    }
+    data.forEach(personalization::addDynamicTemplateData);
+  }
+
+  private Attachments resolveAttachment(AttachmentMetadataDto metadata) {
+    Attachments attachments = new Attachments();
+    attachments.setType(metadata.contentType());
+    attachments.setFilename(metadata.fileName());
+    try {
+      byte[] content = restTemplate.getForObject(metadata.url(), byte[].class);
+      if (content != null) {
+        attachments.setContent(Base64.getEncoder().encodeToString(content));
+      }
+    } catch (Exception ex) {
+      log.warn("Failed to download attachment {}", metadata.url(), ex);
+    }
+    return attachments;
+  }
+}


### PR DESCRIPTION
## Summary
- add SendGrid-driven email sender with template/attachment merging, sandbox test mode support, and a Kafka consumer with retries/dead-letter routing
- persist email logs with statuses, idempotency awareness, and improved Redis token bucket rate limiting
- add configuration for SendGrid, template service integration, schedulers, and Kafka retry headers

## Testing
- mvn -f email-management/pom.xml -pl email-sending-service test -DskipTests *(fails: missing com.ejada:shared-lib:pom:1.0.0 from central repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a313aea7c832f84719816a9f22102)