### PR TITLE
Use public GitHub CLI image for tooling

### DIFF
--- a/docker/tools/docker-compose.yml
+++ b/docker/tools/docker-compose.yml
@@ -136,7 +136,10 @@ services:
         aliases: [otel-collector]
 
   github-cli:
-    image: ghcr.io/cli/cli:2.62.0
+    # Using the Dev Containers GitHub CLI image avoids GitHub Container Registry
+    # authentication requirements that can trigger 403 errors when pulling the
+    # upstream ghcr.io/cli/cli image.
+    image: mcr.microsoft.com/devcontainers/github-cli:latest
     <<: [*restart_policy, *resources_light]
     entrypoint: ["tail", "-f", "/dev/null"]
     environment:


### PR DESCRIPTION
## Summary
- switch the tooling docker-compose GitHub CLI image to the public devcontainers build
- avoid GitHub Container Registry authentication issues when bringing up tooling stack

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691baf1758fc832fbc4ab0499405ece4)