### PR TITLE
Fix Kafka listener SpEL bean references

### DIFF
--- a/email-management/email-sending-service/src/main/java/com/ejada/email/sending/messaging/EmailSendConsumer.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/email/sending/messaging/EmailSendConsumer.java
@@ -45,7 +45,8 @@ public class EmailSendConsumer {
     this.taskScheduler = taskScheduler;
   }
 
-  @KafkaListener(topics = {"#{kafkaTopicsProperties.emailSend}", "#{kafkaTopicsProperties.emailBulk}"})
+  @KafkaListener(
+      topics = {"#{@kafkaTopicsProperties.emailSend}", "#{@kafkaTopicsProperties.emailBulk}"})
   public void consume(
       @Payload EmailEnvelope envelope,
       @Header(name = "x-attempt", required = false) Integer attemptHeader,


### PR DESCRIPTION
## Summary
- correct Kafka listener SpEL expressions to reference the kafkaTopicsProperties bean

## Testing
- mvn -pl email-management/email-sending-service test *(fails: missing com.ejada:shared-lib:pom:1.0.0 artifact)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a81b7d838832fa60606090cb1a824)