### PR TITLE
Implement SendGrid webhook ingestion

### DIFF
--- a/email-management/email-webhook-service/README.md
+++ b/email-management/email-webhook-service/README.md
@@ -1,4 +1,29 @@
 # email-webhook-service
 
-Dedicated SendGrid webhook ingestion surface that verifies signatures, deduplicates payloads with
-Redis, and emits normalized events to Kafka for downstream consumers.
+Public REST surface for SendGrid webhook ingestion. The service verifies signatures, optionally
+restricts requests by source IP, deduplicates payloads via Redis, and emits normalized events to
+Kafka for downstream consumers.
+
+## Endpoints
+
+- `POST /webhooks/sendgrid` – accepts SendGrid event webhooks (array payload), validates the
+  signature headers (`X-Twilio-Email-Event-Webhook-*`), and processes each event idempotently.
+- `GET /admin/events` – returns processed events. Optional `type` query parameter filters by
+  normalized event type.
+- `GET /admin/email-logs` – returns the latest resolved email log status per SendGrid message id.
+- `GET /admin/analytics` – returns counts by normalized event type for simple usage analytics.
+
+## Configuration
+
+Configuration lives under the `sendgrid.webhook` prefix:
+
+| Property | Description |
+| --- | --- |
+| `signing-secret` | SendGrid webhook signing secret. |
+| `tolerance-seconds` | Allowed age of webhook timestamps to mitigate replay attacks. |
+| `allowed-ips` | Optional list of source IPs to accept. Empty list disables the check. |
+| `kafka-topic` | Kafka topic to which normalized events are published. |
+| `deduplication-ttl-seconds` | Redis TTL for event idempotency keys. |
+
+The service also uses standard Spring Boot Redis (`spring.data.redis.*`) and Kafka
+(`spring.kafka.bootstrap-servers`) configuration.

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/EmailWebhookServiceApplication.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/EmailWebhookServiceApplication.java
@@ -1,0 +1,14 @@
+package com.ejada.email.webhook;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@SpringBootApplication
+@EnableConfigurationProperties(SendgridWebhookProperties.class)
+public class EmailWebhookServiceApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(EmailWebhookServiceApplication.class, args);
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/SendgridWebhookProperties.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/SendgridWebhookProperties.java
@@ -1,0 +1,54 @@
+package com.ejada.email.webhook;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "sendgrid.webhook")
+public class SendgridWebhookProperties {
+
+  private String signingSecret;
+  private long toleranceSeconds = 300;
+  private List<String> allowedIps = List.of();
+  private String kafkaTopic = "sendgrid.email-events";
+  private long deduplicationTtlSeconds = 86400;
+
+  public String getSigningSecret() {
+    return signingSecret;
+  }
+
+  public void setSigningSecret(String signingSecret) {
+    this.signingSecret = signingSecret;
+  }
+
+  public long getToleranceSeconds() {
+    return toleranceSeconds;
+  }
+
+  public void setToleranceSeconds(long toleranceSeconds) {
+    this.toleranceSeconds = toleranceSeconds;
+  }
+
+  public List<String> getAllowedIps() {
+    return allowedIps;
+  }
+
+  public void setAllowedIps(List<String> allowedIps) {
+    this.allowedIps = allowedIps;
+  }
+
+  public String getKafkaTopic() {
+    return kafkaTopic;
+  }
+
+  public void setKafkaTopic(String kafkaTopic) {
+    this.kafkaTopic = kafkaTopic;
+  }
+
+  public long getDeduplicationTtlSeconds() {
+    return deduplicationTtlSeconds;
+  }
+
+  public void setDeduplicationTtlSeconds(long deduplicationTtlSeconds) {
+    this.deduplicationTtlSeconds = deduplicationTtlSeconds;
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/controller/AdminController.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/controller/AdminController.java
@@ -1,0 +1,50 @@
+package com.ejada.email.webhook.controller;
+
+import com.ejada.email.webhook.model.EmailEvent;
+import com.ejada.email.webhook.model.EmailEventType;
+import com.ejada.email.webhook.model.EmailLogStatus;
+import com.ejada.email.webhook.repository.EmailEventRepository;
+import com.ejada.email.webhook.repository.EmailLogRepository;
+import com.ejada.email.webhook.service.SendgridEventProcessor;
+import java.util.List;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin")
+public class AdminController {
+
+  private final EmailEventRepository emailEventRepository;
+  private final EmailLogRepository emailLogRepository;
+  private final SendgridEventProcessor processor;
+
+  public AdminController(
+      EmailEventRepository emailEventRepository,
+      EmailLogRepository emailLogRepository,
+      SendgridEventProcessor processor) {
+    this.emailEventRepository = emailEventRepository;
+    this.emailLogRepository = emailLogRepository;
+    this.processor = processor;
+  }
+
+  @GetMapping("/events")
+  public List<EmailEvent> listEvents(@RequestParam(name = "type", required = false) String type) {
+    if (type == null) {
+      return emailEventRepository.findAll();
+    }
+    return emailEventRepository.findByType(EmailEventType.valueOf(type));
+  }
+
+  @GetMapping("/email-logs")
+  public Map<String, EmailLogStatus> emailLogs() {
+    return emailLogRepository.findAll();
+  }
+
+  @GetMapping("/analytics")
+  public Map<String, Long> analytics() {
+    return processor.analytics();
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/controller/WebhookController.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/controller/WebhookController.java
@@ -1,0 +1,72 @@
+package com.ejada.email.webhook.controller;
+
+import com.ejada.email.webhook.model.EmailEvent;
+import com.ejada.email.webhook.model.SendgridEventRequest;
+import com.ejada.email.webhook.service.IpWhitelistService;
+import com.ejada.email.webhook.service.SendgridEventProcessor;
+import com.ejada.email.webhook.service.SignatureValidator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/webhooks/sendgrid")
+public class WebhookController {
+
+  private static final Logger log = LoggerFactory.getLogger(WebhookController.class);
+  private static final String SIGNATURE_HEADER = "X-Twilio-Email-Event-Webhook-Signature";
+  private static final String TIMESTAMP_HEADER = "X-Twilio-Email-Event-Webhook-Timestamp";
+
+  private final SignatureValidator signatureValidator;
+  private final SendgridEventProcessor processor;
+  private final IpWhitelistService ipWhitelistService;
+  private final ObjectMapper objectMapper;
+
+  public WebhookController(
+      SignatureValidator signatureValidator,
+      SendgridEventProcessor processor,
+      IpWhitelistService ipWhitelistService,
+      ObjectMapper objectMapper) {
+    this.signatureValidator = signatureValidator;
+    this.processor = processor;
+    this.ipWhitelistService = ipWhitelistService;
+    this.objectMapper = objectMapper;
+  }
+
+  @PostMapping
+  public ResponseEntity<List<EmailEvent>> receive(
+      @RequestHeader(name = SIGNATURE_HEADER) String signature,
+      @RequestHeader(name = TIMESTAMP_HEADER) String timestamp,
+      @RequestBody String payload,
+      HttpServletRequest request) {
+    if (!ipWhitelistService.isAllowed(request.getRemoteAddr())) {
+      log.warn("Rejected webhook from non-whitelisted IP: {}", request.getRemoteAddr());
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+
+    if (!signatureValidator.isSignatureValid(timestamp, signature, payload)) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    try {
+      List<SendgridEventRequest> events =
+          objectMapper.readValue(payload, new TypeReference<List<SendgridEventRequest>>() {});
+      List<EmailEvent> processed = events.stream().map(processor::process).toList();
+      return ResponseEntity.accepted().body(processed);
+    } catch (IOException ex) {
+      log.error("Unable to parse webhook payload", ex);
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/EmailEvent.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/EmailEvent.java
@@ -1,0 +1,95 @@
+package com.ejada.email.webhook.model;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public class EmailEvent {
+  private final UUID id;
+  private final String eventId;
+  private final EmailEventType type;
+  private final String email;
+  private final String messageId;
+  private final String tenantId;
+  private final Instant occurredAt;
+  private final Instant processedAt;
+  private final Map<String, Object> metadata;
+  private final boolean duplicate;
+
+  public EmailEvent(
+      UUID id,
+      String eventId,
+      EmailEventType type,
+      String email,
+      String messageId,
+      String tenantId,
+      Instant occurredAt,
+      Instant processedAt,
+      Map<String, Object> metadata,
+      boolean duplicate) {
+    this.id = id;
+    this.eventId = eventId;
+    this.type = type;
+    this.email = email;
+    this.messageId = messageId;
+    this.tenantId = tenantId;
+    this.occurredAt = occurredAt;
+    this.processedAt = processedAt;
+    this.metadata = metadata;
+    this.duplicate = duplicate;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getEventId() {
+    return eventId;
+  }
+
+  public EmailEventType getType() {
+    return type;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getMessageId() {
+    return messageId;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public Instant getOccurredAt() {
+    return occurredAt;
+  }
+
+  public Instant getProcessedAt() {
+    return processedAt;
+  }
+
+  public Map<String, Object> getMetadata() {
+    return metadata;
+  }
+
+  public boolean isDuplicate() {
+    return duplicate;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EmailEvent emailEvent = (EmailEvent) o;
+    return Objects.equals(id, emailEvent.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/EmailEventType.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/EmailEventType.java
@@ -1,0 +1,15 @@
+package com.ejada.email.webhook.model;
+
+public enum EmailEventType {
+  DELIVERED,
+  BOUNCED,
+  SPAM_REPORTED,
+  OPENED,
+  CLICKED,
+  UNSUBSCRIBED,
+  GROUP_UNSUBSCRIBED,
+  DEFERRED,
+  DROPPED,
+  PROCESSED,
+  UNKNOWN
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/EmailLogStatus.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/EmailLogStatus.java
@@ -1,0 +1,12 @@
+package com.ejada.email.webhook.model;
+
+public enum EmailLogStatus {
+  PENDING,
+  DELIVERED,
+  BOUNCED,
+  DROPPED,
+  DEFERRED,
+  SPAM_REPORTED,
+  UNSUBSCRIBED,
+  UNKNOWN
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/SendgridEventRequest.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/SendgridEventRequest.java
@@ -1,0 +1,205 @@
+package com.ejada.email.webhook.model;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class SendgridEventRequest {
+
+  private String event;
+
+  private String email;
+
+  @JsonProperty("timestamp")
+  private long timestamp;
+
+  @JsonProperty("sg_event_id")
+  private String eventId;
+
+  @JsonProperty("sg_message_id")
+  private String messageId;
+
+  @JsonProperty("smtp-id")
+  private String smtpId;
+
+  private String reason;
+  private String url;
+  private String ip;
+
+  @JsonProperty("useragent")
+  private String userAgent;
+
+  @JsonProperty("category")
+  private String category;
+
+  @JsonProperty("custom_args")
+  private Map<String, Object> customArgs = new HashMap<>();
+
+  private final Map<String, Object> additionalFields = new HashMap<>();
+
+  public String getEvent() {
+    return event;
+  }
+
+  public void setEvent(String event) {
+    this.event = event;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public String getEventId() {
+    return eventId;
+  }
+
+  public void setEventId(String eventId) {
+    this.eventId = eventId;
+  }
+
+  public String getMessageId() {
+    return messageId;
+  }
+
+  public void setMessageId(String messageId) {
+    this.messageId = messageId;
+  }
+
+  public String getSmtpId() {
+    return smtpId;
+  }
+
+  public void setSmtpId(String smtpId) {
+    this.smtpId = smtpId;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public void setReason(String reason) {
+    this.reason = reason;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public String getIp() {
+    return ip;
+  }
+
+  public void setIp(String ip) {
+    this.ip = ip;
+  }
+
+  public String getUserAgent() {
+    return userAgent;
+  }
+
+  public void setUserAgent(String userAgent) {
+    this.userAgent = userAgent;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+
+  public void setCategory(String category) {
+    this.category = category;
+  }
+
+  public Map<String, Object> getCustomArgs() {
+    return customArgs;
+  }
+
+  public void setCustomArgs(Map<String, Object> customArgs) {
+    this.customArgs = customArgs;
+  }
+
+  public Instant occurredAt() {
+    return Instant.ofEpochSecond(timestamp);
+  }
+
+  public Map<String, Object> getAdditionalFields() {
+    return additionalFields;
+  }
+
+  @JsonAnySetter
+  public void putAdditionalField(String key, Object value) {
+    if (!"event".equals(key)
+        && !"email".equals(key)
+        && !"timestamp".equals(key)
+        && !"sg_event_id".equals(key)
+        && !"sg_message_id".equals(key)
+        && !"smtp-id".equals(key)
+        && !"reason".equals(key)
+        && !"url".equals(key)
+        && !"ip".equals(key)
+        && !"useragent".equals(key)
+        && !"category".equals(key)
+        && !"custom_args".equals(key)) {
+      additionalFields.put(key, value);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "SendgridEventRequest{"
+        + "event='"
+        + event
+        + '\''
+        + ", email='"
+        + email
+        + '\''
+        + ", timestamp="
+        + timestamp
+        + ", eventId='"
+        + eventId
+        + '\''
+        + ", messageId='"
+        + messageId
+        + '\''
+        + '}';
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(event, email, timestamp, eventId, messageId);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    SendgridEventRequest other = (SendgridEventRequest) obj;
+    return timestamp == other.timestamp
+        && Objects.equals(event, other.event)
+        && Objects.equals(email, other.email)
+        && Objects.equals(eventId, other.eventId)
+        && Objects.equals(messageId, other.messageId);
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/repository/EmailEventRepository.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/repository/EmailEventRepository.java
@@ -1,0 +1,16 @@
+package com.ejada.email.webhook.repository;
+
+import com.ejada.email.webhook.model.EmailEvent;
+import com.ejada.email.webhook.model.EmailEventType;
+import java.util.List;
+import java.util.Optional;
+
+public interface EmailEventRepository {
+  EmailEvent save(EmailEvent event);
+
+  Optional<EmailEvent> findByEventId(String eventId);
+
+  List<EmailEvent> findAll();
+
+  List<EmailEvent> findByType(EmailEventType type);
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/repository/EmailLogRepository.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/repository/EmailLogRepository.java
@@ -1,0 +1,13 @@
+package com.ejada.email.webhook.repository;
+
+import com.ejada.email.webhook.model.EmailLogStatus;
+import java.util.Map;
+import java.util.Optional;
+
+public interface EmailLogRepository {
+  void upsertStatus(String messageId, EmailLogStatus status, String tenantId);
+
+  Optional<EmailLogStatus> findStatus(String messageId);
+
+  Map<String, EmailLogStatus> findAll();
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/repository/InMemoryEmailEventRepository.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/repository/InMemoryEmailEventRepository.java
@@ -1,0 +1,39 @@
+package com.ejada.email.webhook.repository;
+
+import com.ejada.email.webhook.model.EmailEvent;
+import com.ejada.email.webhook.model.EmailEventType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryEmailEventRepository implements EmailEventRepository {
+
+  private final Map<String, EmailEvent> eventsByEventId = new ConcurrentHashMap<>();
+  private final Map<String, EmailEvent> eventsById = new ConcurrentHashMap<>();
+
+  @Override
+  public EmailEvent save(EmailEvent event) {
+    eventsByEventId.put(event.getEventId(), event);
+    eventsById.put(event.getId().toString(), event);
+    return event;
+  }
+
+  @Override
+  public Optional<EmailEvent> findByEventId(String eventId) {
+    return Optional.ofNullable(eventsByEventId.get(eventId));
+  }
+
+  @Override
+  public List<EmailEvent> findAll() {
+    return new ArrayList<>(eventsById.values());
+  }
+
+  @Override
+  public List<EmailEvent> findByType(EmailEventType type) {
+    return eventsById.values().stream().filter(event -> event.getType() == type).toList();
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/repository/InMemoryEmailLogRepository.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/repository/InMemoryEmailLogRepository.java
@@ -1,0 +1,39 @@
+package com.ejada.email.webhook.repository;
+
+import com.ejada.email.webhook.model.EmailLogStatus;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryEmailLogRepository implements EmailLogRepository {
+
+  private final Map<String, EmailLogStatus> statusByMessageId = new ConcurrentHashMap<>();
+  private final Map<String, String> tenantByMessageId = new ConcurrentHashMap<>();
+
+  @Override
+  public void upsertStatus(String messageId, EmailLogStatus status, String tenantId) {
+    if (messageId == null || messageId.isEmpty()) {
+      return;
+    }
+    statusByMessageId.put(messageId, status);
+    if (tenantId != null) {
+      tenantByMessageId.put(messageId, tenantId);
+    }
+  }
+
+  @Override
+  public Optional<EmailLogStatus> findStatus(String messageId) {
+    return Optional.ofNullable(statusByMessageId.get(messageId));
+  }
+
+  @Override
+  public Map<String, EmailLogStatus> findAll() {
+    return Map.copyOf(statusByMessageId);
+  }
+
+  public Map<String, String> tenants() {
+    return Map.copyOf(tenantByMessageId);
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/DeduplicationService.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/DeduplicationService.java
@@ -1,0 +1,51 @@
+package com.ejada.email.webhook.service;
+
+import com.ejada.email.webhook.SendgridWebhookProperties;
+import java.time.Duration;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeduplicationService {
+
+  private static final Logger log = LoggerFactory.getLogger(DeduplicationService.class);
+
+  private final StringRedisTemplate redisTemplate;
+  private final SendgridWebhookProperties properties;
+
+  public DeduplicationService(
+      StringRedisTemplate redisTemplate, SendgridWebhookProperties properties) {
+    this.redisTemplate = redisTemplate;
+    this.properties = properties;
+  }
+
+  public String resolveEventId(String providedEventId, String messageId) {
+    if (providedEventId != null && !providedEventId.isBlank()) {
+      return providedEventId;
+    }
+    return "fallback-" + messageId + "-" + UUID.randomUUID();
+  }
+
+  public boolean markIfFirst(String eventId) {
+    try {
+      Boolean success =
+          redisTemplate
+              .opsForValue()
+              .setIfAbsent(
+                  redisKey(eventId),
+                  "1",
+                  Duration.ofSeconds(properties.getDeduplicationTtlSeconds()));
+      return Boolean.TRUE.equals(success);
+    } catch (Exception ex) {
+      log.warn("Redis unavailable, proceeding without deduplication", ex);
+      return true;
+    }
+  }
+
+  private String redisKey(String eventId) {
+    return "sendgrid:event:" + eventId;
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/EventMapper.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/EventMapper.java
@@ -1,0 +1,81 @@
+package com.ejada.email.webhook.service;
+
+import com.ejada.email.webhook.model.EmailEvent;
+import com.ejada.email.webhook.model.EmailEventType;
+import com.ejada.email.webhook.model.EmailLogStatus;
+import com.ejada.email.webhook.model.SendgridEventRequest;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventMapper {
+
+  public EmailEventType mapEventType(String eventName) {
+    if (eventName == null) {
+      return EmailEventType.UNKNOWN;
+    }
+    return switch (eventName.toLowerCase()) {
+      case "processed" -> EmailEventType.PROCESSED;
+      case "delivered" -> EmailEventType.DELIVERED;
+      case "bounce" -> EmailEventType.BOUNCED;
+      case "spamreport" -> EmailEventType.SPAM_REPORTED;
+      case "open" -> EmailEventType.OPENED;
+      case "click" -> EmailEventType.CLICKED;
+      case "unsubscribe" -> EmailEventType.UNSUBSCRIBED;
+      case "group_unsubscribe" -> EmailEventType.GROUP_UNSUBSCRIBED;
+      case "deferred" -> EmailEventType.DEFERRED;
+      case "dropped" -> EmailEventType.DROPPED;
+      default -> EmailEventType.UNKNOWN;
+    };
+  }
+
+  public EmailLogStatus mapLogStatus(EmailEventType type) {
+    return switch (type) {
+      case DELIVERED -> EmailLogStatus.DELIVERED;
+      case BOUNCED -> EmailLogStatus.BOUNCED;
+      case DROPPED -> EmailLogStatus.DROPPED;
+      case DEFERRED -> EmailLogStatus.DEFERRED;
+      case SPAM_REPORTED -> EmailLogStatus.SPAM_REPORTED;
+      case UNSUBSCRIBED, GROUP_UNSUBSCRIBED -> EmailLogStatus.UNSUBSCRIBED;
+      default -> EmailLogStatus.UNKNOWN;
+    };
+  }
+
+  public EmailEvent toEmailEvent(
+      SendgridEventRequest request, String tenantId, String eventId, boolean duplicate) {
+    Map<String, Object> metadata = new HashMap<>();
+    if (request.getReason() != null) {
+      metadata.put("reason", request.getReason());
+    }
+    if (request.getUrl() != null) {
+      metadata.put("url", request.getUrl());
+    }
+    if (request.getIp() != null) {
+      metadata.put("ip", request.getIp());
+    }
+    if (request.getUserAgent() != null) {
+      metadata.put("userAgent", request.getUserAgent());
+    }
+    if (request.getCategory() != null) {
+      metadata.put("category", request.getCategory());
+    }
+    metadata.putAll(request.getAdditionalFields());
+
+    EmailEventType type = mapEventType(request.getEvent());
+    Instant processedAt = Instant.now();
+    return new EmailEvent(
+        UUID.randomUUID(),
+        eventId,
+        type,
+        request.getEmail(),
+        request.getMessageId(),
+        tenantId,
+        request.occurredAt(),
+        processedAt,
+        metadata,
+        duplicate);
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/IpWhitelistService.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/IpWhitelistService.java
@@ -1,0 +1,23 @@
+package com.ejada.email.webhook.service;
+
+import com.ejada.email.webhook.SendgridWebhookProperties;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IpWhitelistService {
+
+  private final SendgridWebhookProperties properties;
+
+  public IpWhitelistService(SendgridWebhookProperties properties) {
+    this.properties = properties;
+  }
+
+  public boolean isAllowed(String ip) {
+    List<String> allowed = properties.getAllowedIps();
+    if (allowed == null || allowed.isEmpty()) {
+      return true;
+    }
+    return allowed.contains(ip);
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/ProcessingMetrics.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/ProcessingMetrics.java
@@ -1,0 +1,44 @@
+package com.ejada.email.webhook.service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProcessingMetrics {
+
+  private final MeterRegistry meterRegistry;
+  private final Counter processed;
+  private final Counter duplicates;
+  private final Counter failures;
+  private final Map<String, Counter> typeCounters = new ConcurrentHashMap<>();
+
+  public ProcessingMetrics(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+    this.processed = meterRegistry.counter("sendgrid.webhook.processed");
+    this.duplicates = meterRegistry.counter("sendgrid.webhook.duplicates");
+    this.failures = meterRegistry.counter("sendgrid.webhook.failures");
+  }
+
+  public void incrementProcessed() {
+    processed.increment();
+  }
+
+  public void incrementDuplicate() {
+    duplicates.increment();
+  }
+
+  public void incrementFailure() {
+    failures.increment();
+  }
+
+  public void incrementType(String type) {
+    typeCounters
+        .computeIfAbsent(
+            type,
+            key -> Counter.builder("sendgrid.webhook.type").tag("type", key).register(meterRegistry))
+        .increment();
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/SendgridEventProcessor.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/SendgridEventProcessor.java
@@ -1,0 +1,96 @@
+package com.ejada.email.webhook.service;
+
+import com.ejada.email.webhook.SendgridWebhookProperties;
+import com.ejada.email.webhook.model.EmailEvent;
+import com.ejada.email.webhook.model.EmailEventType;
+import com.ejada.email.webhook.model.EmailLogStatus;
+import com.ejada.email.webhook.model.SendgridEventRequest;
+import com.ejada.email.webhook.repository.EmailEventRepository;
+import com.ejada.email.webhook.repository.EmailLogRepository;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SendgridEventProcessor {
+
+  private static final Logger log = LoggerFactory.getLogger(SendgridEventProcessor.class);
+
+  private final DeduplicationService deduplicationService;
+  private final EventMapper mapper;
+  private final EmailEventRepository emailEventRepository;
+  private final EmailLogRepository emailLogRepository;
+  private final KafkaTemplate<String, Object> kafkaTemplate;
+  private final SendgridWebhookProperties properties;
+  private final ProcessingMetrics metrics;
+
+  public SendgridEventProcessor(
+      DeduplicationService deduplicationService,
+      EventMapper mapper,
+      EmailEventRepository emailEventRepository,
+      EmailLogRepository emailLogRepository,
+      KafkaTemplate<String, Object> kafkaTemplate,
+      SendgridWebhookProperties properties,
+      ProcessingMetrics metrics) {
+    this.deduplicationService = deduplicationService;
+    this.mapper = mapper;
+    this.emailEventRepository = emailEventRepository;
+    this.emailLogRepository = emailLogRepository;
+    this.kafkaTemplate = kafkaTemplate;
+    this.properties = properties;
+    this.metrics = metrics;
+  }
+
+  public EmailEvent process(SendgridEventRequest request) {
+    String eventId = deduplicationService.resolveEventId(request.getEventId(), request.getMessageId());
+    boolean first = deduplicationService.markIfFirst(eventId);
+    EmailEvent event = mapper.toEmailEvent(request, resolveTenantId(request), eventId, !first);
+    emailEventRepository.save(event);
+
+    EmailEventType type = event.getType();
+    EmailLogStatus status = mapper.mapLogStatus(type);
+    emailLogRepository.upsertStatus(event.getMessageId(), status, event.getTenantId());
+
+    publish(event);
+
+    metrics.incrementType(type.name());
+    if (first) {
+      metrics.incrementProcessed();
+    } else {
+      metrics.incrementDuplicate();
+    }
+
+    if (!first) {
+      log.info("Duplicate SendGrid event suppressed: {}", eventId);
+    }
+    return event;
+  }
+
+  private void publish(EmailEvent event) {
+    try {
+      kafkaTemplate.send(properties.getKafkaTopic(), event.getEventId(), event);
+    } catch (Exception ex) {
+      metrics.incrementFailure();
+      log.error("Failed to publish event {} to Kafka", event.getEventId(), ex);
+    }
+  }
+
+  private String resolveTenantId(SendgridEventRequest request) {
+    if (request.getCustomArgs() == null) {
+      return null;
+    }
+    Object tenantId = request.getCustomArgs().getOrDefault("tenantId", request.getCustomArgs().get("tenant_id"));
+    return tenantId != null ? tenantId.toString() : null;
+  }
+
+  public Map<String, Long> analytics() {
+    Map<String, Long> counts = new HashMap<>();
+    for (EmailEventType type : EmailEventType.values()) {
+      counts.put(type.name(), (long) emailEventRepository.findByType(type).size());
+    }
+    return counts;
+  }
+}

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/SignatureValidator.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/SignatureValidator.java
@@ -1,0 +1,56 @@
+package com.ejada.email.webhook.service;
+
+import com.ejada.email.webhook.SendgridWebhookProperties;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Base64Utils;
+
+@Component
+public class SignatureValidator {
+
+  private static final String HMAC_SHA256 = "HmacSHA256";
+
+  private final SendgridWebhookProperties properties;
+
+  public SignatureValidator(SendgridWebhookProperties properties) {
+    this.properties = properties;
+  }
+
+  public boolean isSignatureValid(String timestamp, String signature, String payload) {
+    if (timestamp == null || signature == null || payload == null) {
+      return false;
+    }
+    if (!isTimestampFresh(timestamp)) {
+      return false;
+    }
+    try {
+      Mac mac = Mac.getInstance(HMAC_SHA256);
+      mac.init(new SecretKeySpec(properties.getSigningSecret().getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
+      byte[] expected = mac.doFinal((timestamp + payload).getBytes(StandardCharsets.UTF_8));
+      String expectedSignature = Base64Utils.encodeToString(expected);
+      return constantTimeEquals(expectedSignature, signature);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private boolean isTimestampFresh(String timestamp) {
+    long ts = Long.parseLong(timestamp);
+    long now = Instant.now().getEpochSecond();
+    return Math.abs(now - ts) <= properties.getToleranceSeconds();
+  }
+
+  private boolean constantTimeEquals(String a, String b) {
+    if (a == null || b == null || a.length() != b.length()) {
+      return false;
+    }
+    int result = 0;
+    for (int i = 0; i < a.length(); i++) {
+      result |= a.charAt(i) ^ b.charAt(i);
+    }
+    return result == 0;
+  }
+}

--- a/email-management/email-webhook-service/src/main/resources/application.yaml
+++ b/email-management/email-webhook-service/src/main/resources/application.yaml
@@ -13,3 +13,6 @@ sendgrid:
   webhook:
     signing-secret: change-me
     tolerance-seconds: 300
+    allowed-ips: []
+    kafka-topic: sendgrid.email-events
+    deduplication-ttl-seconds: 86400


### PR DESCRIPTION
## Summary
- add SendGrid webhook application with signature validation, optional IP whitelisting, Redis deduplication, and Kafka publishing
- normalize inbound events into in-memory repositories, update email log statuses, and expose admin analytics endpoints
- document webhook configuration and defaults

## Testing
- `mvn -pl email-webhook-service test` *(fails: missing com.ejada:shared-lib parent dependency in Maven repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a333fe180832fb2b7e8021ade9077)