### PR TITLE
Defensively copy default attachments list

### DIFF
--- a/email-management/email-sending-service/src/main/java/com/ejada/sending/client/dto/TemplateDescriptor.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/sending/client/dto/TemplateDescriptor.java
@@ -10,4 +10,9 @@ public record TemplateDescriptor(
     defaultAttachments =
         defaultAttachments == null ? List.of() : List.copyOf(defaultAttachments);
   }
+
+  @Override
+  public List<AttachmentMetadataDto> defaultAttachments() {
+    return List.copyOf(defaultAttachments);
+  }
 }


### PR DESCRIPTION
## Summary
- ensure TemplateDescriptor returns a defensive copy of default attachments to avoid exposing internal state

## Testing
- mvn -f email-management/pom.xml -pl email-sending-service -am verify *(fails: missing com.ejada:shared-lib dependency in Maven central; local build not completed)*
- mvn -f shared-lib/pom.xml install *(fails: coverage checks not met for shared-test-support)*
- mvn -f shared-lib/pom.xml install -DskipTests -Djacoco.skip=true *(aborted: lengthy dependency build; command interrupted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a6eada838832fad860bed52127e26)