### PR TITLE
Add JWT tenant enforcement to email management APIs

### DIFF
--- a/email-management/email-sending-service/pom.xml
+++ b/email-management/email-sending-service/pom.xml
@@ -54,6 +54,10 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
+      <artifactId>starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
       <artifactId>starter-openapi</artifactId>
     </dependency>
     <dependency>

--- a/email-management/email-sending-service/src/main/java/com/ejada/email/sending/controller/EmailSendController.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/email/sending/controller/EmailSendController.java
@@ -1,12 +1,14 @@
 package com.ejada.email.sending.controller;
 
+import com.ejada.common.context.ContextManager;
 import com.ejada.email.sending.dto.BulkEmailSendRequest;
 import com.ejada.email.sending.dto.EmailSendRequest;
 import com.ejada.email.sending.dto.EmailSendResponse;
 import com.ejada.email.sending.service.EmailDispatchService;
+import com.ejada.starter_core.tenant.RequireTenant;
 import jakarta.validation.Valid;
+import java.util.Objects;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,7 +16,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/tenants/{tenantId}/emails")
+@RequestMapping("/api/v1/emails")
+@RequireTenant
 public class EmailSendController {
 
   private final EmailDispatchService service;
@@ -26,14 +29,16 @@ public class EmailSendController {
   @PostMapping("/send")
   @ResponseStatus(HttpStatus.ACCEPTED)
   public EmailSendResponse send(
-      @PathVariable String tenantId, @Valid @RequestBody EmailSendRequest request) {
+      @Valid @RequestBody EmailSendRequest request) {
+    String tenantId = Objects.requireNonNull(ContextManager.Tenant.get(), "tenantId is required");
     return service.sendEmail(tenantId, request);
   }
 
   @PostMapping("/send/bulk")
   @ResponseStatus(HttpStatus.ACCEPTED)
   public void bulkSend(
-      @PathVariable String tenantId, @Valid @RequestBody BulkEmailSendRequest request) {
+      @Valid @RequestBody BulkEmailSendRequest request) {
+    String tenantId = Objects.requireNonNull(ContextManager.Tenant.get(), "tenantId is required");
     service.sendBulk(tenantId, request);
   }
 }

--- a/email-management/email-sending-service/src/main/resources/application.yaml
+++ b/email-management/email-sending-service/src/main/resources/application.yaml
@@ -36,6 +36,17 @@ rate-limit:
   refill-per-minute: 200
 
 shared:
+  security:
+    mode: hs256
+    hs256:
+      secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
+    tenant-claim: tenant
+    resource-server:
+      enabled: true
+      permit-all:
+        - /actuator/health
+        - /v3/api-docs/**
+        - /swagger-ui/**
   core:
     tenant:
       resolve-from-jwt: true

--- a/email-management/email-template-service/src/main/java/com/ejada/email/template/controller/TemplateController.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/email/template/controller/TemplateController.java
@@ -12,6 +12,7 @@ import com.ejada.email.template.dto.TemplateVersionCreateRequest;
 import com.ejada.email.template.dto.TemplateVersionDto;
 import com.ejada.email.template.dto.UpdateTemplateRequest;
 import com.ejada.email.template.service.TemplateService;
+import com.ejada.starter_core.tenant.RequireTenant;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/templates")
+@RequireTenant
 public class TemplateController {
 
   private final TemplateService templateService;

--- a/email-management/email-usage-service/pom.xml
+++ b/email-management/email-usage-service/pom.xml
@@ -50,6 +50,10 @@
     </dependency>
     <dependency>
       <groupId>com.ejada</groupId>
+      <artifactId>starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ejada</groupId>
       <artifactId>starter-openapi</artifactId>
     </dependency>
     <dependency>

--- a/email-management/email-usage-service/src/main/java/com/ejada/email/usage/controller/UsageController.java
+++ b/email-management/email-usage-service/src/main/java/com/ejada/email/usage/controller/UsageController.java
@@ -1,23 +1,26 @@
 package com.ejada.email.usage.controller;
 
+import com.ejada.common.context.ContextManager;
 import com.ejada.email.usage.domain.AnomalyAlert;
 import com.ejada.email.usage.domain.QuotaStatus;
 import com.ejada.email.usage.domain.UsageReportRow;
 import com.ejada.email.usage.domain.UsageSummary;
 import com.ejada.email.usage.domain.UsageTrendPoint;
 import com.ejada.email.usage.service.UsageAnalyticsService;
+import com.ejada.starter_core.tenant.RequireTenant;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/usage")
+@RequireTenant
 public class UsageController {
 
   private final UsageAnalyticsService usageAnalyticsService;
@@ -26,45 +29,47 @@ public class UsageController {
     this.usageAnalyticsService = usageAnalyticsService;
   }
 
-  @GetMapping("/tenants/{tenantId}/usage/summary")
+  @GetMapping("/summary")
   public ResponseEntity<UsageSummary> usageSummary(
-      @PathVariable String tenantId,
       @RequestParam(value = "from", required = false)
           @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
           LocalDate from,
       @RequestParam(value = "to", required = false)
           @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
           LocalDate to) {
+    String tenantId = Objects.requireNonNull(ContextManager.Tenant.get(), "tenantId is required");
     LocalDate resolvedTo = to != null ? to : LocalDate.now();
     LocalDate resolvedFrom = from != null ? from : resolvedTo.minusDays(30);
     return ResponseEntity.ok(usageAnalyticsService.summarize(tenantId, resolvedFrom, resolvedTo));
   }
 
-  @GetMapping("/tenants/{tenantId}/usage/trends")
+  @GetMapping("/trends")
   public ResponseEntity<List<UsageTrendPoint>> usageTrends(
-      @PathVariable String tenantId,
       @RequestParam(value = "from", required = false)
           @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
           LocalDate from,
       @RequestParam(value = "to", required = false)
           @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
           LocalDate to) {
+    String tenantId = Objects.requireNonNull(ContextManager.Tenant.get(), "tenantId is required");
     LocalDate resolvedTo = to != null ? to : LocalDate.now();
     LocalDate resolvedFrom = from != null ? from : resolvedTo.minusDays(30);
     return ResponseEntity.ok(usageAnalyticsService.trend(tenantId, resolvedFrom, resolvedTo));
   }
 
-  @GetMapping("/tenants/{tenantId}/usage/quota")
-  public ResponseEntity<QuotaStatus> quotaStatus(@PathVariable String tenantId) {
+  @GetMapping("/quota")
+  public ResponseEntity<QuotaStatus> quotaStatus() {
+    String tenantId = Objects.requireNonNull(ContextManager.Tenant.get(), "tenantId is required");
     return ResponseEntity.ok(usageAnalyticsService.quotaStatus(tenantId));
   }
 
-  @GetMapping("/tenants/{tenantId}/usage/anomalies")
-  public ResponseEntity<List<AnomalyAlert>> anomalies(@PathVariable String tenantId) {
+  @GetMapping("/anomalies")
+  public ResponseEntity<List<AnomalyAlert>> anomalies() {
+    String tenantId = Objects.requireNonNull(ContextManager.Tenant.get(), "tenantId is required");
     return ResponseEntity.ok(usageAnalyticsService.detectAnomalies(tenantId));
   }
 
-  @GetMapping("/admin/usage/reports/daily")
+  @GetMapping("/admin/reports/daily")
   public ResponseEntity<List<UsageReportRow>> dailyReport(
       @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
     return ResponseEntity.ok(usageAnalyticsService.dailyReport(date));

--- a/email-management/email-usage-service/src/main/resources/application.yaml
+++ b/email-management/email-usage-service/src/main/resources/application.yaml
@@ -18,6 +18,17 @@ spring:
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
 
 shared:
+  security:
+    mode: hs256
+    hs256:
+      secret: ${JWT_SECRET:7h1aH9UllV2E7Yka4P6s2F+1Vn6V5w9zIXhmJ5aB1kA=}
+    tenant-claim: tenant
+    resource-server:
+      enabled: true
+      permit-all:
+        - /actuator/health
+        - /v3/api-docs/**
+        - /swagger-ui/**
   core:
     tenant:
       resolve-from-jwt: true


### PR DESCRIPTION
## Summary
- require tenant context for email template, sending, and usage controllers by deriving the tenant from JWT instead of path variables
- enable resource server security with tenant claim handling for sending and usage services
- add JWT configuration defaults so tenant headers are propagated automatically

## Testing
- mvn -f email-management/pom.xml -pl email-sending-service,email-usage-service -am -DskipTests compile *(fails: missing private parent modules and absent email-management-service module definition)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0bf0c26c832fbc527a2c75742e73)