### PR TITLE
Define SpotBugs version property

### DIFF
--- a/email-management/pom.xml
+++ b/email-management/pom.xml
@@ -37,6 +37,8 @@
     <plugin.checkstyle.version>3.5.0</plugin.checkstyle.version>
     <plugin.spotbugs.version>4.8.6.5</plugin.spotbugs.version>
 
+    <spotbugs.version>4.8.6</spotbugs.version>
+
     <checkerframework.version>3.49.3</checkerframework.version>
   </properties>
 


### PR DESCRIPTION
## Summary
- add a SpotBugs annotations version property to the email-management parent POM so module dependencies resolve

## Testing
- mvn -pl email-template-service -am -DskipTests compile *(fails: com.ejada:shared-lib:pom:1.0.0 not found in Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a37ff372c832fb465cfd8d9c4a73f)