### PR TITLE
Fix UsageReportDto constructor assignment

### DIFF
--- a/email-management/email-usage-service/src/main/java/com/ejada/usage/dto/UsageReportDto.java
+++ b/email-management/email-usage-service/src/main/java/com/ejada/usage/dto/UsageReportDto.java
@@ -4,7 +4,8 @@ import java.util.List;
 
 public record UsageReportDto(String tenantId, List<UsageMetricDto> metrics) {
 
-  public UsageReportDto {
+  public UsageReportDto(String tenantId, List<UsageMetricDto> metrics) {
+    this.tenantId = tenantId;
     this.metrics = metrics == null ? List.of() : List.copyOf(metrics);
   }
 


### PR DESCRIPTION
## Summary
- replace the compact record constructor with an explicit canonical constructor so metrics can be safely initialized and copied

## Testing
- mvn test *(fails: missing com.ejada:shared-lib:pom:1.0.0 dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a743e51e0832f90ef33aa34ceee37)