### PR TITLE
Align springdoc starter versions

### DIFF
--- a/email-management/pom.xml
+++ b/email-management/pom.xml
@@ -29,7 +29,7 @@
     <maven.min.version>3.9.6</maven.min.version>
 
     <ejada.shared.version>1.0.0</ejada.shared.version>
-    <springdoc.version>2.6.0</springdoc.version>
+    <springdoc.version>2.7.0</springdoc.version>
 
     <plugin.enforcer.version>3.5.0</plugin.enforcer.version>
     <plugin.jacoco.version>0.8.12</plugin.jacoco.version>


### PR DESCRIPTION
## Summary
- align the springdoc starter property to use version 2.7.0 consistently and avoid dependency convergence issues

## Testing
- mvn -pl . -am -DskipTests verify *(fails: missing com.ejada:shared-lib:1.0.0 in local/central repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a79fc2ba0832f9958dfa5ad3cafa2)