### PR TITLE
Add Spring AOP dependency to email management service

### DIFF
--- a/email-management/email-management-service/pom.xml
+++ b/email-management/email-management-service/pom.xml
@@ -26,6 +26,10 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.ejada</groupId>
       <artifactId>starter-actuator</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary
- add Spring AOP starter to the email-management-service module to supply missing AspectJ annotations at runtime

## Testing
- mvn -pl email-management-service -am test *(fails: missing com.ejada shared artifacts from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b074c76bc832f961e43e6546ac6b9)