### PR TITLE
Fix RestClient test stubbing

### DIFF
--- a/email-management/email-management-service/src/test/java/com/ejada/management/service/ChildServiceInvokerTest.java
+++ b/email-management/email-management-service/src/test/java/com/ejada/management/service/ChildServiceInvokerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,10 +43,10 @@ class ChildServiceInvokerTest {
     RestClient.RequestHeadersSpec<?> requestHeadersSpec = mock(RestClient.RequestHeadersSpec.class);
     RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
 
-    when(restClient.get()).thenReturn(requestSpec);
-    when(requestSpec.uri(any(URI.class))).thenReturn(requestHeadersSpec);
-    when(requestHeadersSpec.accept(MediaType.APPLICATION_JSON)).thenReturn(requestHeadersSpec);
-    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    doReturn(requestSpec).when(restClient).get();
+    doReturn(requestHeadersSpec).when(requestSpec).uri(any(URI.class));
+    doReturn(requestHeadersSpec).when(requestHeadersSpec).accept(MediaType.APPLICATION_JSON);
+    doReturn(responseSpec).when(requestHeadersSpec).retrieve();
     when(responseSpec.body(String.class)).thenReturn("response-body");
 
     URI baseUrl = URI.create("https://child.test/api/");


### PR DESCRIPTION
## Summary
- adjust ChildServiceInvokerTest to use doReturn for RestClient stubbing
- add missing Mockito import to support updated stubbing

## Testing
- mvn test (fails: missing shared-lib parent dependency in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a38c54d84832fb992e4027967d0c0)