### PR TITLE
Align email services with shared library

### DIFF
--- a/email-management/email-management-service/pom.xml
+++ b/email-management/email-management-service/pom.xml
@@ -24,8 +24,16 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-openapi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/email-management/email-sending-service/pom.xml
+++ b/email-management/email-sending-service/pom.xml
@@ -24,8 +24,8 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-redis</artifactId>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-redis</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -41,12 +41,20 @@
       <version>4.10.3</version>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka</artifactId>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-kafka</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-openapi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/email-management/email-usage-service/pom.xml
+++ b/email-management/email-usage-service/pom.xml
@@ -41,8 +41,16 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-openapi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/email-management/email-webhook-service/pom.xml
+++ b/email-management/email-webhook-service/pom.xml
@@ -24,16 +24,24 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka</artifactId>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-kafka</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-redis</artifactId>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-redis</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
+      <artifactId>starter-openapi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/email-management/pom.xml
+++ b/email-management/pom.xml
@@ -4,10 +4,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.5</version>
-    <relativePath/>
+    <groupId>com.ejada</groupId>
+    <artifactId>shared-lib</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../shared-lib/pom.xml</relativePath>
   </parent>
 
   <groupId>com.ejada</groupId>


### PR DESCRIPTION
## Summary
- move the email-management parent to the shared-lib parent so it inherits the shared BOM and build standards
- switch the email microservices to shared starters for actuator, core, openapi, Kafka, and Redis to keep infrastructure consistent
- keep existing Spring Boot functionality while relying on the shared library-managed versions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691af6037420832f818574b6370b0e01)