### PR TITLE
Configure Kafka consumer group for email listener

### DIFF
--- a/email-management/email-sending-service/src/main/resources/application.yaml
+++ b/email-management/email-sending-service/src/main/resources/application.yaml
@@ -4,6 +4,8 @@ server:
 spring:
   kafka:
     bootstrap-servers: localhost:29092
+    consumer:
+      group-id: ${KAFKA_CONSUMER_GROUP_ID:email-sending-service}
   data:
     redis:
       host: localhost


### PR DESCRIPTION
## Summary
- set a default Kafka consumer group id for the email sending service listeners to allow startup when group management is enabled

## Testing
- mvn test -q *(fails: missing com.ejada:shared-lib parent POM locally)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691adca00238832f9bc8bba7d9f5b057)