### PR TITLE
Fix SpotBugs exposure warnings in email-sending-service

### DIFF
--- a/email-management/email-sending-service/pom.xml
+++ b/email-management/email-sending-service/pom.xml
@@ -53,6 +53,12 @@
       <artifactId>lombok</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>4.8.6</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/client/dto/TemplateDescriptor.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/client/dto/TemplateDescriptor.java
@@ -7,6 +7,7 @@ public record TemplateDescriptor(
     String templateKey, List<AttachmentMetadataDto> defaultAttachments, boolean sandboxEnabled) {
 
   public TemplateDescriptor {
-    defaultAttachments = defaultAttachments == null ? List.of() : defaultAttachments;
+    defaultAttachments =
+        defaultAttachments == null ? List.of() : List.copyOf(defaultAttachments);
   }
 }

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/client/impl/HttpTemplateClient.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/client/impl/HttpTemplateClient.java
@@ -3,6 +3,7 @@ package com.ejada.sending.client.impl;
 import com.ejada.sending.client.TemplateClient;
 import com.ejada.sending.client.dto.TemplateDescriptor;
 import com.ejada.sending.config.EmailSendingProperties;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 @Component
+@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Dependencies are injected and not exposed")
 public class HttpTemplateClient implements TemplateClient {
 
   private static final Logger log = LoggerFactory.getLogger(HttpTemplateClient.class);

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/BulkEmailSendRequest.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/BulkEmailSendRequest.java
@@ -4,4 +4,9 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
-public record BulkEmailSendRequest(@NotEmpty List<@Valid EmailSendRequest> entries) {}
+public record BulkEmailSendRequest(@NotEmpty List<@Valid EmailSendRequest> entries) {
+
+  public BulkEmailSendRequest {
+    entries = List.copyOf(entries);
+  }
+}

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/EmailSendRequest.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/dto/EmailSendRequest.java
@@ -18,6 +18,14 @@ public record EmailSendRequest(
     @NotNull SendMode mode,
     String idempotencyKey) {
 
+  public EmailSendRequest {
+    to = List.copyOf(to);
+    cc = cc == null ? List.of() : List.copyOf(cc);
+    bcc = bcc == null ? List.of() : List.copyOf(bcc);
+    dynamicData = dynamicData == null ? Map.of() : Map.copyOf(dynamicData);
+    attachments = attachments == null ? List.of() : List.copyOf(attachments);
+  }
+
   public enum SendMode {
     PRODUCTION,
     TEST,

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/messaging/EmailEnvelope.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/messaging/EmailEnvelope.java
@@ -20,6 +20,14 @@ public record EmailEnvelope(
     Instant createdAt,
     String idempotencyKey) {
 
+  public EmailEnvelope {
+    to = to == null ? List.of() : List.copyOf(to);
+    cc = cc == null ? List.of() : List.copyOf(cc);
+    bcc = bcc == null ? List.of() : List.copyOf(bcc);
+    dynamicData = dynamicData == null ? Map.of() : Map.copyOf(dynamicData);
+    attachments = attachments == null ? List.of() : List.copyOf(attachments);
+  }
+
   public static EmailEnvelope from(String tenantId, EmailSendRequest request) {
     return new EmailEnvelope(
         UUID.randomUUID().toString(),

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/messaging/EmailSendConsumer.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/messaging/EmailSendConsumer.java
@@ -4,6 +4,7 @@ import com.ejada.sending.config.EmailSendingProperties;
 import com.ejada.sending.config.KafkaTopicsProperties;
 import com.ejada.sending.service.EmailLogService;
 import com.ejada.sending.service.EmailSender;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +18,7 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
 @Component
+@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Dependencies are managed by Spring")
 public class EmailSendConsumer {
 
   private static final Logger log = LoggerFactory.getLogger(EmailSendConsumer.class);

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/EmailDispatchServiceImpl.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/EmailDispatchServiceImpl.java
@@ -9,6 +9,7 @@ import com.ejada.sending.service.EmailDispatchService;
 import com.ejada.sending.service.IdempotencyService;
 import com.ejada.sending.service.EmailLogService;
 import com.ejada.sending.service.RateLimiterService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.KafkaHeaders;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
 @Service
+@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Dependencies are injected and not exposed")
 public class EmailDispatchServiceImpl implements EmailDispatchService {
 
   private final KafkaTemplate<String, EmailEnvelope> kafkaTemplate;

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/RedisIdempotencyService.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/RedisIdempotencyService.java
@@ -2,10 +2,12 @@ package com.ejada.sending.service.impl;
 
 import com.ejada.sending.service.IdempotencyService;
 import java.time.Duration;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
+@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Redis template is managed by Spring")
 public class RedisIdempotencyService implements IdempotencyService {
 
   private final StringRedisTemplate redisTemplate;

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/RedisRateLimiterService.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/RedisRateLimiterService.java
@@ -4,11 +4,13 @@ import com.ejada.sending.config.RateLimitProperties;
 import com.ejada.sending.service.RateLimiterService;
 import java.time.Instant;
 import java.util.List;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
 @Service
+@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Dependencies are managed beans")
 public class RedisRateLimiterService implements RateLimiterService {
 
   private final StringRedisTemplate redisTemplate;

--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/SendGridEmailSender.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/service/impl/SendGridEmailSender.java
@@ -8,6 +8,7 @@ import com.ejada.sending.dto.AttachmentMetadataDto;
 import com.ejada.sending.messaging.EmailEnvelope;
 import com.ejada.sending.service.AttachmentMergeService;
 import com.ejada.sending.service.EmailSender;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.sendgrid.Method;
 import com.sendgrid.Request;
 import com.sendgrid.Response;
@@ -29,6 +30,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.RestTemplate;
 
 @Service
+@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Dependencies are injected and managed externally")
 public class SendGridEmailSender implements EmailSender {
 
   private static final Logger log = LoggerFactory.getLogger(SendGridEmailSender.class);


### PR DESCRIPTION
## Summary
- add defensive copies in email sending DTOs to avoid exposing mutable collections
- suppress SpotBugs EI_EXPOSE_REP2 warnings on injected beans and include spotbugs annotations dependency

## Testing
- mvn -pl email-sending-service -am test *(fails: missing com.ejada:shared-lib:1.0.0 in Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a6cee7fc0832f90b153df8fa336ab)