### PR TITLE
Handle missing tenant context with validation errors

### DIFF
--- a/email-management/email-sending-service/src/main/java/com/ejada/email/sending/controller/EmailSendController.java
+++ b/email-management/email-sending-service/src/main/java/com/ejada/email/sending/controller/EmailSendController.java
@@ -1,13 +1,13 @@
 package com.ejada.email.sending.controller;
 
 import com.ejada.common.context.ContextManager;
+import com.ejada.common.exception.ValidationException;
 import com.ejada.email.sending.dto.BulkEmailSendRequest;
 import com.ejada.email.sending.dto.EmailSendRequest;
 import com.ejada.email.sending.dto.EmailSendResponse;
 import com.ejada.email.sending.service.EmailDispatchService;
 import com.ejada.starter_core.tenant.RequireTenant;
 import jakarta.validation.Valid;
-import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,7 +30,7 @@ public class EmailSendController {
   @ResponseStatus(HttpStatus.ACCEPTED)
   public EmailSendResponse send(
       @Valid @RequestBody EmailSendRequest request) {
-    String tenantId = Objects.requireNonNull(ContextManager.Tenant.get(), "tenantId is required");
+    String tenantId = requireTenantId();
     return service.sendEmail(tenantId, request);
   }
 
@@ -38,7 +38,15 @@ public class EmailSendController {
   @ResponseStatus(HttpStatus.ACCEPTED)
   public void bulkSend(
       @Valid @RequestBody BulkEmailSendRequest request) {
-    String tenantId = Objects.requireNonNull(ContextManager.Tenant.get(), "tenantId is required");
+    String tenantId = requireTenantId();
     service.sendBulk(tenantId, request);
+  }
+
+  private String requireTenantId() {
+    String tenantId = ContextManager.Tenant.get();
+    if (tenantId == null) {
+      throw new ValidationException("Tenant context is missing", "tenantId is required");
+    }
+    return tenantId;
   }
 }

--- a/email-management/email-template-service/src/main/java/com/ejada/email/template/service/impl/EmailSendServiceImpl.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/email/template/service/impl/EmailSendServiceImpl.java
@@ -24,11 +24,11 @@ import com.ejada.email.template.service.support.TemplateLookupService;
 import com.ejada.email.template.service.support.TemplateValidator;
 import com.ejada.email.template.service.support.RateLimiterService;
 import com.ejada.email.template.service.support.RedisIdempotencyService;
+import com.ejada.common.exception.ValidationException;
 import jakarta.transaction.Transactional;
 import java.time.Instant;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -180,6 +180,10 @@ public class EmailSendServiceImpl implements EmailSendService {
   }
 
   private String requireTenantId() {
-    return Objects.requireNonNull(ContextManager.Tenant.get(), "tenantId is required");
+    String tenantId = ContextManager.Tenant.get();
+    if (tenantId == null) {
+      throw new ValidationException("Tenant context is missing", "tenantId is required");
+    }
+    return tenantId;
   }
 }

--- a/email-management/email-template-service/src/main/java/com/ejada/email/template/service/impl/TemplateServiceImpl.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/email/template/service/impl/TemplateServiceImpl.java
@@ -25,13 +25,13 @@ import com.ejada.email.template.service.TemplateService;
 import com.ejada.email.template.service.support.SendGridTemplateClient;
 import com.ejada.email.template.service.support.TemplateRenderer;
 import com.ejada.email.template.service.support.TemplateValidator;
+import com.ejada.common.exception.ValidationException;
 import jakarta.transaction.Transactional;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -288,6 +288,10 @@ public class TemplateServiceImpl implements TemplateService {
   }
 
   private String requireTenantId() {
-    return Objects.requireNonNull(ContextManager.Tenant.get(), "tenantId is required");
+    String tenantId = ContextManager.Tenant.get();
+    if (tenantId == null) {
+      throw new ValidationException("Tenant context is missing", "tenantId is required");
+    }
+    return tenantId;
   }
 }

--- a/email-management/email-template-service/src/main/java/com/ejada/email/template/service/support/TemplateLookupService.java
+++ b/email-management/email-template-service/src/main/java/com/ejada/email/template/service/support/TemplateLookupService.java
@@ -1,11 +1,11 @@
 package com.ejada.email.template.service.support;
 
 import com.ejada.common.context.ContextManager;
+import com.ejada.common.exception.ValidationException;
 import com.ejada.email.template.domain.entity.TemplateVersionEntity;
 import com.ejada.email.template.domain.enums.TemplateVersionStatus;
 import com.ejada.email.template.exception.TemplateVersionNotFoundException;
 import com.ejada.email.template.repository.TemplateVersionRepository;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
@@ -21,7 +21,10 @@ public class TemplateLookupService {
       key =
           "T(com.ejada.common.context.ContextManager$Tenant).get() + ':' + #templateId + ':active'")
   public TemplateVersionEntity getActivePublishedVersion(Long templateId) {
-    String tenantId = Objects.requireNonNull(ContextManager.Tenant.get(), "tenantId is required");
+    String tenantId = ContextManager.Tenant.get();
+    if (tenantId == null) {
+      throw new ValidationException("Tenant context is missing", "tenantId is required");
+    }
     return templateVersionRepository
         .findFirstByTemplateIdAndTemplate_TenantIdAndStatusOrderByVersionNumberDesc(
             templateId, tenantId, TemplateVersionStatus.PUBLISHED)


### PR DESCRIPTION
## Summary
- raise validation exceptions when tenant context is missing across email services
- ensure tenant lookup helpers replace null checks to surface user-facing errors instead of NPEs

## Testing
- mvn -pl email-template-service,email-sending-service,email-usage-service -am -DskipTests compile *(fails: missing internal shared-lib artifacts and missing module email-management-service)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b172045dc832f9a6bdd947c1e6c16)