### PR TITLE
Handle missing provider in webhook signature verification

### DIFF
--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/WebhookServiceImpl.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/WebhookServiceImpl.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sendgrid.helpers.eventwebhook.EventWebhook;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -64,8 +65,8 @@ public class WebhookServiceImpl implements WebhookService {
       if (!valid) {
         throw new IllegalArgumentException("Invalid webhook signature");
       }
-    } catch (NoSuchAlgorithmException ex) {
-      throw new IllegalStateException("Verification algorithm is not available", ex);
+    } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
+      throw new IllegalStateException("Verification algorithm or provider is not available", ex);
     } catch (RuntimeException ex) {
       throw new IllegalArgumentException("Unable to verify webhook signature", ex);
     }


### PR DESCRIPTION
## Summary
- catch `NoSuchProviderException` when verifying SendGrid webhook signatures to ensure compilation
- update error message to cover missing algorithm/provider cases

## Testing
- mvn -pl email-template-service -am test *(fails: missing dependency com.ejada:shared-lib:1.0.0 from Maven Central)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3b8a6650832fa8c4bb3fed5e6d8e)