### PR TITLE
Define infrastructure volumes for app compose

### DIFF
--- a/docker/app/docker-compose.yml
+++ b/docker/app/docker-compose.yml
@@ -25,6 +25,12 @@ networks:
   backend:
     driver: bridge
 
+volumes:
+  pgdata:
+  zkdata:
+  zklog:
+  kafkadata:
+
 # ----------------------------- #
 #       Application stack       #
 # ----------------------------- #


### PR DESCRIPTION
## Summary
- declare shared infrastructure volumes in the app docker-compose to match the tooling stack definitions

## Testing
- Not run (docker-compose CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb17453f8832fbb622062ed553af8)