### PR TITLE
Handle signature verification exception

### DIFF
--- a/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/WebhookServiceImpl.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/template/service/impl/WebhookServiceImpl.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 import java.time.Instant;
@@ -68,7 +69,7 @@ public class WebhookServiceImpl implements WebhookService {
         throw new IllegalArgumentException("Invalid webhook signature");
       }
     } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeyException
-        | InvalidKeySpecException ex) {
+        | InvalidKeySpecException | SignatureException ex) {
       throw new IllegalStateException("Verification algorithm or provider is not available", ex);
     } catch (RuntimeException ex) {
       throw new IllegalArgumentException("Unable to verify webhook signature", ex);


### PR DESCRIPTION
## Summary
- handle SignatureException from SendGrid webhook signature verification to keep webhook validation flow compiling

## Testing
- mvn -f email-management/pom.xml -pl email-template-service -am test *(fails: missing artifact com.ejada:shared-lib:1.0.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3dd48ca0832fa66b367d70bbca50)