### PR TITLE
Fix Kafka listener topic resolution

### DIFF
--- a/email-management/email-sending-service/src/main/java/com/ejada/email/sending/messaging/EmailSendConsumer.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/email/sending/messaging/EmailSendConsumer.java
@@ -45,8 +45,7 @@ public class EmailSendConsumer {
     this.taskScheduler = taskScheduler;
   }
 
-  @KafkaListener(
-      topics = {"#{@kafkaTopicsProperties.emailSend}", "#{@kafkaTopicsProperties.emailBulk}"})
+  @KafkaListener(topics = {"${kafka.topics.email-send}", "${kafka.topics.email-bulk}"})
   public void consume(
       @Payload EmailEnvelope envelope,
       @Header(name = "x-attempt", required = false) Integer attemptHeader,


### PR DESCRIPTION
## Summary
- fix Kafka listener topic values to use property placeholders instead of a bean name

## Testing
- mvn test *(fails: missing com.ejada:shared-lib:pom:1.0.0 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a834f28a4832f9b8b169542327f01)