### PR TITLE
Handle NoSuchAlgorithmException during webhook signature verification

### DIFF
--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/WebhookServiceImpl.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/WebhookServiceImpl.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sendgrid.helpers.eventwebhook.EventWebhook;
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -63,6 +64,8 @@ public class WebhookServiceImpl implements WebhookService {
       if (!valid) {
         throw new IllegalArgumentException("Invalid webhook signature");
       }
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("Verification algorithm is not available", ex);
     } catch (RuntimeException ex) {
       throw new IllegalArgumentException("Unable to verify webhook signature", ex);
     }


### PR DESCRIPTION
## Summary
- add explicit handling for missing cryptography algorithms when verifying webhook signatures
- introduce NoSuchAlgorithmException import for webhook service implementation

## Testing
- ⚠️ `mvn -pl email-template-service -am test -DskipTests` (interrupted due to prolonged dependency downloads)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3a523c08832f8ed911e511a7aac8)