### PR TITLE
Ensure email schema is created for template migrations

### DIFF
--- a/email-management/email-template-service/src/main/resources/application.yaml
+++ b/email-management/email-template-service/src/main/resources/application.yaml
@@ -21,6 +21,9 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration/common,classpath:db/migration/{vendor}
+    baseline-on-migrate: true
+    schemas: email
+    default-schema: email
   cache:
     type: redis
 

--- a/email-management/email-template-service/src/main/resources/db/migration/common/V10__init_email_template_schema.sql
+++ b/email-management/email-template-service/src/main/resources/db/migration/common/V10__init_email_template_schema.sql
@@ -1,6 +1,9 @@
 -- Email template service schema managed by Flyway.
 -- Tables target the current schema configured via spring.flyway.
 
+CREATE SCHEMA IF NOT EXISTS email;
+SET search_path TO email;
+
 CREATE TABLE IF NOT EXISTS email_template (
   id            BIGSERIAL PRIMARY KEY,
   tenant_id     VARCHAR(64),

--- a/email-management/email-template-service/src/main/resources/db/migration/common/V11__create_email_usage_log.sql
+++ b/email-management/email-template-service/src/main/resources/db/migration/common/V11__create_email_usage_log.sql
@@ -1,4 +1,7 @@
 -- Read-model table used by the email usage service for daily aggregations.
+CREATE SCHEMA IF NOT EXISTS email;
+SET search_path TO email;
+
 CREATE TABLE IF NOT EXISTS email_event_log (
   id           BIGSERIAL PRIMARY KEY,
   tenant_id    VARCHAR(64) NOT NULL,


### PR DESCRIPTION
## Summary
- configure Flyway to baseline and use the email schema by default
- ensure email schema is created and selected within email-template migrations so tables land in the correct schema

## Testing
- mvn -pl email-template-service -am -DskipTests package *(fails: shared parent artifacts are not available in Maven Central in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b104b3aec832f81957716e6a18cad)