### PR TITLE
Add springdoc common dependency

### DIFF
--- a/email-management/pom.xml
+++ b/email-management/pom.xml
@@ -71,6 +71,11 @@
       <version>${springdoc.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-common</artifactId>
+      <version>${springdoc.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <optional>true</optional>


### PR DESCRIPTION
## Summary
- add the springdoc-openapi-starter-common dependency to the email-management parent to ensure required Swagger resources are available

## Testing
- mvn -pl email-management/email-webhook-service -am test *(fails: com.ejada:shared-lib:1.0.0 POM not found in local repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a77d42ef0832fa486e361a7d89f57)