### PR TITLE
Refactor tenant propagation filter

### DIFF
--- a/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/JwtTenantFilter.java
+++ b/shared-lib/shared-starters/starter-security/src/main/java/com/ejada/starter_security/JwtTenantFilter.java
@@ -1,44 +1,52 @@
 package com.ejada.starter_security;
 
-import com.ejada.common.context.ContextManager;
 import com.ejada.common.constants.HeaderNames;
+import com.ejada.common.context.ContextManager;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
+class JwtTenantFilter extends OncePerRequestFilter {
 
-class JwtTenantFilter extends HttpFilter {
+  private final String tenantClaim;
 
-    private static final long serialVersionUID = 1L;
-	private final String tenantClaim;
+  JwtTenantFilter(String tenantClaim) {
+    this.tenantClaim = tenantClaim;
+  }
 
-    JwtTenantFilter(String tenantClaim) {
-        this.tenantClaim = tenantClaim;
+  @Override
+  protected void doFilterInternal(HttpServletRequest request,
+                                  HttpServletResponse response,
+                                  FilterChain filterChain) throws ServletException, IOException {
+    try {
+      propagateTenant(response);
+      filterChain.doFilter(request, response);
+    } finally {
+      ContextManager.Tenant.clear();
+    }
+  }
+
+  private void propagateTenant(HttpServletResponse response) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (!(authentication instanceof JwtAuthenticationToken jwtAuth)) {
+      return;
     }
 
-    @Override
-    protected void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
-        try {
-            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-            if (auth instanceof JwtAuthenticationToken jwtAuth) {
-                Jwt jwt = jwtAuth.getToken();
-                Object tid = jwt.getClaims().get(tenantClaim);
-                if (tid != null) {
-                        String tenant = String.valueOf(tid);
-                        ContextManager.Tenant.set(tenant);
-                        response.setHeader(HeaderNames.X_TENANT_ID, tenant);
-                }
-            }
-            chain.doFilter(request, response);
-        } finally {
-                ContextManager.Tenant.clear();
-        }
+    Jwt jwt = jwtAuth.getToken();
+    Object tenantFromClaim = jwt.getClaims().get(tenantClaim);
+    if (tenantFromClaim == null) {
+      return;
     }
+
+    String tenantId = String.valueOf(tenantFromClaim);
+    ContextManager.Tenant.set(tenantId);
+    response.setHeader(HeaderNames.X_TENANT_ID, tenantId);
+  }
 }


### PR DESCRIPTION
## Summary
- refactored the JWT tenant propagation filter to use `OncePerRequestFilter` and clearer control flow
- ensured tenant context and header are only applied when a tenant claim is present in the JWT

## Testing
- mvn -f shared-lib/pom.xml -pl shared-starters/starter-security -am test *(fails: central maven 502 while resolving log4j parent)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a89aa968832f8e6920bbee4fed9c)