### PR TITLE
Update Handlebars dependency version

### DIFF
--- a/email-management/email-template-service/pom.xml
+++ b/email-management/email-template-service/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>com.github.jknack</groupId>
       <artifactId>handlebars</artifactId>
-      <version>4.4.3</version>
+      <version>4.5.0</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
## Summary
- update the email-template-service Handlebars dependency to a version available on Maven Central

## Testing
- mvn -pl email-template-service -am clean package


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3564378c832fa9b2adeafb74e426)