### PR TITLE
Add AOP starter to email webhook service

### DIFF
--- a/email-management/email-webhook-service/pom.xml
+++ b/email-management/email-webhook-service/pom.xml
@@ -24,6 +24,10 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-kafka</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary
- add spring-boot-starter-aop to email-webhook-service to provide AspectJ classes required for auto-proxy creation

## Testing
- mvn -pl email-webhook-service -am test *(fails: missing internal shared-lib/shared-bom artifacts from repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b06d29c00832fa1761a24127aef24)