### PR TITLE
Implement WhatsApp management services scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository houses several components:
 - **shared-lib** – a collection of reusable Spring Boot starter modules and utilities.
 - **lms-setup** – a Spring Boot microservice for reference lookups and tenant/platform configuration.
 - **tenant-persistence** – central JPA entities, repositories, and Flyway migrations for the tenant domain.
+- **whatsapp-management** – Maven multi-module build for the WhatsApp gateway plus template, sending,
+  webhook, and usage microservices.
 
 ## Getting Started
 

--- a/whatsapp-management/README.md
+++ b/whatsapp-management/README.md
@@ -1,0 +1,26 @@
+# WhatsApp Management Platform
+
+This module now defines the tenant-facing WhatsApp orchestration stack as a Maven multi-module build.
+The parent service fronts tenant onboarding, configuration, and runtime operations, while child
+microservices handle templates, sending, webhooks, and usage analytics.
+
+| Module | Purpose |
+| --- | --- |
+| `whatsapp-management-service` | API gateway for tenant onboarding via Meta's embedded signup, storing WABA IDs and credentials in GCP Secret Manager, enforcing quotas/RBAC, and routing to child services. |
+| `whatsapp-template-service` | CRUD and approval tracking for WhatsApp Highly Structured Message (HSM) templates, including attachment upload/caching and Meta submission workflows. |
+| `whatsapp-sending-service` | Accepts templated or ad-hoc sends, enforces the 24-hour session window, queues jobs to Kafka, and retries with dead-letter handling. |
+| `whatsapp-webhook-service` | Secure ingestion of Meta webhook events with signature/IP validation, normalization, deduplication, and Kafka event emission. |
+| `whatsapp-usage-service` | Aggregates per-tenant messaging and template usage metrics, monitors quotas, and exposes reporting APIs. |
+
+Shared concerns across the stack:
+
+- **Persistence and caching** – PostgreSQL for tenant-scoped metadata and logs; Redis for caching template/media lookups and rate limiting.
+- **Media management** – Attachment uploads cached as Meta media IDs and reused across templates and sends.
+- **Security** – Tenant credentials and access tokens stored in GCP Secret Manager; RBAC enforced by the parent gateway.
+- **Observability** – Kafka used for async send queues and event propagation to analytics and billing pipelines.
+
+Build everything:
+
+```bash
+mvn -pl whatsapp-management -am clean package
+```

--- a/whatsapp-management/pom.xml
+++ b/whatsapp-management/pom.xml
@@ -1,0 +1,212 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.5.5</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>com.ejada</groupId>
+  <artifactId>whatsapp-management</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <name>whatsapp-management</name>
+
+  <modules>
+    <module>whatsapp-management-service</module>
+    <module>whatsapp-template-service</module>
+    <module>whatsapp-sending-service</module>
+    <module>whatsapp-webhook-service</module>
+    <module>whatsapp-usage-service</module>
+  </modules>
+
+  <properties>
+    <java.version>21</java.version>
+    <maven.min.version>3.9.6</maven.min.version>
+
+    <ejada.shared.version>1.0.0</ejada.shared.version>
+    <springdoc.version>2.6.0</springdoc.version>
+
+    <plugin.enforcer.version>3.5.0</plugin.enforcer.version>
+    <plugin.jacoco.version>0.8.12</plugin.jacoco.version>
+    <plugin.spotless.version>2.43.0</plugin.spotless.version>
+    <plugin.checkstyle.version>3.5.0</plugin.checkstyle.version>
+    <plugin.spotbugs.version>4.8.6.5</plugin.spotbugs.version>
+
+    <spotbugs.version>4.8.6</spotbugs.version>
+
+    <checkerframework.version>3.49.3</checkerframework.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.ejada</groupId>
+        <artifactId>shared-lib</artifactId>
+        <version>${ejada.shared.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <version>${checkerframework.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>${springdoc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Maven Central</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <releases>
+        <updatePolicy>always</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- Enforcer -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${plugin.enforcer.version}</version>
+          <executions>
+            <execution>
+              <id>enforce</id>
+              <goals><goal>enforce</goal></goals>
+              <configuration>
+                <fail>true</fail>
+                <rules>
+                  <requireMavenVersion>
+                    <version>[${maven.min.version},)</version>
+                  </requireMavenVersion>
+                  <requireJavaVersion>
+                    <version>[${java.version},)</version>
+                  </requireJavaVersion>
+                  <dependencyConvergence/>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${plugin.jacoco.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${plugin.spotless.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>${plugin.checkstyle.version}</version>
+          <configuration>
+            <configLocation>
+              ${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/checkstyle.xml
+            </configLocation>
+            <suppressionsLocation>
+              ${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/suppressions.xml
+            </suppressionsLocation>
+            <consoleOutput>true</consoleOutput>
+            <failOnViolation>false</failOnViolation>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>${plugin.spotbugs.version}</version>
+          <configuration>
+            <effort>Max</effort>
+            <threshold>Low</threshold>
+            <xmlOutput>true</xmlOutput>
+            <htmlOutput>true</htmlOutput>
+            <outputDirectory>${project.build.directory}/spotbugs</outputDirectory>
+            <excludeFilterFile>${maven.multiModuleProjectDirectory}/shared-lib/shared-quality/spotbugs-exclude.xml</excludeFilterFile>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.12.0</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.13.0</version>
+          <configuration>
+            <source>21</source>
+            <target>21</target>
+            <parameters>true</parameters>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/whatsapp-management/whatsapp-management-service/README.md
+++ b/whatsapp-management/whatsapp-management-service/README.md
@@ -1,0 +1,6 @@
+# whatsapp-management-service
+
+API gateway that fronts the WhatsApp tenant experience. It owns onboarding through Meta's embedded
+signup, stores WABA identifiers and credentials in GCP Secret Manager, applies per-tenant rate limits
+and RBAC, and routes traffic to the downstream WhatsApp template, sending, webhook, and usage
+services. The gateway also aggregates responses for the tenant/admin APIs exposed to the LMS portal.

--- a/whatsapp-management/whatsapp-management-service/pom.xml
+++ b/whatsapp-management/whatsapp-management-service/pom.xml
@@ -1,0 +1,58 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>whatsapp-management</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>whatsapp-management-service</artifactId>
+  <name>whatsapp-management-service</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/whatsapp-management/whatsapp-sending-service/README.md
+++ b/whatsapp-management/whatsapp-sending-service/README.md
@@ -1,0 +1,6 @@
+# whatsapp-sending-service
+
+Accepts templated and session messages, enforces WhatsApp's 24-hour window rules, and performs
+Redis-backed idempotency and rate limiting. Send requests are queued to Kafka for resilient delivery
+workers that call the WhatsApp Business Cloud API, with retries and dead-letter handling for
+failures.

--- a/whatsapp-management/whatsapp-sending-service/pom.xml
+++ b/whatsapp-management/whatsapp-sending-service/pom.xml
@@ -1,0 +1,67 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>whatsapp-management</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>whatsapp-sending-service</artifactId>
+  <name>whatsapp-sending-service</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>${spotbugs.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/whatsapp-management/whatsapp-template-service/README.md
+++ b/whatsapp-management/whatsapp-template-service/README.md
@@ -1,0 +1,6 @@
+# whatsapp-template-service
+
+Provides CRUD, validation, and Meta submission workflows for WhatsApp Highly Structured Message
+templates. The service manages attachment uploads, caches Meta media IDs for reuse, tracks approval
+statuses and versions, and publishes Kafka events when template changes need to be synchronized
+with sending or usage pipelines.

--- a/whatsapp-management/whatsapp-template-service/pom.xml
+++ b/whatsapp-management/whatsapp-template-service/pom.xml
@@ -1,0 +1,84 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>whatsapp-management</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>whatsapp-template-service</artifactId>
+  <name>whatsapp-template-service</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>${spotbugs.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/whatsapp-management/whatsapp-usage-service/README.md
+++ b/whatsapp-management/whatsapp-usage-service/README.md
@@ -1,0 +1,5 @@
+# whatsapp-usage-service
+
+Aggregates tenant-level messaging volumes, template usage, delivery outcomes, and engagement metrics.
+The service enforces quotas, raises alerts as limits approach, and exposes reporting APIs for tenant
+portals and billing systems to consume.

--- a/whatsapp-management/whatsapp-usage-service/pom.xml
+++ b/whatsapp-management/whatsapp-usage-service/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>whatsapp-management</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>whatsapp-usage-service</artifactId>
+  <name>whatsapp-usage-service</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/whatsapp-management/whatsapp-webhook-service/README.md
+++ b/whatsapp-management/whatsapp-webhook-service/README.md
@@ -1,0 +1,5 @@
+# whatsapp-webhook-service
+
+Receives Meta webhook callbacks for delivery receipts, message statuses, and inbound replies. The
+service verifies HMAC signatures and source IPs, normalizes and deduplicates events, updates message
+logs, and emits Kafka notifications for analytics and conversation workflows.

--- a/whatsapp-management/whatsapp-webhook-service/pom.xml
+++ b/whatsapp-management/whatsapp-webhook-service/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.ejada</groupId>
+    <artifactId>whatsapp-management</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>whatsapp-webhook-service</artifactId>
+  <name>whatsapp-webhook-service</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>${spotbugs.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
## Summary
- convert whatsapp-management into a Maven multi-module project for the gateway and child services
- add service-specific READMEs describing responsibilities for management, template, sending, webhook, and usage components
- add starter Maven configurations for each WhatsApp microservice

## Testing
- not run (configuration and documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a73adc8a0832fae363711399b3400)