### PR TITLE
Refactor security auto configuration

### DIFF
--- a/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
+++ b/shared-lib/shared-common/src/main/java/com/ejada/common/constants/HeaderNames.java
@@ -44,6 +44,7 @@ public final class HeaderNames {
     public static final String ACCEPT = "Accept";
     public static final String ACCEPT_LANGUAGE = "Accept-Language";
     public static final String LOCALE = "X-Locale";
+    public static final String X_REQUESTED_WITH = "X-Requested-With";
 
     // ⏱️ Performance / Caching
     public static final String CACHE_CONTROL = "Cache-Control";


### PR DESCRIPTION
## Summary
- streamline `SecurityAutoConfiguration` with helpers, shared constants, and clearer JWT authority extraction
- reuse shared header constants for CORS configuration

## Testing
- mvn -pl shared-starters/starter-security -am -DskipTests compile


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a1e7d2cc832fa01b3b9796360a22)