### PR TITLE
Ensure UsageReport metrics are defensively copied

### DIFF
--- a/email-management/email-management-service/src/main/java/com/ejada/management/dto/UsageReport.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/management/dto/UsageReport.java
@@ -7,4 +7,9 @@ public record UsageReport(String tenantId, List<UsageMetric> metrics) {
   public UsageReport {
     metrics = metrics == null ? List.of() : List.copyOf(metrics);
   }
+
+  @Override
+  public List<UsageMetric> metrics() {
+    return List.copyOf(metrics);
+  }
 }


### PR DESCRIPTION
## Summary
- add an accessor override to UsageReport to return a defensive copy of the metrics list

## Testing
- mvn -pl email-management-service -am clean verify -DskipTests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a337fc948832f803d9c3daf6bbed1)