### PR TITLE
Handle SendGrid webhook key validation exceptions

### DIFF
--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/WebhookServiceImpl.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/WebhookServiceImpl.java
@@ -9,8 +9,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sendgrid.helpers.eventwebhook.EventWebhook;
 import java.io.IOException;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -65,7 +67,8 @@ public class WebhookServiceImpl implements WebhookService {
       if (!valid) {
         throw new IllegalArgumentException("Invalid webhook signature");
       }
-    } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
+    } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeyException
+        | InvalidKeySpecException ex) {
       throw new IllegalStateException("Verification algorithm or provider is not available", ex);
     } catch (RuntimeException ex) {
       throw new IllegalArgumentException("Unable to verify webhook signature", ex);


### PR DESCRIPTION
## Summary
- handle SendGrid webhook signature verification exceptions by catching invalid key errors

## Testing
- mvn -f email-management/pom.xml -pl email-template-service -am test (fails: missing shared-lib 1.0.0 artifact in Maven Central)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3cbb2d24832f961602f2ee486f95)