### PR TITLE
Add unit tests for child services

### DIFF
--- a/email-management/email-management-service/pom.xml
+++ b/email-management/email-management-service/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>lombok</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/email-management/email-management-service/src/test/java/com/ejada/management/config/ChildServicePropertiesTest.java
+++ b/email-management/email-management-service/src/test/java/com/ejada/management/config/ChildServicePropertiesTest.java
@@ -1,0 +1,39 @@
+package com.ejada.management.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ChildServicePropertiesTest {
+
+  @Test
+  void getTemplateShouldReturnDefensiveCopy() {
+    ChildServiceProperties properties = new ChildServiceProperties();
+    ChildServiceProperties.ServiceEndpoint internalTemplate =
+        (ChildServiceProperties.ServiceEndpoint) ReflectionTestUtils.getField(properties, "template");
+    URI templateUri = URI.create("https://template.test");
+    ReflectionTestUtils.setField(internalTemplate, "baseUrl", templateUri);
+
+    ChildServiceProperties.ServiceEndpoint retrievedTemplate = properties.getTemplate();
+
+    assertThat(retrievedTemplate).isNotSameAs(internalTemplate);
+    assertThat(retrievedTemplate.getBaseUrl()).isEqualTo(templateUri);
+
+    retrievedTemplate.setBaseUrl(URI.create("https://mutated.test"));
+    ChildServiceProperties.ServiceEndpoint secondRead = properties.getTemplate();
+
+    assertThat(secondRead.getBaseUrl()).isEqualTo(templateUri);
+  }
+
+  @Test
+  void settersShouldUpdateBaseUrl() {
+    ChildServiceProperties.ServiceEndpoint endpoint = new ChildServiceProperties.ServiceEndpoint();
+    URI baseUrl = URI.create("https://child.test/api");
+
+    endpoint.setBaseUrl(baseUrl);
+
+    assertThat(endpoint.getBaseUrl()).isEqualTo(baseUrl);
+  }
+}

--- a/email-management/email-management-service/src/test/java/com/ejada/management/service/ChildServiceInvokerTest.java
+++ b/email-management/email-management-service/src/test/java/com/ejada/management/service/ChildServiceInvokerTest.java
@@ -1,0 +1,81 @@
+package com.ejada.management.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ejada.management.exception.ChildServiceException;
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+class ChildServiceInvokerTest {
+
+  private RestClient baseClient;
+  private RestClient.Builder builder;
+  private RestClient restClient;
+  private ChildServiceInvoker invoker;
+
+  @BeforeEach
+  void setUp() {
+    baseClient = mock(RestClient.class);
+    builder = mock(RestClient.Builder.class);
+    restClient = mock(RestClient.class);
+
+    when(baseClient.mutate()).thenReturn(builder);
+    when(builder.build()).thenReturn(restClient);
+
+    invoker = new ChildServiceInvoker(baseClient);
+  }
+
+  @Test
+  void getShouldInvokeRestClientAndReturnResponse() {
+    RestClient.RequestHeadersUriSpec<?> requestSpec = mock(RestClient.RequestHeadersUriSpec.class);
+    RestClient.RequestHeadersSpec<?> requestHeadersSpec = mock(RestClient.RequestHeadersSpec.class);
+    RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+    when(restClient.get()).thenReturn(requestSpec);
+    when(requestSpec.uri(any(URI.class))).thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.accept(MediaType.APPLICATION_JSON)).thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.body(String.class)).thenReturn("response-body");
+
+    URI baseUrl = URI.create("https://child.test/api/");
+    String result = invoker.get(baseUrl, "resource", String.class);
+
+    ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+    verify(requestSpec).uri(uriCaptor.capture());
+
+    assertThat(uriCaptor.getValue()).isEqualTo(baseUrl.resolve("resource"));
+    assertThat(result).isEqualTo("response-body");
+  }
+
+  @Test
+  void postShouldWrapRestClientExceptions() {
+    RestClient.RequestBodyUriSpec requestBodySpec = mock(RestClient.RequestBodyUriSpec.class);
+    RestClient.RequestBodySpec requestSpec = mock(RestClient.RequestBodySpec.class);
+    RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+    when(restClient.post()).thenReturn(requestBodySpec);
+    when(requestBodySpec.uri(any(URI.class))).thenReturn(requestSpec);
+    when(requestSpec.contentType(MediaType.APPLICATION_JSON)).thenReturn(requestSpec);
+    when(requestSpec.accept(MediaType.APPLICATION_JSON)).thenReturn(requestSpec);
+    when(requestSpec.body(any())).thenReturn(requestSpec);
+    when(requestSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.body(eq(String.class))).thenThrow(new RestClientException("failure"));
+
+    URI baseUrl = URI.create("https://child.test/api/");
+
+    assertThatThrownBy(() -> invoker.post(baseUrl, "submit", "payload", String.class))
+        .isInstanceOf(ChildServiceException.class)
+        .hasMessageContaining("https://child.test/api/");
+  }
+}


### PR DESCRIPTION
## Summary
- add Spring Boot test dependencies to the email-management-service module
- add unit tests covering ChildServiceProperties defensive copies
- add unit tests verifying ChildServiceInvoker success and error handling

## Testing
- mvn -f email-management/pom.xml -pl email-management-service test -am *(fails: missing com.ejada:shared-lib:1.0.0 artifact in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a36d4dc54832f88b7e505b575e81d)