### PR TITLE
Add defensive copies for child service properties

### DIFF
--- a/email-management/email-management-service/src/main/java/com/ejada/email/management/config/ChildServiceProperties.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/email/management/config/ChildServiceProperties.java
@@ -11,8 +11,19 @@ public class ChildServiceProperties {
   private ServiceEndpoint webhook = new ServiceEndpoint();
   private ServiceEndpoint usage = new ServiceEndpoint();
 
+  public ChildServiceProperties() {
+    // default constructor
+  }
+
+  private ChildServiceProperties(ChildServiceProperties other) {
+    this.template = copyOf(other.template);
+    this.sending = copyOf(other.sending);
+    this.webhook = copyOf(other.webhook);
+    this.usage = copyOf(other.usage);
+  }
+
   public ServiceEndpoint getTemplate() {
-    return template;
+    return copyOf(template);
   }
 
   public void setTemplate(ServiceEndpoint template) {
@@ -20,7 +31,7 @@ public class ChildServiceProperties {
   }
 
   public ServiceEndpoint getSending() {
-    return sending;
+    return copyOf(sending);
   }
 
   public void setSending(ServiceEndpoint sending) {
@@ -28,7 +39,7 @@ public class ChildServiceProperties {
   }
 
   public ServiceEndpoint getWebhook() {
-    return webhook;
+    return copyOf(webhook);
   }
 
   public void setWebhook(ServiceEndpoint webhook) {
@@ -36,11 +47,15 @@ public class ChildServiceProperties {
   }
 
   public ServiceEndpoint getUsage() {
-    return usage;
+    return copyOf(usage);
   }
 
   public void setUsage(ServiceEndpoint usage) {
     this.usage = copyOf(usage);
+  }
+
+  public ChildServiceProperties copy() {
+    return new ChildServiceProperties(this);
   }
 
   public static class ServiceEndpoint {

--- a/email-management/email-management-service/src/main/java/com/ejada/email/management/service/EmailGatewayService.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/email/management/service/EmailGatewayService.java
@@ -14,7 +14,7 @@ public class EmailGatewayService {
   private final ChildServiceInvoker invoker;
 
   public EmailGatewayService(ChildServiceProperties properties, ChildServiceInvoker invoker) {
-    this.properties = properties;
+    this.properties = requireProperties(properties);
     this.invoker = invoker;
   }
 
@@ -27,5 +27,10 @@ public class EmailGatewayService {
   private URI requireEndpoint(URI uri, String name) {
     Assert.notNull(uri, () -> "Missing baseUrl for " + name + " service");
     return uri;
+  }
+
+  private ChildServiceProperties requireProperties(ChildServiceProperties properties) {
+    Assert.notNull(properties, "Child service properties must not be null");
+    return properties.copy();
   }
 }

--- a/email-management/email-management-service/src/main/java/com/ejada/email/management/service/TemplateGatewayService.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/email/management/service/TemplateGatewayService.java
@@ -16,7 +16,7 @@ public class TemplateGatewayService {
   private final ChildServiceInvoker invoker;
 
   public TemplateGatewayService(ChildServiceProperties properties, ChildServiceInvoker invoker) {
-    this.properties = properties;
+    this.properties = requireProperties(properties);
     this.invoker = invoker;
   }
 
@@ -42,5 +42,10 @@ public class TemplateGatewayService {
   private URI requireEndpoint(URI uri, String name) {
     Assert.notNull(uri, () -> "Missing baseUrl for " + name + " service");
     return uri;
+  }
+
+  private ChildServiceProperties requireProperties(ChildServiceProperties properties) {
+    Assert.notNull(properties, "Child service properties must not be null");
+    return properties.copy();
   }
 }

--- a/email-management/email-management-service/src/main/java/com/ejada/email/management/service/UsageGatewayService.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/email/management/service/UsageGatewayService.java
@@ -17,7 +17,7 @@ public class UsageGatewayService {
   private final ChildServiceInvoker invoker;
 
   public UsageGatewayService(ChildServiceProperties properties, ChildServiceInvoker invoker) {
-    this.properties = properties;
+    this.properties = requireProperties(properties);
     this.invoker = invoker;
   }
 
@@ -37,5 +37,10 @@ public class UsageGatewayService {
   private URI requireEndpoint(URI uri, String name) {
     Assert.notNull(uri, () -> "Missing baseUrl for " + name + " service");
     return uri;
+  }
+
+  private ChildServiceProperties requireProperties(ChildServiceProperties properties) {
+    Assert.notNull(properties, "Child service properties must not be null");
+    return properties.copy();
   }
 }

--- a/email-management/email-management-service/src/main/java/com/ejada/email/management/service/WebhookGatewayService.java
+++ b/email-management/email-management-service/src/main/java/com/ejada/email/management/service/WebhookGatewayService.java
@@ -13,7 +13,7 @@ public class WebhookGatewayService {
   private final ChildServiceInvoker invoker;
 
   public WebhookGatewayService(ChildServiceProperties properties, ChildServiceInvoker invoker) {
-    this.properties = properties;
+    this.properties = requireProperties(properties);
     this.invoker = invoker;
   }
 
@@ -25,5 +25,10 @@ public class WebhookGatewayService {
   private URI requireEndpoint(URI uri, String name) {
     Assert.notNull(uri, () -> "Missing baseUrl for " + name + " service");
     return uri;
+  }
+
+  private ChildServiceProperties requireProperties(ChildServiceProperties properties) {
+    Assert.notNull(properties, "Child service properties must not be null");
+    return properties.copy();
   }
 }

--- a/email-management/email-management-service/src/test/java/com/ejada/email/management/config/ChildServicePropertiesTest.java
+++ b/email-management/email-management-service/src/test/java/com/ejada/email/management/config/ChildServicePropertiesTest.java
@@ -8,16 +8,6 @@ import org.junit.jupiter.api.Test;
 class ChildServicePropertiesTest {
 
   @Test
-  void getTemplateShouldExposeBackingInstance() {
-    ChildServiceProperties properties = new ChildServiceProperties();
-    URI templateUri = URI.create("https://template.test");
-
-    properties.getTemplate().setBaseUrl(templateUri);
-
-    assertThat(properties.getTemplate().getBaseUrl()).isEqualTo(templateUri);
-  }
-
-  @Test
   void settersShouldUpdateBaseUrl() {
     ChildServiceProperties.ServiceEndpoint endpoint = new ChildServiceProperties.ServiceEndpoint();
     URI baseUrl = URI.create("https://child.test/api");
@@ -38,5 +28,22 @@ class ChildServicePropertiesTest {
 
     assertThat(properties.getTemplate().getBaseUrl()).isEqualTo(baseUrl);
     assertThat(properties.getTemplate()).isNotSameAs(endpoint);
+  }
+
+  @Test
+  void getterShouldReturnCopyWithConfiguredValue() {
+    ChildServiceProperties properties = new ChildServiceProperties();
+    ChildServiceProperties.ServiceEndpoint endpoint = new ChildServiceProperties.ServiceEndpoint();
+    URI baseUrl = URI.create("https://template.test");
+    endpoint.setBaseUrl(baseUrl);
+
+    properties.setTemplate(endpoint);
+
+    ChildServiceProperties.ServiceEndpoint copy = properties.getTemplate();
+
+    assertThat(copy.getBaseUrl()).isEqualTo(baseUrl);
+    copy.setBaseUrl(URI.create("https://other.test"));
+
+    assertThat(properties.getTemplate().getBaseUrl()).isEqualTo(baseUrl);
   }
 }


### PR DESCRIPTION
## Summary
- add defensive copies in ChildServiceProperties to prevent exposing internal state
- copy child service properties when injecting into gateway services
- update ChildServiceProperties tests to reflect defensive copying behavior

## Testing
- mvn test -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ae04dcd1c832f9c1c220e4e60d274)