### PR TITLE
Fix configuration binding for child service endpoints

### DIFF
--- a/email-management/email-management-service/src/main/java/com/ejada/email/management/config/ChildServiceProperties.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/email/management/config/ChildServiceProperties.java
@@ -6,25 +6,41 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "child-services")
 public class ChildServiceProperties {
 
-  private final ServiceEndpoint template = new ServiceEndpoint();
-  private final ServiceEndpoint sending = new ServiceEndpoint();
-  private final ServiceEndpoint webhook = new ServiceEndpoint();
-  private final ServiceEndpoint usage = new ServiceEndpoint();
+  private ServiceEndpoint template = new ServiceEndpoint();
+  private ServiceEndpoint sending = new ServiceEndpoint();
+  private ServiceEndpoint webhook = new ServiceEndpoint();
+  private ServiceEndpoint usage = new ServiceEndpoint();
 
   public ServiceEndpoint getTemplate() {
-    return new ServiceEndpoint(template);
+    return template;
+  }
+
+  public void setTemplate(ServiceEndpoint template) {
+    this.template = copyOf(template);
   }
 
   public ServiceEndpoint getSending() {
-    return new ServiceEndpoint(sending);
+    return sending;
+  }
+
+  public void setSending(ServiceEndpoint sending) {
+    this.sending = copyOf(sending);
   }
 
   public ServiceEndpoint getWebhook() {
-    return new ServiceEndpoint(webhook);
+    return webhook;
+  }
+
+  public void setWebhook(ServiceEndpoint webhook) {
+    this.webhook = copyOf(webhook);
   }
 
   public ServiceEndpoint getUsage() {
-    return new ServiceEndpoint(usage);
+    return usage;
+  }
+
+  public void setUsage(ServiceEndpoint usage) {
+    this.usage = copyOf(usage);
   }
 
   public static class ServiceEndpoint {
@@ -45,5 +61,12 @@ public class ChildServiceProperties {
     public void setBaseUrl(URI baseUrl) {
       this.baseUrl = baseUrl;
     }
+  }
+
+  private static ServiceEndpoint copyOf(ServiceEndpoint source) {
+    if (source == null) {
+      return new ServiceEndpoint();
+    }
+    return new ServiceEndpoint(source);
   }
 }

--- a/email-management/email-management-service/src/test/java/com/ejada/email/management/config/ChildServicePropertiesTest.java
+++ b/email-management/email-management-service/src/test/java/com/ejada/email/management/config/ChildServicePropertiesTest.java
@@ -4,27 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 class ChildServicePropertiesTest {
 
   @Test
-  void getTemplateShouldReturnDefensiveCopy() {
+  void getTemplateShouldExposeBackingInstance() {
     ChildServiceProperties properties = new ChildServiceProperties();
-    ChildServiceProperties.ServiceEndpoint internalTemplate =
-        (ChildServiceProperties.ServiceEndpoint) ReflectionTestUtils.getField(properties, "template");
     URI templateUri = URI.create("https://template.test");
-    ReflectionTestUtils.setField(internalTemplate, "baseUrl", templateUri);
 
-    ChildServiceProperties.ServiceEndpoint retrievedTemplate = properties.getTemplate();
+    properties.getTemplate().setBaseUrl(templateUri);
 
-    assertThat(retrievedTemplate).isNotSameAs(internalTemplate);
-    assertThat(retrievedTemplate.getBaseUrl()).isEqualTo(templateUri);
-
-    retrievedTemplate.setBaseUrl(URI.create("https://mutated.test"));
-    ChildServiceProperties.ServiceEndpoint secondRead = properties.getTemplate();
-
-    assertThat(secondRead.getBaseUrl()).isEqualTo(templateUri);
+    assertThat(properties.getTemplate().getBaseUrl()).isEqualTo(templateUri);
   }
 
   @Test
@@ -35,5 +25,18 @@ class ChildServicePropertiesTest {
     endpoint.setBaseUrl(baseUrl);
 
     assertThat(endpoint.getBaseUrl()).isEqualTo(baseUrl);
+  }
+
+  @Test
+  void settersShouldCopyEndpoints() {
+    ChildServiceProperties properties = new ChildServiceProperties();
+    ChildServiceProperties.ServiceEndpoint endpoint = new ChildServiceProperties.ServiceEndpoint();
+    URI baseUrl = URI.create("https://child.test/api");
+    endpoint.setBaseUrl(baseUrl);
+
+    properties.setTemplate(endpoint);
+
+    assertThat(properties.getTemplate().getBaseUrl()).isEqualTo(baseUrl);
+    assertThat(properties.getTemplate()).isNotSameAs(endpoint);
   }
 }


### PR DESCRIPTION
## Summary
- update `ChildServiceProperties` to expose mutable service endpoints with setters suitable for Spring Boot configuration binding
- keep defensive copying when assigning new endpoints to avoid shared references
- refresh configuration property tests to match the new binding approach

## Testing
- `mvn test` *(fails: missing dependency com.ejada:shared-lib:1.0.0 in Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ade890174832f89c819d613d967cc)