### PR TITLE
Ensure app compose includes infra services

### DIFF
--- a/docker/app/docker-compose.yml
+++ b/docker/app/docker-compose.yml
@@ -191,3 +191,41 @@ services:
       - "8094:8084"
     networks:
       backend:
+
+  # ----------------------------- #
+  #     Infrastructure (reuse)    #
+  # ----------------------------- #
+  postgres:
+    extends:
+      file: ../tools/docker-compose.yml
+      service: postgres
+    networks:
+      backend:
+
+  zookeeper:
+    extends:
+      file: ../tools/docker-compose.yml
+      service: zookeeper
+    networks:
+      backend:
+
+  kafka:
+    extends:
+      file: ../tools/docker-compose.yml
+      service: kafka
+    networks:
+      backend:
+
+  otel-collector:
+    extends:
+      file: ../tools/docker-compose.yml
+      service: otel-collector
+    networks:
+      backend:
+
+  redis:
+    extends:
+      file: ../tools/docker-compose.yml
+      service: redis
+    networks:
+      backend:


### PR DESCRIPTION
## Summary
- reuse shared tooling services in the application docker compose via extends to eliminate missing dependency errors
- make redis, kafka, postgres, and telemetry services available when running the app stack alone

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb0941850832fa3abf12daef068f1)