### PR TITLE
Fix SpotBugs findings in email-webhook-service

### DIFF
--- a/email-management/email-webhook-service/pom.xml
+++ b/email-management/email-webhook-service/pom.xml
@@ -40,6 +40,12 @@
       <artifactId>lombok</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>4.8.6</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/SendgridWebhookProperties.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/SendgridWebhookProperties.java
@@ -29,11 +29,11 @@ public class SendgridWebhookProperties {
   }
 
   public List<String> getAllowedIps() {
-    return allowedIps;
+    return List.copyOf(allowedIps);
   }
 
   public void setAllowedIps(List<String> allowedIps) {
-    this.allowedIps = allowedIps;
+    this.allowedIps = allowedIps == null ? List.of() : List.copyOf(allowedIps);
   }
 
   public String getKafkaTopic() {

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/controller/WebhookController.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/controller/WebhookController.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -38,10 +39,10 @@ public class WebhookController {
       SendgridEventProcessor processor,
       IpWhitelistService ipWhitelistService,
       ObjectMapper objectMapper) {
-    this.signatureValidator = signatureValidator;
-    this.processor = processor;
-    this.ipWhitelistService = ipWhitelistService;
-    this.objectMapper = objectMapper;
+    this.signatureValidator = Objects.requireNonNull(signatureValidator);
+    this.processor = Objects.requireNonNull(processor);
+    this.ipWhitelistService = Objects.requireNonNull(ipWhitelistService);
+    this.objectMapper = Objects.requireNonNull(objectMapper).copy();
   }
 
   @PostMapping

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/EmailEvent.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/EmailEvent.java
@@ -36,7 +36,7 @@ public class EmailEvent {
     this.tenantId = tenantId;
     this.occurredAt = occurredAt;
     this.processedAt = processedAt;
-    this.metadata = metadata;
+    this.metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
     this.duplicate = duplicate;
   }
 

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/SendgridEventRequest.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/model/SendgridEventRequest.java
@@ -129,11 +129,11 @@ public class SendgridEventRequest {
   }
 
   public Map<String, Object> getCustomArgs() {
-    return customArgs;
+    return Map.copyOf(customArgs);
   }
 
   public void setCustomArgs(Map<String, Object> customArgs) {
-    this.customArgs = customArgs;
+    this.customArgs = customArgs == null ? Map.of() : new HashMap<>(customArgs);
   }
 
   public Instant occurredAt() {
@@ -141,7 +141,7 @@ public class SendgridEventRequest {
   }
 
   public Map<String, Object> getAdditionalFields() {
-    return additionalFields;
+    return Map.copyOf(additionalFields);
   }
 
   @JsonAnySetter

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/DeduplicationService.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/DeduplicationService.java
@@ -1,6 +1,7 @@
 package com.ejada.email.webhook.service;
 
 import com.ejada.email.webhook.SendgridWebhookProperties;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -9,6 +10,9 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Dependencies are managed by Spring and are not modified externally")
 public class DeduplicationService {
 
   private static final Logger log = LoggerFactory.getLogger(DeduplicationService.class);

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/EventMapper.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/EventMapper.java
@@ -6,6 +6,7 @@ import com.ejada.email.webhook.model.EmailLogStatus;
 import com.ejada.email.webhook.model.SendgridEventRequest;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
@@ -17,7 +18,7 @@ public class EventMapper {
     if (eventName == null) {
       return EmailEventType.UNKNOWN;
     }
-    return switch (eventName.toLowerCase()) {
+    return switch (eventName.toLowerCase(Locale.ROOT)) {
       case "processed" -> EmailEventType.PROCESSED;
       case "delivered" -> EmailEventType.DELIVERED;
       case "bounce" -> EmailEventType.BOUNCED;

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/IpWhitelistService.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/IpWhitelistService.java
@@ -1,10 +1,14 @@
 package com.ejada.email.webhook.service;
 
 import com.ejada.email.webhook.SendgridWebhookProperties;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Properties are managed by Spring and not mutated externally")
 public class IpWhitelistService {
 
   private final SendgridWebhookProperties properties;

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/ProcessingMetrics.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/ProcessingMetrics.java
@@ -2,11 +2,15 @@ package com.ejada.email.webhook.service;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 
 @Component
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "MeterRegistry is provided by Spring and safely managed")
 public class ProcessingMetrics {
 
   private final MeterRegistry meterRegistry;

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/SendgridEventProcessor.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/SendgridEventProcessor.java
@@ -7,6 +7,7 @@ import com.ejada.email.webhook.model.EmailLogStatus;
 import com.ejada.email.webhook.model.SendgridEventRequest;
 import com.ejada.email.webhook.repository.EmailEventRepository;
 import com.ejada.email.webhook.repository.EmailLogRepository;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -15,6 +16,9 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Dependencies are Spring-managed beans and not externally mutated")
 public class SendgridEventProcessor {
 
   private static final Logger log = LoggerFactory.getLogger(SendgridEventProcessor.class);

--- a/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/SignatureValidator.java
+++ b/email-management/email-webhook-service/src/main/java/com/ejada/email/webhook/service/SignatureValidator.java
@@ -1,6 +1,9 @@
 package com.ejada.email.webhook.service;
 
 import com.ejada.email.webhook.SendgridWebhookProperties;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
@@ -9,6 +12,9 @@ import javax.crypto.spec.SecretKeySpec;
 import org.springframework.stereotype.Component;
 
 @Component
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Properties are provided by Spring and not mutated externally")
 public class SignatureValidator {
 
   private static final String HMAC_SHA256 = "HmacSHA256";
@@ -32,7 +38,7 @@ public class SignatureValidator {
       byte[] expected = mac.doFinal((timestamp + payload).getBytes(StandardCharsets.UTF_8));
       String expectedSignature = Base64.getEncoder().encodeToString(expected);
       return constantTimeEquals(expectedSignature, signature);
-    } catch (Exception e) {
+    } catch (NoSuchAlgorithmException | InvalidKeyException e) {
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- add defensive copies for webhook request data and configuration lists to prevent exposing internal state
- suppress benign SpotBugs EI_EXPOSE_REP2 warnings on Spring-managed dependencies and harden locale/exception handling
- include spotbugs-annotations dependency to support SpotBugs suppressions

## Testing
- `mvn test -q` *(fails: Non-resolvable import POM com.ejada:shared-lib:pom:1.0.0)*
- `mvn -pl email-management/email-webhook-service -am test -q` *(fails: project path not found in reactor)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a71cf9f18832facd0e15259d7dbf0)